### PR TITLE
refactor(shared-kernel): implement composite AccountId for regional s…

### DIFF
--- a/crates/account/migrations/postgres/202601020000_account.sql
+++ b/crates/account/migrations/postgres/202601020000_account.sql
@@ -1,17 +1,6 @@
--- 1. ENUMS (Identité et rôles)
-DO $$ BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'account_state') THEN
-        CREATE TYPE account_state AS ENUM ('PENDING', 'ACTIVE', 'DEACTIVATED', 'SUSPENDED', 'BANNED');
-    END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'internal_role') THEN
-        CREATE TYPE internal_role AS ENUM ('USER', 'MODERATOR', 'STAFF', 'ADMIN');
-    END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'beta_tier') THEN
-        CREATE TYPE beta_tier AS ENUM ('NONE', 'BETA', 'ALPHA', 'INTERNAL');
-END IF;
-END $$;
 
--- 2. FONCTION DE TRIGGER (Crucial : à définir AVANT les tables)
+
+-- 1. FONCTION DE TRIGGER (Crucial : à définir AVANT les tables)
 CREATE OR REPLACE FUNCTION trigger_set_timestamp()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -21,54 +10,61 @@ END;
 $$ LANGUAGE plpgsql;
 
 
--- 3. IDENTITY (Table racine)
+-- 2. IDENTITY (Table racine)
 CREATE TABLE IF NOT EXISTS account_identity (
-    account_id UUID PRIMARY KEY,
-    sub_id TEXT,
-    email TEXT UNIQUE,
-    phone_number TEXT UNIQUE,
-    state account_state NOT NULL DEFAULT 'PENDING',
-    birth_date DATE,
-    locale VARCHAR(10) NOT NULL DEFAULT 'en',
+    account_id UUID,
     region_code VARCHAR(10) NOT NULL,
+    sub_id TEXT,
+    email TEXT,
+    phone_number TEXT,
+    state TEXT NOT NULL DEFAULT 'PENDING',
+    birth_date DATE,
+    locale VARCHAR(10) NOT NULL DEFAULT 'EN',
     version BIGINT NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     aggregate_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_active_at TIMESTAMPTZ,
+    PRIMARY KEY (region_code, account_id),
+    CONSTRAINT uq_email UNIQUE (email, region_code),
+    CONSTRAINT uq_phone_number UNIQUE (phone_number, region_code),
     CONSTRAINT uq_sub_id UNIQUE (sub_id)
 );
 
--- 4. SETTINGS (Relation 1:1 co-localisée)
+-- 3. SETTINGS (Relation 1:1 co-localisée)
 CREATE TABLE IF NOT EXISTS account_settings (
-    account_id UUID PRIMARY KEY,
+    account_id UUID,
+    region_code VARCHAR(10) NOT NULL,
     preferences JSONB NOT NULL DEFAULT '{}',
     timezone TEXT NOT NULL DEFAULT 'UTC',
     push_tokens TEXT[] DEFAULT '{}',
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT fk_settings_identity FOREIGN KEY (account_id) REFERENCES account_identity(account_id) ON DELETE CASCADE
+    PRIMARY KEY (region_code, account_id),
+    CONSTRAINT fk_settings_identity FOREIGN KEY (region_code, account_id) REFERENCES account_identity(region_code, account_id) ON DELETE CASCADE
 );
 
--- 5. GOVERNANCE (Relation 1:1 co-localisée)
+-- 4. GOVERNANCE (Relation 1:1 co-localisée)
 CREATE TABLE IF NOT EXISTS account_governance (
-    account_id UUID PRIMARY KEY,
-    role internal_role NOT NULL DEFAULT 'USER',
-    beta_tier beta_tier NOT NULL DEFAULT 'NONE',
+    account_id UUID,
+    region_code VARCHAR(10) NOT NULL,
+    role TEXT NOT NULL DEFAULT 'USER',
+    beta_tier TEXT NOT NULL DEFAULT 'NONE',
     is_shadowbanned BOOLEAN NOT NULL DEFAULT FALSE,
     trust_score INT NOT NULL DEFAULT 100,
     moderation_notes TEXT,
     last_moderation_at TIMESTAMPTZ,
     last_ip_addr INET,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT fk_governance_identity FOREIGN KEY (account_id) REFERENCES account_identity(account_id) ON DELETE CASCADE
+    PRIMARY KEY (region_code, account_id),
+    CONSTRAINT fk_governance_identity FOREIGN KEY (region_code, account_id) REFERENCES account_identity(region_code, account_id) ON DELETE CASCADE
 );
 
--- 6. INDEXATION
-CREATE INDEX IF NOT EXISTS idx_accounts_sub_id ON account_identity (sub_id);
-CREATE INDEX IF NOT EXISTS idx_governance_flagged ON account_governance (account_id) 
+-- 5. INDEXATION
+CREATE INDEX IF NOT EXISTS idx_accounts_sub_id ON account_identity (region_code, sub_id);
+CREATE INDEX IF NOT EXISTS idx_governance_flagged ON account_governance (region_code, account_id) 
 WHERE is_shadowbanned IS TRUE OR trust_score < 50;
 
--- 7. TRIGGERS (Automatisation du updated_at)
+-- 6. TRIGGERS (Automatisation du updated_at)
 DROP TRIGGER IF EXISTS trg_set_timestamp_identity ON account_identity;
 CREATE TRIGGER trg_set_timestamp_identity BEFORE UPDATE ON account_identity FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();
 
@@ -77,6 +73,3 @@ CREATE TRIGGER trg_set_timestamp_settings BEFORE UPDATE ON account_settings FOR 
 
 DROP TRIGGER IF EXISTS trg_set_timestamp_governance ON account_governance;
 CREATE TRIGGER trg_set_timestamp_governance BEFORE UPDATE ON account_governance FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();
-
--- 7. INDEXATION (En dernier)
-CREATE INDEX IF NOT EXISTS idx_accounts_sub_id ON account_identity (sub_id);

--- a/crates/account/src/application/context/context.rs
+++ b/crates/account/src/application/context/context.rs
@@ -36,8 +36,8 @@ impl AccountAppContext {
         }
     }
 
-    pub fn create_context(&self, account_id: AccountId, region: RegionCode) -> AccountContext {
-        AccountContext::new(self.clone(), account_id, region)
+    pub fn create_context(&self, account_id: AccountId) -> AccountContext {
+        AccountContext::new(self.clone(), account_id)
     }
 
     pub fn base(&self) -> &BaseAppContext {
@@ -62,16 +62,11 @@ impl AccountAppContext {
 pub struct AccountContext {
     app: AccountAppContext,
     account_id: AccountId,
-    region: RegionCode,
 }
 
 impl AccountContext {
-    pub(crate) fn new(app: AccountAppContext, account_id: AccountId, region: RegionCode) -> Self {
-        Self {
-            app,
-            account_id,
-            region,
-        }
+    pub(crate) fn new(app: AccountAppContext, account_id: AccountId) -> Self {
+        Self { app, account_id }
     }
 
     // --- Accès aux Repositories ---
@@ -81,7 +76,7 @@ impl AccountContext {
     }
 
     pub fn region(&self) -> &RegionCode {
-        &self.region
+        self.account_id.region()
     }
 
     pub fn account_repo(&self) -> Arc<dyn AccountRepository> {
@@ -111,21 +106,17 @@ impl AccountContext {
                 entity: "Account",
                 id: self.account_id.to_string(),
             })?;
-
-        self.ensure_region(&account)?;
-
         Ok(account)
     }
 
     pub async fn save(&self, account: &mut Account, command_id: Option<uuid::Uuid>) -> Result<()> {
         // 1. Isolation du contexte
-        if account.identity().account_id() != &self.account_id {
+        if account.identity().account_id().uuid() != self.account_id.uuid() {
             return Err(DomainError::Validation {
                 field: "account_id".into(),
-                reason: "Account ID mismatch for this context".into(),
+                reason: "Identity mismatch: cannot change the technical UUID of an account".into(),
             });
         }
-
         let mut tx = self.begin_transaction().await?;
 
         // 2. Idempotence Technique
@@ -183,20 +174,5 @@ impl AccountContext {
                 Ok(Box::new(FakeTransaction::new()) as Box<dyn Transaction>)
             }
         }
-    }
-
-    // --- Sécurité ---
-
-    fn ensure_region(&self, account: &Account) -> Result<()> {
-        let account_region = account.identity().region_code();
-        let context_region = &self.region;
-
-        if account_region != context_region {
-            return Err(DomainError::NotFound {
-                entity: "Account",
-                id: account.identity().account_id().to_string(),
-            });
-        }
-        Ok(())
     }
 }

--- a/crates/account/src/application/context/context_builder.rs
+++ b/crates/account/src/application/context/context_builder.rs
@@ -67,7 +67,6 @@ impl AccountContextBuilder {
                 .expect("AccountAppContext is required. Use .with_app()"),
             self.account_id
                 .expect("account_id is required for AccountContext"),
-            self.region.expect("region is required for AccountContext"),
         )
     }
 }

--- a/crates/account/src/application/use_cases/access_management/link_sub_identity/link_sub_identity_command.rs
+++ b/crates/account/src/application/use_cases/access_management/link_sub_identity/link_sub_identity_command.rs
@@ -22,17 +22,10 @@ impl LinkSubIdentityCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
-            sub_id: SubId::try_from(req.sub_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "sub_id",
-                    reason: e.to_string(),
-                }
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
+            sub_id: SubId::try_from(req.sub_id).map_err(|e| DomainError::Validation {
+                field: "sub_id",
+                reason: e.to_string(),
             })?,
         })
     }

--- a/crates/account/src/application/use_cases/access_management/link_sub_identity/link_sub_identity_use_case_test.rs
+++ b/crates/account/src/application/use_cases/access_management/link_sub_identity/link_sub_identity_use_case_test.rs
@@ -1,9 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::application::context::AccountContext;
-    use crate::application::use_cases::access_management::{
-        LinkSubIdentityCommand,
-    };
+    use crate::application::use_cases::access_management::LinkSubIdentityCommand;
     use crate::application::utils::TestFixture;
     use crate::domain::events::AccountEvent;
     use shared_kernel::domain::events::AggregateRoot;
@@ -145,32 +143,6 @@ mod tests {
         })
         .await?;
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange : Donnée aux US, contexte de test en EU
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        f.account_repo().insert(account);
-
-        let cmd = LinkSubIdentityCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            sub_id: SubId::try_new("steam_456")?,
-        };
-
-        // 2. Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, LinkSubIdentityCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // 3. Assert : Isolation régionale (NotFound)
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
         Ok(())
     }
 }

--- a/crates/account/src/application/use_cases/access_management/register/register_use_case.rs
+++ b/crates/account/src/application/use_cases/access_management/register/register_use_case.rs
@@ -20,7 +20,7 @@ impl CommandHandler for RegisterHandler {
 
     async fn handle(&self, ctx: &AccountContext, cmd: RegisterCommand) -> Result<Self::Output> {
         let account_id = cmd.account_id.clone();
-        let mut builder = Account::builder(account_id.clone(), cmd.region.clone(), cmd.identifier);
+        let mut builder = Account::builder(account_id.clone(), cmd.identifier);
 
         if let Some(ext_id) = cmd.sub_id {
             builder = builder.with_sub_id(ext_id);

--- a/crates/account/src/application/use_cases/access_management/register/register_use_case_test.rs
+++ b/crates/account/src/application/use_cases/access_management/register/register_use_case_test.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests {
     use shared_kernel::domain::events::{AggregateMetadata, AggregateRoot};
-    use shared_kernel::domain::value_objects::{AccountId, Email, SubId};
+    use shared_kernel::domain::value_objects::{AccountId, Email, RegionCode, SubId};
     use shared_kernel::errors::{DomainError, Result};
     use uuid::Uuid;
 
@@ -31,7 +31,7 @@ mod tests {
             ip_addr: ip.clone(),
         };
 
-        let ctx = f.app_ctx().create_context(f.account_id(), f.region());
+        let ctx = f.app_ctx().create_context(f.account_id());
         let result = f
             .bus()
             .execute::<AccountContext, RegisterCommand, AccountId>(f.account_ctx().clone(), cmd)
@@ -75,7 +75,7 @@ mod tests {
         // 1. Arrange : On pré-enregistre un compte existant dans le repo
         let existing_acc = f
             .account_builder()?
-            .with_account_id(AccountId::new())
+            .with_account_id(AccountId::generate(RegionCode::default()))
             .with_sub_id(existing_ext_id.clone())
             .build()?;
         f.account_repo().insert(existing_acc.clone());
@@ -91,7 +91,7 @@ mod tests {
         };
 
         // 2. Act
-        f.app_ctx().create_context(f.account_id(), f.region());
+        f.app_ctx().create_context(f.account_id());
 
         let result = f
             .bus()
@@ -128,7 +128,7 @@ mod tests {
         };
 
         // 2. Act
-        let ctx = f.app_ctx().create_context(f.account_id(), f.region());
+        let ctx = f.app_ctx().create_context(f.account_id());
         let result = f
             .bus()
             .execute::<AccountContext, RegisterCommand, ()>(f.account_ctx().clone(), cmd)

--- a/crates/account/src/application/use_cases/lifecycle/activate/activate_command.rs
+++ b/crates/account/src/application/use_cases/lifecycle/activate/activate_command.rs
@@ -18,12 +18,7 @@ impl ActivateCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
         })
     }
 }

--- a/crates/account/src/application/use_cases/lifecycle/activate/activate_use_case_test.rs
+++ b/crates/account/src/application/use_cases/lifecycle/activate/activate_use_case_test.rs
@@ -153,36 +153,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::try_new("US")?;
-
-        // Arrange : On insère un compte qui n'est pas dans la région du contexte (eu)
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = ActivateCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-        };
-
-        // 2. Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, ActivateCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // 3. Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe via le repo (car le contexte ne le trouvera pas)
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/lifecycle/change_beta_tier/change_beta_tier_command.rs
+++ b/crates/account/src/application/use_cases/lifecycle/change_beta_tier/change_beta_tier_command.rs
@@ -25,12 +25,7 @@ impl ChangeBetaTierCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             new_tier: BetaTier::try_from(req.new_tier).map_err(|e| DomainError::Validation {
                 field: "new_tier",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/lifecycle/change_beta_tier/change_beta_tier_use_case_test.rs
+++ b/crates/account/src/application/use_cases/lifecycle/change_beta_tier/change_beta_tier_use_case_test.rs
@@ -113,36 +113,4 @@ mod tests {
         f.assert_outbox(0, None); // Pas d'événement produit
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Compte créé en US alors que le contexte TestFixture est EU par défaut
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-
-        f.account_repo().insert(account);
-
-        let cmd = ChangeBetaTierCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_tier: BetaTier::INTERNAL,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, ChangeBetaTierCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Le UseCase ne doit pas trouver le compte car il filtre par région
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe pour confirmer que rien n'a bougé
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/lifecycle/change_role/change_role_command.rs
+++ b/crates/account/src/application/use_cases/lifecycle/change_role/change_role_command.rs
@@ -25,12 +25,7 @@ impl ChangeRoleCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             new_role: AccountRole::try_from(req.new_role).map_err(|e| DomainError::Validation {
                 field: "new_role",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/lifecycle/change_role/change_role_use_case_test.rs
+++ b/crates/account/src/application/use_cases/lifecycle/change_role/change_role_use_case_test.rs
@@ -110,34 +110,4 @@ mod tests {
         f.assert_outbox(0, None);
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-
-        f.account_repo().insert(account);
-
-        let cmd = ChangeRoleCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_role: AccountRole::MODERATOR,
-            reason: AuditReason::try_new("some_reason")?,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, ChangeRoleCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe via le repo (car le contexte ne le trouvera pas)
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/lifecycle/deactivate/deactivate_command.rs
+++ b/crates/account/src/application/use_cases/lifecycle/deactivate/deactivate_command.rs
@@ -20,12 +20,7 @@ impl DeactivateCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::from_str(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             reason: req
                 .reason

--- a/crates/account/src/application/use_cases/lifecycle/deactivate/deactivate_use_case_test.rs
+++ b/crates/account/src/application/use_cases/lifecycle/deactivate/deactivate_use_case_test.rs
@@ -136,36 +136,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange : Compte aux USA, mais contexte Europe
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = DeactivateCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: None,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, DeactivateCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert : Obfuscation de sécurité
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/lifecycle/suspend/suspend_command.rs
+++ b/crates/account/src/application/use_cases/lifecycle/suspend/suspend_command.rs
@@ -22,12 +22,7 @@ impl SuspendCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             reason: AuditReason::try_from(req.reason).map_err(|e| DomainError::Validation {
                 field: "account_id",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/lifecycle/suspend/suspend_use_case_test.rs
+++ b/crates/account/src/application/use_cases/lifecycle/suspend/suspend_use_case_test.rs
@@ -113,35 +113,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = SuspendCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: AuditReason::try_new("some_reason")?,
-        };
-
-        // 2. Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, SuspendCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // 3. Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/lifecycle/unsuspend/unsuspend_command.rs
+++ b/crates/account/src/application/use_cases/lifecycle/unsuspend/unsuspend_command.rs
@@ -22,12 +22,7 @@ impl UnsuspendCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             reason: AuditReason::try_from(req.reason).map_err(|e| DomainError::Validation {
                 field: "account_id",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/lifecycle/unsuspend/unsuspend_use_case_test.rs
+++ b/crates/account/src/application/use_cases/lifecycle/unsuspend/unsuspend_use_case_test.rs
@@ -114,35 +114,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = UnsuspendCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: AuditReason::try_new("Good behavior")?,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, UnsuspendCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/moderation/ban/ban_command.rs
+++ b/crates/account/src/application/use_cases/moderation/ban/ban_command.rs
@@ -20,12 +20,7 @@ impl BanCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             reason: AuditReason::try_from(req.reason).map_err(|e| DomainError::Validation {
                 field: "reason",

--- a/crates/account/src/application/use_cases/moderation/ban/ban_use_case_test.rs
+++ b/crates/account/src/application/use_cases/moderation/ban/ban_use_case_test.rs
@@ -194,37 +194,4 @@ mod tests {
         // Note: Le stub doit être configuré pour ne pas persister si check_error fail
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        let account = f.account_builder_for(wrong_region)?.build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = BanCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: AuditReason::try_new("System ban")?,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, BanCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/moderation/decrease_trust_score/decrease_trust_score_command.rs
+++ b/crates/account/src/application/use_cases/moderation/decrease_trust_score/decrease_trust_score_command.rs
@@ -26,12 +26,7 @@ impl DecreaseTrustScoreCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             amount: TrustDelta::try_from(req.delta).map_err(|e| DomainError::Validation {
                 field: "delta",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/moderation/decrease_trust_score/decrease_trust_score_use_case_test.rs
+++ b/crates/account/src/application/use_cases/moderation/decrease_trust_score/decrease_trust_score_use_case_test.rs
@@ -200,41 +200,4 @@ mod tests {
         f.assert_outbox(1, Some(AccountEvent::TRUST_SCORE_ADJUSTED));
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Compte aux US, Contexte en EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = DecreaseTrustScoreCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            amount: TrustDelta::from_raw(1),
-            reason: AuditReason::try_new("Test")?,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, DecreaseTrustScoreCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/moderation/increase_trust_score/increase_trust_score_command.rs
+++ b/crates/account/src/application/use_cases/moderation/increase_trust_score/increase_trust_score_command.rs
@@ -26,12 +26,7 @@ impl IncreaseTrustScoreCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             amount: TrustDelta::try_from(req.delta).map_err(|e| DomainError::Validation {
                 field: "delta",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/moderation/increase_trust_score/increase_trust_score_use_case_test.rs
+++ b/crates/account/src/application/use_cases/moderation/increase_trust_score/increase_trust_score_use_case_test.rs
@@ -168,45 +168,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange : Compte US vs Contexte EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-        let version_snapshot = account.version();
-
-        f.account_repo().insert(account);
-
-        let cmd = IncreaseTrustScoreCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            amount: TrustDelta::from_raw(10),
-            reason: AuditReason::try_new("No matter")?,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, IncreaseTrustScoreCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/moderation/lift_shadowban/lift_shadowban_command.rs
+++ b/crates/account/src/application/use_cases/moderation/lift_shadowban/lift_shadowban_command.rs
@@ -1,7 +1,10 @@
 // crates/account/src/application/lift_shadowban/lift_shadowban_command.rs
 
 use serde::Deserialize;
-use shared_kernel::{domain::value_objects::{AccountId, AuditReason}, errors::{DomainError, Result}};
+use shared_kernel::{
+    domain::value_objects::{AccountId, AuditReason},
+    errors::{DomainError, Result},
+};
 use shared_proto::account::v1::ModerationRequest;
 use uuid::Uuid;
 
@@ -20,12 +23,7 @@ impl LiftShadowbanCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             reason: AuditReason::try_from(req.reason).map_err(|e| DomainError::Validation {
                 field: "reason",

--- a/crates/account/src/application/use_cases/moderation/lift_shadowban/lift_shadowban_use_case_test.rs
+++ b/crates/account/src/application/use_cases/moderation/lift_shadowban/lift_shadowban_use_case_test.rs
@@ -120,44 +120,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::BANNED)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = LiftShadowbanCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: AuditReason::try_new("Accidental click")?,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, LiftShadowbanCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/moderation/shadowban/shadowban_command.rs
+++ b/crates/account/src/application/use_cases/moderation/shadowban/shadowban_command.rs
@@ -1,6 +1,9 @@
 // crates/account/src/application/shadowban_account/shadowban_command.rs
 
-use shared_kernel::{domain::value_objects::{AccountId, AuditReason}, errors::{DomainError, Result}};
+use shared_kernel::{
+    domain::value_objects::{AccountId, AuditReason},
+    errors::{DomainError, Result},
+};
 use shared_proto::account::v1::ModerationRequest;
 use uuid::Uuid;
 
@@ -19,12 +22,7 @@ impl ShadowbanCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             reason: AuditReason::try_from(req.reason).map_err(|e| DomainError::Validation {
                 field: "reason",

--- a/crates/account/src/application/use_cases/moderation/shadowban/shadowban_use_case_test.rs
+++ b/crates/account/src/application/use_cases/moderation/shadowban/shadowban_use_case_test.rs
@@ -119,44 +119,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-        let version_snapshot = account.version();
-
-        f.account_repo().insert(account);
-
-        let cmd = ShadowbanCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: AuditReason::try_new("Spam")?,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, ShadowbanCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/moderation/unban/unban_command.rs
+++ b/crates/account/src/application/use_cases/moderation/unban/unban_command.rs
@@ -1,6 +1,9 @@
 // crates/account/src/application/unban_account/unban_command.rs
 use serde::Deserialize;
-use shared_kernel::{domain::value_objects::{AccountId, AuditReason}, errors::{DomainError, Result}};
+use shared_kernel::{
+    domain::value_objects::{AccountId, AuditReason},
+    errors::{DomainError, Result},
+};
 use shared_proto::account::v1::ModerationRequest;
 use uuid::Uuid;
 
@@ -19,12 +22,7 @@ impl UnbanCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             reason: AuditReason::try_from(req.reason).map_err(|e| DomainError::Validation {
                 field: "reason",

--- a/crates/account/src/application/use_cases/moderation/unban/unban_use_case_test.rs
+++ b/crates/account/src/application/use_cases/moderation/unban/unban_use_case_test.rs
@@ -121,43 +121,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = ShadowbanCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            reason: AuditReason::try_new("Spam")?,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, ShadowbanCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/add_push_token/add_push_token_command.rs
+++ b/crates/account/src/application/use_cases/settings/add_push_token/add_push_token_command.rs
@@ -19,18 +19,11 @@ impl AddPushTokenCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
-            token: PushToken::try_new(&req.token).map_err(|e| {
-                DomainError::Validation {
-                    field: "push_token",
-                    reason: e.to_string(),
-                }
+            token: PushToken::try_new(&req.token).map_err(|e| DomainError::Validation {
+                field: "push_token",
+                reason: e.to_string(),
             })?,
         })
     }

--- a/crates/account/src/application/use_cases/settings/add_push_token/add_push_token_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/add_push_token/add_push_token_use_case_test.rs
@@ -180,42 +180,4 @@ mod tests {
         f.assert_outbox(1, Some(AccountEvent::PUSH_TOKEN_ADDED));
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Compte US, Contexte EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-        let version_snapshot = account.version();
-
-        f.account_repo().insert(account);
-
-        let cmd = AddPushTokenCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            token: PushToken::try_new("token_test_123")?,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, AddPushTokenCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        assert_eq!(
-            saved.version(),
-            version_snapshot,
-            "La version ne doit pas avoir bougé"
-        );
-
-        f.assert_outbox(0, None);
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/change_birth_date/change_birth_date_command.rs
+++ b/crates/account/src/application/use_cases/settings/change_birth_date/change_birth_date_command.rs
@@ -40,12 +40,7 @@ impl ChangeBirthDateCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             new_birth_date,
         })

--- a/crates/account/src/application/use_cases/settings/change_birth_date/change_birth_date_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/change_birth_date/change_birth_date_use_case_test.rs
@@ -171,37 +171,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = ChangeBirthDateCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_birth_date: adult_birth_date(),
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, ChangeBirthDateCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // On vérifie directement via le repo
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/change_email/change_email_command.rs
+++ b/crates/account/src/application/use_cases/settings/change_email/change_email_command.rs
@@ -22,12 +22,7 @@ impl ChangeEmailCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             new_email: Email::try_from(req.new_email).map_err(|e| DomainError::Validation {
                 field: "account_id",
                 reason: e.to_string(),

--- a/crates/account/src/application/use_cases/settings/change_email/change_email_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/change_email/change_email_use_case_test.rs
@@ -219,38 +219,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = ChangeEmailCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_email: Email::try_new("new@test.com")?,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, ChangeEmailCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe (le contexte ne voit pas le compte)
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-        f.assert_outbox(0, None);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/change_phone_number/change_phone_number_command.rs
+++ b/crates/account/src/application/use_cases/settings/change_phone_number/change_phone_number_command.rs
@@ -22,12 +22,7 @@ impl ChangePhoneNumberCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
             new_phone: PhoneNumber::try_from(req.new_phone).map_err(|e| {
                 DomainError::Validation {
                     field: "new_phone",

--- a/crates/account/src/application/use_cases/settings/change_phone_number/change_phone_number_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/change_phone_number/change_phone_number_use_case_test.rs
@@ -172,38 +172,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Compte US dans un contexte européen
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = ChangePhoneNumberCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_phone: PhoneNumber::try_new("+33611223344")?,
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, ChangePhoneNumberCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe via le repo (car f.assert_account échouerait sur le RegionCheck)
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/change_region/change_region_command.rs
+++ b/crates/account/src/application/use_cases/settings/change_region/change_region_command.rs
@@ -23,12 +23,7 @@ impl ChangeRegionCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             new_region: RegionCode::try_new(&req.new_region).map_err(|e| {
                 DomainError::Validation {

--- a/crates/account/src/application/use_cases/settings/change_region/change_region_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/change_region/change_region_use_case_test.rs
@@ -4,7 +4,6 @@ mod tests {
     use crate::application::use_cases::settings::ChangeRegionCommand;
     use crate::application::utils::TestFixture;
     use crate::domain::events::AccountEvent;
-    use crate::domain::repositories::AccountRepository;
     use crate::domain::value_objects::AccountState;
     use shared_kernel::domain::events::AggregateRoot;
     use shared_kernel::domain::value_objects::RegionCode;
@@ -14,48 +13,52 @@ mod tests {
     #[tokio::test]
     async fn test_change_region_success() -> Result<()> {
         let f = TestFixture::new();
+        let old_id = f.account_id(); // ex: EU:uuid
         let new_region = RegionCode::from_raw("US");
+
+        // L'ID attendu après le changement
+        let expected_new_id =
+            shared_kernel::domain::value_objects::AccountId::new(old_id.uuid(), new_region.clone());
 
         let account = f
             .account_builder()?
             .with_state(AccountState::ACTIVE)
             .build()?;
-        let version_snapshot = account.version();
-        // DEBUG pour confirmer
-        assert_eq!(account.identity().region_code().as_str(), "EU");
 
+        let version_snapshot = account.version();
         f.account_repo().insert(account.clone());
 
         let cmd = ChangeRegionCommand {
             command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
+            account_id: old_id.clone(),
             new_region: new_region.clone(),
         };
 
-        // 1. On vérifie manuellement si le stub a l'objet
-        let direct_check = f.account_repo().find_direct(&f.account_id());
-
-        // 2. On vérifie via le trait (ce que le Bus utilise)
-        let trait_check = f.account_repo().find_by_id(&f.account_id(), None).await?;
-
+        // Act
         f.bus()
             .execute::<AccountContext, ChangeRegionCommand, ()>(f.account_ctx().clone(), cmd)
             .await?;
 
-        assert_eq!(
-            account.identity().account_id().to_string(),
-            f.account_id().to_string(),
-            "L'ID de l'objet ne correspond pas à l'ID de la fixture !"
-        );
-        f.assert_account(|acc| {
+        // ASSERTION CORRIGÉE :
+        // On ne peut plus utiliser f.assert_account car elle cherche l'ancien ID (EU:uuid)
+        // On doit chercher le compte via son NOUVEL ID (US:uuid)
+        f.assert_account_by_id(&expected_new_id, |acc| {
             assert_eq!(acc.identity().region_code(), &new_region);
+            assert_eq!(acc.identity().account_id(), &expected_new_id);
             assert_eq!(acc.version(), version_snapshot + 1);
         })
         .await?;
 
+        // On vérifie aussi que l'ancien ID n'existe plus (facultatif mais propre)
+        assert!(
+            f.account_repo().find_direct(&old_id).is_none(),
+            "L'ancien ID devrait avoir disparu"
+        );
+
         f.assert_outbox(1, Some(AccountEvent::REGION_CHANGED));
         Ok(())
     }
+
 
     #[tokio::test]
     async fn test_change_region_business_idempotency() -> Result<()> {
@@ -149,28 +152,6 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(DomainError::Forbidden { .. })));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let db_region = RegionCode::from_raw("US");
-        let account = f.account_builder_for(db_region.clone())?.build()?;
-        f.account_repo().insert(account);
-
-        let cmd = ChangeRegionCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_region: RegionCode::from_raw("EU"),
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, ChangeRegionCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
         Ok(())
     }
 }

--- a/crates/account/src/application/use_cases/settings/remove_push_token/remove_push_token_command.rs
+++ b/crates/account/src/application/use_cases/settings/remove_push_token/remove_push_token_command.rs
@@ -22,12 +22,7 @@ impl RemovePushTokenCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             token: PushToken::try_new(&req.token).map_err(|e| DomainError::Validation {
                 field: "push_token",

--- a/crates/account/src/application/use_cases/settings/remove_push_token/remove_push_token_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/remove_push_token/remove_push_token_use_case_test.rs
@@ -131,41 +131,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-        let token = PushToken::try_new("valid_token_123")?;
-
-        // Arrange : Compte US dans contexte EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = RemovePushTokenCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            token: token.clone(),
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, RemovePushTokenCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification intégrité
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/update_locale/update_locale_command.rs
+++ b/crates/account/src/application/use_cases/settings/update_locale/update_locale_command.rs
@@ -24,12 +24,7 @@ impl UpdateLocaleCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             new_locale: Locale::try_new(&req.locale).map_err(|e| DomainError::Validation {
                 field: "new_locale",

--- a/crates/account/src/application/use_cases/settings/update_locale/update_locale_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/update_locale/update_locale_use_case_test.rs
@@ -131,40 +131,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Compte aux US, Contexte en EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = UpdateLocaleCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_locale: Locale::from_raw("US"),
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, UpdateLocaleCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe via le repo
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/update_preferences/update_preferences_command.rs
+++ b/crates/account/src/application/use_cases/settings/update_preferences/update_preferences_command.rs
@@ -5,7 +5,6 @@ use serde::Deserialize;
 use shared_kernel::domain::value_objects::AccountId;
 use shared_kernel::errors::{DomainError, Result};
 use shared_proto::account::v1::UpdatePreferencesRequest;
-use std::str::FromStr;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -18,16 +17,15 @@ pub struct UpdatePreferencesCommand {
 }
 
 impl UpdatePreferencesCommand {
-    pub fn try_from_proto(proto: UpdatePreferencesRequest) -> Result<Self> {
-        let command_id =
-            Uuid::parse_str(&proto.command_id).map_err(|_| DomainError::Validation {
-                field: "command_id",
-                reason: "Invalid UUID format".to_string(),
-            })?;
+    pub fn try_from_proto(req: UpdatePreferencesRequest) -> Result<Self> {
+        let command_id = Uuid::parse_str(&req.command_id).map_err(|_| DomainError::Validation {
+            field: "command_id",
+            reason: "Invalid UUID format".to_string(),
+        })?;
 
-        let account_id = AccountId::from_str(&proto.account_id)?;
+        let account_id = req.account_id.parse().map_err(|e: DomainError| e)?;
 
-        let privacy = proto.privacy.map(|p| {
+        let privacy = req.privacy.map(|p| {
             PrivacyPreferences::restore(
                 p.profile_visible_to_public,
                 p.show_last_active,
@@ -35,7 +33,7 @@ impl UpdatePreferencesCommand {
             )
         });
 
-        let notifications = proto.notifications.map(|n| {
+        let notifications = req.notifications.map(|n| {
             NotificationPreferences::restore(
                 n.email_enabled,
                 n.push_enabled,
@@ -44,7 +42,7 @@ impl UpdatePreferencesCommand {
             )
         });
 
-        let appearance = proto.appearance.map(|a| {
+        let appearance = req.appearance.map(|a| {
             AppearancePreferences::restore(
                 // On cast l'i32 du proto vers ton enum de domaine (ex: Theme)
                 a.theme.try_into().unwrap_or_default(),

--- a/crates/account/src/application/use_cases/settings/update_preferences/update_preferences_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/update_preferences/update_preferences_use_case_test.rs
@@ -138,42 +138,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange : Compte US vs contexte EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = UpdatePreferencesCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            privacy: None,
-            notifications: None,
-            appearance: None,
-        };
-
-        // Act
-        let result = f
-            .bus()
-            .execute::<AccountContext, UpdatePreferencesCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification intégrité
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/use_cases/settings/update_timezone/update_timezone_command.rs
+++ b/crates/account/src/application/use_cases/settings/update_timezone/update_timezone_command.rs
@@ -19,12 +19,7 @@ impl UpdateTimezoneCommand {
                 reason: "Invalid UUID format".to_string(),
             })?,
 
-            account_id: AccountId::try_new(&req.account_id).map_err(|e| {
-                DomainError::Validation {
-                    field: "account_id",
-                    reason: e.to_string(),
-                }
-            })?,
+            account_id: req.account_id.parse().map_err(|e: DomainError| e)?,
 
             new_timezone: Timezone::try_new(&req.timezone).map_err(|e| {
                 DomainError::Validation {

--- a/crates/account/src/application/use_cases/settings/update_timezone/update_timezone_use_case_test.rs
+++ b/crates/account/src/application/use_cases/settings/update_timezone/update_timezone_use_case_test.rs
@@ -161,39 +161,4 @@ mod tests {
         );
         Ok(())
     }
-
-    #[tokio::test]
-    async fn test_region_mismatch_returns_not_found() -> Result<()> {
-        let f = TestFixture::new();
-        let wrong_region = RegionCode::from_raw("US");
-
-        // Arrange : Compte US vs contexte EU
-        let account = f
-            .account_builder_for(wrong_region)?
-            .with_state(AccountState::ACTIVE)
-            .build()?;
-
-        let version_snapshot = account.version();
-        f.account_repo().insert(account);
-
-        let cmd = UpdateTimezoneCommand {
-            command_id: Uuid::new_v4(),
-            account_id: f.account_id(),
-            new_timezone: Timezone::from_raw("Europe/Paris"),
-        };
-
-        let result = f
-            .bus()
-            .execute::<AccountContext, UpdateTimezoneCommand, ()>(f.account_ctx().clone(), cmd)
-            .await;
-
-        // Assert
-        assert!(matches!(result, Err(DomainError::NotFound { .. })));
-
-        // Vérification directe via le repo pour l'isolation
-        let saved = f.account_repo().find_direct(&f.account_id()).unwrap();
-        assert_eq!(saved.version(), version_snapshot);
-
-        Ok(())
-    }
 }

--- a/crates/account/src/application/utils/test_utils.rs
+++ b/crates/account/src/application/utils/test_utils.rs
@@ -59,9 +59,8 @@ impl TestFixture {
             idempotency_repo.clone(),
         );
 
-        let account_id = AccountId::new();
-        let region = RegionCode::from_raw("EU");
-        let account_ctx = AccountContext::new(app_ctx.clone(), account_id, region);
+        let account_id = AccountId::generate(RegionCode::default());
+        let account_ctx = AccountContext::new(app_ctx.clone(), account_id);
 
         let mut bus = CommandBus::new();
 
@@ -171,7 +170,6 @@ impl TestFixture {
     pub fn account_builder_for(&self, region: RegionCode) -> Result<AccountBuilder> {
         Ok(Account::builder(
             self.account_id(),
-            region,
             RegistrationIdentifier::try_from_email("test@example.com")?,
         ))
     }

--- a/crates/account/src/domain/account/builders/account_builder.rs
+++ b/crates/account/src/domain/account/builders/account_builder.rs
@@ -26,10 +26,9 @@ pub struct AccountBuilder {
 impl AccountBuilder {
     pub(crate) fn new(
         account_id: AccountId,
-        region: RegionCode,
         identifier: RegistrationIdentifier,
     ) -> Self {
-        let mut identity_builder = AccountIdentityBuilder::new(account_id.clone(), region);
+        let mut identity_builder = AccountIdentityBuilder::new(account_id.clone());
         let governance_builder = AccountGovernanceBuilder::new(account_id.clone());
         let settings_builder = AccountSettingsBuilder::new(account_id);
 

--- a/crates/account/src/domain/account/builders/identity_builder.rs
+++ b/crates/account/src/domain/account/builders/identity_builder.rs
@@ -3,12 +3,11 @@
 use crate::domain::account::entities::AccountIdentity;
 use crate::domain::value_objects::{AccountState, BirthDate, Locale};
 use chrono::{DateTime, Utc};
-use shared_kernel::domain::value_objects::{AccountId, Email, PhoneNumber, RegionCode, SubId};
+use shared_kernel::domain::value_objects::{AccountId, Email, PhoneNumber, SubId};
 use shared_kernel::errors::{DomainError, Result};
 
 pub struct AccountIdentityBuilder {
     account_id: AccountId,
-    region_code: RegionCode,
     sub_id: Option<SubId>,
     email: Option<Email>,
     locale: Option<Locale>,
@@ -19,10 +18,9 @@ pub struct AccountIdentityBuilder {
 }
 
 impl AccountIdentityBuilder {
-    pub(crate) fn new(account_id: AccountId, region_code: RegionCode) -> Self {
+    pub(crate) fn new(account_id: AccountId) -> Self {
         Self {
             account_id,
-            region_code,
             email: None,
             sub_id: None,
             locale: None,
@@ -97,7 +95,6 @@ impl AccountIdentityBuilder {
 
         Ok(AccountIdentity::restore(
             self.account_id,
-            self.region_code,
             self.sub_id,
             self.email,
             self.phone,

--- a/crates/account/src/domain/account/entities/account.rs
+++ b/crates/account/src/domain/account/entities/account.rs
@@ -37,10 +37,9 @@ pub struct Account {
 impl Account {
     pub fn builder(
         account_id: AccountId,
-        region: RegionCode,
         identifier: RegistrationIdentifier,
     ) -> AccountBuilder {
-        AccountBuilder::new(account_id, region, identifier)
+        AccountBuilder::new(account_id, identifier)
     }
 
     pub(crate) fn restore(

--- a/crates/account/src/domain/account/entities/identity.rs
+++ b/crates/account/src/domain/account/entities/identity.rs
@@ -21,7 +21,6 @@ use crate::domain::{
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountIdentity {
     account_id: AccountId,
-    region_code: RegionCode,
     sub_id: Option<SubId>,
     email: Option<Email>,
     phone_number: Option<PhoneNumber>,
@@ -35,15 +34,14 @@ pub struct AccountIdentity {
 }
 
 impl AccountIdentity {
-    pub fn builder(account_id: AccountId, region_code: RegionCode) -> AccountIdentityBuilder {
-        AccountIdentityBuilder::new(account_id, region_code)
+    pub fn builder(account_id: AccountId) -> AccountIdentityBuilder {
+        AccountIdentityBuilder::new(account_id)
     }
 
     /// Utilisé par le Builder ou le Repository pour restaurer l'état.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn restore(
         account_id: AccountId,
-        region_code: RegionCode,
         sub_id: Option<SubId>,
         email: Option<Email>,
         phone_number: Option<PhoneNumber>,
@@ -57,7 +55,6 @@ impl AccountIdentity {
     ) -> Self {
         Self {
             account_id,
-            region_code,
             sub_id,
             email,
             phone_number,
@@ -77,7 +74,7 @@ impl AccountIdentity {
         &self.account_id
     }
     pub fn region_code(&self) -> &RegionCode {
-        &self.region_code
+        self.account_id.region()
     }
     pub fn sub_id(&self) -> Option<&SubId> {
         self.sub_id.as_ref()
@@ -112,10 +109,11 @@ impl AccountIdentity {
     // ==========================================
 
     pub(crate) fn apply_region_change(&mut self, new_region: RegionCode) -> Result<bool> {
-        if self.region_code == new_region {
+        if self.region_code() == &new_region {
             return Ok(false);
         }
-        self.region_code = new_region;
+
+        self.account_id = AccountId::new(self.account_id.uuid(), new_region);
         Ok(true)
     }
 

--- a/crates/account/src/domain/account/entities/tests/account_test.rs
+++ b/crates/account/src/domain/account/entities/tests/account_test.rs
@@ -8,12 +8,11 @@ mod tests {
 
     /// Helper pour créer un compte de test valide et actif
     fn create_test_account() -> Account {
-        let id = AccountId::new();
-        let region = RegionCode::try_new("EU").unwrap();
+        let id = AccountId::generate(RegionCode::default());
         let identifier =
             RegistrationIdentifier::from_email(Email::try_new("john@doe.com").unwrap());
 
-        Account::builder(id, region, identifier)
+        Account::builder(id, identifier)
             .build()
             .expect("Failed to build test account")
     }

--- a/crates/account/src/domain/account/entities/tests/governance_test.rs
+++ b/crates/account/src/domain/account/entities/tests/governance_test.rs
@@ -4,7 +4,7 @@ mod tests {
     use shared_kernel::{
         domain::{
             entities::Entity,
-            value_objects::{AccountId, AuditReason, TrustContext},
+            value_objects::{AccountId, AuditReason, RegionCode, TrustContext},
         },
         errors::Result,
     };
@@ -18,7 +18,7 @@ mod tests {
     };
 
     fn create_test_governance() -> Result<AccountGovernance> {
-        let account_id = AccountId::new();
+        let account_id = AccountId::generate(RegionCode::default());
         let ip_addr = IpAddr::try_new("127.0.0.1")?;
 
         // Utilisation du restore simplifié (sans metadata/version/updated_at)

--- a/crates/account/src/domain/account/entities/tests/identity_test.rs
+++ b/crates/account/src/domain/account/entities/tests/identity_test.rs
@@ -16,12 +16,11 @@ mod tests {
     };
 
     fn create_test_account() -> Account {
-        let id = AccountId::new();
-        let region = RegionCode::try_new("EU").unwrap();
+        let account_id: AccountId = AccountId::generate(RegionCode::default());
         let identifier =
             RegistrationIdentifier::from_email(Email::try_new("john@example.com").unwrap());
 
-        Account::builder(id, region, identifier)
+        Account::builder(account_id, identifier)
             .build()
             .expect("Failed to build test account")
     }

--- a/crates/account/src/domain/account/entities/tests/settings_test.rs
+++ b/crates/account/src/domain/account/entities/tests/settings_test.rs
@@ -11,7 +11,7 @@ mod tests {
     };
 
     fn create_test_settings() -> Result<AccountSettings> {
-        let account_id = AccountId::new();
+        let account_id = AccountId::generate(RegionCode::default());
         let preferences = AccountPreferences::new(
             PrivacyPreferences::default(),
             NotificationPreferences::default(),

--- a/crates/account/src/domain/repositories/account_repository_stub.rs
+++ b/crates/account/src/domain/repositories/account_repository_stub.rs
@@ -144,15 +144,33 @@ impl AccountRepository for AccountRepositoryStub {
         self.check_error()?;
 
         let mut map = self.accounts.lock().unwrap();
-        let id = account.identity().account_id().clone();
+        let new_id = account.identity().account_id().clone();
         let new_version = account.metadata().version();
-        let existing_opt = map.get(&id);
+
+        // 1. DÉTECTION DE MIGRATION (Changement de Région)
+        // On cherche si l'UUID existe déjà sous une autre clé (une autre région)
+        let old_id_opt = map
+            .iter()
+            .find(|(_, a)| {
+                a.identity().account_id().uuid() == new_id.uuid()
+                    && a.identity().account_id() != &new_id
+            })
+            .map(|(id, _)| id.clone());
+
+        if let Some(old_id) = old_id_opt.clone() {
+            // Si on a trouvé l'ancien ID, on le supprime pour simuler le déplacement
+            map.remove(&old_id);
+            // On continue en mode "Update" car techniquement le compte existe déjà
+        }
+
+        // 2. RÉCUPÉRATION DU COMPTE (soit l'actuel, soit None si c'est une pure création)
+        let existing_opt = map.get(&new_id);
 
         match existing_opt {
             None => {
                 // --- MODE INSERT (Logique identique à create) ---
                 // Vérifier que c'est bien une création (version initiale)
-                if new_version > 1 {
+                if new_version > 1 && old_id_opt.is_none() {
                     return Err(DomainError::ConcurrencyConflict {
                         reason: format!("Cannot insert new account with version {}", new_version),
                     });
@@ -172,24 +190,17 @@ impl AccountRepository for AccountRepositoryStub {
             Some(existing) => {
                 // --- MODE UPDATE (OCC) ---
                 let current_version = existing.metadata().version();
-
-                // Vérification OCC
                 if new_version < current_version || new_version > current_version + 1 {
                     return Err(DomainError::ConcurrencyConflict {
-                        reason: format!(
-                            "OCC mismatch: Stub v{}, Input v{} (Expected v{} or v{})",
-                            current_version,
-                            new_version,
-                            current_version,
-                            current_version + 1
-                        ),
+                        reason: format!("OCC mismatch: v{} -> v{}", current_version, new_version),
                     });
                 }
 
                 // Vérification de l'unicité du sub_id (au cas où il a changé)
                 if let Some(new_sub) = account.identity().sub_id() {
                     let duplicate_exists = map.values().any(|a| {
-                        a.identity().account_id() != &id && a.identity().sub_id() == Some(new_sub)
+                        a.identity().account_id() != &new_id
+                            && a.identity().sub_id() == Some(new_sub)
                     });
 
                     if duplicate_exists {
@@ -204,7 +215,7 @@ impl AccountRepository for AccountRepositoryStub {
         }
 
         // Dans tous les cas, on insère/écrase
-        map.insert(id, account.clone());
+        map.insert(new_id, account.clone());
         Ok(())
     }
 

--- a/crates/account/src/infrastructure/api/grpc/access_service.rs
+++ b/crates/account/src/infrastructure/api/grpc/access_service.rs
@@ -1,7 +1,7 @@
 // crates/account/src/infrastructure/api/grpc/access_service.rs
 
 use shared_kernel::domain::events::AggregateRoot;
-use shared_kernel::domain::value_objects::AccountId;
+use shared_kernel::domain::value_objects::{AccountId, RegionCode};
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
@@ -46,19 +46,23 @@ impl AccountAccessService for GrpcAccessService {
     ) -> Result<Response<AccountIdentity>, Status> {
         let req = request.into_inner();
 
+        let region = RegionCode::try_new(req.region_code.clone())
+            .map_err(|e| Status::invalid_argument(format!("Invalid region: {}", e)))?;
+
         let account_id = match &req.sub_id {
-            Some(id) if !id.is_empty() => AccountId::try_new(id.clone())
-                .map_err(|e| Status::invalid_argument(e.to_string()))?,
-            _ => AccountId::new(),
+            Some(id) if !id.is_empty() => {
+                // Si on reçoit un UUID de Keycloak, on l'associe à la région
+                let uuid = uuid::Uuid::parse_str(id)
+                    .map_err(|_| Status::invalid_argument("Invalid sub_id UUID"))?;
+                AccountId::new(uuid, region.clone())
+            }
+            _ => AccountId::generate(region.clone()),
         };
 
-        let command = RegisterCommand::try_from_proto(req, account_id)
+        let command = RegisterCommand::try_from_proto(req, account_id.clone())
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
-        // 2. Le contexte utilisera maintenant l'ID stable
-        let ctx = self
-            .app_ctx
-            .create_context(command.account_id.clone(), command.region.clone());
+        let ctx = self.app_ctx.create_context(command.account_id.clone());
 
         self.execute_and_fetch::<RegisterCommand, AccountId, AccountIdentity, _>(
             &ctx,

--- a/crates/account/src/infrastructure/api/grpc/shared.rs
+++ b/crates/account/src/infrastructure/api/grpc/shared.rs
@@ -28,10 +28,7 @@ pub trait GrpcServiceUtils {
             .and_then(|v| v.to_str().ok())
             .ok_or_else(|| Status::unauthenticated("Missing x-region header"))?;
 
-        let region = RegionCode::try_new(region_str)
-            .map_err(|_| Status::invalid_argument("Invalid region format"))?;
-
-        Ok(self.app_ctx().create_context(account_id.clone(), region))
+        Ok(self.app_ctx().create_context(account_id.clone()))
     }
 
     /// Exécute une commande et recharge l'agrégat pour renvoyer la réponse

--- a/crates/account/src/infrastructure/postgres/repositories/postgres_account_repository.rs
+++ b/crates/account/src/infrastructure/postgres/repositories/postgres_account_repository.rs
@@ -30,8 +30,8 @@ impl PostgresAccountRepository {
     }
 
     pub fn cache_key(id: &AccountId) -> String {
-        format!("account:aggregate:{}", id.as_uuid())
-    }
+    format!("account:aggregate:{}:{}", id.region().as_str(), id.uuid())
+}
 }
 
 #[async_trait]
@@ -68,10 +68,9 @@ impl AccountRepository for PostgresAccountRepository {
                            s.preferences, s.timezone, s.push_tokens, s.updated_at as settings_updated_at,
                            g.role, g.beta_tier, g.is_shadowbanned, g.trust_score, g.moderation_notes, 
                            g.last_moderation_at, g.last_ip_addr, g.updated_at as governance_updated_at
-                    FROM account_identity i
-                    LEFT JOIN account_settings s ON i.account_id = s.account_id
-                    LEFT JOIN account_governance g ON i.account_id = g.account_id
-                    WHERE i.account_id = $1"#;
+                    LEFT JOIN account_settings s ON i.account_id = s.account_id AND i.region_code = s.region_code
+                    LEFT JOIN account_governance g ON i.account_id = g.account_id AND i.region_code = g.region_code
+                    WHERE i.account_id = $1 AND i.region_code = $2"#;
 
                 let row_opt = sqlx::query_as::<_, PostgresAccountRow>(sql)
                     .bind(uid)
@@ -126,7 +125,6 @@ impl AccountRepository for PostgresAccountRepository {
         let gov_row = PostgresAccountGovernanceRow::from_domain(account);
         let sett_row = PostgresAccountSettingsRow::from_domain(account);
 
-        let uid = ident_row.account_id;
         let next_version = account.metadata().version() as i64;
 
         <dyn Transaction>::execute_on(&self.pool, tx, |conn| {
@@ -134,9 +132,10 @@ impl AccountRepository for PostgresAccountRepository {
                 // 1. On vérifie si le compte existe et on verrouille la ligne (FOR UPDATE) 
                 // pour garantir que personne ne modifie la version entre le check et l'écriture
                 let db_v: Option<i64> = sqlx::query_scalar(
-                    "SELECT version FROM account_identity WHERE account_id = $1 FOR UPDATE"
+                    "SELECT version FROM account_identity WHERE account_id = $1 AND region_code = $2 FOR UPDATE"
                 )
-                .bind(uid)
+                .bind(&ident_row.account_id)
+                .bind(&ident_row.region_code)
                 .fetch_optional(&mut *conn)
                 .await
                 .map_domain_infra("Account: check version for upsert")?;
@@ -147,10 +146,10 @@ impl AccountRepository for PostgresAccountRepository {
                         // On insère l'identité
                         sqlx::query(
                             r#"INSERT INTO account_identity 
-                                (account_id, sub_id, region_code, email, state, locale, version, last_active_at)
+                                (account_id, region_code, sub_id, email, state, locale, version, last_active_at)
                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#
                         )
-                        .bind(uid).bind(ident_row.sub_id).bind(ident_row.region_code).bind(ident_row.email)
+                        .bind(&ident_row.account_id).bind(&ident_row.region_code).bind(ident_row.sub_id).bind(ident_row.email)
                         .bind(ident_row.state).bind(ident_row.locale)
                         .bind(next_version).bind(ident_row.last_active_at)
                         .execute(&mut *conn).await.map_domain_infra("Account: insert identity")?;
@@ -158,10 +157,10 @@ impl AccountRepository for PostgresAccountRepository {
                         // On insère la gouvernance
                         sqlx::query(
                             r#"INSERT INTO account_governance 
-                                (account_id, role, beta_tier, is_shadowbanned, trust_score, moderation_notes, last_moderation_at, last_ip_addr)
-                               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#
+                                (account_id, region_code, role, beta_tier, is_shadowbanned, trust_score, moderation_notes, last_moderation_at, last_ip_addr)
+                               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"#
                         )
-                        .bind(uid).bind(gov_row.role).bind(gov_row.beta_tier)
+                        .bind(&ident_row.account_id).bind(&ident_row.region_code).bind(gov_row.role).bind(gov_row.beta_tier)
                         .bind(gov_row.is_shadowbanned).bind(gov_row.trust_score)
                         .bind(gov_row.moderation_notes).bind(gov_row.last_moderation_at)
                         .bind(gov_row.last_ip_addr)
@@ -169,10 +168,10 @@ impl AccountRepository for PostgresAccountRepository {
 
                         // On insère les settings
                         sqlx::query(
-                            r#"INSERT INTO account_settings (account_id, preferences, timezone, push_tokens)
-                               VALUES ($1, $2, $3, $4)"#
+                            r#"INSERT INTO account_settings (account_id, region_code, preferences, timezone, push_tokens)
+                               VALUES ($1, $2, $3, $4, $5)"#
                         )
-                        .bind(uid).bind(sett_row.preferences).bind(sett_row.timezone).bind(sett_row.push_tokens)
+                        .bind(&ident_row.account_id).bind(&ident_row.region_code).bind(sett_row.preferences).bind(sett_row.timezone).bind(sett_row.push_tokens)
                         .execute(&mut *conn).await.map_domain_infra("Account: insert settings")?;
                     }
                     Some(v) => {
@@ -180,41 +179,62 @@ impl AccountRepository for PostgresAccountRepository {
                         let current_version_expected = next_version - 1;
                         if v != current_version_expected {
                             return Err(DomainError::ConcurrencyConflict {
-                                reason: format!("Account {}: OCC mismatch (DB v{}, App expected v{})", uid, v, current_version_expected),
+                                reason: format!("Account {}: OCC mismatch (DB v{}, App expected v{})", &ident_row.account_id, v, current_version_expected),
                             });
                         }
 
                         // Update Identity
                         sqlx::query(
-                            r#"UPDATE account_identity SET 
-                                sub_id = $2, email = $3, state = $4, locale = $5, version = $6, last_active_at = $7
-                               WHERE account_id = $1"#
-                        )
-                        .bind(uid).bind(ident_row.sub_id).bind(ident_row.email)
-                        .bind(ident_row.state).bind(ident_row.locale)
-                        .bind(next_version).bind(ident_row.last_active_at)
-                        .execute(&mut *conn).await.map_domain_infra("Account: update identity")?;
+                                r#"UPDATE account_identity SET 
+                                    sub_id = $3, email = $4, state = $5, locale = $6, version = $7, last_active_at = $8
+                                WHERE account_id = $1 AND region_code = $2"#
+                            )
+                        .bind(&ident_row.account_id)
+                        .bind(&ident_row.region_code)
+                        .bind(ident_row.sub_id)
+                        .bind(ident_row.email)
+                        .bind(ident_row.state)
+                        .bind(ident_row.locale)
+                        .bind(next_version)
+                        .bind(ident_row.last_active_at)
+                        .execute(&mut *conn)
+                        .await
+                        .map_domain_infra("Account: update identity")?;
 
                         // Update Governance
                         sqlx::query(
                             r#"UPDATE account_governance SET
-                                role = $2, beta_tier = $3, is_shadowbanned = $4, trust_score = $5, 
-                                moderation_notes = $6, last_moderation_at = $7, last_ip_addr = $8
-                               WHERE account_id = $1"#
+                                role = $3, beta_tier = $4, is_shadowbanned = $5, trust_score = $6, 
+                                moderation_notes = $7, last_moderation_at = $8, last_ip_addr = $9
+                            WHERE account_id = $1 AND region_code = $2"#
                         )
-                        .bind(uid).bind(gov_row.role).bind(gov_row.beta_tier)
-                        .bind(gov_row.is_shadowbanned).bind(gov_row.trust_score)
-                        .bind(gov_row.moderation_notes).bind(gov_row.last_moderation_at)
+                        .bind(&ident_row.account_id)
+                        .bind(&ident_row.region_code)
+                        .bind(gov_row.role)
+                        .bind(gov_row.beta_tier)
+                        .bind(gov_row.is_shadowbanned)
+                        .bind(gov_row.trust_score)
+                        .bind(gov_row.moderation_notes)
+                        .bind(gov_row.last_moderation_at)
                         .bind(gov_row.last_ip_addr)
-                        .execute(&mut *conn).await.map_domain_infra("Account: update governance")?;
+                        .execute(&mut *conn)
+                        .await
+                        .map_domain_infra("Account: update governance")?;
 
                         // Update Settings
                         sqlx::query(
-                            r#"UPDATE account_settings SET preferences = $2, timezone = $3, push_tokens = $4
-                               WHERE account_id = $1"#
+                            r#"UPDATE account_settings SET 
+                                preferences = $3, timezone = $4, push_tokens = $5
+                            WHERE account_id = $1 AND region_code = $2"#
                         )
-                        .bind(uid).bind(sett_row.preferences).bind(sett_row.timezone).bind(sett_row.push_tokens)
-                        .execute(&mut *conn).await.map_domain_infra("Account: insert settings")?;
+                        .bind(&ident_row.account_id)
+                        .bind(&ident_row.region_code)
+                        .bind(sett_row.preferences)
+                        .bind(sett_row.timezone) 
+                        .bind(sett_row.push_tokens)
+                        .execute(&mut *conn)
+                        .await
+                        .map_domain_infra("Account: update settings")?;
                     }
                 }
                 Ok(())

--- a/crates/account/src/infrastructure/postgres/rows/postgres_account_row.rs
+++ b/crates/account/src/infrastructure/postgres/rows/postgres_account_row.rs
@@ -58,12 +58,12 @@ pub struct PostgresAccountRow {
 
 impl PostgresAccountRow {
     pub fn to_domain(self) -> Result<Account> {
-        let account_id = AccountId::from_uuid(self.account_id);
+        let region = RegionCode::try_new(self.region_code)?;
+        let account_id = AccountId::new(self.account_id, region);
 
         // 1. Reconstruction de Identity
         let identity = AccountIdentity::restore(
-            account_id,
-            RegionCode::try_new(self.region_code)?,
+            account_id.clone(),
             self.sub_id.map(SubId::try_new).transpose()?,
             self.email.map(Email::try_new).transpose()?,
             self.phone_number.map(PhoneNumber::try_new).transpose()?,
@@ -77,7 +77,7 @@ impl PostgresAccountRow {
         );
 
         let governance = AccountGovernance::restore(
-            account_id,
+            account_id.clone(),
             self.role
                 .map(AccountRole::from)
                 .unwrap_or(AccountRole::default()),

--- a/crates/account/tests/repositories/account_repository_it.rs
+++ b/crates/account/tests/repositories/account_repository_it.rs
@@ -36,13 +36,11 @@ async fn get_test_context() -> (
 #[tokio::test]
 async fn test_account_full_lifecycle_and_atomicity() -> Result<()> {
     let (repo, pg_ctx, _) = get_test_context().await;
-    let account_id = AccountId::new();
-    let region = RegionCode::from_raw("EU");
+    let account_id = AccountId::generate(RegionCode::default());
     let email = Email::try_new("full@lifecycle.com")?;
 
     let account = Account::builder(
         account_id.clone(),
-        region.clone(),
         RegistrationIdentifier::try_from_email(email.to_string())?,
     )
     .build()?;
@@ -101,10 +99,9 @@ async fn test_account_full_lifecycle_and_atomicity() -> Result<()> {
 #[tokio::test]
 async fn test_concurrency_protection_occ() -> Result<()> {
     let (repo, pg_ctx, _) = get_test_context().await;
-    let account_id = AccountId::new();
+    let account_id = AccountId::generate(RegionCode::default());
     let account = Account::builder(
         account_id,
-        RegionCode::from_raw("EU"),
         RegistrationIdentifier::try_from_email("occ@test.com")?,
     )
     .build()?;
@@ -136,12 +133,11 @@ async fn test_concurrency_protection_occ() -> Result<()> {
 async fn test_cache_logic_integrity() -> Result<()> {
     let (repo, pg_ctx, redis_ctx) = get_test_context().await;
     let cache = redis_ctx.repository();
-    let account_id = AccountId::new();
+    let account_id = AccountId::generate(RegionCode::default());
     let cache_key = format!("account:aggregate:{}", account_id.as_uuid());
 
     let account = Account::builder(
         account_id.clone(),
-        RegionCode::from_raw("EU"),
         RegistrationIdentifier::try_from_email("cache@test.com")?,
     )
     .build()?;
@@ -178,14 +174,12 @@ async fn test_unique_constraints() -> Result<()> {
     let identifier = RegistrationIdentifier::try_from_email("unique@test.com")?;
 
     let acc1 = Account::builder(
-        AccountId::new(),
-        RegionCode::from_raw("EU"),
+        AccountId::generate(RegionCode::default()),
         identifier.clone(),
     )
     .build()?;
     let acc2 = Account::builder(
-        AccountId::new(),
-        RegionCode::from_raw("EU"),
+        AccountId::generate(RegionCode::default()),
         identifier.clone(),
     )
     .build()?;
@@ -208,9 +202,9 @@ async fn test_lookups() -> Result<()> {
     let email = Email::try_new("lookup@test.com")?;
     let identifier = RegistrationIdentifier::try_from_email(email.to_string())?;
     let ext_id = SubId::from_raw("ext_123");
-    let account_id = AccountId::new();
+    let account_id = AccountId::generate(RegionCode::default());
 
-    let account = Account::builder(account_id.clone(), RegionCode::from_raw("EU"), identifier)
+    let account = Account::builder(account_id.clone(), identifier)
         .with_sub_id(ext_id.clone())
         .with_email(email.clone())
         .build()?;
@@ -237,10 +231,9 @@ async fn test_lookups() -> Result<()> {
 #[tokio::test]
 async fn test_rollback_works_properly() -> Result<()> {
     let (repo, pg_ctx, _) = get_test_context().await;
-    let account_id = AccountId::new();
+    let account_id = AccountId::generate(RegionCode::default());
     let account = Account::builder(
         account_id.clone(),
-        RegionCode::from_raw("EU"),
         RegistrationIdentifier::try_from_email("rollback@test.com")?,
     )
     .build()?;
@@ -260,11 +253,10 @@ async fn test_rollback_works_properly() -> Result<()> {
 #[tokio::test]
 async fn test_cache_hit_proven_by_db_deletion() -> Result<()> {
     let (repo, pg_ctx, redis_ctx) = get_test_context().await;
-    let account_id = AccountId::new();
+    let account_id = AccountId::generate(RegionCode::default());
 
     let account = Account::builder(
         account_id.clone(),
-        RegionCode::from_raw("EU"),
         RegistrationIdentifier::try_from_email("cache-check@test.com")?,
     )
     .build()?;
@@ -310,12 +302,11 @@ async fn test_cache_hit_proven_by_db_deletion() -> Result<()> {
 #[tokio::test]
 async fn test_cache_performance_benefit() -> Result<()> {
     let (repo, pg_ctx, redis_ctx) = get_test_context().await;
-    let account_id = AccountId::new();
+    let account_id = AccountId::generate(RegionCode::default());
 
     // On prépare un compte
     let account = Account::builder(
         account_id.clone(),
-        RegionCode::from_raw("EU"),
         RegistrationIdentifier::try_from_email("perf@test.com")?,
     )
     .build()?;
@@ -355,8 +346,7 @@ async fn test_cache_performance_benefit() -> Result<()> {
 #[tokio::test]
 async fn test_rigorous_partial_fetch_integrity() -> Result<()> {
     let (repo, pg_ctx, _) = get_test_context().await;
-    let account_id = AccountId::new();
-    let region = RegionCode::try_new("EU")?;
+    let account_id = AccountId::generate(RegionCode::default());
     let email = Email::try_new("partial@integrity.com")?;
 
     // --- 1. INSERTION MANUELLE PARTIELLE (SIMULATION BUG/LATENCE) ---
@@ -364,7 +354,7 @@ async fn test_rigorous_partial_fetch_integrity() -> Result<()> {
     sqlx::query("INSERT INTO account_identity (account_id, region_code, email, locale, state, version, created_at, updated_at, aggregate_updated_at) 
                  VALUES ($1, $2, $3, 'fr-FR', 'ACTIVE'::account_state, 0, NOW(), NOW(), NOW())")
         .bind(account_id.as_uuid())
-        .bind(region.to_string())
+        .bind(account_id.region().to_string())
         .bind(email.to_string())
         .execute(&pg_ctx.pool())
         .await

--- a/crates/shared-kernel/src/domain/value_objects/account_id.rs
+++ b/crates/shared-kernel/src/domain/value_objects/account_id.rs
@@ -1,91 +1,105 @@
 // crates/shared-kernel/src/domain/value_object/account_id.rs
 
-use crate::domain::identifier::Identifier; // Nouvel import
-use crate::domain::value_objects::ValueObject;
+use crate::domain::identifier::Identifier;
+use crate::domain::value_objects::{RegionCode, ValueObject};
 use crate::errors::{DomainError, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
 
-/// Identifiant unique pour un compte, basé sur UUID v7 (triable temporellement).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct AccountId(Uuid);
+/// Identifiant unique composite pour un compte.
+/// Encapsule l'identité technique (UUID) et la localisation (RegionCode).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AccountId {
+    uuid: Uuid,
+    region: RegionCode,
+}
 
 impl AccountId {
-    /// Génère un nouvel identifiant unique (UUID v7).
-    pub fn new() -> Self {
-        Self(Uuid::now_v7())
+    /// Crée un nouvel identifiant à partir d'un UUID et d'un RegionCode.
+    pub fn new(uuid: Uuid, region: RegionCode) -> Self {
+        Self { uuid, region }
     }
 
-    /// Crée une instance à partir d'une chaîne de caractères avec validation.
-    pub fn try_new(id: impl Into<String>) -> Result<Self> {
-        Self::from_str(&id.into())
+    /// Génère un nouvel identifiant (UUID v7) pour une région donnée.
+    pub fn generate(region: RegionCode) -> Self {
+        Self::new(Uuid::now_v7(), region)
+    }
+
+    /// Accesseur pour l'UUID.
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Accesseur pour le RegionCode.
+    pub fn region(&self) -> &RegionCode {
+        &self.region
     }
 }
 
-// Implémentation du contrat d'identité générique
+// Implémentation du contrat d'identité
 impl Identifier for AccountId {
     fn as_uuid(&self) -> Uuid {
-        self.0
+        self.uuid
     }
 
+    /// Retourne "REGION:UUID" (ex: "EU:018f3a...")
     fn as_string(&self) -> String {
-        self.0.to_string()
+        format!("{}:{}", self.region, self.uuid)
     }
 
     fn from_uuid(uuid: Uuid) -> Self {
-        Self(uuid)
+        Self {
+            uuid,
+            region: RegionCode::default(),
+        }
     }
 }
 
 impl ValueObject for AccountId {
     fn validate(&self) -> Result<()> {
-        if self.0.is_nil() {
+        if self.uuid.is_nil() {
             return Err(DomainError::Validation {
                 field: "account_id",
-                reason: "Account ID cannot be nil".to_string(),
+                reason: "UUID part cannot be nil".to_string(),
             });
         }
-        Ok(())
-    }
-}
-
-impl Default for AccountId {
-    fn default() -> Self {
-        Self::new()
+        // La validation de la région est déléguée au VO RegionCode
+        self.region.validate()
     }
 }
 
 // --- CONVERSIONS ---
 
-impl From<Uuid> for AccountId {
-    fn from(uuid: Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl TryFrom<String> for AccountId {
-    type Error = DomainError;
-    fn try_from(value: String) -> Result<Self> {
-        Self::from_str(&value)
-    }
-}
-
 impl FromStr for AccountId {
     type Err = DomainError;
+
+    /// Parse une chaîne au format "REGION:UUID"
     fn from_str(s: &str) -> Result<Self> {
-        Uuid::parse_str(s)
-            .map(Self)
-            .map_err(|_| DomainError::Validation {
+        let parts: Vec<&str> = s.split(':').collect();
+
+        if parts.len() != 2 {
+            return Err(DomainError::Validation {
                 field: "account_id",
-                reason: format!("'{}' is not a valid UUID", s),
-            })
+                reason: format!("'{}' is not a valid AccountId. Expected 'REGION:UUID'", s),
+            });
+        }
+
+        // On utilise FromStr de RegionCode qui valide déjà le code
+        let region = RegionCode::from_str(parts[0])?;
+
+        let uuid = Uuid::parse_str(parts[1]).map_err(|_| DomainError::Validation {
+            field: "account_id",
+            reason: format!("'{}' is not a valid UUID", parts[1]),
+        })?;
+
+        Ok(Self { uuid, region })
     }
 }
 
 impl fmt::Display for AccountId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}:{}", self.region, self.uuid)
     }
 }

--- a/crates/shared-kernel/src/domain/value_objects/region_code.rs
+++ b/crates/shared-kernel/src/domain/value_objects/region_code.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RegionCode(String);
 
 impl RegionCode {


### PR DESCRIPTION
…harding

Convert AccountId to composite (region:uuid) for partitioned routing.

Update AccountContext to ensure identity isolation via UUID stability.

Refactor AccountBuilder and Repositories to remove redundant RegionCode parameters.

Update TestFixture and Stubs to handle regional identity migration.