### PR TITLE
feat(transport): implement core transport crate for gRPC and Kafka co…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5009,6 +5009,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "transport"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "error",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "prost 0.14.4",
+ "rdkafka",
+ "resilience",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
     "crates/post/audio",
     "crates/shared/error",
     "crates/shared/resilience",
-    "crates/shared/telemetry",
+    "crates/shared/telemetry", "crates/shared/transport",
     # "crates/comment",
 ]
 resolver = "2"

--- a/crates/shared/transport/Cargo.toml
+++ b/crates/shared/transport/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "transport"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description.workspace = true
+
+[dependencies]
+# Internal crates
+error = { workspace = true }
+resilience = { workspace = true }
+
+# gRPC — Tonic + Tower
+tonic = { workspace = true }
+tower = { workspace = true }
+
+# Kafka
+rdkafka = { workspace = true }
+
+# HTTP primitives (used in Tower layer signatures)
+http = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+prost = { workspace = true }
+
+# Async runtime and utilities
+tokio = { workspace = true }
+futures = { workspace = true }
+futures-util = { workspace = true }
+
+# Observability
+tracing = { workspace = true }
+thiserror = { workspace = true }
+
+# OpenTelemetry — pinned to the same versions as the `telemetry` crate
+# so context propagation is wire-compatible across the platform.
+opentelemetry = { version = "0.27", features = ["trace"] }
+tracing-opentelemetry = "0.28"
+
+# Byte utilities (used in protobuf codec and tonic body handling)
+bytes = "1"

--- a/crates/shared/transport/README.md
+++ b/crates/shared/transport/README.md
@@ -1,0 +1,281 @@
+# `transport` — Interface Contract
+
+## Responsibility
+
+Provide the single, platform-wide communication layer for the hyperscale social network backend. It orchestrates:
+
+- **Synchronous RPC** (gRPC via Tonic + Tower) with circuit-breaker, timeout, and automatic W3C TraceContext injection.
+- **Asynchronous event-driven messaging** (Kafka via rdkafka) with automatic W3C TraceContext injection on produce and extraction on consume.
+- **Payload serialization** (JSON and Protobuf codecs) shared across both transports.
+
+This crate owns **no business logic**. It is a pure infrastructure library that every microservice depends on.
+
+---
+
+## Directory Layout
+
+```
+src/
+├── lib.rs
+├── error.rs                        TransportError + CodecError (top-level enums)
+├── propagation/
+│   ├── carrier.rs                  MetadataCarrier trait + inject_context / extract_context
+│   ├── grpc.rs                     GrpcHeaderInjector / GrpcHeaderExtractor (http::HeaderMap)
+│   └── kafka.rs                    KafkaHeaderInjector / KafkaHeaderExtractor (OwnedHeaders / BorrowedHeaders)
+├── codec/
+│   ├── json.rs                     encode<T: Serialize> / decode<T: DeserializeOwned>
+│   └── protobuf.rs                 encode<M: Message> / decode<M: Message + Default>
+├── grpc/
+│   ├── error.rs                    GrpcTransportError + grpc_severity()
+│   ├── layer/
+│   │   ├── outbound.rs             OutboundTraceLayer — injects trace into outgoing headers
+│   │   └── inbound.rs              InboundTraceLayer  — extracts trace from incoming headers
+│   ├── client/
+│   │   ├── config.rs               GrpcClientConfig + GrpcResilienceConfig + GrpcTlsConfig
+│   │   └── builder.rs              GrpcClientBuilder → GrpcClientService (BoxService)
+│   └── server/
+│       ├── config.rs               GrpcServerConfig + GrpcServerTlsConfig
+│       └── builder.rs              GrpcServerBuilder → tonic::Server (with InboundTraceLayer)
+└── kafka/
+    ├── error.rs                    KafkaTransportError
+    ├── envelope.rs                 EventEnvelope<T> + PublishablePayload + ConsumablePayload
+    ├── config/
+    │   ├── client.rs               KafkaClientConfig (shared broker / SASL settings)
+    │   ├── producer.rs             ProducerConfig (acks, compression, linger_ms)
+    │   └── consumer.rs             ConsumerConfig (group_id, auto_offset_reset)
+    ├── producer/
+    │   ├── builder.rs              KafkaProducerBuilder → KafkaProducerHandle
+    │   └── handle.rs               KafkaProducerHandle — .publish<T>() / .publish_raw()
+    └── consumer/
+        ├── builder.rs              KafkaConsumerBuilder → KafkaConsumerHandle
+        └── handle.rs               KafkaConsumerHandle — .stream<T>() / .commit()
+```
+
+---
+
+## Public Interfaces
+
+### `TransportError` — unified error type
+
+```rust
+pub enum TransportError {
+    Grpc(GrpcTransportError),         // tonic::transport::Error or tonic::Status
+    Kafka(KafkaTransportError),       // rdkafka::error::KafkaError
+    Codec(CodecError),                // serde_json / prost encode/decode
+    CircuitOpen,                      // resilience::CircuitBreakerLayer rejected the call
+    Timeout(Duration),                // resilience::TimeoutLayer deadline exceeded
+    MaxRetriesExhausted(u32),         // resilience::RetryLayer (application-level callers)
+}
+```
+
+`TransportError` implements `From<tonic::transport::Error>`, `From<tonic::Status>`, and `From<GrpcTransportError>` / `From<KafkaTransportError>` / `From<CodecError>` for ergonomic `?` propagation.
+
+---
+
+### `propagation` module
+
+```rust
+// Inject the current tracing span's context into any carrier (gRPC headers / Kafka headers)
+pub fn inject_context<C: Injector>(carrier: &mut C);
+
+// Extract a remote context from any carrier
+pub fn extract_context<C: Extractor>(carrier: &C) -> opentelemetry::Context;
+
+// Wire a remote context as the parent of a local span
+pub fn set_parent(span: &tracing::Span, cx: opentelemetry::Context);
+```
+
+Carrier implementations:
+
+| Carrier | Transport | Direction |
+|---------|-----------|-----------|
+| `GrpcHeaderInjector<'_>` | gRPC | Outbound (mutates `&mut http::HeaderMap`) |
+| `GrpcHeaderExtractor<'_>` | gRPC | Inbound (reads `&http::HeaderMap`) |
+| `KafkaHeaderInjector` | Kafka | Outbound (owns `OwnedHeaders`) |
+| `KafkaHeaderExtractor<'_>` | Kafka | Inbound (reads `&BorrowedHeaders`) |
+
+All four implement `opentelemetry::propagation::Injector` / `Extractor` and thus satisfy the `MetadataCarrier` supertrait.
+
+---
+
+### gRPC — client side
+
+```rust
+let config = GrpcClientConfig::new("https://post-command-server:50051");
+
+// Fully-composed service: OutboundTrace + CircuitBreaker + Timeout, errors → TransportError
+let svc: GrpcClientService = GrpcClientBuilder::new(config).build().await?;
+let mut client = PostServiceClient::new(svc);
+
+// Or: raw channel (cloneable, no middleware pre-applied)
+let channel: tonic::transport::Channel = GrpcClientBuilder::new(config).connect().await?;
+```
+
+**Stack composition (outermost → innermost):**
+
+```text
+TimeoutLayer
+  └─ map_err → TransportError
+      └─ CircuitBreakerLayer
+          └─ map_err → TransportError
+              └─ OutboundTraceLayer   (injects traceparent / tracestate)
+                  └─ tonic::transport::Channel
+```
+
+**Why no `RetryLayer` at the transport level?**
+
+HTTP/2 request bodies are streams. Once consumed they cannot be replayed without buffering the entire payload upfront, which is prohibitive. Apply `RetryLayer` at the **application layer** (around the generated gRPC client call, before serialization), not around the channel.
+
+---
+
+### gRPC — server side
+
+```rust
+let server = GrpcServerBuilder::new(GrpcServerConfig::default())
+    .build()?                              // pre-installs InboundTraceLayer
+    .add_service(PostServiceServer::new(my_handler))
+    .serve(config.addr)
+    .await?;
+```
+
+**Stack:**
+
+```text
+tonic::Server
+  └─ InboundTraceLayer
+      ├─ extracts traceparent / tracestate from request headers
+      ├─ reconstructs remote OpenTelemetry context
+      ├─ sets it as parent of a new `grpc.server` span
+      └─ wraps the entire handler invocation inside that span
+```
+
+---
+
+### Kafka — producer
+
+```rust
+let handle: KafkaProducerHandle = KafkaProducerBuilder::new(
+    ProducerConfig::new(KafkaClientConfig::from_env())
+).build()?;
+
+let envelope = EventEnvelope::new("posts.created", post_id.to_string(), PostCreatedEvent { ... })
+    .with_header("x-source-service", "post-command-server");
+
+handle.publish(envelope).await?;
+// traceparent + tracestate automatically injected into Kafka record headers.
+```
+
+---
+
+### Kafka — consumer
+
+```rust
+let handle: KafkaConsumerHandle = KafkaConsumerBuilder::new(
+    ConsumerConfig::new(KafkaClientConfig::from_env(), "profile-projection-consumer")
+)
+.subscribe("posts.created")
+.build()?;
+
+let mut stream = handle.stream::<PostCreatedEvent>();
+while let Some(result) = stream.next().await {
+    let envelope = result?;
+    // Current span is already linked to the producer's trace via extracted traceparent.
+    process(envelope.payload).await?;
+}
+```
+
+---
+
+### `EventEnvelope<T>`
+
+```rust
+pub struct EventEnvelope<T> {
+    pub topic: String,
+    pub key: String,        // Kafka partition key — use a stable domain ID for ordering
+    pub payload: T,
+    pub headers: HashMap<String, String>,  // user headers (trace headers are transport-internal)
+    pub timestamp_ms: Option<i64>,
+}
+```
+
+---
+
+### `codec` module
+
+Both functions return `Result<_, CodecError>`, which maps to `TransportError::Codec` via `From`.
+
+```rust
+// JSON
+pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError>;
+pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError>;
+
+// Protobuf
+pub fn encode<M: prost::Message>(msg: &M) -> Result<Bytes, CodecError>;
+pub fn decode<M: prost::Message + Default>(bytes: &[u8]) -> Result<M, CodecError>;
+```
+
+---
+
+## Integration with sibling crates
+
+| Crate | How this crate uses it |
+|-------|----------------------|
+| `error` | `GrpcTransportError::grpc_severity()` maps `tonic::Code` to `error::Severity` for structured logging |
+| `resilience` | `CircuitBreakerLayer` and `TimeoutLayer` are composed inside `GrpcClientBuilder::build()`; `TransportError::from_resilience*` helpers flatten `ResilienceError<E>` |
+| `telemetry` | Must be initialised (`telemetry::init()`) before any transport call; the transport layer reads from and writes to the **global** OTel propagator installed by `telemetry::init()` |
+
+---
+
+## Required runtime environment
+
+No environment variables are **required** — all have safe defaults.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KAFKA_BROKERS` | `localhost:9092` | Broker addresses (used by `KafkaClientConfig::from_env()`) |
+| `KAFKA_SECURITY_PROTOCOL` | `PLAINTEXT` | `PLAINTEXT`, `SASL_SSL`, etc. |
+| `KAFKA_SASL_MECHANISM` | — | `PLAIN`, `SCRAM-SHA-256` |
+| `KAFKA_SASL_USERNAME` | — | |
+| `KAFKA_SASL_PASSWORD` | — | |
+
+OpenTelemetry configuration is inherited from the `telemetry` crate (same env vars: `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.).
+
+---
+
+## Adding to a service
+
+```toml
+# service Cargo.toml
+transport = { path = "crates/shared/transport" }
+```
+
+**Bootstrap sequence every binary must follow:**
+
+```rust
+#[tokio::main]
+async fn main() {
+    // 1. Init telemetry FIRST — registers the global OTel propagator that
+    //    transport reads for trace injection / extraction.
+    let _guard = telemetry::init(TelemetryConfig::from_env(
+        "my-service", env!("CARGO_PKG_VERSION")
+    )).expect("telemetry init failed");
+
+    // 2. Build transport clients / servers (they read from the global propagator).
+    let svc = GrpcClientBuilder::new(GrpcClientConfig::new("https://dep:50051"))
+        .build()
+        .await
+        .expect("grpc client build failed");
+
+    // 3. Use clients — trace context flows automatically.
+}
+```
+
+---
+
+## Key invariants
+
+1. `telemetry::init()` must be called before the first `inject_context` or `extract_context` call; without the global propagator both are no-ops.
+2. `KafkaProducerHandle` is `Clone` — it wraps an `Arc`-backed `FutureProducer` internally via rdkafka.
+3. `GrpcClientService` (`BoxService`) is **not** `Clone`. If you need a cloneable gRPC client, use `GrpcClientBuilder::connect()` and apply layers manually.
+4. `InboundTraceLayer` and `OutboundTraceLayer` carry no state — they are `Clone + Default` and can be applied to multiple servers / channels.
+5. Consumer offset commitment is the caller's responsibility when `enable_auto_commit = false` (the default).

--- a/crates/shared/transport/src/codec/json.rs
+++ b/crates/shared/transport/src/codec/json.rs
@@ -1,0 +1,11 @@
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::error::CodecError;
+
+pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+    serde_json::to_vec(value).map_err(CodecError::Json)
+}
+
+pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CodecError> {
+    serde_json::from_slice(bytes).map_err(CodecError::Json)
+}

--- a/crates/shared/transport/src/codec/mod.rs
+++ b/crates/shared/transport/src/codec/mod.rs
@@ -1,0 +1,5 @@
+pub mod json;
+pub mod protobuf;
+
+pub use json::{decode as json_decode, encode as json_encode};
+pub use protobuf::{decode as proto_decode, encode as proto_encode};

--- a/crates/shared/transport/src/codec/protobuf.rs
+++ b/crates/shared/transport/src/codec/protobuf.rs
@@ -1,0 +1,14 @@
+use bytes::{Bytes, BytesMut};
+use prost::Message;
+
+use crate::error::CodecError;
+
+pub fn encode<M: Message>(msg: &M) -> Result<Bytes, CodecError> {
+    let mut buf = BytesMut::with_capacity(msg.encoded_len());
+    msg.encode(&mut buf).map_err(CodecError::ProtobufEncode)?;
+    Ok(buf.freeze())
+}
+
+pub fn decode<M: Message + Default>(bytes: &[u8]) -> Result<M, CodecError> {
+    M::decode(bytes).map_err(CodecError::ProtobufDecode)
+}

--- a/crates/shared/transport/src/error.rs
+++ b/crates/shared/transport/src/error.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use thiserror::Error;
+
+use crate::grpc::error::GrpcTransportError;
+use crate::kafka::error::KafkaTransportError;
+
+#[derive(Debug, Error)]
+pub enum CodecError {
+    #[error("JSON serialization error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("protobuf encode error: {0}")]
+    ProtobufEncode(#[from] prost::EncodeError),
+
+    #[error("protobuf decode error: {0}")]
+    ProtobufDecode(#[from] prost::DecodeError),
+}
+
+/// Top-level transport error.
+///
+/// Every public function in this crate that can fail returns `Result<_, TransportError>`.
+/// Sub-domain errors (`GrpcTransportError`, `KafkaTransportError`, `CodecError`) are kept
+/// separate so callers can match precisely; the `#[from]` derives give ergonomic `?` usage.
+#[derive(Debug, Error)]
+pub enum TransportError {
+    #[error("gRPC error: {0}")]
+    Grpc(#[from] GrpcTransportError),
+
+    #[error("Kafka error: {0}")]
+    Kafka(#[from] KafkaTransportError),
+
+    #[error("codec error: {0}")]
+    Codec(#[from] CodecError),
+
+    #[error("circuit breaker is open — request rejected")]
+    CircuitOpen,
+
+    #[error("request timed out after {0:?}")]
+    Timeout(Duration),
+
+    #[error("all {0} retry attempts exhausted")]
+    MaxRetriesExhausted(u32),
+}
+
+impl TransportError {
+    /// Flattens `ResilienceError<tonic::transport::Error>` (produced by circuit-breaker or
+    /// timeout layers wrapping the raw channel) into `TransportError`.
+    pub fn from_resilience_connect(
+        e: resilience::error::ResilienceError<tonic::transport::Error>,
+    ) -> Self {
+        use resilience::error::ResilienceError;
+        match e {
+            ResilienceError::CircuitOpen => Self::CircuitOpen,
+            ResilienceError::Timeout(d) => Self::Timeout(d),
+            ResilienceError::MaxRetriesExhausted(n) => Self::MaxRetriesExhausted(n),
+            ResilienceError::Inner(e) => Self::Grpc(GrpcTransportError::Connect(e)),
+        }
+    }
+
+    /// Flattens `ResilienceError<TransportError>` produced by a resilience layer that already
+    /// has a previously-mapped `TransportError` as its inner error type.
+    pub fn from_resilience(e: resilience::error::ResilienceError<TransportError>) -> Self {
+        use resilience::error::ResilienceError;
+        match e {
+            ResilienceError::CircuitOpen => Self::CircuitOpen,
+            ResilienceError::Timeout(d) => Self::Timeout(d),
+            ResilienceError::MaxRetriesExhausted(n) => Self::MaxRetriesExhausted(n),
+            ResilienceError::Inner(t) => t,
+        }
+    }
+}
+
+/// Convenience `From` impl so `tonic::transport::Error` can be propagated via `?` in
+/// functions that return `Result<_, TransportError>`.
+impl From<tonic::transport::Error> for TransportError {
+    fn from(e: tonic::transport::Error) -> Self {
+        Self::Grpc(GrpcTransportError::Connect(e))
+    }
+}
+
+/// Convenience `From` impl so `tonic::Status` can be propagated via `?`.
+impl From<tonic::Status> for TransportError {
+    fn from(s: tonic::Status) -> Self {
+        Self::Grpc(GrpcTransportError::from(s))
+    }
+}

--- a/crates/shared/transport/src/grpc/client/builder.rs
+++ b/crates/shared/transport/src/grpc/client/builder.rs
@@ -1,0 +1,103 @@
+use tower::Layer;
+
+use crate::{
+    error::TransportError,
+    grpc::{
+        client::config::GrpcClientConfig,
+        layer::outbound::{OutboundTraceLayer, OutboundTraceService},
+    },
+};
+
+/// Builds a Tonic gRPC client channel, with optional TLS and outbound trace injection.
+///
+/// # Two entry points
+///
+/// | Method | Returns | Cloneable | Middleware |
+/// |--------|---------|-----------|-----------|
+/// | `connect()` | raw `Channel` | ✅ | none |
+/// | `build_traced()` | `OutboundTraceService<Channel>` | ✅ | trace injection only |
+///
+/// # Stacking resilience layers
+///
+/// HTTP/2 request bodies are streams — they cannot be replayed without buffering, so
+/// `RetryLayer` is intentionally absent at the transport level. Apply it at the RPC
+/// application layer instead.  To add `CircuitBreakerLayer` + `TimeoutLayer` on top
+/// of a traced channel:
+///
+/// ```rust,ignore
+/// use tower::ServiceBuilder;
+/// use resilience::{circuit_breaker::layer::CircuitBreakerLayer, timeout::layer::TimeoutLayer};
+///
+/// let channel = GrpcClientBuilder::new(cfg).build_traced().await?;
+///
+/// let svc = ServiceBuilder::new()
+///     .map_err(TransportError::from_resilience)
+///     .layer(TimeoutLayer::new(resilience_cfg.timeout))
+///     .map_err(TransportError::from_resilience_connect)
+///     .layer(CircuitBreakerLayer::new(resilience_cfg.circuit_breaker))
+///     .service(channel);
+///
+/// let client = PostServiceClient::new(svc);
+/// ```
+pub struct GrpcClientBuilder {
+    config: GrpcClientConfig,
+}
+
+impl GrpcClientBuilder {
+    pub fn new(config: GrpcClientConfig) -> Self {
+        Self { config }
+    }
+
+    /// Connects to the remote endpoint and returns a raw, cloneable
+    /// [`tonic::transport::Channel`].
+    ///
+    /// No middleware is applied. Prefer this when you need to share the channel across
+    /// multiple tonic client types, or when you want full control over the Tower stack.
+    pub async fn connect(self) -> Result<tonic::transport::Channel, TransportError> {
+        build_channel(&self.config).await
+    }
+
+    /// Connects and wraps the channel in [`OutboundTraceLayer`], which automatically
+    /// injects W3C `traceparent` / `tracestate` headers on every outgoing gRPC call.
+    ///
+    /// The returned service is [`Clone`] (both `Channel` and `OutboundTraceService` are
+    /// cheaply cloneable) and can be used directly with generated tonic clients:
+    ///
+    /// ```rust,ignore
+    /// let svc = GrpcClientBuilder::new(config).build_traced().await?;
+    /// let client = PostServiceClient::new(svc);
+    /// ```
+    pub async fn build_traced(
+        self,
+    ) -> Result<OutboundTraceService<tonic::transport::Channel>, TransportError> {
+        let channel = build_channel(&self.config).await?;
+        Ok(OutboundTraceLayer.layer(channel))
+    }
+}
+
+async fn build_channel(cfg: &GrpcClientConfig) -> Result<tonic::transport::Channel, TransportError> {
+    use tonic::transport::{Certificate, ClientTlsConfig, Endpoint, Identity};
+
+    let mut endpoint = Endpoint::new(cfg.endpoint.clone())
+        .map_err(|e| TransportError::Grpc(crate::grpc::error::GrpcTransportError::Connect(e)))?
+        .connect_timeout(cfg.connect_timeout);
+
+    if let Some(tls) = &cfg.tls {
+        let mut tls_config = ClientTlsConfig::new();
+
+        if let Some(ca_pem) = &tls.ca_pem {
+            tls_config = tls_config.ca_certificate(Certificate::from_pem(ca_pem));
+        }
+
+        if let Some(id) = &tls.identity {
+            tls_config =
+                tls_config.identity(Identity::from_pem(&id.cert_pem, &id.key_pem));
+        }
+
+        endpoint = endpoint.tls_config(tls_config).map_err(|e| {
+            TransportError::Grpc(crate::grpc::error::GrpcTransportError::Tls(e.to_string()))
+        })?;
+    }
+
+    endpoint.connect().await.map_err(TransportError::from)
+}

--- a/crates/shared/transport/src/grpc/client/config.rs
+++ b/crates/shared/transport/src/grpc/client/config.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use resilience::{
+    circuit_breaker::config::CircuitBreakerConfig,
+    timeout::config::TimeoutConfig,
+};
+
+/// Top-level configuration for a gRPC client channel.
+#[derive(Debug, Clone)]
+pub struct GrpcClientConfig {
+    /// Remote endpoint URI, e.g. `https://post-command-server:50051`.
+    pub endpoint: String,
+
+    /// Optional TLS settings. When `None` the connection is plaintext (suitable for
+    /// in-cluster service-mesh scenarios where mTLS is handled at the sidecar level).
+    pub tls: Option<GrpcTlsConfig>,
+
+    /// How long to wait for the initial TCP + TLS handshake before failing.
+    pub connect_timeout: Duration,
+
+    /// Resilience knobs applied at the transport layer. `None` disables all middleware.
+    pub resilience: Option<GrpcResilienceConfig>,
+}
+
+impl GrpcClientConfig {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            tls: None,
+            connect_timeout: Duration::from_secs(5),
+            resilience: Some(GrpcResilienceConfig::default()),
+        }
+    }
+
+    pub fn with_tls(mut self, tls: GrpcTlsConfig) -> Self {
+        self.tls = Some(tls);
+        self
+    }
+
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    pub fn without_resilience(mut self) -> Self {
+        self.resilience = None;
+        self
+    }
+}
+
+/// TLS settings for a gRPC client channel.
+#[derive(Debug, Clone)]
+pub struct GrpcTlsConfig {
+    /// PEM-encoded CA certificate bundle. When `None` the system root store is used.
+    pub ca_pem: Option<Vec<u8>>,
+
+    /// Optional client certificate and private key for mutual TLS (mTLS).
+    pub identity: Option<GrpcTlsIdentity>,
+}
+
+/// Client certificate + key pair for mutual TLS.
+#[derive(Debug, Clone)]
+pub struct GrpcTlsIdentity {
+    pub cert_pem: Vec<u8>,
+    pub key_pem: Vec<u8>,
+}
+
+/// Resilience middleware configuration for gRPC client channels.
+///
+/// # Why no `RetryConfig`?
+///
+/// HTTP/2 request bodies are streams — once consumed they cannot be replayed without
+/// buffering the entire body. Retry at the raw transport level would require copying
+/// every request body upfront, which is prohibitively expensive for large payloads.
+///
+/// **Recommended pattern:** implement retry at the application layer (e.g. retry the
+/// tonic client call) using the `resilience` crate's `RetryLayer` around the generated
+/// gRPC client method, not the underlying channel.
+#[derive(Debug, Clone)]
+pub struct GrpcResilienceConfig {
+    pub circuit_breaker: CircuitBreakerConfig,
+    pub timeout: TimeoutConfig,
+}
+
+impl Default for GrpcResilienceConfig {
+    fn default() -> Self {
+        Self {
+            circuit_breaker: CircuitBreakerConfig::default(),
+            timeout: TimeoutConfig::from_secs(10),
+        }
+    }
+}

--- a/crates/shared/transport/src/grpc/client/mod.rs
+++ b/crates/shared/transport/src/grpc/client/mod.rs
@@ -1,0 +1,5 @@
+pub mod builder;
+pub mod config;
+
+pub use builder::GrpcClientBuilder;
+pub use config::{GrpcClientConfig, GrpcResilienceConfig, GrpcTlsConfig};

--- a/crates/shared/transport/src/grpc/error.rs
+++ b/crates/shared/transport/src/grpc/error.rs
@@ -1,0 +1,48 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GrpcTransportError {
+    /// Low-level TCP/TLS connection failure reported by the Tonic transport.
+    #[error("gRPC connection error: {0}")]
+    Connect(#[from] tonic::transport::Error),
+
+    /// Application-level gRPC status code returned by the remote server.
+    #[error("gRPC status {code:?}: {message}")]
+    Status {
+        code: tonic::Code,
+        message: String,
+    },
+
+    #[error("invalid gRPC metadata value: {0}")]
+    InvalidMetadata(String),
+
+    #[error("TLS configuration error: {0}")]
+    Tls(String),
+}
+
+impl From<tonic::Status> for GrpcTransportError {
+    fn from(s: tonic::Status) -> Self {
+        Self::Status {
+            code: s.code(),
+            message: s.message().to_string(),
+        }
+    }
+}
+
+/// Maps the severity of a gRPC status code to a platform [`error::Severity`] so callers
+/// can decide whether to page on-call.
+///
+/// - `UNAVAILABLE`, `DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED` → `High` (usually transient)
+/// - `INTERNAL`, `DATA_LOSS`, `UNKNOWN` → `Critical`
+/// - `PERMISSION_DENIED`, `UNAUTHENTICATED` → `Medium`
+/// - everything else → `Low`
+pub fn grpc_severity(code: tonic::Code) -> error::Severity {
+    use error::Severity;
+    use tonic::Code;
+    match code {
+        Code::Internal | Code::DataLoss | Code::Unknown => Severity::Critical,
+        Code::Unavailable | Code::DeadlineExceeded | Code::ResourceExhausted => Severity::High,
+        Code::PermissionDenied | Code::Unauthenticated => Severity::Medium,
+        _ => Severity::Low,
+    }
+}

--- a/crates/shared/transport/src/grpc/layer/inbound.rs
+++ b/crates/shared/transport/src/grpc/layer/inbound.rs
@@ -1,0 +1,82 @@
+use std::task::{Context, Poll};
+
+use futures::future::BoxFuture;
+use tower::{Layer, Service};
+use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::propagation::{carrier::extract_context, grpc::GrpcHeaderExtractor};
+
+/// Tower [`Layer`] that extracts the remote OpenTelemetry trace context from every
+/// incoming gRPC request and wires it as the parent span of the current `tracing` span.
+///
+/// # Placement in the stack
+///
+/// Apply this layer on the **server side** via [`tonic::transport::Server::layer`]:
+///
+/// ```text
+/// tonic::Server
+///   └─ InboundTraceLayer   ← wraps every handler
+///       └─ generated gRPC service impl
+/// ```
+///
+/// # Span attributes
+///
+/// The injected span carries:
+/// - `rpc.system = "grpc"`
+/// - `rpc.method` = the full URI path (e.g. `/social.PostService/CreatePost`)
+///
+/// These align with the [OpenTelemetry RPC semantic conventions](https://opentelemetry.io/docs/specs/semconv/rpc/).
+#[derive(Debug, Clone, Default)]
+pub struct InboundTraceLayer;
+
+impl<S> Layer<S> for InboundTraceLayer {
+    type Service = InboundTraceService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        InboundTraceService { inner }
+    }
+}
+
+/// The concrete service produced by [`InboundTraceLayer`].
+pub struct InboundTraceService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<http::Request<B>> for InboundTraceService<S>
+where
+    S: Service<http::Request<B>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: Send + 'static,
+    S::Error: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    // BoxFuture because we instrument the inner future with a new span, changing its type.
+    type Future = BoxFuture<'static, Result<S::Response, S::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        // 1. Extract the remote trace context from the request headers.
+        let parent_cx = extract_context(&GrpcHeaderExtractor(req.headers()));
+
+        // 2. Build a server-side span with the remote context as parent.
+        //    Using `info_span!` so that sampling decisions from the upstream propagate.
+        let method = req.uri().path().to_owned();
+        let span = tracing::info_span!(
+            "grpc.server",
+            rpc.system = "grpc",
+            rpc.method = %method,
+        );
+        span.set_parent(parent_cx);
+
+        // 3. Instrument the inner future so the span covers the full handler execution.
+        //    `S::Future: Send + 'static` ensures the resulting BoxFuture is moveable
+        //    across task boundaries without holding a reference into `self`.
+        Box::pin(self.inner.call(req).instrument(span))
+    }
+}

--- a/crates/shared/transport/src/grpc/layer/mod.rs
+++ b/crates/shared/transport/src/grpc/layer/mod.rs
@@ -1,0 +1,5 @@
+pub mod inbound;
+pub mod outbound;
+
+pub use inbound::InboundTraceLayer;
+pub use outbound::OutboundTraceLayer;

--- a/crates/shared/transport/src/grpc/layer/outbound.rs
+++ b/crates/shared/transport/src/grpc/layer/outbound.rs
@@ -1,0 +1,63 @@
+use std::task::{Context, Poll};
+
+use tower::{Layer, Service};
+
+use crate::propagation::{carrier::inject_context, grpc::GrpcHeaderInjector};
+
+/// Tower [`Layer`] that injects the active OpenTelemetry trace context into every
+/// outgoing gRPC request's HTTP headers before forwarding to the inner service.
+///
+/// # Placement in the stack
+///
+/// Apply this layer directly around the raw [`tonic::transport::Channel`] so that
+/// trace headers are injected on every attempt, including retries:
+///
+/// ```text
+/// TimeoutLayer
+///   └─ CircuitBreakerLayer
+///       └─ OutboundTraceLayer   ← here
+///           └─ tonic::transport::Channel
+/// ```
+///
+/// # Context source
+///
+/// The injected context is read from the **current `tracing` span** at call time via
+/// `tracing_opentelemetry::OpenTelemetrySpanExt::context`. The active span must exist
+/// (i.e., `telemetry::init()` has been called and an instrumented task is running);
+/// if no span is active the propagator will inject an empty context.
+#[derive(Debug, Clone, Default)]
+pub struct OutboundTraceLayer;
+
+impl<S> Layer<S> for OutboundTraceLayer {
+    type Service = OutboundTraceService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        OutboundTraceService { inner }
+    }
+}
+
+/// The concrete service produced by [`OutboundTraceLayer`].
+#[derive(Debug, Clone)]
+pub struct OutboundTraceService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<http::Request<B>> for OutboundTraceService<S>
+where
+    S: Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        // Inject the current span's trace context into the request headers.
+        // All work is synchronous so the future type is unchanged — no boxing required.
+        inject_context(&mut GrpcHeaderInjector(req.headers_mut()));
+        self.inner.call(req)
+    }
+}

--- a/crates/shared/transport/src/grpc/mod.rs
+++ b/crates/shared/transport/src/grpc/mod.rs
@@ -1,0 +1,6 @@
+pub mod client;
+pub mod error;
+pub mod layer;
+pub mod server;
+
+pub use error::GrpcTransportError;

--- a/crates/shared/transport/src/grpc/server/builder.rs
+++ b/crates/shared/transport/src/grpc/server/builder.rs
@@ -1,0 +1,62 @@
+use tower::layer::util::{Identity, Stack};
+use tonic::transport::{Identity as TlsIdentity, Server, ServerTlsConfig};
+
+use crate::{
+    error::TransportError,
+    grpc::{layer::inbound::InboundTraceLayer, server::config::GrpcServerConfig},
+};
+
+/// Concrete server type produced by [`GrpcServerBuilder::build`].
+///
+/// `Server<Stack<InboundTraceLayer, Identity>>` is the tonic type after calling
+/// `Server::builder().layer(InboundTraceLayer)`. Exposed as a public alias so callers
+/// can name the type in struct fields or `Arc<>` wrappers.
+pub type TracedGrpcServer = Server<Stack<InboundTraceLayer, Identity>>;
+
+/// Builds a Tonic gRPC server with [`InboundTraceLayer`] pre-installed.
+///
+/// Every request that hits any service registered on this server will have its
+/// W3C TraceContext headers extracted and linked as the parent span automatically.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let server = GrpcServerBuilder::new(GrpcServerConfig::default())
+///     .build()?
+///     .add_service(PostServiceServer::new(my_handler))
+///     .serve(config.addr)
+///     .await?;
+/// ```
+pub struct GrpcServerBuilder {
+    config: GrpcServerConfig,
+}
+
+impl GrpcServerBuilder {
+    pub fn new(config: GrpcServerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Returns a [`TracedGrpcServer`] with [`InboundTraceLayer`] applied.
+    ///
+    /// Call `.add_service(...)` and `.serve(addr)` on the returned server to start
+    /// accepting connections.
+    pub fn build(self) -> Result<TracedGrpcServer, TransportError> {
+        let mut server = Server::builder().layer(InboundTraceLayer);
+
+        if let Some(tls) = self.config.tls {
+            let identity = TlsIdentity::from_pem(&tls.cert_pem, &tls.key_pem);
+            let mut tls_config = ServerTlsConfig::new().identity(identity);
+
+            if let Some(ca) = tls.client_ca_pem {
+                tls_config = tls_config
+                    .client_ca_root(tonic::transport::Certificate::from_pem(ca));
+            }
+
+            server = server.tls_config(tls_config).map_err(|e| {
+                TransportError::Grpc(crate::grpc::error::GrpcTransportError::Tls(e.to_string()))
+            })?;
+        }
+
+        Ok(server)
+    }
+}

--- a/crates/shared/transport/src/grpc/server/config.rs
+++ b/crates/shared/transport/src/grpc/server/config.rs
@@ -1,0 +1,52 @@
+use std::net::SocketAddr;
+
+/// Configuration for a Tonic gRPC server.
+#[derive(Debug, Clone)]
+pub struct GrpcServerConfig {
+    /// Address to bind. Defaults to `0.0.0.0:50051`.
+    pub addr: SocketAddr,
+
+    /// Optional TLS settings. When `None` the server accepts plaintext connections.
+    pub tls: Option<GrpcServerTlsConfig>,
+
+    /// Enables gRPC server reflection (useful for `grpcurl` and Postman during development).
+    pub enable_reflection: bool,
+}
+
+impl Default for GrpcServerConfig {
+    fn default() -> Self {
+        Self {
+            addr: "0.0.0.0:50051".parse().expect("static address is valid"),
+            tls: None,
+            enable_reflection: false,
+        }
+    }
+}
+
+impl GrpcServerConfig {
+    pub fn with_addr(mut self, addr: SocketAddr) -> Self {
+        self.addr = addr;
+        self
+    }
+
+    pub fn with_tls(mut self, tls: GrpcServerTlsConfig) -> Self {
+        self.tls = Some(tls);
+        self
+    }
+
+    pub fn with_reflection(mut self) -> Self {
+        self.enable_reflection = true;
+        self
+    }
+}
+
+/// TLS settings for a gRPC server.
+#[derive(Debug, Clone)]
+pub struct GrpcServerTlsConfig {
+    /// PEM-encoded server certificate.
+    pub cert_pem: Vec<u8>,
+    /// PEM-encoded server private key.
+    pub key_pem: Vec<u8>,
+    /// Optional PEM-encoded CA for client certificate verification (mTLS).
+    pub client_ca_pem: Option<Vec<u8>>,
+}

--- a/crates/shared/transport/src/grpc/server/mod.rs
+++ b/crates/shared/transport/src/grpc/server/mod.rs
@@ -1,0 +1,5 @@
+pub mod builder;
+pub mod config;
+
+pub use builder::{GrpcServerBuilder, TracedGrpcServer};
+pub use config::{GrpcServerConfig, GrpcServerTlsConfig};

--- a/crates/shared/transport/src/kafka/config/client.rs
+++ b/crates/shared/transport/src/kafka/config/client.rs
@@ -1,0 +1,83 @@
+/// Shared Kafka client settings inherited by both producers and consumers.
+#[derive(Debug, Clone)]
+pub struct KafkaClientConfig {
+    /// Comma-separated list of broker addresses, e.g. `kafka-0:9092,kafka-1:9092`.
+    pub brokers: String,
+
+    /// Security protocol. Use `"PLAINTEXT"` for in-cluster without TLS (default),
+    /// `"SASL_SSL"` for cloud-managed brokers (Confluent Cloud, MSK, etc.).
+    pub security_protocol: String,
+
+    /// SASL mechanism, e.g. `"PLAIN"`, `"SCRAM-SHA-256"`. Required when
+    /// `security_protocol` is `SASL_PLAINTEXT` or `SASL_SSL`.
+    pub sasl_mechanism: Option<String>,
+
+    /// SASL username.
+    pub sasl_username: Option<String>,
+
+    /// SASL password.
+    pub sasl_password: Option<String>,
+
+    /// Log-level forwarded to rdkafka's internal debug logger.
+    /// Useful values: `"all"`, `"consumer"`, `"producer"`, `"topic"`.
+    pub rdkafka_debug: Option<String>,
+}
+
+impl Default for KafkaClientConfig {
+    fn default() -> Self {
+        Self {
+            brokers: "localhost:9092".to_string(),
+            security_protocol: "PLAINTEXT".to_string(),
+            sasl_mechanism: None,
+            sasl_username: None,
+            sasl_password: None,
+            rdkafka_debug: None,
+        }
+    }
+}
+
+impl KafkaClientConfig {
+    pub fn new(brokers: impl Into<String>) -> Self {
+        Self {
+            brokers: brokers.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Populates settings from environment variables using the standard
+    /// `KAFKA_BROKERS`, `KAFKA_SECURITY_PROTOCOL`, `KAFKA_SASL_*` naming.
+    pub fn from_env() -> Self {
+        Self {
+            brokers: std::env::var("KAFKA_BROKERS")
+                .unwrap_or_else(|_| "localhost:9092".to_string()),
+            security_protocol: std::env::var("KAFKA_SECURITY_PROTOCOL")
+                .unwrap_or_else(|_| "PLAINTEXT".to_string()),
+            sasl_mechanism: std::env::var("KAFKA_SASL_MECHANISM").ok(),
+            sasl_username: std::env::var("KAFKA_SASL_USERNAME").ok(),
+            sasl_password: std::env::var("KAFKA_SASL_PASSWORD").ok(),
+            rdkafka_debug: std::env::var("KAFKA_DEBUG").ok(),
+        }
+    }
+
+    /// Materialises these settings into an [`rdkafka::ClientConfig`].
+    pub(crate) fn to_rdkafka(&self) -> rdkafka::config::ClientConfig {
+        let mut cfg = rdkafka::config::ClientConfig::new();
+        cfg.set("bootstrap.servers", &self.brokers)
+            .set("security.protocol", &self.security_protocol);
+
+        if let Some(m) = &self.sasl_mechanism {
+            cfg.set("sasl.mechanism", m);
+        }
+        if let Some(u) = &self.sasl_username {
+            cfg.set("sasl.username", u);
+        }
+        if let Some(p) = &self.sasl_password {
+            cfg.set("sasl.password", p);
+        }
+        if let Some(d) = &self.rdkafka_debug {
+            cfg.set("debug", d);
+        }
+
+        cfg
+    }
+}

--- a/crates/shared/transport/src/kafka/config/consumer.rs
+++ b/crates/shared/transport/src/kafka/config/consumer.rs
@@ -1,0 +1,72 @@
+use crate::kafka::config::client::KafkaClientConfig;
+
+/// What to do when a consumer group has no committed offset for a partition.
+#[derive(Debug, Clone, Default)]
+pub enum AutoOffsetReset {
+    /// Start from the earliest available message.
+    Earliest,
+    /// Start from the latest message (skip existing backlog). Default.
+    #[default]
+    Latest,
+}
+
+impl AutoOffsetReset {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Earliest => "earliest",
+            Self::Latest => "latest",
+        }
+    }
+}
+
+/// Kafka consumer settings, extending the shared [`KafkaClientConfig`].
+#[derive(Debug, Clone)]
+pub struct ConsumerConfig {
+    pub client: KafkaClientConfig,
+
+    /// Consumer group ID — all consumers sharing the same ID form a group that load-balances
+    /// partitions. Required.
+    pub group_id: String,
+
+    /// What offset to start from when there is no committed offset. Default: `Latest`.
+    pub auto_offset_reset: AutoOffsetReset,
+
+    /// Whether to commit offsets automatically. Setting `false` (default) lets the
+    /// application control exactly-once or at-least-once semantics by calling
+    /// [`rdkafka::consumer::Consumer::commit_message`] explicitly.
+    pub enable_auto_commit: bool,
+
+    /// Interval in milliseconds at which rdkafka sends keepalive heartbeats to the broker.
+    /// Must be lower than the broker's `session.timeout.ms`. Default: `3000`.
+    pub heartbeat_interval_ms: u32,
+
+    /// Maximum time (ms) the broker waits before considering a consumer dead.
+    /// Default: `10000`.
+    pub session_timeout_ms: u32,
+}
+
+impl ConsumerConfig {
+    pub fn new(client: KafkaClientConfig, group_id: impl Into<String>) -> Self {
+        Self {
+            client,
+            group_id: group_id.into(),
+            auto_offset_reset: AutoOffsetReset::Latest,
+            enable_auto_commit: false,
+            heartbeat_interval_ms: 3_000,
+            session_timeout_ms: 10_000,
+        }
+    }
+
+    pub(crate) fn to_rdkafka(&self) -> rdkafka::config::ClientConfig {
+        let mut cfg = self.client.to_rdkafka();
+        cfg.set("group.id", &self.group_id)
+            .set("auto.offset.reset", self.auto_offset_reset.as_str())
+            .set(
+                "enable.auto.commit",
+                if self.enable_auto_commit { "true" } else { "false" },
+            )
+            .set("heartbeat.interval.ms", &self.heartbeat_interval_ms.to_string())
+            .set("session.timeout.ms", &self.session_timeout_ms.to_string());
+        cfg
+    }
+}

--- a/crates/shared/transport/src/kafka/config/mod.rs
+++ b/crates/shared/transport/src/kafka/config/mod.rs
@@ -1,0 +1,7 @@
+pub mod client;
+pub mod consumer;
+pub mod producer;
+
+pub use client::KafkaClientConfig;
+pub use consumer::ConsumerConfig;
+pub use producer::ProducerConfig;

--- a/crates/shared/transport/src/kafka/config/producer.rs
+++ b/crates/shared/transport/src/kafka/config/producer.rs
@@ -1,0 +1,55 @@
+use crate::kafka::config::client::KafkaClientConfig;
+
+/// Kafka producer settings, extending the shared [`KafkaClientConfig`].
+#[derive(Debug, Clone)]
+pub struct ProducerConfig {
+    pub client: KafkaClientConfig,
+
+    /// Required acknowledgements from brokers before considering a produce successful.
+    /// `"all"` (default) = leader + all in-sync replicas — maximum durability.
+    /// `"1"` = leader only.
+    /// `"0"` = fire-and-forget.
+    pub acks: String,
+
+    /// Compression algorithm applied to batches: `"none"`, `"gzip"`, `"snappy"`,
+    /// `"lz4"`, `"zstd"` (default: `"snappy"` — good throughput/CPU trade-off).
+    pub compression: String,
+
+    /// Milliseconds the producer waits before sending a batch to improve throughput.
+    /// `0` disables batching (lowest latency). Default `5`.
+    pub linger_ms: u32,
+
+    /// Maximum number of in-flight produce requests per broker before blocking.
+    /// Setting this to `1` ensures strict ordering when `acks = "all"`.
+    pub max_in_flight: u32,
+}
+
+impl Default for ProducerConfig {
+    fn default() -> Self {
+        Self {
+            client: KafkaClientConfig::default(),
+            acks: "all".to_string(),
+            compression: "snappy".to_string(),
+            linger_ms: 5,
+            max_in_flight: 5,
+        }
+    }
+}
+
+impl ProducerConfig {
+    pub fn new(client: KafkaClientConfig) -> Self {
+        Self {
+            client,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn to_rdkafka(&self) -> rdkafka::config::ClientConfig {
+        let mut cfg = self.client.to_rdkafka();
+        cfg.set("acks", &self.acks)
+            .set("compression.type", &self.compression)
+            .set("linger.ms", &self.linger_ms.to_string())
+            .set("max.in.flight.requests.per.connection", &self.max_in_flight.to_string());
+        cfg
+    }
+}

--- a/crates/shared/transport/src/kafka/consumer/builder.rs
+++ b/crates/shared/transport/src/kafka/consumer/builder.rs
@@ -1,0 +1,58 @@
+use rdkafka::consumer::{Consumer, StreamConsumer};
+
+use crate::{
+    error::TransportError,
+    kafka::{
+        config::consumer::ConsumerConfig,
+        consumer::handle::KafkaConsumerHandle,
+        error::KafkaTransportError,
+    },
+};
+
+/// Constructs a [`KafkaConsumerHandle`] from a [`ConsumerConfig`] and a list of topics.
+pub struct KafkaConsumerBuilder {
+    config: ConsumerConfig,
+    topics: Vec<String>,
+}
+
+impl KafkaConsumerBuilder {
+    pub fn new(config: ConsumerConfig) -> Self {
+        Self {
+            config,
+            topics: Vec::new(),
+        }
+    }
+
+    pub fn subscribe(mut self, topic: impl Into<String>) -> Self {
+        self.topics.push(topic.into());
+        self
+    }
+
+    pub fn subscribe_many(mut self, topics: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.topics.extend(topics.into_iter().map(Into::into));
+        self
+    }
+
+    /// Creates the rdkafka [`StreamConsumer`], subscribes to the configured topics,
+    /// and returns a [`KafkaConsumerHandle`].
+    pub fn build(self) -> Result<KafkaConsumerHandle, TransportError> {
+        let consumer: StreamConsumer = self
+            .config
+            .to_rdkafka()
+            .create()
+            .map_err(|e| TransportError::Kafka(KafkaTransportError::Config(e.to_string())))?;
+
+        let topic_refs: Vec<&str> = self.topics.iter().map(String::as_str).collect();
+        consumer
+            .subscribe(&topic_refs)
+            .map_err(|e| TransportError::Kafka(KafkaTransportError::Subscribe(e)))?;
+
+        tracing::info!(
+            topics = ?self.topics,
+            group_id = %self.config.group_id,
+            "Kafka consumer subscribed"
+        );
+
+        Ok(KafkaConsumerHandle::new(consumer))
+    }
+}

--- a/crates/shared/transport/src/kafka/consumer/handle.rs
+++ b/crates/shared/transport/src/kafka/consumer/handle.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+
+use futures_util::StreamExt;
+use rdkafka::{
+    consumer::StreamConsumer,
+    message::{Headers, Message},
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::{
+    error::{CodecError, TransportError},
+    kafka::{
+        envelope::{ConsumablePayload, EventEnvelope},
+        error::KafkaTransportError,
+    },
+    propagation::{carrier::extract_context, kafka::KafkaHeaderExtractor},
+};
+
+/// A handle to a Kafka consumer that automatically extracts distributed trace context
+/// from every incoming message and exposes a typed async stream of [`EventEnvelope<T>`].
+///
+/// # Trace context propagation
+///
+/// For each received message, the handle:
+/// 1. Extracts `traceparent` / `tracestate` from the Kafka record headers.
+/// 2. Reconstructs the remote [`opentelemetry::Context`].
+/// 3. Sets it as the parent of the current `tracing` span, establishing a continuous
+///    distributed trace from the producer to this consumer.
+pub struct KafkaConsumerHandle {
+    consumer: StreamConsumer,
+}
+
+impl KafkaConsumerHandle {
+    pub(crate) fn new(consumer: StreamConsumer) -> Self {
+        Self { consumer }
+    }
+
+    /// Returns an infinite async stream of deserialized [`EventEnvelope<T>`].
+    ///
+    /// Each poll extracts trace headers and sets the parent span before deserializing the
+    /// payload, so all downstream `tracing` spans created while processing the message
+    /// are automatically linked to the upstream producer's trace.
+    ///
+    /// # Offset management
+    ///
+    /// With `enable_auto_commit = false` (recommended), callers must commit offsets
+    /// explicitly after successful processing. Use [`KafkaConsumerHandle::commit`] or
+    /// [`rdkafka::consumer::Consumer::commit_message`] directly.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let mut stream = handle.stream::<PostCreatedEvent>();
+    /// while let Some(result) = stream.next().await {
+    ///     let envelope = result?;
+    ///     process(envelope.payload).await?;
+    /// }
+    /// ```
+    pub fn stream<T: ConsumablePayload>(
+        &self,
+    ) -> impl futures::Stream<Item = Result<EventEnvelope<T>, TransportError>> + '_ {
+        self.consumer.stream().map(|msg_result| {
+            let msg = msg_result
+                .map_err(|e| TransportError::Kafka(KafkaTransportError::Consumer(e)))?;
+
+            // ── Trace context extraction ─────────────────────────────────────────────
+            // Extract the remote context and set it as the parent of the current span.
+            // Any `tracing` span opened after this point within the same task will be a
+            // child of the upstream producer's span.
+            if let Some(headers) = msg.headers() {
+                let parent_cx = extract_context(&KafkaHeaderExtractor(headers));
+                tracing::Span::current().set_parent(parent_cx);
+            }
+
+            // ── Payload deserialization ──────────────────────────────────────────────
+            let payload_bytes = msg
+                .payload()
+                .ok_or(TransportError::Kafka(KafkaTransportError::EmptyPayload))?;
+
+            let payload: T = serde_json::from_slice(payload_bytes)
+                .map_err(|e| TransportError::Codec(CodecError::Json(e)))?;
+
+            // ── Reconstruct user headers (excluding trace headers) ───────────────────
+            let user_headers: HashMap<String, String> = msg
+                .headers()
+                .map(|h| {
+                    (0..h.count())
+                        .filter_map(|i| {
+                            let header = h.get(i);
+                            // Skip W3C trace context headers — those are transport-internal.
+                            if header.key == "traceparent" || header.key == "tracestate" {
+                                return None;
+                            }
+                            let value = header
+                                .value
+                                .and_then(|v| std::str::from_utf8(v).ok())
+                                .unwrap_or("")
+                                .to_string();
+                            Some((header.key.to_string(), value))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let envelope = EventEnvelope {
+                topic: msg.topic().to_string(),
+                key: msg
+                    .key()
+                    .and_then(|k| std::str::from_utf8(k).ok())
+                    .unwrap_or("")
+                    .to_string(),
+                payload,
+                headers: user_headers,
+                timestamp_ms: msg.timestamp().to_millis(),
+            };
+
+            tracing::debug!(
+                topic = %envelope.topic,
+                key = %envelope.key,
+                "Kafka message received and deserialized"
+            );
+
+            Ok(envelope)
+        })
+    }
+
+    /// Commits the offset for `msg` asynchronously.
+    ///
+    /// Pass the original `BorrowedMessage` from the rdkafka stream. Use this when
+    /// `enable_auto_commit = false` (the default) to advance the consumer group offset
+    /// after successful processing.
+    pub fn commit<'a>(
+        &'a self,
+        msg: &rdkafka::message::BorrowedMessage<'a>,
+    ) -> Result<(), TransportError> {
+        use rdkafka::consumer::Consumer;
+        self.consumer
+            .commit_message(msg, rdkafka::consumer::CommitMode::Async)
+            .map_err(|e| TransportError::Kafka(KafkaTransportError::Consumer(e)))
+    }
+}

--- a/crates/shared/transport/src/kafka/consumer/mod.rs
+++ b/crates/shared/transport/src/kafka/consumer/mod.rs
@@ -1,0 +1,5 @@
+pub mod builder;
+pub mod handle;
+
+pub use builder::KafkaConsumerBuilder;
+pub use handle::KafkaConsumerHandle;

--- a/crates/shared/transport/src/kafka/envelope.rs
+++ b/crates/shared/transport/src/kafka/envelope.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+
+use serde::{de::DeserializeOwned, Serialize};
+
+/// A typed Kafka message wrapper used by both the producer and the consumer.
+///
+/// `T` is the domain payload type (must be serializable to send, deserializable to receive).
+/// Trace context headers are NOT stored here — they are injected at publish time by
+/// [`crate::kafka::producer::handle::KafkaProducerHandle`] and extracted at consume time
+/// by [`crate::kafka::consumer::handle::KafkaConsumerHandle`].
+///
+/// # Custom headers
+///
+/// Any key-value pairs placed in `headers` before calling `publish` are included in the
+/// Kafka record alongside the automatically-injected trace headers. Header values must be
+/// valid UTF-8 strings.
+#[derive(Debug, Clone)]
+pub struct EventEnvelope<T> {
+    /// Destination topic for producers; source topic for consumers.
+    pub topic: String,
+
+    /// Message key used by Kafka's partitioner. Using a stable domain identifier
+    /// (e.g. post ID) ensures all events for the same entity land on the same partition,
+    /// preserving ordering guarantees.
+    pub key: String,
+
+    /// Typed domain payload.
+    pub payload: T,
+
+    /// Arbitrary string headers included in the Kafka record. Trace context headers
+    /// (`traceparent`, `tracestate`) are injected automatically and must not be set here.
+    pub headers: HashMap<String, String>,
+
+    /// Optional Unix timestamp in milliseconds. When `None`, the Kafka broker assigns the
+    /// broker-side creation time.
+    pub timestamp_ms: Option<i64>,
+}
+
+impl<T> EventEnvelope<T> {
+    pub fn new(topic: impl Into<String>, key: impl Into<String>, payload: T) -> Self {
+        Self {
+            topic: topic.into(),
+            key: key.into(),
+            payload,
+            headers: HashMap::new(),
+            timestamp_ms: None,
+        }
+    }
+
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_timestamp(mut self, ts_ms: i64) -> Self {
+        self.timestamp_ms = Some(ts_ms);
+        self
+    }
+
+    /// Converts this envelope to a serializable form, consuming `self`.
+    /// Used internally by the producer handle.
+    pub fn into_parts(self) -> (String, String, T, HashMap<String, String>, Option<i64>) {
+        (
+            self.topic,
+            self.key,
+            self.payload,
+            self.headers,
+            self.timestamp_ms,
+        )
+    }
+}
+
+/// Marker trait bound used by [`crate::kafka::producer::handle::KafkaProducerHandle`].
+/// Every publishable payload must be serializable to JSON bytes.
+pub trait PublishablePayload: Serialize + Send + Sync + 'static {}
+impl<T: Serialize + Send + Sync + 'static> PublishablePayload for T {}
+
+/// Marker trait bound used by [`crate::kafka::consumer::handle::KafkaConsumerHandle`].
+/// Every receivable payload must be deserializable from JSON bytes.
+pub trait ConsumablePayload: DeserializeOwned + Send + Sync + 'static {}
+impl<T: DeserializeOwned + Send + Sync + 'static> ConsumablePayload for T {}

--- a/crates/shared/transport/src/kafka/error.rs
+++ b/crates/shared/transport/src/kafka/error.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KafkaTransportError {
+    #[error("Kafka producer error: {0}")]
+    Producer(rdkafka::error::KafkaError),
+
+    #[error("Kafka consumer error: {0}")]
+    Consumer(rdkafka::error::KafkaError),
+
+    #[error("Kafka client configuration error: {0}")]
+    Config(String),
+
+    #[error("message payload is empty")]
+    EmptyPayload,
+
+    #[error("invalid header value — must be valid UTF-8: {0}")]
+    InvalidHeader(String),
+
+    #[error("topic subscription error: {0}")]
+    Subscribe(rdkafka::error::KafkaError),
+}
+
+impl From<rdkafka::error::KafkaError> for KafkaTransportError {
+    fn from(e: rdkafka::error::KafkaError) -> Self {
+        Self::Producer(e)
+    }
+}

--- a/crates/shared/transport/src/kafka/mod.rs
+++ b/crates/shared/transport/src/kafka/mod.rs
@@ -1,0 +1,8 @@
+pub mod config;
+pub mod consumer;
+pub mod envelope;
+pub mod error;
+pub mod producer;
+
+pub use envelope::EventEnvelope;
+pub use error::KafkaTransportError;

--- a/crates/shared/transport/src/kafka/producer/builder.rs
+++ b/crates/shared/transport/src/kafka/producer/builder.rs
@@ -1,0 +1,35 @@
+use rdkafka::producer::FutureProducer;
+
+use crate::{
+    error::TransportError,
+    kafka::{
+        config::producer::ProducerConfig,
+        error::KafkaTransportError,
+        producer::handle::KafkaProducerHandle,
+    },
+};
+
+/// Constructs a [`KafkaProducerHandle`] from a [`ProducerConfig`].
+pub struct KafkaProducerBuilder {
+    config: ProducerConfig,
+}
+
+impl KafkaProducerBuilder {
+    pub fn new(config: ProducerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Builds the rdkafka [`FutureProducer`] and wraps it in [`KafkaProducerHandle`].
+    ///
+    /// Returns an error if the rdkafka client configuration is invalid (e.g. unreachable
+    /// brokers are detected only at first produce time, not here).
+    pub fn build(self) -> Result<KafkaProducerHandle, TransportError> {
+        let producer: FutureProducer = self
+            .config
+            .to_rdkafka()
+            .create()
+            .map_err(|e| TransportError::Kafka(KafkaTransportError::Config(e.to_string())))?;
+
+        Ok(KafkaProducerHandle::new(producer))
+    }
+}

--- a/crates/shared/transport/src/kafka/producer/handle.rs
+++ b/crates/shared/transport/src/kafka/producer/handle.rs
@@ -1,0 +1,131 @@
+use rdkafka::{
+    message::OwnedHeaders,
+    producer::{FutureProducer, FutureRecord},
+    util::Timeout,
+};
+
+use crate::{
+    error::{CodecError, TransportError},
+    kafka::{
+        envelope::{EventEnvelope, PublishablePayload},
+        error::KafkaTransportError,
+    },
+    propagation::{
+        carrier::inject_context,
+        kafka::KafkaHeaderInjector,
+    },
+};
+
+/// A cheaply cloneable handle to a Kafka producer.
+///
+/// Holds an `Arc`-backed [`FutureProducer`] so handles can be shared across Tokio tasks
+/// without additional synchronisation overhead.
+///
+/// # Trace context propagation
+///
+/// Every call to [`publish`] automatically injects the current `tracing` span's W3C
+/// `traceparent` and `tracestate` into the Kafka record headers before produce.
+/// The consumer counterpart extracts these headers and re-establishes the parent span,
+/// giving end-to-end distributed traces across the async message boundary.
+///
+/// [`publish`]: KafkaProducerHandle::publish
+#[derive(Clone)]
+pub struct KafkaProducerHandle {
+    producer: FutureProducer,
+}
+
+impl KafkaProducerHandle {
+    pub(crate) fn new(producer: FutureProducer) -> Self {
+        Self { producer }
+    }
+
+    /// Serialises `envelope.payload` to JSON and publishes the record to Kafka,
+    /// injecting the current span's trace context into the record's headers.
+    ///
+    /// # Delivery guarantee
+    ///
+    /// The future resolves when the broker has acknowledged the produce request according
+    /// to the `acks` setting in [`crate::kafka::config::producer::ProducerConfig`].
+    /// With `acks = "all"` this means at-least-once delivery.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransportError::Codec`] if serialisation fails.
+    /// Returns [`TransportError::Kafka`] on broker-level produce failure.
+    pub async fn publish<T: PublishablePayload>(
+        &self,
+        envelope: EventEnvelope<T>,
+    ) -> Result<(), TransportError> {
+        let (topic, key, payload, user_headers, timestamp_ms) = envelope.into_parts();
+
+        let payload_bytes =
+            serde_json::to_vec(&payload).map_err(|e| TransportError::Codec(CodecError::Json(e)))?;
+
+        let headers = build_headers_with_trace(user_headers);
+
+        let mut record = FutureRecord::to(&topic)
+            .key(&key)
+            .payload(&payload_bytes)
+            .headers(headers);
+
+        if let Some(ts) = timestamp_ms {
+            record = record.timestamp(ts);
+        }
+
+        self.producer
+            .send(record, Timeout::Never)
+            .await
+            .map_err(|(e, _msg)| TransportError::Kafka(KafkaTransportError::Producer(e)))?;
+
+        tracing::debug!(topic = %topic, key = %key, "Kafka message published");
+
+        Ok(())
+    }
+
+    /// Publishes a raw byte payload, bypassing JSON serialisation.
+    ///
+    /// Trace context is still injected automatically.
+    pub async fn publish_raw(
+        &self,
+        topic: &str,
+        key: &str,
+        payload: &[u8],
+        user_headers: std::collections::HashMap<String, String>,
+    ) -> Result<(), TransportError> {
+        let headers = build_headers_with_trace(user_headers);
+
+        self.producer
+            .send(
+                FutureRecord::to(topic)
+                    .key(key)
+                    .payload(payload)
+                    .headers(headers),
+                Timeout::Never,
+            )
+            .await
+            .map_err(|(e, _msg)| TransportError::Kafka(KafkaTransportError::Producer(e)))?;
+
+        Ok(())
+    }
+}
+
+/// Builds an [`OwnedHeaders`] instance from user-defined key-value pairs, then
+/// injects the current span's W3C trace context as additional headers.
+fn build_headers_with_trace(
+    user_headers: std::collections::HashMap<String, String>,
+) -> OwnedHeaders {
+    use opentelemetry::propagation::Injector;
+
+    let mut injector = user_headers
+        .into_iter()
+        .fold(KafkaHeaderInjector::new(), |mut inj, (k, v)| {
+            // User-defined headers are added through the same Injector mechanism as trace
+            // headers so that the OwnedHeaders builder pattern is managed in one place.
+            inj.set(&k, v);
+            inj
+        });
+
+    inject_context(&mut injector);
+
+    injector.into_headers()
+}

--- a/crates/shared/transport/src/kafka/producer/mod.rs
+++ b/crates/shared/transport/src/kafka/producer/mod.rs
@@ -1,0 +1,5 @@
+pub mod builder;
+pub mod handle;
+
+pub use builder::KafkaProducerBuilder;
+pub use handle::KafkaProducerHandle;

--- a/crates/shared/transport/src/lib.rs
+++ b/crates/shared/transport/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod codec;
+pub mod error;
+pub mod grpc;
+pub mod kafka;
+pub mod propagation;
+
+pub use error::TransportError;

--- a/crates/shared/transport/src/propagation/carrier.rs
+++ b/crates/shared/transport/src/propagation/carrier.rs
@@ -1,0 +1,43 @@
+use opentelemetry::{
+    global,
+    propagation::{Extractor, Injector},
+    Context,
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// Marker supertrait that combines OTel's [`Injector`] and [`Extractor`] into a single
+/// bound. All carrier types in this module (`GrpcHeaderInjector`, `KafkaHeaderInjector`,
+/// etc.) implicitly satisfy it through their concrete impls.
+pub trait MetadataCarrier: Injector + Extractor {}
+
+impl<T: Injector + Extractor> MetadataCarrier for T {}
+
+/// Injects the current `tracing` span's OpenTelemetry context into `carrier` using
+/// the globally-registered text-map propagator (W3C TraceContext by default when
+/// `telemetry::init()` has been called).
+///
+/// Call this before dispatching any outbound request — gRPC or Kafka.
+pub fn inject_context<C: Injector>(carrier: &mut C) {
+    let cx = tracing::Span::current().context();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, carrier);
+    });
+}
+
+/// Extracts an OpenTelemetry [`Context`] from `carrier` using the globally-registered
+/// text-map propagator. Returns a root context when no trace headers are present.
+///
+/// Call this on every inbound request — gRPC or Kafka — and call
+/// [`tracing_opentelemetry::OpenTelemetrySpanExt::set_parent`] on the current span.
+pub fn extract_context<C: Extractor>(carrier: &C) -> Context {
+    global::get_text_map_propagator(|propagator| propagator.extract(carrier))
+}
+
+/// Sets `cx` as the parent of `span`, wiring the remote trace into the local
+/// `tracing` hierarchy.
+///
+/// This is a thin convenience wrapper so callers do not need to import
+/// `tracing_opentelemetry` directly.
+pub fn set_parent(span: &tracing::Span, cx: Context) {
+    span.set_parent(cx);
+}

--- a/crates/shared/transport/src/propagation/grpc.rs
+++ b/crates/shared/transport/src/propagation/grpc.rs
@@ -1,0 +1,45 @@
+use opentelemetry::propagation::{Extractor, Injector};
+
+/// Mutable carrier that injects W3C TraceContext headers into an outgoing HTTP request's
+/// [`http::HeaderMap`].
+///
+/// Used by [`crate::grpc::layer::outbound::OutboundTraceService`] before forwarding
+/// every client-side gRPC call.
+pub struct GrpcHeaderInjector<'a>(pub &'a mut http::HeaderMap);
+
+impl Injector for GrpcHeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        match (
+            http::header::HeaderName::from_bytes(key.as_bytes()),
+            http::header::HeaderValue::from_str(&value),
+        ) {
+            (Ok(name), Ok(val)) => {
+                self.0.insert(name, val);
+            }
+            _ => {
+                tracing::warn!(
+                    key,
+                    value,
+                    "skipping non-ASCII trace header during gRPC injection"
+                );
+            }
+        }
+    }
+}
+
+/// Read-only carrier that extracts W3C TraceContext headers from an incoming HTTP request's
+/// [`http::HeaderMap`].
+///
+/// Used by [`crate::grpc::layer::inbound::InboundTraceService`] on every server-side
+/// gRPC call.
+pub struct GrpcHeaderExtractor<'a>(pub &'a http::HeaderMap);
+
+impl Extractor for GrpcHeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(http::header::HeaderName::as_str).collect()
+    }
+}

--- a/crates/shared/transport/src/propagation/kafka.rs
+++ b/crates/shared/transport/src/propagation/kafka.rs
@@ -1,0 +1,70 @@
+use opentelemetry::propagation::{Extractor, Injector};
+use rdkafka::message::{BorrowedHeaders, Header, Headers, OwnedHeaders};
+
+/// Mutable carrier that injects W3C TraceContext into a Kafka [`OwnedHeaders`] builder.
+///
+/// `OwnedHeaders::insert` uses a consuming builder pattern, so ownership is temporarily
+/// moved out via `std::mem::replace` and then moved back after each insertion.
+///
+/// Obtain the final headers by consuming the injector:
+/// ```rust,ignore
+/// let mut injector = KafkaHeaderInjector::new();
+/// inject_context(&mut injector);
+/// let headers: OwnedHeaders = injector.into_headers();
+/// ```
+pub struct KafkaHeaderInjector(OwnedHeaders);
+
+impl KafkaHeaderInjector {
+    pub fn new() -> Self {
+        Self(OwnedHeaders::new())
+    }
+
+    pub fn into_headers(self) -> OwnedHeaders {
+        self.0
+    }
+}
+
+impl Default for KafkaHeaderInjector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Injector for KafkaHeaderInjector {
+    fn set(&mut self, key: &str, value: String) {
+        // OwnedHeaders::insert takes `self` and returns `Self`, so we swap
+        // ownership in-place to satisfy the `&mut self` Injector contract.
+        let headers = std::mem::replace(&mut self.0, OwnedHeaders::new());
+        self.0 = headers.insert(Header {
+            key,
+            value: Some(value.as_str()),
+        });
+    }
+}
+
+/// Read-only carrier that extracts W3C TraceContext from incoming Kafka message headers.
+///
+/// The underlying [`BorrowedHeaders`] borrows from the rdkafka message and is valid for
+/// the lifetime of the [`rdkafka::message::BorrowedMessage`] it came from.
+pub struct KafkaHeaderExtractor<'a>(pub &'a BorrowedHeaders);
+
+impl<'a> Extractor for KafkaHeaderExtractor<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        (0..self.0.count()).find_map(|i| {
+            let header = self.0.get(i);
+            if header.key == key {
+                header
+                    .value
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        (0..self.0.count())
+            .map(|i| self.0.get(i).key)
+            .collect()
+    }
+}

--- a/crates/shared/transport/src/propagation/mod.rs
+++ b/crates/shared/transport/src/propagation/mod.rs
@@ -1,0 +1,5 @@
+pub mod carrier;
+pub mod grpc;
+pub mod kafka;
+
+pub use carrier::{extract_context, inject_context};


### PR DESCRIPTION
…mmunication

Introduces crates/shared/transport — the platform-wide communication layer:

- propagation/: MetadataCarrier supertrait (Injector + Extractor) with carrier impls for http::HeaderMap (gRPC) and rdkafka OwnedHeaders/BorrowedHeaders (Kafka), plus inject_context / extract_context free functions wired to the global OTel propagator

- grpc/layer/: InboundTraceLayer (server-side, BoxFuture, W3C context extraction + parent span wiring) and OutboundTraceLayer (client-side, zero-cost, S::Future unchanged)

- grpc/client/: GrpcClientBuilder with TLS support; build_traced() returns OutboundTraceService<Channel> (concrete, cloneable); RetryLayer intentionally absent at HTTP/2 transport level — bodies are streams and cannot be replayed

- grpc/server/: GrpcServerBuilder returning TracedGrpcServer type alias (Server<Stack<InboundTraceLayer, Identity>>) with pre-wired inbound trace extraction

- kafka/: EventEnvelope<T>, KafkaProducerHandle (trace headers injected on every publish via KafkaHeaderInjector), KafkaConsumerHandle (trace headers extracted and parent span set before every deserialization), full config hierarchy (KafkaClientConfig → ProducerConfig / ConsumerConfig)

- codec/: JSON and Protobuf encode/decode returning CodecError → TransportError

- README.md: full interface contract with stack diagrams, env vars, and bootstrap sequence