### PR TITLE
feat(auth): implement provider-agnostic JWT validation and identity p…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-context"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "cqrs",
+ "jsonwebtoken",
+ "reqwest",
+ "rsa",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "auth-test-utils"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ members = [
     "crates/shared/cqrs",
     "crates/shared/storage/postgres",
     "crates/shared/storage/scylla",
-    "crates/shared/storage/redis",
+    "crates/shared/storage/redis", "crates/shared/auth-context",
     # "crates/comment",
 ]
 resolver = "2"

--- a/crates/shared/auth-context/Cargo.toml
+++ b/crates/shared/auth-context/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name         = "auth-context"
+version.workspace     = true
+edition.workspace     = true
+license.workspace     = true
+authors.workspace     = true
+repository.workspace  = true
+description           = "Provider-agnostic JWT validation and task-local identity propagation for the core-platform."
+
+[features]
+default           = []
+cqrs-integration  = ["dep:cqrs"]
+
+[dependencies]
+# Intra-workspace
+cqrs = { path = "../cqrs", optional = true }
+
+# Async runtime
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }
+
+# Serialisation
+serde      = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Observability
+tracing = { workspace = true }
+
+# JWT / JWKS
+jsonwebtoken = { workspace = true }
+
+# HTTP client for JWKS fetch
+reqwest = { workspace = true }
+
+# Identifiers
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio              = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }
+tracing-subscriber = { workspace = true }
+serde_json         = { workspace = true }
+base64             = { workspace = true }
+# RSA key-pair generation for offline test tokens (not used in production code).
+# rsa 0.9 depends on rand_core 0.6; we must use its re-exported OsRng to avoid
+# the version-split between the workspace rand (rand_core 0.9) and rsa.
+rsa = { version = "0.9", features = ["pem"] }

--- a/crates/shared/auth-context/README.md
+++ b/crates/shared/auth-context/README.md
@@ -1,0 +1,310 @@
+# auth-context — Provider-agnostic JWT validation & task-local identity propagation
+
+## 🎯 Overview & Service Role
+
+`auth-context` is the platform's **security translator**: it sits at every service's inbound boundary, converts an opaque Bearer token into a strongly-typed [`CurrentPrincipal<C>`], and makes that identity available throughout the entire async call-stack without threading it through every function signature.
+
+**Core technical objectives:**
+
+- **Zero network overhead per request** — public keys are fetched once from the OIDC JWKS endpoint by a background Tokio task and stored in a lock-optimised in-memory cache. Every token verification is a pure CPU operation on the hot path.
+- **Provider agnosticism** — supports Keycloak (`realm_access.roles`), Auth0 (`permissions` array), Okta (`groups`), and any OIDC-compliant issuer via the pluggable [`ClaimsExtractor<C>`] strategy trait.
+- **Type-safe identity** — raw claims travel with the principal as a generic type parameter `C`, giving business logic full access to provider-specific fields without a second decode pass.
+- **Transparent propagation** — `tokio::task_local!` storage integrates with the CQRS `Envelope<T>` metadata map and `tracing` spans with two one-liner calls.
+
+---
+
+## 📐 Architecture & Concepts
+
+### Verification pipeline (per request)
+
+```
+  Bearer token string
+        │
+        ▼
+  decode_header()          ← extract kid — no crypto yet
+        │
+        ▼
+  JwksCache::get(kid)      ← O(1), shared RwLock read
+        │
+        ▼
+  jsonwebtoken::decode()   ← RS256 / ES256 signature + exp/nbf/iss/aud
+        │
+        ▼
+  ClaimsExtractor::extract ← raw C → CurrentPrincipal<C>
+        │
+        ▼
+  with_principal(p, fut)   ← bind to tokio::task_local!
+        │
+        ▼
+  inject_into_span()       ← enrich tracing span
+  inject_into_envelope(e)  ← stamp Envelope<T>::metadata
+```
+
+### Background JWKS refresh loop
+
+```
+  ┌─ JwksRefresher::spawn() ──────────────────────────────────┐
+  │                                                           │
+  │  loop {                                                   │
+  │    sleep(delay)                 ← 0 on first iteration   │
+  │    match JwksClient::fetch()                              │
+  │      Ok(keys) → JwksCache::replace(keys)  delay = interval│
+  │      Err(e)   → WARN log          delay = backoff (2×)   │
+  │  }                                backoff ≤ max_backoff  │
+  └───────────────────────────────────────────────────────────┘
+```
+
+### Resilience guarantees
+
+| Scenario | Behaviour |
+|---|---|
+| JWKS endpoint temporarily unreachable | Stale keys remain in cache; exponential backoff (1 s → `max_backoff`) |
+| Key rotation at IdP | New key picked up within one `refresh_interval`; tokens with old `kid` return `UnknownKid` |
+| Cache empty at startup | First fetch is immediate (zero delay); requests arriving before first fetch get `UnknownKid` |
+| Decoding CPU burst | `JwtDecoder::decode` is sync-on-the-executor; no `spawn_blocking` needed for ≤ 4096-bit RSA |
+| `tokio::spawn` isolation | Task-local principal is NOT propagated to spawned sub-tasks — explicit `with_principal()` required |
+
+---
+
+## 🔌 Public Interfaces & API Contract
+
+### Core types
+
+```rust
+/// Opaque platform user identifier (wraps the raw JWT `sub` string).
+pub struct PrincipalId(pub String);
+
+/// A single normalised permission token (e.g. `"posts:write"`, `"ROLE_ADMIN"`).
+pub struct Permission(pub String);
+
+/// Canonical in-process identity extracted from a verified JWT.
+pub struct CurrentPrincipal<C> {
+    pub user_id:     PrincipalId,
+    pub tenant_id:   Option<String>,
+    pub permissions: Vec<Permission>,
+    pub raw_claims:  C,              // provider-specific; preserved verbatim
+}
+```
+
+### Strategy trait
+
+```rust
+pub trait ClaimsExtractor<C>: Send + Sync + 'static {
+    fn extract(&self, raw: C) -> Result<CurrentPrincipal<C>, AuthError>;
+}
+```
+
+### JWKS cache
+
+```rust
+impl JwksCache {
+    pub fn new() -> Self;
+    pub async fn get(&self, kid: &str) -> Option<DecodingKey>;
+    pub async fn replace(&self, keys: HashMap<String, DecodingKey>);
+    pub async fn len(&self) -> usize;
+    pub async fn is_empty(&self) -> bool;
+}
+```
+
+### JWT decoder
+
+```rust
+impl<C, E: ClaimsExtractor<C>> JwtDecoder<C, E> {
+    pub fn new(config: &AuthContextConfig, cache: JwksCache, extractor: E) -> Self;
+    pub async fn decode(&self, token: &str) -> Result<CurrentPrincipal<C>, AuthError>;
+}
+```
+
+### Task-local context API
+
+```rust
+pub fn with_principal<P, Fut>(principal: Arc<P>, future: Fut) -> impl Future<Output = Fut::Output>
+where P: AnyPrincipal + 'static, Fut: Future;
+
+pub fn current_principal() -> Option<Arc<dyn AnyPrincipal>>;
+
+pub fn inject_into_span();                                // always available
+
+#[cfg(feature = "cqrs-integration")]
+pub fn inject_into_envelope<T>(envelope: &mut cqrs::Envelope<T>);
+```
+
+### Error variants
+
+```rust
+pub enum AuthError {
+    InvalidSignature,
+    TokenExpired,
+    TokenNotYetValid,
+    MissingKid,
+    UnknownKid(String),
+    JwksUnavailable(String),
+    MalformedToken(String),
+    InvalidAudience,
+    InvalidIssuer,
+    ClaimsExtractionFailed(String),
+}
+```
+
+---
+
+## 📦 Integration & Usage
+
+### `Cargo.toml`
+
+```toml
+[dependencies]
+auth-context = { path = "../../crates/shared/auth-context" }
+# or with CQRS envelope injection:
+auth-context = { path = "../../crates/shared/auth-context", features = ["cqrs-integration"] }
+```
+
+### Standard bootstrap pattern
+
+```rust
+use std::sync::Arc;
+use auth_context::{
+    AuthContextConfig, JwksCache, JwksClient, JwksRefresher, JwtDecoder,
+    OidcClaimsExtractor, OidcExtractorConfig, with_principal, inject_into_span,
+};
+
+#[tokio::main]
+async fn main() {
+    let config = Arc::new(AuthContextConfig {
+        jwks_url: std::env::var("JWKS_URL").expect("JWKS_URL required"),
+        expected_issuer:  Some(std::env::var("OIDC_ISSUER").expect("OIDC_ISSUER required")),
+        expected_audience: Some(std::env::var("OIDC_AUDIENCE").expect("OIDC_AUDIENCE required")),
+        ..Default::default()
+    });
+
+    let cache = JwksCache::new();
+    let client = JwksClient::new(&config.jwks_url, config.fetch_timeout);
+
+    // Warm the cache immediately, then refresh on schedule.
+    let _refresher = JwksRefresher::spawn(
+        client,
+        cache.clone(),
+        config.refresh_interval,
+        config.max_backoff,
+    );
+
+    let decoder = Arc::new(JwtDecoder::new(
+        &config,
+        cache,
+        OidcClaimsExtractor::new(OidcExtractorConfig::default()),
+    ));
+
+    // Inside a request handler:
+    let bearer_token = extract_bearer_from_header(/* ... */);
+
+    let principal = Arc::new(decoder.decode(&bearer_token).await?);
+
+    with_principal(principal, async {
+        inject_into_span();            // enriches the current tracing span
+        // inject_into_envelope(&mut env); // with feature = "cqrs-integration"
+        handle_request().await
+    }).await
+}
+```
+
+---
+
+## ⚙️ Configuration & Runtime Environment
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `JWKS_URL` | **Yes** | — | Full JWKS endpoint URL (e.g. `https://idp/realms/x/protocol/openid-connect/certs`) |
+| `OIDC_ISSUER` | Recommended | `None` | Expected `iss` claim value; disabling issuer check is not recommended for production |
+| `OIDC_AUDIENCE` | Recommended | `None` | Expected `aud` claim value; disabling is acceptable only on fully-trusted internal networks |
+| `AUTH_REFRESH_INTERVAL_SECS` | No | `300` | JWKS cache refresh period in seconds |
+| `AUTH_MAX_BACKOFF_SECS` | No | `60` | Maximum exponential backoff on JWKS fetch failure |
+| `AUTH_CLOCK_SKEW_SECS` | No | `5` | Leeway applied to `exp` and `nbf` checks |
+| `AUTH_FETCH_TIMEOUT_SECS` | No | `10` | Per-request HTTP timeout for JWKS fetches |
+
+### Cargo feature flags
+
+| Feature | Default | Effect |
+|---|---|---|
+| `cqrs-integration` | off | Enables `inject_into_envelope()` and a dep on `crates/shared/cqrs` |
+
+---
+
+## 📈 Telemetry, Performance & Metrics
+
+### Execution prerequisites
+
+- Tokio multi-thread runtime (`#[tokio::main]` or `Runtime::new()`).
+- A reachable JWKS endpoint at startup is not strictly required — the refresher backs off gracefully — but requests will return `UnknownKid` until the first successful fetch.
+
+### Emitted tracing events
+
+| Level | Event | Key fields |
+|---|---|---|
+| `INFO` | JWKS cache refreshed | `key_count`, `next_refresh_secs` |
+| `WARN` | JWKS refresh failed | `error`, `retry_after_secs` |
+| `DEBUG` | JWKS key loaded | `kid`, `kty` |
+| `WARN` | Undecodable JWKS key skipped | `kid`, `kty`, `reason` |
+
+### Recommended OTel / Prometheus alerts
+
+| Alert | Condition | Severity |
+|---|---|---|
+| `auth_jwks_fetch_failure` | `WARN` log rate > 3 per minute sustained | **P2** — IdP connectivity issue |
+| `auth_unknown_kid_rate` | `UnknownKid` error rate > 1 % of requests | **P3** — possible key rotation lag |
+| `auth_token_expired_rate` | `TokenExpired` error rate > 5 % of requests | **P3** — client-side token management issue |
+| `auth_cache_empty` | `JwksCache::is_empty()` true for > 30 s | **P1** — service cannot authenticate any request |
+
+---
+
+## 🛠️ Local Development & Contribution
+
+```bash
+# Build
+cargo build -p auth-context
+
+# Unit + integration tests (no external services needed)
+cargo test -p auth-context
+
+# With CQRS integration feature
+cargo test -p auth-context --features cqrs-integration
+
+# Lint
+cargo clippy -p auth-context -- -D warnings
+
+# Format check
+cargo fmt -p auth-context -- --check
+```
+
+**No `docker compose` is required.** All tests use in-process RSA key generation and a pre-seeded `JwksCache` — there is no live IdP dependency.
+
+---
+
+## 🚨 Troubleshooting & Runbook
+
+### `UnknownKid` errors on every request immediately after deploy
+
+**Root cause:** The `JwksRefresher` background task has not completed its first fetch yet, or the JWKS endpoint returned a key set that does not include the `kid` embedded in the tokens being issued.
+
+**Mitigation:**
+1. Check logs for `"JWKS refresh failed"` WARN entries — the `error` field contains the underlying HTTP error.
+2. Verify `JWKS_URL` resolves from inside the container (`curl $JWKS_URL`).
+3. Confirm the IdP is issuing tokens with a `kid` that matches a key published in the JWKS document.
+
+---
+
+### `InvalidSignature` errors after key rotation
+
+**Root cause:** The IdP rotated its signing key and issued new tokens before the `JwksRefresher` picked up the new key. The old `DecodingKey` in the cache no longer matches.
+
+**Mitigation:**
+1. Reduce `AUTH_REFRESH_INTERVAL_SECS` during the rotation window (e.g. to `30`).
+2. Ensure the IdP publishes the new key in JWKS *before* it starts issuing tokens signed with it (standard OIDC rotation protocol).
+3. Trigger a manual cache refresh by restarting the process if interval-based recovery is too slow.
+
+---
+
+### `ClaimsExtractionFailed: JWT 'sub' claim is absent or empty`
+
+**Root cause:** The IdP is issuing client-credentials-flow tokens or machine-to-machine tokens where the `sub` claim is absent or set to the client ID rather than a user identifier.
+
+**Mitigation:** Implement a custom `ClaimsExtractor<C>` that maps the client ID (`azp`, `client_id`) to `user_id` for service-account flows, and register it in place of `OidcClaimsExtractor`.

--- a/crates/shared/auth-context/src/config.rs
+++ b/crates/shared/auth-context/src/config.rs
@@ -1,0 +1,68 @@
+use std::time::Duration;
+
+/// Runtime configuration for the auth-context layer.
+///
+/// Build one instance per process and share it (via `Arc<AuthContextConfig>` or
+/// by cloning) wherever the [`JwksRefresher`] and [`JwtDecoder`] are constructed.
+///
+/// [`JwksRefresher`]: crate::JwksRefresher
+/// [`JwtDecoder`]: crate::JwtDecoder
+#[derive(Debug, Clone)]
+pub struct AuthContextConfig {
+    /// Full URL of the OIDC JWKS endpoint.
+    ///
+    /// Examples:
+    /// - Keycloak: `https://keycloak.example.com/realms/platform/protocol/openid-connect/certs`
+    /// - Auth0:    `https://your-tenant.auth0.com/.well-known/jwks.json`
+    /// - Okta:     `https://your-org.okta.com/oauth2/default/v1/keys`
+    pub jwks_url: String,
+
+    /// Interval between successful JWKS refreshes.
+    ///
+    /// Production default: 5 minutes. Key rotation events typically have a
+    /// multi-hour propagation window, so this interval is intentionally
+    /// conservative to avoid thundering-herd against the IdP.
+    pub refresh_interval: Duration,
+
+    /// Maximum backoff applied when the JWKS endpoint is unreachable.
+    ///
+    /// The refresher starts at 1 s and doubles on each consecutive failure,
+    /// capping at this value. Stale keys remain in the cache throughout.
+    pub max_backoff: Duration,
+
+    /// Expected `aud` claim value.
+    ///
+    /// Set to `Some("my-api-resource-identifier")` to enable audience validation.
+    /// `None` disables the check — acceptable only when the JWT never leaves an
+    /// internal, fully-trusted network boundary.
+    pub expected_audience: Option<String>,
+
+    /// Expected `iss` claim value.
+    ///
+    /// Set to the exact issuer URL advertised in the OIDC discovery document.
+    /// `None` disables issuer validation (not recommended for production).
+    pub expected_issuer: Option<String>,
+
+    /// Tolerance applied to `exp` and `nbf` timestamp checks.
+    ///
+    /// Absorbs minor clock drift between the token issuer and this service.
+    /// Keep ≤ 60 s in production to avoid issuing meaningful grace windows.
+    pub clock_skew: Duration,
+
+    /// Per-request HTTP timeout for JWKS fetch calls.
+    pub fetch_timeout: Duration,
+}
+
+impl Default for AuthContextConfig {
+    fn default() -> Self {
+        Self {
+            jwks_url: String::new(),
+            refresh_interval: Duration::from_secs(300),
+            max_backoff: Duration::from_secs(60),
+            expected_audience: None,
+            expected_issuer: None,
+            clock_skew: Duration::from_secs(5),
+            fetch_timeout: Duration::from_secs(10),
+        }
+    }
+}

--- a/crates/shared/auth-context/src/context/mod.rs
+++ b/crates/shared/auth-context/src/context/mod.rs
@@ -1,0 +1,6 @@
+pub mod task_local;
+
+pub use task_local::{AnyPrincipal, current_principal, inject_into_span, with_principal};
+
+#[cfg(feature = "cqrs-integration")]
+pub use task_local::inject_into_envelope;

--- a/crates/shared/auth-context/src/context/task_local.rs
+++ b/crates/shared/auth-context/src/context/task_local.rs
@@ -1,0 +1,160 @@
+use std::any::Any;
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::{CurrentPrincipal, Permission, PrincipalId};
+
+// ── Object-safe principal facade ─────────────────────────────────────────────
+
+/// Object-safe view over a [`CurrentPrincipal<C>`] for type-erased task-local
+/// storage.
+///
+/// Exposes only the provider-agnostic fields so telemetry middleware and
+/// envelope injection helpers can operate without knowing the concrete `C` type.
+/// Use [`as_any`] to downcast back to `CurrentPrincipal<C>` when the concrete
+/// type is available in scope.
+///
+/// [`as_any`]: AnyPrincipal::as_any
+pub trait AnyPrincipal: Send + Sync {
+    fn user_id(&self) -> &PrincipalId;
+    fn tenant_id(&self) -> Option<&str>;
+    fn permissions(&self) -> &[Permission];
+
+    /// Enables downcasting to the concrete `CurrentPrincipal<C>` type when
+    /// the caller knows `C` at the point of use.
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<C: Send + Sync + 'static> AnyPrincipal for CurrentPrincipal<C> {
+    fn user_id(&self) -> &PrincipalId {
+        &self.user_id
+    }
+
+    fn tenant_id(&self) -> Option<&str> {
+        self.tenant_id.as_deref()
+    }
+
+    fn permissions(&self) -> &[Permission] {
+        &self.permissions
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Task-local storage ────────────────────────────────────────────────────────
+
+tokio::task_local! {
+    /// The authenticated principal bound to the current async task.
+    ///
+    /// Set by [`with_principal`]; read by [`current_principal`].
+    /// Absent outside of a [`with_principal`] scope — `try_with` returns `None`.
+    static CURRENT_PRINCIPAL: Arc<dyn AnyPrincipal>;
+}
+
+// ── Public lifecycle API ──────────────────────────────────────────────────────
+
+/// Runs `future` with `principal` bound to the task-local identity slot.
+///
+/// All code within `future` — including calls across `.await` points on the
+/// same logical task — can retrieve the principal via [`current_principal`]
+/// without passing it through function signatures.
+///
+/// Nesting is supported: an inner [`with_principal`] call shadows the outer
+/// one for its subtree, restoring the original on exit.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let principal = Arc::new(CurrentPrincipal { ... });
+///
+/// with_principal(principal, async {
+///     // current_principal() is Some(...) here
+///     some_service_call().await;
+/// }).await;
+///
+/// // current_principal() is None again here
+/// ```
+pub fn with_principal<P, Fut>(principal: Arc<P>, future: Fut) -> impl Future<Output = Fut::Output>
+where
+    P: AnyPrincipal + 'static,
+    Fut: Future,
+{
+    CURRENT_PRINCIPAL.scope(principal as Arc<dyn AnyPrincipal>, future)
+}
+
+/// Returns the principal currently bound to this task, or `None` if called
+/// outside a [`with_principal`] scope.
+pub fn current_principal() -> Option<Arc<dyn AnyPrincipal>> {
+    CURRENT_PRINCIPAL.try_with(Arc::clone).ok()
+}
+
+// ── Integration helpers ───────────────────────────────────────────────────────
+
+/// Enriches the *current* `tracing` span with the identity fields of the
+/// task-local principal.
+///
+/// ## Fields written
+///
+/// | Span field             | Source                        |
+/// |------------------------|-------------------------------|
+/// | `principal.user_id`    | [`PrincipalId`] string        |
+/// | `principal.tenant_id`  | Tenant string (if present)    |
+///
+/// ## Pre-requisites
+///
+/// The surrounding span must declare these fields as `Empty` for the record
+/// call to take effect:
+///
+/// ```rust,ignore
+/// #[tracing::instrument(fields(
+///     principal.user_id  = tracing::field::Empty,
+///     principal.tenant_id = tracing::field::Empty,
+/// ))]
+/// async fn my_handler(...) {
+///     inject_into_span();
+///     // ...
+/// }
+/// ```
+///
+/// This is a no-op when called outside a [`with_principal`] scope.
+pub fn inject_into_span() {
+    if let Some(p) = current_principal() {
+        let span = tracing::Span::current();
+        span.record("principal.user_id", p.user_id().as_str());
+        if let Some(tid) = p.tenant_id() {
+            span.record("principal.tenant_id", tid);
+        }
+    }
+}
+
+/// Injects the task-local principal's identity into an [`Envelope`]'s
+/// `metadata` map.
+///
+/// ## Keys written
+///
+/// | Metadata key           | Value                         |
+/// |------------------------|-------------------------------|
+/// | `principal.user_id`    | [`PrincipalId`] string        |
+/// | `principal.tenant_id`  | Tenant string (if present)    |
+///
+/// This is a no-op when called outside a [`with_principal`] scope.
+///
+/// Requires the `cqrs-integration` Cargo feature.
+///
+/// [`Envelope`]: cqrs::Envelope
+#[cfg(feature = "cqrs-integration")]
+pub fn inject_into_envelope<T>(envelope: &mut cqrs::Envelope<T>) {
+    if let Some(p) = current_principal() {
+        envelope.metadata.insert(
+            "principal.user_id".to_owned(),
+            p.user_id().to_string(),
+        );
+        if let Some(tid) = p.tenant_id() {
+            envelope
+                .metadata
+                .insert("principal.tenant_id".to_owned(), tid.to_owned());
+        }
+    }
+}

--- a/crates/shared/auth-context/src/decoder/jwt.rs
+++ b/crates/shared/auth-context/src/decoder/jwt.rs
@@ -1,0 +1,162 @@
+use std::marker::PhantomData;
+
+use jsonwebtoken::{decode, decode_header, Algorithm, Validation};
+use serde::de::DeserializeOwned;
+
+use crate::{AuthContextConfig, AuthError, ClaimsExtractor, CurrentPrincipal, JwksCache};
+
+/// Stateless JWT verifier that delegates cryptographic key lookup to [`JwksCache`]
+/// and claim transformation to a [`ClaimsExtractor`].
+///
+/// ## Verification pipeline
+///
+/// ```text
+/// raw token string
+///   │
+///   ▼
+/// decode_header()          ← extract kid (no signature check yet)
+///   │
+///   ▼
+/// JwksCache::get(kid)      ← O(1) in-memory read under a shared RwLock
+///   │
+///   ▼
+/// jsonwebtoken::decode()   ← verify RS256/ES256 signature + exp/nbf/iss/aud
+///   │
+///   ▼
+/// ClaimsExtractor::extract ← map raw claims → CurrentPrincipal<C>
+/// ```
+///
+/// ## Thread safety
+///
+/// `JwtDecoder` is `Clone + Send + Sync`. Wrap in `Arc` and share across all
+/// request handlers in the process.
+///
+/// ## Generic parameters
+///
+/// - `C` — the concrete claim struct (e.g. [`crate::OidcClaims`]). Must be
+///   `DeserializeOwned + Send + Sync + 'static`.
+/// - `E` — the [`ClaimsExtractor`] implementation.
+pub struct JwtDecoder<C, E>
+where
+    C: DeserializeOwned + Send + Sync + 'static,
+    E: ClaimsExtractor<C>,
+{
+    cache: JwksCache,
+    extractor: E,
+    validation: Validation,
+    _marker: PhantomData<fn() -> C>,
+}
+
+impl<C, E> JwtDecoder<C, E>
+where
+    C: DeserializeOwned + Send + Sync + 'static,
+    E: ClaimsExtractor<C>,
+{
+    /// Constructs a decoder from an [`AuthContextConfig`], a pre-seeded (or
+    /// empty) [`JwksCache`], and a [`ClaimsExtractor`].
+    ///
+    /// Pass the *same* `JwksCache` instance to both [`JwksRefresher::spawn`]
+    /// and this constructor so key rotations are picked up transparently.
+    ///
+    /// [`JwksRefresher::spawn`]: crate::JwksRefresher::spawn
+    pub fn new(config: &AuthContextConfig, cache: JwksCache, extractor: E) -> Self {
+        let mut validation = Validation::new(Algorithm::RS256);
+
+        match &config.expected_audience {
+            Some(aud) => validation.set_audience(&[aud.as_str()]),
+            None => validation.validate_aud = false,
+        }
+
+        if let Some(ref iss) = config.expected_issuer {
+            validation.set_issuer(&[iss.as_str()]);
+        }
+
+        validation.leeway = config.clock_skew.as_secs();
+
+        Self {
+            cache,
+            extractor,
+            validation,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Constructs a decoder that also accepts ES256 tokens.
+    ///
+    /// Use this when the JWKS may contain both RSA and EC keys.
+    pub fn with_algorithms(
+        config: &AuthContextConfig,
+        cache: JwksCache,
+        extractor: E,
+        algorithms: Vec<Algorithm>,
+    ) -> Self {
+        let mut decoder = Self::new(config, cache, extractor);
+        decoder.validation = {
+            let mut v = Validation::new(algorithms[0]);
+            v.algorithms = algorithms;
+            if let Some(ref aud) = config.expected_audience {
+                v.set_audience(&[aud.as_str()]);
+            } else {
+                v.validate_aud = false;
+            }
+            if let Some(ref iss) = config.expected_issuer {
+                v.set_issuer(&[iss.as_str()]);
+            }
+            v.leeway = config.clock_skew.as_secs();
+            v
+        };
+        decoder
+    }
+
+    /// Verifies `token` and returns the extracted [`CurrentPrincipal`].
+    ///
+    /// This method is `async` because the cache lookup acquires a
+    /// `tokio::sync::RwLock`. The actual cryptographic work is synchronous
+    /// (CPU-bound on the calling thread), so avoid spawning this inside a
+    /// `spawn_blocking` — the work is short and not I/O-bound.
+    ///
+    /// # Errors
+    ///
+    /// | Variant | Condition |
+    /// |---------|-----------|
+    /// | [`AuthError::MissingKid`]           | No `kid` in JWT header        |
+    /// | [`AuthError::UnknownKid`]           | `kid` not found in cache      |
+    /// | [`AuthError::InvalidSignature`]     | Signature mismatch            |
+    /// | [`AuthError::TokenExpired`]         | `exp` exceeded (+ leeway)     |
+    /// | [`AuthError::TokenNotYetValid`]     | `nbf` in the future           |
+    /// | [`AuthError::InvalidAudience`]      | `aud` mismatch                |
+    /// | [`AuthError::InvalidIssuer`]        | `iss` mismatch                |
+    /// | [`AuthError::MalformedToken`]       | Structural / algorithm error  |
+    /// | [`AuthError::ClaimsExtractionFailed`] | Extractor rejected claims   |
+    pub async fn decode(&self, token: &str) -> Result<CurrentPrincipal<C>, AuthError> {
+        let header =
+            decode_header(token).map_err(|e| AuthError::MalformedToken(e.to_string()))?;
+
+        let kid = header.kid.ok_or(AuthError::MissingKid)?;
+
+        let decoding_key = self
+            .cache
+            .get(&kid)
+            .await
+            .ok_or_else(|| AuthError::UnknownKid(kid.clone()))?;
+
+        let token_data = decode::<C>(token, &decoding_key, &self.validation)
+            .map_err(map_jwt_error)?;
+
+        self.extractor.extract(token_data.claims)
+    }
+}
+
+// ── Error mapping ─────────────────────────────────────────────────────────────
+
+fn map_jwt_error(e: jsonwebtoken::errors::Error) -> AuthError {
+    use jsonwebtoken::errors::ErrorKind;
+    match e.kind() {
+        ErrorKind::ExpiredSignature => AuthError::TokenExpired,
+        ErrorKind::ImmatureSignature => AuthError::TokenNotYetValid,
+        ErrorKind::InvalidSignature => AuthError::InvalidSignature,
+        ErrorKind::InvalidAudience => AuthError::InvalidAudience,
+        ErrorKind::InvalidIssuer => AuthError::InvalidIssuer,
+        _ => AuthError::MalformedToken(e.to_string()),
+    }
+}

--- a/crates/shared/auth-context/src/decoder/mod.rs
+++ b/crates/shared/auth-context/src/decoder/mod.rs
@@ -1,0 +1,3 @@
+pub mod jwt;
+
+pub use jwt::JwtDecoder;

--- a/crates/shared/auth-context/src/error.rs
+++ b/crates/shared/auth-context/src/error.rs
@@ -1,0 +1,61 @@
+use thiserror::Error;
+
+/// All failure modes that can be returned by the auth-context layer.
+///
+/// The variants are intentionally coarse enough to be safe to surface to
+/// callers (no internal implementation details leak), but granular enough
+/// for structured log filtering and operational alerting.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// The JWT cryptographic signature does not match the public key.
+    #[error("JWT signature is invalid")]
+    InvalidSignature,
+
+    /// The `exp` claim is in the past (beyond the configured clock-skew leeway).
+    #[error("JWT has expired")]
+    TokenExpired,
+
+    /// The `nbf` claim is in the future (beyond the configured clock-skew leeway).
+    #[error("JWT is not yet valid (nbf constraint violated)")]
+    TokenNotYetValid,
+
+    /// The JWT header is present but does not contain a `kid` field.
+    ///
+    /// Both the OIDC spec and the JWKS key-lookup algorithm require `kid`.
+    /// Tokens without it cannot be verified without trying every cached key.
+    #[error("JWT header is missing the required 'kid' field")]
+    MissingKid,
+
+    /// The `kid` from the JWT header has no matching key in the local JWKS cache.
+    ///
+    /// This may indicate key rotation in progress. The refresher will pick up
+    /// the new key on the next scheduled cycle.
+    #[error("no JWKS key found for kid '{0}'")]
+    UnknownKid(String),
+
+    /// The JWKS endpoint returned an error or was unreachable.
+    ///
+    /// The enclosed message contains the underlying HTTP or parsing error detail,
+    /// safe for operational logs but not for API error responses.
+    #[error("JWKS endpoint is unavailable: {0}")]
+    JwksUnavailable(String),
+
+    /// The token string is structurally invalid (not three base64url segments,
+    /// unsupported algorithm declared in the header, etc.).
+    #[error("JWT is malformed: {0}")]
+    MalformedToken(String),
+
+    /// The `aud` claim does not contain the expected audience value.
+    #[error("JWT audience validation failed")]
+    InvalidAudience,
+
+    /// The `iss` claim does not match the expected issuer URL.
+    #[error("JWT issuer validation failed")]
+    InvalidIssuer,
+
+    /// The [`ClaimsExtractor`] rejected the decoded claims.
+    ///
+    /// [`ClaimsExtractor`]: crate::ClaimsExtractor
+    #[error("claims extraction failed: {0}")]
+    ClaimsExtractionFailed(String),
+}

--- a/crates/shared/auth-context/src/extractor/mod.rs
+++ b/crates/shared/auth-context/src/extractor/mod.rs
@@ -1,0 +1,5 @@
+pub mod oidc;
+pub mod traits;
+
+pub use oidc::{OidcClaims, OidcClaimsExtractor, OidcExtractorConfig, RealmAccess, RoleSource};
+pub use traits::ClaimsExtractor;

--- a/crates/shared/auth-context/src/extractor/oidc.rs
+++ b/crates/shared/auth-context/src/extractor/oidc.rs
@@ -1,0 +1,231 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{AuthError, ClaimsExtractor, CurrentPrincipal, Permission, PrincipalId};
+
+// ── Raw claim types ──────────────────────────────────────────────────────────
+
+/// Standard OIDC JWT payload, extended to cover the proprietary role/scope
+/// layouts used by Keycloak, Auth0, and Okta.
+///
+/// Unknown claims fall through into [`extra`][OidcClaims::extra] via `#[serde(flatten)]`
+/// so no information is silently dropped.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcClaims {
+    /// Subject — the unique user identifier issued by the IdP.
+    pub sub: String,
+
+    /// Issuer URL.
+    pub iss: Option<String>,
+
+    /// Audience — a single string or a JSON array of strings.
+    pub aud: Option<serde_json::Value>,
+
+    /// Expiration timestamp (Unix seconds). Required by RFC 7519.
+    pub exp: i64,
+
+    /// Not-before timestamp (Unix seconds).
+    pub nbf: Option<i64>,
+
+    /// Issued-at timestamp (Unix seconds).
+    pub iat: Option<i64>,
+
+    /// JWT ID — unique identifier for this specific token instance.
+    pub jti: Option<String>,
+
+    /// Space-separated scope string (standard OIDC and Auth0).
+    pub scope: Option<String>,
+
+    /// Keycloak realm-level roles.
+    pub realm_access: Option<RealmAccess>,
+
+    /// Keycloak per-resource (client) roles, keyed by client ID.
+    pub resource_access: Option<HashMap<String, RealmAccess>>,
+
+    /// Auth0-style flat permissions array.
+    pub permissions: Option<Vec<String>>,
+
+    /// Okta / generic groups array.
+    pub groups: Option<Vec<String>>,
+
+    /// Tenant identifier — provider-specific claim key, resolved at runtime by
+    /// [`OidcExtractorConfig::tenant_id_claim`].
+    pub tid: Option<String>,
+
+    /// Catch-all for provider-specific or custom claims not listed above.
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Keycloak realm or resource access block containing a `roles` array.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealmAccess {
+    pub roles: Option<Vec<String>>,
+}
+
+// ── Extractor configuration ──────────────────────────────────────────────────
+
+/// Which JWT fields the [`OidcClaimsExtractor`] harvests permissions from.
+///
+/// Sources are evaluated in declaration order; duplicates are removed while
+/// preserving first-seen insertion order.
+#[derive(Debug, Clone)]
+pub enum RoleSource {
+    /// Space-separated `scope` claim (standard OIDC, Auth0).
+    Scope,
+
+    /// `realm_access.roles` array (Keycloak).
+    RealmAccessRoles,
+
+    /// `permissions` array (Auth0).
+    PermissionsClaim,
+
+    /// `groups` array (Okta, Azure AD, custom providers).
+    Groups,
+
+    /// Arbitrary top-level claim containing a JSON string array.
+    Custom(String),
+}
+
+/// Configuration for [`OidcClaimsExtractor`].
+#[derive(Debug, Clone)]
+pub struct OidcExtractorConfig {
+    /// Top-level claim key used to resolve the tenant identifier.
+    ///
+    /// The extractor first looks in [`OidcClaims::extra`] under this key, then
+    /// falls back to the typed [`OidcClaims::tid`] field.
+    /// Default: `"tid"`.
+    pub tenant_id_claim: String,
+
+    /// Ordered list of sources from which permissions are aggregated.
+    ///
+    /// Default: `[Scope, RealmAccessRoles, PermissionsClaim]` — covers standard
+    /// OIDC, Keycloak, and Auth0 without any configuration change.
+    pub role_sources: Vec<RoleSource>,
+}
+
+impl Default for OidcExtractorConfig {
+    fn default() -> Self {
+        Self {
+            tenant_id_claim: "tid".to_owned(),
+            role_sources: vec![
+                RoleSource::Scope,
+                RoleSource::RealmAccessRoles,
+                RoleSource::PermissionsClaim,
+            ],
+        }
+    }
+}
+
+// ── Extractor implementation ─────────────────────────────────────────────────
+
+/// Default [`ClaimsExtractor`] for standard OIDC-compliant providers.
+///
+/// Supports Keycloak, Auth0, Okta, and any custom issuer that follows the OIDC
+/// core specification. The permission aggregation strategy is fully configurable
+/// via [`OidcExtractorConfig`].
+///
+/// ## Permission deduplication
+///
+/// Permissions are collected from all configured [`RoleSource`] entries and
+/// deduplicated (preserving first-seen order) before being stored in
+/// [`CurrentPrincipal::permissions`].
+pub struct OidcClaimsExtractor {
+    config: OidcExtractorConfig,
+}
+
+impl OidcClaimsExtractor {
+    pub fn new(config: OidcExtractorConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for OidcClaimsExtractor {
+    fn default() -> Self {
+        Self::new(OidcExtractorConfig::default())
+    }
+}
+
+impl ClaimsExtractor<OidcClaims> for OidcClaimsExtractor {
+    fn extract(&self, raw: OidcClaims) -> Result<CurrentPrincipal<OidcClaims>, AuthError> {
+        if raw.sub.is_empty() {
+            return Err(AuthError::ClaimsExtractionFailed(
+                "JWT 'sub' claim is absent or empty".to_owned(),
+            ));
+        }
+
+        let user_id = PrincipalId::new(&raw.sub);
+
+        let tenant_id = raw
+            .extra
+            .get(&self.config.tenant_id_claim)
+            .and_then(|v| v.as_str())
+            .map(str::to_owned)
+            .or_else(|| raw.tid.clone());
+
+        let mut permissions: Vec<Permission> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+
+        let mut push = |value: &str| {
+            if seen.insert(value.to_owned()) {
+                permissions.push(Permission::new(value));
+            }
+        };
+
+        for source in &self.config.role_sources {
+            match source {
+                RoleSource::Scope => {
+                    if let Some(ref scope) = raw.scope {
+                        for token in scope.split_whitespace() {
+                            push(token);
+                        }
+                    }
+                }
+
+                RoleSource::RealmAccessRoles => {
+                    if let Some(ref realm) = raw.realm_access {
+                        if let Some(ref roles) = realm.roles {
+                            for role in roles {
+                                push(role);
+                            }
+                        }
+                    }
+                }
+
+                RoleSource::PermissionsClaim => {
+                    if let Some(ref perms) = raw.permissions {
+                        for perm in perms {
+                            push(perm);
+                        }
+                    }
+                }
+
+                RoleSource::Groups => {
+                    if let Some(ref groups) = raw.groups {
+                        for group in groups {
+                            push(group);
+                        }
+                    }
+                }
+
+                RoleSource::Custom(key) => {
+                    if let Some(val) = raw.extra.get(key) {
+                        if let Some(arr) = val.as_array() {
+                            for item in arr.iter().filter_map(|v| v.as_str()) {
+                                push(item);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(CurrentPrincipal {
+            user_id,
+            tenant_id,
+            permissions,
+            raw_claims: raw,
+        })
+    }
+}

--- a/crates/shared/auth-context/src/extractor/traits.rs
+++ b/crates/shared/auth-context/src/extractor/traits.rs
@@ -1,0 +1,42 @@
+use crate::{AuthError, CurrentPrincipal};
+
+/// Strategy for transforming raw JWT claims into a [`CurrentPrincipal`].
+///
+/// Implementations are injected into [`JwtDecoder`] at construction time.
+/// The decoder calls [`extract`] once per verified token — after the
+/// cryptographic signature check has already passed — so implementations can
+/// assume the claims are structurally valid and not tampered with.
+///
+/// # Implementing for a custom provider
+///
+/// ```rust,ignore
+/// use auth_context::{ClaimsExtractor, CurrentPrincipal, AuthError, Permission, PrincipalId};
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct MyClaims { sub: String, roles: Vec<String> }
+///
+/// struct MyExtractor;
+///
+/// impl ClaimsExtractor<MyClaims> for MyExtractor {
+///     fn extract(&self, raw: MyClaims) -> Result<CurrentPrincipal<MyClaims>, AuthError> {
+///         Ok(CurrentPrincipal {
+///             user_id: PrincipalId::new(&raw.sub),
+///             tenant_id: None,
+///             permissions: raw.roles.iter().map(Permission::new).collect(),
+///             raw_claims: raw,
+///         })
+///     }
+/// }
+/// ```
+///
+/// [`JwtDecoder`]: crate::JwtDecoder
+pub trait ClaimsExtractor<C>: Send + Sync + 'static {
+    /// Maps the provider-specific claim set `C` into a [`CurrentPrincipal<C>`].
+    ///
+    /// # Errors
+    ///
+    /// Return [`AuthError::ClaimsExtractionFailed`] when a required claim is
+    /// absent, has an unexpected type, or cannot be mapped to the platform model.
+    fn extract(&self, raw: C) -> Result<CurrentPrincipal<C>, AuthError>;
+}

--- a/crates/shared/auth-context/src/jwks/cache.rs
+++ b/crates/shared/auth-context/src/jwks/cache.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use jsonwebtoken::DecodingKey;
+use tokio::sync::RwLock;
+
+/// Thread-safe, in-memory store of JWKS decoding keys, keyed by `kid`.
+///
+/// ## Concurrency model
+///
+/// - **Reads** (`get`) acquire a shared `tokio::sync::RwLock` read guard.
+///   Hundreds of concurrent JWT decoders can call this simultaneously without
+///   contending against each other — they only contend against the single
+///   periodic writer.
+/// - **Writes** (`replace`) hold the write lock only for the duration of the
+///   `HashMap` pointer swap (nanoseconds), not for the network fetch itself.
+///   The [`JwksRefresher`] fetches the new key set over HTTP *before* acquiring
+///   the write lock, minimising the write-lock hold time.
+///
+/// ## Key rotation
+///
+/// `replace` does a full swap. During the brief window between a write finishing
+/// and the next read, a request arriving with the old `kid` will receive
+/// [`crate::AuthError::UnknownKid`]. This is the correct behaviour: if a key
+/// was rotated away at the IdP, it should no longer be trusted.
+///
+/// [`JwksRefresher`]: crate::JwksRefresher
+#[derive(Clone)]
+pub struct JwksCache {
+    inner: Arc<RwLock<HashMap<String, DecodingKey>>>,
+}
+
+impl JwksCache {
+    /// Creates an empty cache. The first successful JWKS fetch populates it.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Looks up the [`DecodingKey`] for `kid`.
+    ///
+    /// Returns a clone of the stored key so the read lock is not held by
+    /// the caller during subsequent JWT verification work.
+    pub async fn get(&self, kid: &str) -> Option<DecodingKey> {
+        self.inner.read().await.get(kid).cloned()
+    }
+
+    /// Atomically replaces the entire key set with `keys`.
+    ///
+    /// The write lock is held only for the pointer swap itself.
+    /// Called exclusively by [`JwksRefresher`] after a successful JWKS fetch.
+    ///
+    /// [`JwksRefresher`]: crate::JwksRefresher
+    pub async fn replace(&self, keys: HashMap<String, DecodingKey>) {
+        *self.inner.write().await = keys;
+    }
+
+    /// Returns the number of keys currently in the cache.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Returns `true` if the cache holds no keys.
+    ///
+    /// A `true` result at request time means the first JWKS fetch has not
+    /// completed yet — the refresher logs this condition at startup.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+impl Default for JwksCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/shared/auth-context/src/jwks/client.rs
+++ b/crates/shared/auth-context/src/jwks/client.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use jsonwebtoken::DecodingKey;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::AuthError;
+
+// ── Wire types ───────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct JwksResponse {
+    keys: Vec<JwkKey>,
+}
+
+#[derive(Deserialize)]
+struct JwkKey {
+    kid: String,
+    kty: String,
+    // RSA public key components (base64url-encoded, no padding)
+    n: Option<String>,
+    e: Option<String>,
+    // EC public key components
+    crv: Option<String>,
+    x: Option<String>,
+    y: Option<String>,
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Stateless HTTP client that fetches a JWKS document and converts each key
+/// into a [`DecodingKey`] ready for use by [`JwtDecoder`].
+///
+/// A single `JwksClient` instance is shared by the [`JwksRefresher`] background
+/// task across its entire lifetime. It carries no mutable state between fetches.
+///
+/// [`JwtDecoder`]: crate::JwtDecoder
+/// [`JwksRefresher`]: crate::JwksRefresher
+pub struct JwksClient {
+    http: Client,
+    url: String,
+}
+
+impl JwksClient {
+    /// Constructs a client targeting `url` with the given per-request `timeout`.
+    ///
+    /// The underlying `reqwest::Client` is built once and reused across all
+    /// fetches, sharing the connection pool.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the TLS backend cannot be initialised (extremely unlikely in
+    /// a correctly linked binary).
+    pub fn new(url: impl Into<String>, timeout: Duration) -> Self {
+        let http = Client::builder()
+            .timeout(timeout)
+            .https_only(false) // allow http:// in local/test deployments
+            .build()
+            .expect("failed to build JWKS HTTP client — TLS backend unavailable");
+
+        Self {
+            http,
+            url: url.into(),
+        }
+    }
+
+    /// Fetches the JWKS document and returns a map of `kid → DecodingKey`.
+    ///
+    /// Keys whose `kty` is unsupported (e.g. `oct`, `OKP`) are skipped with a
+    /// `WARN` log rather than causing the entire fetch to fail. This tolerates
+    /// mixed-type JWKS responses from providers that publish both signing and
+    /// encryption keys in the same set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::JwksUnavailable`] on any HTTP or parse failure.
+    pub async fn fetch(&self) -> Result<HashMap<String, DecodingKey>, AuthError> {
+        let response = self
+            .http
+            .get(&self.url)
+            .send()
+            .await
+            .map_err(|e| AuthError::JwksUnavailable(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(AuthError::JwksUnavailable(format!(
+                "JWKS endpoint returned HTTP {status}"
+            )));
+        }
+
+        let body: JwksResponse = response
+            .json()
+            .await
+            .map_err(|e| AuthError::JwksUnavailable(format!("JWKS parse error: {e}")))?;
+
+        let mut keys: HashMap<String, DecodingKey> = HashMap::with_capacity(body.keys.len());
+
+        for jwk in body.keys {
+            match Self::build_decoding_key(&jwk) {
+                Ok(key) => {
+                    tracing::debug!(kid = %jwk.kid, kty = %jwk.kty, "JWKS key loaded");
+                    keys.insert(jwk.kid, key);
+                }
+                Err(reason) => {
+                    tracing::warn!(kid = %jwk.kid, kty = %jwk.kty, %reason, "skipping undecodable JWKS key");
+                }
+            }
+        }
+
+        Ok(keys)
+    }
+
+    fn build_decoding_key(jwk: &JwkKey) -> Result<DecodingKey, String> {
+        match jwk.kty.as_str() {
+            "RSA" => {
+                let n = jwk.n.as_deref().ok_or("RSA key missing 'n'")?;
+                let e = jwk.e.as_deref().ok_or("RSA key missing 'e'")?;
+                DecodingKey::from_rsa_components(n, e)
+                    .map_err(|e| format!("RSA key construction failed: {e}"))
+            }
+
+            "EC" => {
+                let _crv = jwk.crv.as_deref().unwrap_or("P-256");
+                let x = jwk.x.as_deref().ok_or("EC key missing 'x'")?;
+                let y = jwk.y.as_deref().ok_or("EC key missing 'y'")?;
+                DecodingKey::from_ec_components(x, y)
+                    .map_err(|e| format!("EC key construction failed: {e}"))
+            }
+
+            kty => Err(format!("unsupported key type: {kty}")),
+        }
+    }
+}

--- a/crates/shared/auth-context/src/jwks/mod.rs
+++ b/crates/shared/auth-context/src/jwks/mod.rs
@@ -1,0 +1,7 @@
+pub mod cache;
+pub mod client;
+pub mod refresher;
+
+pub use cache::JwksCache;
+pub use client::JwksClient;
+pub use refresher::JwksRefresher;

--- a/crates/shared/auth-context/src/jwks/refresher.rs
+++ b/crates/shared/auth-context/src/jwks/refresher.rs
@@ -1,0 +1,97 @@
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio::time;
+
+use super::{JwksCache, JwksClient};
+
+/// Background Tokio task that keeps the [`JwksCache`] populated and fresh.
+///
+/// ## Lifecycle
+///
+/// 1. [`JwksRefresher::spawn`] immediately schedules the first fetch so that
+///    the cache is warm before the first HTTP request arrives at the service.
+/// 2. After each successful fetch the task sleeps for `refresh_interval`.
+/// 3. On failure the task applies exponential backoff starting at 1 s, doubling
+///    on each consecutive error, capped at `max_backoff`. The stale key set
+///    remains in the cache throughout — requests continue to be served until
+///    the IdP is reachable again.
+/// 4. Call [`JwksRefresher::shutdown`] during graceful process shutdown.
+///    The Tokio abort is clean because the task holds no `Drop`-sensitive
+///    resources (the `JwksClient` HTTP connection pool is owned by `reqwest`).
+///
+/// ## Observability
+///
+/// Every successful refresh emits `tracing::info!` with the `key_count` field.
+/// Every failed refresh emits `tracing::warn!` with the error and next
+/// retry interval, enabling alert rules on repeated WARN bursts.
+pub struct JwksRefresher {
+    handle: JoinHandle<()>,
+}
+
+impl JwksRefresher {
+    /// Spawns the background refresh task and returns immediately.
+    ///
+    /// The caller must hold the returned [`JwksRefresher`] for the full
+    /// lifetime of the process. Dropping it does **not** shut down the task
+    /// (the `JoinHandle` is detached on drop). Call [`shutdown`] explicitly.
+    ///
+    /// [`shutdown`]: JwksRefresher::shutdown
+    pub fn spawn(
+        client: JwksClient,
+        cache: JwksCache,
+        refresh_interval: Duration,
+        max_backoff: Duration,
+    ) -> Self {
+        let handle = tokio::spawn(Self::run(client, cache, refresh_interval, max_backoff));
+        Self { handle }
+    }
+
+    /// Aborts the background refresh task.
+    ///
+    /// Returns immediately; any in-flight JWKS fetch is cancelled.
+    pub fn shutdown(self) {
+        self.handle.abort();
+    }
+
+    async fn run(
+        client: JwksClient,
+        cache: JwksCache,
+        refresh_interval: Duration,
+        max_backoff: Duration,
+    ) {
+        let mut backoff = Duration::from_secs(1);
+        // First iteration fires with zero delay so the cache is immediately warm.
+        let mut delay = Duration::ZERO;
+
+        loop {
+            time::sleep(delay).await;
+
+            match client.fetch().await {
+                Ok(keys) => {
+                    let count = keys.len();
+                    cache.replace(keys).await;
+
+                    tracing::info!(
+                        key_count = count,
+                        next_refresh_secs = refresh_interval.as_secs(),
+                        "JWKS cache refreshed successfully"
+                    );
+
+                    backoff = Duration::from_secs(1);
+                    delay = refresh_interval;
+                }
+
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        retry_after_secs = backoff.as_secs(),
+                        "JWKS refresh failed; serving stale keys until recovered"
+                    );
+                    delay = backoff;
+                    backoff = (backoff * 2).min(max_backoff);
+                }
+            }
+        }
+    }
+}

--- a/crates/shared/auth-context/src/lib.rs
+++ b/crates/shared/auth-context/src/lib.rs
@@ -1,0 +1,21 @@
+pub mod config;
+pub mod context;
+pub mod decoder;
+pub mod error;
+pub mod extractor;
+pub mod jwks;
+pub mod principal;
+
+pub use config::AuthContextConfig;
+pub use context::{AnyPrincipal, current_principal, inject_into_span, with_principal};
+pub use decoder::JwtDecoder;
+pub use error::AuthError;
+pub use extractor::{
+    ClaimsExtractor, OidcClaims, OidcClaimsExtractor, OidcExtractorConfig, RealmAccess,
+    RoleSource,
+};
+pub use jwks::{JwksCache, JwksClient, JwksRefresher};
+pub use principal::{CurrentPrincipal, Permission, PrincipalId};
+
+#[cfg(feature = "cqrs-integration")]
+pub use context::inject_into_envelope;

--- a/crates/shared/auth-context/src/principal/mod.rs
+++ b/crates/shared/auth-context/src/principal/mod.rs
@@ -1,0 +1,3 @@
+pub mod principal;
+
+pub use principal::{CurrentPrincipal, Permission, PrincipalId};

--- a/crates/shared/auth-context/src/principal/principal.rs
+++ b/crates/shared/auth-context/src/principal/principal.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Opaque, platform-canonical user identifier.
+///
+/// The raw value is the `sub` claim string as received from the IdP.
+/// Auth0 subs look like `google-oauth2|123456` while Keycloak subs are UUID
+/// strings. Keep it as a `String` so both layouts work without a lossy
+/// coercion step at the boundary. Services that require a [`uuid::Uuid`]
+/// internally should call [`PrincipalId::try_as_uuid`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PrincipalId(pub String);
+
+impl PrincipalId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Attempts to parse the inner value as a [`uuid::Uuid`].
+    ///
+    /// Returns `None` when the IdP uses a non-UUID subject format (Auth0,
+    /// federated providers, etc.).
+    pub fn try_as_uuid(&self) -> Option<uuid::Uuid> {
+        self.0.parse().ok()
+    }
+}
+
+impl fmt::Display for PrincipalId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for PrincipalId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for PrincipalId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+/// A single, normalised platform permission token.
+///
+/// The string is opaque to the auth layer — business meaning is defined by
+/// the consuming service. Examples: `"posts:write"`, `"admin"`, `"ROLE_USER"`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Permission(pub String);
+
+impl Permission {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for Permission {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for Permission {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+/// The platform-canonical, strongly-typed identity extracted from a verified JWT.
+///
+/// `C` is the provider-specific raw claims struct (e.g. [`crate::OidcClaims`]).
+/// It is preserved verbatim so that services requiring non-standard fields do
+/// not need an additional decode pass.
+///
+/// # Thread safety
+///
+/// `CurrentPrincipal<C>` is `Send + Sync` whenever `C: Send + Sync`, which is
+/// true for all generated claim structs. It is safe to share via `Arc` across
+/// async task boundaries.
+#[derive(Debug, Clone)]
+pub struct CurrentPrincipal<C> {
+    /// Platform-canonical user identifier, derived from the `sub` JWT claim.
+    pub user_id: PrincipalId,
+
+    /// Optional tenant scope for multi-tenant deployments.
+    ///
+    /// Populated from a configurable claim key (default: `tid`) if present.
+    pub tenant_id: Option<String>,
+
+    /// Unified, deduplicated permission set produced by [`ClaimsExtractor`].
+    ///
+    /// All authorisation checks in business logic must operate exclusively on
+    /// this normalised set, never on `raw_claims` directly.
+    ///
+    /// [`ClaimsExtractor`]: crate::ClaimsExtractor
+    pub permissions: Vec<Permission>,
+
+    /// The raw decoded claims, exactly as they came out of the JWT payload.
+    pub raw_claims: C,
+}
+
+impl<C: Send + Sync + 'static> CurrentPrincipal<C> {
+    /// Returns `true` if `permission` is present in the normalised set.
+    pub fn has_permission(&self, permission: &str) -> bool {
+        self.permissions.iter().any(|p| p.0 == permission)
+    }
+
+    /// Returns `true` if all listed permissions are present.
+    pub fn has_all_permissions(&self, required: &[&str]) -> bool {
+        required.iter().all(|r| self.has_permission(r))
+    }
+
+    /// Returns `true` if at least one of the listed permissions is present.
+    pub fn has_any_permission(&self, candidates: &[&str]) -> bool {
+        candidates.iter().any(|c| self.has_permission(c))
+    }
+}

--- a/crates/shared/auth-context/tests/claims_extraction.rs
+++ b/crates/shared/auth-context/tests/claims_extraction.rs
@@ -1,0 +1,179 @@
+mod common;
+
+use std::collections::HashMap;
+
+use auth_context::{
+    ClaimsExtractor, OidcClaims, OidcClaimsExtractor, OidcExtractorConfig, RealmAccess,
+    RoleSource,
+};
+
+const ISS: &str = "https://idp.example.com/realms/platform";
+const AUD: &str = "platform-api";
+const SUB: &str = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+
+fn base_claims() -> OidcClaims {
+    OidcClaims {
+        sub: SUB.to_owned(),
+        iss: Some(ISS.to_owned()),
+        aud: Some(serde_json::json!(AUD)),
+        exp: 9_999_999_999,
+        nbf: None,
+        iat: None,
+        jti: None,
+        scope: None,
+        realm_access: None,
+        resource_access: None,
+        permissions: None,
+        groups: None,
+        tid: None,
+        extra: HashMap::new(),
+    }
+}
+
+#[test]
+fn sub_maps_to_user_id() {
+    let extractor = OidcClaimsExtractor::default();
+    let principal = extractor.extract(base_claims()).unwrap();
+    assert_eq!(principal.user_id.as_str(), SUB);
+}
+
+#[test]
+fn empty_sub_returns_error() {
+    let extractor = OidcClaimsExtractor::default();
+    let mut claims = base_claims();
+    claims.sub = String::new();
+    assert!(matches!(
+        extractor.extract(claims),
+        Err(auth_context::AuthError::ClaimsExtractionFailed(_))
+    ));
+}
+
+#[test]
+fn scope_splits_into_permissions() {
+    let extractor = OidcClaimsExtractor::default();
+    let mut claims = base_claims();
+    claims.scope = Some("openid profile posts:write".to_owned());
+
+    let principal = extractor.extract(claims).unwrap();
+    let perms: Vec<&str> = principal.permissions.iter().map(|p| p.as_str()).collect();
+
+    assert!(perms.contains(&"openid"));
+    assert!(perms.contains(&"profile"));
+    assert!(perms.contains(&"posts:write"));
+}
+
+#[test]
+fn realm_access_roles_map_to_permissions() {
+    let config = OidcExtractorConfig {
+        role_sources: vec![RoleSource::RealmAccessRoles],
+        ..Default::default()
+    };
+    let extractor = OidcClaimsExtractor::new(config);
+    let mut claims = base_claims();
+    claims.realm_access = Some(RealmAccess {
+        roles: Some(vec!["ROLE_USER".to_owned(), "ROLE_ADMIN".to_owned()]),
+    });
+
+    let principal = extractor.extract(claims).unwrap();
+    assert!(principal.has_permission("ROLE_USER"));
+    assert!(principal.has_permission("ROLE_ADMIN"));
+}
+
+#[test]
+fn auth0_permissions_claim_maps_correctly() {
+    let config = OidcExtractorConfig {
+        role_sources: vec![RoleSource::PermissionsClaim],
+        ..Default::default()
+    };
+    let extractor = OidcClaimsExtractor::new(config);
+    let mut claims = base_claims();
+    claims.permissions = Some(vec!["read:users".to_owned(), "write:posts".to_owned()]);
+
+    let principal = extractor.extract(claims).unwrap();
+    assert!(principal.has_permission("read:users"));
+    assert!(principal.has_permission("write:posts"));
+}
+
+#[test]
+fn duplicate_permissions_are_deduplicated() {
+    let config = OidcExtractorConfig {
+        role_sources: vec![RoleSource::Scope, RoleSource::PermissionsClaim],
+        ..Default::default()
+    };
+    let extractor = OidcClaimsExtractor::new(config);
+    let mut claims = base_claims();
+    claims.scope = Some("openid posts:write".to_owned());
+    claims.permissions = Some(vec!["posts:write".to_owned(), "read:users".to_owned()]);
+
+    let principal = extractor.extract(claims).unwrap();
+    let count = principal
+        .permissions
+        .iter()
+        .filter(|p| p.as_str() == "posts:write")
+        .count();
+
+    assert_eq!(count, 1, "posts:write must appear exactly once");
+}
+
+#[test]
+fn custom_role_source_reads_arbitrary_claim() {
+    let config = OidcExtractorConfig {
+        role_sources: vec![RoleSource::Custom("platform_roles".to_owned())],
+        ..Default::default()
+    };
+    let extractor = OidcClaimsExtractor::new(config);
+    let mut claims = base_claims();
+    claims
+        .extra
+        .insert("platform_roles".to_owned(), serde_json::json!(["geo:admin", "social:mod"]));
+
+    let principal = extractor.extract(claims).unwrap();
+    assert!(principal.has_permission("geo:admin"));
+    assert!(principal.has_permission("social:mod"));
+}
+
+#[test]
+fn tenant_id_resolved_from_tid_claim() {
+    let extractor = OidcClaimsExtractor::default();
+    let mut claims = base_claims();
+    claims.tid = Some("tenant-acme".to_owned());
+
+    let principal = extractor.extract(claims).unwrap();
+    assert_eq!(principal.tenant_id.as_deref(), Some("tenant-acme"));
+}
+
+#[test]
+fn tenant_id_resolved_from_custom_claim_key() {
+    let config = OidcExtractorConfig {
+        tenant_id_claim: "org_id".to_owned(),
+        ..Default::default()
+    };
+    let extractor = OidcClaimsExtractor::new(config);
+    let mut claims = base_claims();
+    claims
+        .extra
+        .insert("org_id".to_owned(), serde_json::json!("org-xyz"));
+
+    let principal = extractor.extract(claims).unwrap();
+    assert_eq!(principal.tenant_id.as_deref(), Some("org-xyz"));
+}
+
+#[test]
+fn has_all_permissions_returns_false_when_one_missing() {
+    let extractor = OidcClaimsExtractor::default();
+    let mut claims = base_claims();
+    claims.scope = Some("openid posts:read".to_owned());
+
+    let principal = extractor.extract(claims).unwrap();
+    assert!(!principal.has_all_permissions(&["openid", "posts:write"]));
+}
+
+#[test]
+fn has_any_permission_returns_true_when_one_matches() {
+    let extractor = OidcClaimsExtractor::default();
+    let mut claims = base_claims();
+    claims.scope = Some("openid".to_owned());
+
+    let principal = extractor.extract(claims).unwrap();
+    assert!(principal.has_any_permission(&["posts:write", "openid"]));
+}

--- a/crates/shared/auth-context/tests/common/keys.rs
+++ b/crates/shared/auth-context/tests/common/keys.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use base64::Engine as _;
+use jsonwebtoken::{DecodingKey, EncodingKey};
+// rsa 0.9 requires rand_core 0.6; use its re-exported OsRng to avoid the
+// version split caused by the workspace's rand crate (rand_core 0.9).
+use rsa::rand_core::OsRng;
+use rsa::traits::PublicKeyParts as _;
+use rsa::{pkcs1::EncodeRsaPrivateKey, RsaPrivateKey};
+
+/// In-memory RSA-2048 key pair produced at test-start, with no disk I/O and
+/// no external process dependencies.
+///
+/// Each call to [`TestKeyPair::generate`] produces a fresh, unique key pair
+/// so test runs are isolated from one another even when run in parallel.
+pub struct TestKeyPair {
+    pub kid: String,
+    pub encoding_key: EncodingKey,
+    pub decoding_key: DecodingKey,
+}
+
+impl TestKeyPair {
+    /// Generates a fresh RSA-2048 key pair.
+    ///
+    /// Using 2048 bits keeps test execution fast while still exercising the
+    /// real RS256 code path. Production SHOULD use 3072 or 4096 bits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if key generation fails — considered fatal in a test environment.
+    pub fn generate() -> Self {
+        let private_key = RsaPrivateKey::new(&mut OsRng, 2048)
+            .expect("RSA-2048 key generation failed");
+
+        let pem = private_key
+            .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+            .expect("failed to encode private key as PKCS#1 PEM");
+
+        let encoding_key = EncodingKey::from_rsa_pem(pem.as_bytes())
+            .expect("failed to build EncodingKey from PKCS#1 PEM");
+
+        let n_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(private_key.n().to_bytes_be());
+        let e_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(private_key.e().to_bytes_be());
+
+        let decoding_key = DecodingKey::from_rsa_components(&n_b64, &e_b64)
+            .expect("failed to build DecodingKey from RSA components");
+
+        // Use now_v7 — the workspace uuid crate only enables the v7 feature.
+        let kid = uuid::Uuid::now_v7().to_string();
+
+        Self {
+            kid,
+            encoding_key,
+            decoding_key,
+        }
+    }
+
+    /// Returns a `kid → DecodingKey` map suitable for pre-seeding a
+    /// [`JwksCache`] without performing any network fetch.
+    ///
+    /// Does not consume `self` — the `EncodingKey` remains available for
+    /// subsequent token minting in the same test.
+    ///
+    /// [`JwksCache`]: auth_context::JwksCache
+    pub fn as_cache_map(&self) -> HashMap<String, DecodingKey> {
+        let mut map = HashMap::new();
+        map.insert(self.kid.clone(), self.decoding_key.clone());
+        map
+    }
+}

--- a/crates/shared/auth-context/tests/common/mod.rs
+++ b/crates/shared/auth-context/tests/common/mod.rs
@@ -1,0 +1,7 @@
+#![allow(dead_code, unused_imports)]
+
+pub mod keys;
+pub mod tokens;
+
+pub use keys::TestKeyPair;
+pub use tokens::TokenFactory;

--- a/crates/shared/auth-context/tests/common/tokens.rs
+++ b/crates/shared/auth-context/tests/common/tokens.rs
@@ -1,0 +1,164 @@
+use jsonwebtoken::{encode, Algorithm, Header};
+use serde_json::json;
+
+use auth_context::OidcClaims;
+
+use super::TestKeyPair;
+
+/// Helper that mints JWTs signed with a [`TestKeyPair`], covering the common
+/// claim shapes needed across test modules.
+///
+/// All methods produce real RS256 signatures — there is no mocking of the
+/// cryptographic layer.
+pub struct TokenFactory<'a> {
+    key: &'a TestKeyPair,
+}
+
+impl<'a> TokenFactory<'a> {
+    pub fn new(key: &'a TestKeyPair) -> Self {
+        Self { key }
+    }
+
+    /// A well-formed, non-expired RS256 token with standard OIDC claims.
+    pub fn valid(
+        &self,
+        sub: &str,
+        issuer: &str,
+        audience: &str,
+        scope: &str,
+    ) -> String {
+        let now = now_unix();
+        let claims = OidcClaims {
+            sub: sub.to_owned(),
+            iss: Some(issuer.to_owned()),
+            aud: Some(json!(audience)),
+            exp: now + 3600,
+            nbf: Some(now - 5),
+            iat: Some(now),
+            jti: None,
+            scope: Some(scope.to_owned()),
+            realm_access: None,
+            resource_access: None,
+            permissions: None,
+            groups: None,
+            tid: None,
+            extra: Default::default(),
+        };
+        self.sign(claims)
+    }
+
+    /// A token whose `exp` is 60 seconds in the past (no clock-skew leeway
+    /// is applied by the factory — leeway is the decoder's responsibility).
+    pub fn expired(&self, sub: &str, issuer: &str, audience: &str) -> String {
+        let past = now_unix() - 60;
+        let claims = OidcClaims {
+            sub: sub.to_owned(),
+            iss: Some(issuer.to_owned()),
+            aud: Some(json!(audience)),
+            exp: past,
+            nbf: None,
+            iat: Some(past - 3600),
+            jti: None,
+            scope: None,
+            realm_access: None,
+            resource_access: None,
+            permissions: None,
+            groups: None,
+            tid: None,
+            extra: Default::default(),
+        };
+        self.sign(claims)
+    }
+
+    /// A valid token but signed with a different key whose `kid` is not in the
+    /// test cache, simulating an unknown-kid scenario.
+    pub fn unknown_kid(&self, sub: &str, issuer: &str, audience: &str) -> String {
+        let other = TestKeyPair::generate();
+        let factory = TokenFactory::new(&other);
+        // Override the header kid to a value not registered in the cache.
+        factory.valid(sub, issuer, audience, "openid")
+    }
+
+    /// A valid token structure but with `iss` replaced by an untrusted value.
+    pub fn wrong_issuer(&self, sub: &str, audience: &str) -> String {
+        self.valid(sub, "https://evil.example.com", audience, "openid")
+    }
+
+    /// A valid token structure but with `aud` set to a different audience.
+    pub fn wrong_audience(&self, sub: &str, issuer: &str) -> String {
+        self.valid(sub, issuer, "wrong-audience", "openid")
+    }
+
+    /// A valid token with Keycloak-style `realm_access.roles`.
+    pub fn with_realm_roles(
+        &self,
+        sub: &str,
+        issuer: &str,
+        audience: &str,
+        roles: Vec<String>,
+    ) -> String {
+        use auth_context::RealmAccess;
+        let now = now_unix();
+        let claims = OidcClaims {
+            sub: sub.to_owned(),
+            iss: Some(issuer.to_owned()),
+            aud: Some(json!(audience)),
+            exp: now + 3600,
+            nbf: Some(now - 5),
+            iat: Some(now),
+            jti: None,
+            scope: Some("openid".to_owned()),
+            realm_access: Some(RealmAccess { roles: Some(roles) }),
+            resource_access: None,
+            permissions: None,
+            groups: None,
+            tid: None,
+            extra: Default::default(),
+        };
+        self.sign(claims)
+    }
+
+    /// A token with a tenant identifier in the `tid` claim.
+    pub fn with_tenant(
+        &self,
+        sub: &str,
+        issuer: &str,
+        audience: &str,
+        tenant_id: &str,
+    ) -> String {
+        let now = now_unix();
+        let claims = OidcClaims {
+            sub: sub.to_owned(),
+            iss: Some(issuer.to_owned()),
+            aud: Some(json!(audience)),
+            exp: now + 3600,
+            nbf: Some(now - 5),
+            iat: Some(now),
+            jti: None,
+            scope: Some("openid".to_owned()),
+            realm_access: None,
+            resource_access: None,
+            permissions: None,
+            groups: None,
+            tid: Some(tenant_id.to_owned()),
+            extra: Default::default(),
+        };
+        self.sign(claims)
+    }
+
+    fn sign(&self, claims: OidcClaims) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(self.key.kid.clone());
+
+        encode(&header, &claims, &self.key.encoding_key)
+            .expect("test token signing failed — encoding key is invalid")
+    }
+}
+
+fn now_unix() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before Unix epoch")
+        .as_secs() as i64
+}

--- a/crates/shared/auth-context/tests/context_propagation.rs
+++ b/crates/shared/auth-context/tests/context_propagation.rs
@@ -1,0 +1,144 @@
+mod common;
+
+use std::sync::Arc;
+
+use auth_context::{
+    current_principal, inject_into_span, with_principal, CurrentPrincipal, Permission, PrincipalId,
+};
+
+fn make_principal(user_id: &str, tenant_id: Option<&str>, perms: &[&str]) -> CurrentPrincipal<()> {
+    CurrentPrincipal {
+        user_id: PrincipalId::new(user_id),
+        tenant_id: tenant_id.map(str::to_owned),
+        permissions: perms.iter().map(|p| Permission::new(*p)).collect(),
+        raw_claims: (),
+    }
+}
+
+#[tokio::test]
+async fn current_principal_is_none_outside_scope() {
+    assert!(
+        current_principal().is_none(),
+        "current_principal() must return None before with_principal() is called"
+    );
+}
+
+#[tokio::test]
+async fn principal_is_accessible_inside_scope() {
+    let principal = Arc::new(make_principal("user-1", None, &["openid"]));
+
+    with_principal(Arc::clone(&principal), async {
+        let stored = current_principal().expect("principal must be Some inside with_principal()");
+        assert_eq!(stored.user_id().as_str(), "user-1");
+        assert_eq!(stored.permissions()[0].as_str(), "openid");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn principal_available_across_await_points() {
+    let principal = Arc::new(make_principal("user-2", Some("tenant-x"), &["posts:write"]));
+
+    with_principal(Arc::clone(&principal), async {
+        tokio::task::yield_now().await;
+
+        let stored = current_principal().unwrap();
+        assert_eq!(stored.user_id().as_str(), "user-2");
+        assert_eq!(stored.tenant_id(), Some("tenant-x"));
+
+        tokio::task::yield_now().await;
+
+        let stored2 = current_principal().unwrap();
+        assert!(stored2.permissions().iter().any(|p| p.as_str() == "posts:write"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn principal_is_none_after_scope_exits() {
+    let principal = Arc::new(make_principal("user-3", None, &[]));
+
+    with_principal(Arc::clone(&principal), async {
+        assert!(current_principal().is_some());
+    })
+    .await;
+
+    assert!(
+        current_principal().is_none(),
+        "current_principal() must be None after the with_principal() future completes"
+    );
+}
+
+#[tokio::test]
+async fn nested_with_principal_shadows_outer() {
+    let outer = Arc::new(make_principal("user-outer", None, &[]));
+    let inner = Arc::new(make_principal("user-inner", None, &[]));
+
+    with_principal(Arc::clone(&outer), async {
+        assert_eq!(current_principal().unwrap().user_id().as_str(), "user-outer");
+
+        with_principal(Arc::clone(&inner), async {
+            assert_eq!(current_principal().unwrap().user_id().as_str(), "user-inner");
+        })
+        .await;
+
+        // Outer scope restored after inner exits.
+        assert_eq!(current_principal().unwrap().user_id().as_str(), "user-outer");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn inject_into_span_does_not_panic_outside_scope() {
+    // Must be a no-op, not a panic, when called outside a with_principal() scope.
+    inject_into_span();
+}
+
+#[tokio::test]
+async fn inject_into_span_does_not_panic_inside_scope() {
+    let principal = Arc::new(make_principal("user-span", Some("t-1"), &[]));
+
+    with_principal(Arc::clone(&principal), async {
+        // Span is created here; fields may be Empty if not instrumented,
+        // but record() must not panic.
+        inject_into_span();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn downcast_to_concrete_type_succeeds() {
+    let principal = Arc::new(make_principal("user-cast", None, &["admin"]));
+
+    with_principal(Arc::clone(&principal), async {
+        let any_p = current_principal().unwrap();
+        let concrete = any_p
+            .as_any()
+            .downcast_ref::<CurrentPrincipal<()>>()
+            .expect("downcast to CurrentPrincipal<()> must succeed");
+
+        assert_eq!(concrete.user_id.as_str(), "user-cast");
+    })
+    .await;
+}
+
+/// Verifies that `current_principal()` on a spawned sub-task does NOT
+/// inherit the parent task's principal (task-local is per-task, not
+/// propagated across `tokio::spawn` boundaries by default).
+#[tokio::test]
+async fn spawned_task_does_not_inherit_principal() {
+    let principal = Arc::new(make_principal("user-parent", None, &[]));
+
+    with_principal(principal, async {
+        let child = tokio::spawn(async {
+            current_principal()
+        });
+
+        let result = child.await.unwrap();
+        assert!(
+            result.is_none(),
+            "a spawned task must not see the parent's task-local principal"
+        );
+    })
+    .await;
+}

--- a/crates/shared/auth-context/tests/signature_verification.rs
+++ b/crates/shared/auth-context/tests/signature_verification.rs
@@ -1,0 +1,134 @@
+mod common;
+
+use auth_context::{AuthContextConfig, AuthError, JwksCache, JwtDecoder, OidcClaimsExtractor};
+use common::{TestKeyPair, TokenFactory};
+
+const ISS: &str = "https://idp.example.com/realms/platform";
+const AUD: &str = "platform-api";
+const SUB: &str = "user-sig-test";
+
+async fn seeded_cache(key: &TestKeyPair) -> JwksCache {
+    let cache = JwksCache::new();
+    cache.replace(key.as_cache_map()).await;
+    cache
+}
+
+fn permissive_config() -> AuthContextConfig {
+    AuthContextConfig {
+        expected_issuer: Some(ISS.to_owned()),
+        expected_audience: Some(AUD.to_owned()),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn tampered_payload_returns_invalid_signature() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+    let decoder = JwtDecoder::new(&permissive_config(), cache, OidcClaimsExtractor::default());
+    let factory = TokenFactory::new(&key);
+
+    let token = factory.valid(SUB, ISS, AUD, "openid");
+
+    // Flip a character in the payload segment to break the signature.
+    let mut parts: Vec<&str> = token.splitn(3, '.').collect();
+    let original_payload = parts[1].to_owned();
+    let tampered_payload = {
+        let mut chars: Vec<char> = original_payload.chars().collect();
+        let last = chars.len() - 1;
+        chars[last] = if chars[last] == 'A' { 'B' } else { 'A' };
+        chars.into_iter().collect::<String>()
+    };
+    parts[1] = &tampered_payload;
+    let tampered_token = parts.join(".");
+
+    let err = decoder.decode(&tampered_token).await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            AuthError::InvalidSignature | AuthError::MalformedToken(_)
+        ),
+        "expected InvalidSignature or MalformedToken, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn token_signed_with_unknown_key_returns_unknown_kid() {
+    let registered_key = TestKeyPair::generate();
+    let unknown_key = TestKeyPair::generate();
+
+    let cache = seeded_cache(&registered_key).await;
+    let decoder = JwtDecoder::new(&permissive_config(), cache, OidcClaimsExtractor::default());
+
+    // Token signed with the unknown key — its kid is not in the cache.
+    let token = TokenFactory::new(&unknown_key).valid(SUB, ISS, AUD, "openid");
+
+    let err = decoder.decode(&token).await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::UnknownKid(_)),
+        "expected UnknownKid, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn completely_malformed_string_returns_malformed_token() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+    let decoder = JwtDecoder::new(&permissive_config(), cache, OidcClaimsExtractor::default());
+
+    let err = decoder.decode("not.a.jwt").await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::MalformedToken(_) | AuthError::MissingKid | AuthError::UnknownKid(_)),
+        "expected a structural error variant, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn token_without_kid_header_returns_missing_kid() {
+    // Build a token that has no kid in the header by using jsonwebtoken directly.
+    use jsonwebtoken::{encode, Algorithm, Header};
+    use serde_json::json;
+
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+    let decoder = JwtDecoder::new(&permissive_config(), cache, OidcClaimsExtractor::default());
+
+    let header = Header::new(Algorithm::RS256); // no .kid set
+    let claims = json!({
+        "sub": SUB,
+        "iss": ISS,
+        "aud": AUD,
+        "exp": 9_999_999_999i64,
+    });
+    let token = encode(&header, &claims, &key.encoding_key).unwrap();
+
+    let err = decoder.decode(&token).await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::MissingKid),
+        "expected MissingKid, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn key_rotation_new_key_accepted_after_cache_replace() {
+    let old_key = TestKeyPair::generate();
+    let new_key = TestKeyPair::generate();
+
+    let cache = seeded_cache(&old_key).await;
+    let decoder = JwtDecoder::new(&permissive_config(), cache.clone(), OidcClaimsExtractor::default());
+
+    // Token signed with old key works before rotation.
+    let old_token = TokenFactory::new(&old_key).valid(SUB, ISS, AUD, "openid");
+    decoder.decode(&old_token).await.unwrap();
+
+    // Rotate: replace the cache with the new key set only.
+    cache.replace(new_key.as_cache_map()).await;
+
+    // Old token is now rejected (unknown kid).
+    let err = decoder.decode(&old_token).await.unwrap_err();
+    assert!(matches!(err, AuthError::UnknownKid(_)));
+
+    // New token is accepted.
+    let new_token = TokenFactory::new(&new_key).valid(SUB, ISS, AUD, "openid");
+    decoder.decode(&new_token).await.unwrap();
+}

--- a/crates/shared/auth-context/tests/token_validation.rs
+++ b/crates/shared/auth-context/tests/token_validation.rs
@@ -1,0 +1,130 @@
+mod common;
+
+use std::time::Duration;
+
+use auth_context::{AuthContextConfig, AuthError, JwksCache, JwtDecoder, OidcClaimsExtractor};
+
+use common::{TestKeyPair, TokenFactory};
+
+const ISS: &str = "https://idp.example.com/realms/platform";
+const AUD: &str = "platform-api";
+const SUB: &str = "user-abc-123";
+
+async fn seeded_cache(key: &TestKeyPair) -> JwksCache {
+    let cache = JwksCache::new();
+    cache.replace(key.as_cache_map()).await;
+    cache
+}
+
+fn default_config() -> AuthContextConfig {
+    AuthContextConfig {
+        jwks_url: String::new(),
+        expected_issuer: Some(ISS.to_owned()),
+        expected_audience: Some(AUD.to_owned()),
+        clock_skew: Duration::from_secs(5),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn valid_token_decodes_successfully() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+    let decoder = JwtDecoder::new(&default_config(), cache, OidcClaimsExtractor::default());
+    let factory = TokenFactory::new(&key);
+
+    let token = factory.valid(SUB, ISS, AUD, "openid profile");
+    let principal = decoder.decode(&token).await.unwrap();
+
+    assert_eq!(principal.user_id.as_str(), SUB);
+    assert!(principal.has_permission("openid"));
+    assert!(principal.has_permission("profile"));
+}
+
+#[tokio::test]
+async fn expired_token_returns_token_expired_error() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+
+    let config = AuthContextConfig {
+        clock_skew: Duration::ZERO,
+        expected_issuer: Some(ISS.to_owned()),
+        expected_audience: Some(AUD.to_owned()),
+        ..Default::default()
+    };
+
+    let decoder = JwtDecoder::new(&config, cache, OidcClaimsExtractor::default());
+    let token = TokenFactory::new(&key).expired(SUB, ISS, AUD);
+
+    let err = decoder.decode(&token).await.unwrap_err();
+    assert!(
+        matches!(err, AuthError::TokenExpired),
+        "expected TokenExpired, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn wrong_issuer_returns_invalid_issuer_error() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+    let decoder = JwtDecoder::new(&default_config(), cache, OidcClaimsExtractor::default());
+
+    let token = TokenFactory::new(&key).wrong_issuer(SUB, AUD);
+    let err = decoder.decode(&token).await.unwrap_err();
+
+    assert!(
+        matches!(err, AuthError::InvalidIssuer),
+        "expected InvalidIssuer, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn wrong_audience_returns_invalid_audience_error() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+    let decoder = JwtDecoder::new(&default_config(), cache, OidcClaimsExtractor::default());
+
+    let token = TokenFactory::new(&key).wrong_audience(SUB, ISS);
+    let err = decoder.decode(&token).await.unwrap_err();
+
+    assert!(
+        matches!(err, AuthError::InvalidAudience),
+        "expected InvalidAudience, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn audience_validation_disabled_accepts_any_aud() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+
+    let config = AuthContextConfig {
+        expected_issuer: Some(ISS.to_owned()),
+        expected_audience: None,
+        ..Default::default()
+    };
+
+    let decoder = JwtDecoder::new(&config, cache, OidcClaimsExtractor::default());
+    let token = TokenFactory::new(&key).valid(SUB, ISS, "completely-different-audience", "openid");
+
+    decoder.decode(&token).await.unwrap();
+}
+
+#[tokio::test]
+async fn clock_skew_tolerates_slight_expiry() {
+    let key = TestKeyPair::generate();
+    let cache = seeded_cache(&key).await;
+
+    // expired() sets exp = now - 60; leeway of 120 s covers it.
+    let config = AuthContextConfig {
+        clock_skew: Duration::from_secs(120),
+        expected_issuer: Some(ISS.to_owned()),
+        expected_audience: Some(AUD.to_owned()),
+        ..Default::default()
+    };
+
+    let decoder = JwtDecoder::new(&config, cache, OidcClaimsExtractor::default());
+    let token = TokenFactory::new(&key).expired(SUB, ISS, AUD);
+
+    decoder.decode(&token).await.unwrap();
+}


### PR DESCRIPTION
…ropagation crate (#413)

Introduces crates/shared/auth-context, the platform security translator that validates OIDC-compliant JWTs in-memory against a background-refreshed JWKS cache and propagates the extracted identity through tokio::task_local! storage into tracing spans and CQRS Envelope<T> metadata.