### PR TITLE
feat(social-graph): implement production-grade DDD social-graph micro…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "social-graph"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "auth-context",
+ "base64 0.22.1",
+ "chrono",
+ "cqrs",
+ "error",
+ "fred",
+ "futures",
+ "http",
+ "prost 0.14.4",
+ "prost-types",
+ "redis-storage",
+ "scylla",
+ "scylla-storage",
+ "serde",
+ "serde_json",
+ "telemetry",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-build",
+ "tonic-health",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-reflection",
+ "tracing",
+ "transport",
+ "uuid",
+ "validate-core",
+ "validation",
+]
+
+[[package]]
 name = "social-test-utils"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
     "crates/shared/auth-context",
     "crates/shared/validate-core",
     "crates/shared/validation",
-    "crates/services/account", "crates/services/profile",
+    "crates/services/account", "crates/services/profile", "crates/services/social-graph",
     # "crates/comment",
 ]
 resolver = "2"

--- a/crates/services/social-graph/Cargo.toml
+++ b/crates/services/social-graph/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+name        = "social-graph"
+version.workspace   = true
+edition.workspace   = true
+license.workspace   = true
+authors.workspace   = true
+repository.workspace = true
+description = "Social-graph microservice — directional follow/block relationships between opaque ProfileId primitives."
+
+[dependencies]
+# ── Shared platform infrastructure ───────────────────────────────────────────
+error            = { workspace = true }
+validate-core    = { workspace = true }
+validation       = { workspace = true }
+scylla-storage   = { path = "../../shared/storage/scylla", package = "scylla-storage" }
+redis-storage    = { path = "../../shared/storage/redis", package = "redis-storage" }
+
+# ── Shared platform crates ────────────────────────────────────────────────────
+cqrs         = { path = "../../shared/cqrs" }
+auth-context = { path = "../../shared/auth-context" }
+telemetry    = { path = "../../shared/telemetry" }
+transport    = { path = "../../shared/transport" }
+
+# ── Async runtime & utilities ─────────────────────────────────────────────────
+tokio        = { workspace = true }
+futures      = { workspace = true }
+async-trait  = { workspace = true }
+
+# ── Serialisation ─────────────────────────────────────────────────────────────
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+base64       = { workspace = true }
+
+# ── Domain types ──────────────────────────────────────────────────────────────
+uuid         = { workspace = true }
+chrono       = { workspace = true }
+
+# ── Error handling ────────────────────────────────────────────────────────────
+thiserror    = { workspace = true }
+
+# ── Observability ─────────────────────────────────────────────────────────────
+tracing      = { workspace = true }
+
+# ── gRPC / Protobuf ───────────────────────────────────────────────────────────
+tonic             = { workspace = true }
+tonic-prost       = { workspace = true }
+prost             = { workspace = true }
+prost-types       = { workspace = true }
+tonic-health      = { workspace = true }
+tonic-reflection  = { workspace = true }
+http              = { workspace = true }
+
+# ── Storage drivers (direct access for advanced query patterns) ───────────────
+scylla = { workspace = true }
+fred   = { workspace = true }
+
+[build-dependencies]
+tonic-build       = { workspace = true }
+tonic-prost-build = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/services/social-graph/README.md
+++ b/crates/services/social-graph/README.md
@@ -1,0 +1,194 @@
+# social-graph
+
+Production-grade social graph microservice implementing directional follow/block relationships between opaque `ProfileId` (UUIDv7) primitives.
+
+## Bounded Context
+
+This service is the strict owner of **who follows whom** and **who blocks whom**.
+
+| In scope | Out of scope |
+|---|---|
+| Follow, Unfollow, Block, Unblock | Profile metadata (handles, bios, avatars) |
+| Follower/following counts (Redis) | Account management |
+| Block-gate enforcement | Timeline feed construction |
+| Mutual-follow derivation (Redis) | Notification delivery |
+| Kafka event emission | Post/content ownership |
+
+Profiles are treated as opaque UUIDv7 identifiers. This service never imports `services/profile` or `services/account`.
+
+---
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────┐
+│  gRPC (Tonic)  SocialGraphService                 │
+│  ─────────────────────────────────────────────── │
+│  Commands: Follow / Unfollow / Block / Unblock     │
+│  Queries:  GetRelationStatus / ListFollowers /     │
+│            ListFollowing / ListBlocks              │
+└───────────────────────┬───────────────────────────┘
+                        │ CQRS bus
+        ┌───────────────┼───────────────────┐
+        ▼               ▼                   ▼
+  Command Handlers  Query Handlers    EventPublisher
+        │               │                   │
+        ▼               ▼                   ▼
+  SocialGraphRepository  SocialGraphCache  KafkaProducerHandle
+        │                      │
+        ▼                      ▼
+   ScyllaDB (4 tables)    Redis (sets + counters)
+```
+
+### Layer responsibilities
+
+| Layer | Responsibility |
+|---|---|
+| `domain/aggregate/relation.rs` | Invariant enforcement (self-interaction, block-gate, sever-on-block) |
+| `application/command/` | Orchestrate repo + cache + publisher; no domain logic |
+| `application/query/` | Assemble read-model from ScyllaDB + Redis |
+| `infrastructure/persistence/` | ScyllaDB queries (strict/fast profiles) |
+| `infrastructure/cache/` | Redis Set (following, blocks) + INCR counters |
+| `infrastructure/publisher/` | Kafka JSON envelope per domain event |
+| `infrastructure/grpc/` | Proto↔domain mapping; error→Status translation |
+
+---
+
+## ScyllaDB Schema
+
+### Keyspace
+
+```cql
+CREATE KEYSPACE social_graph
+    WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3};
+```
+
+### Table Overview
+
+| Table | Partition Key | Clustering Key | Purpose |
+|---|---|---|---|
+| `followers` | `followee_id` | `followed_at DESC, follower_id ASC` | Fan-in: who follows X? |
+| `following` | `follower_id` | `followed_at DESC, followee_id ASC` | Fan-out: who does X follow? |
+| `follow_status` | `follower_id` | `followee_id ASC` | Point-lookup + `followed_at` for DELETE |
+| `blocks` | `blocker_id` | `blockee_id ASC` | Block point-lookup + list |
+
+#### Why `follow_status`?
+
+ScyllaDB DELETE requires the **full clustering key**. The `followers` and `following` tables include `followed_at` in their clustering key, so unfollowing and block-severing operations must know this timestamp before issuing a DELETE. `follow_status` stores it as a regular column, avoiding any read-before-write on the adjacency list tables.
+
+#### Why no `blocked_by` mirror?
+
+The block-gate check requires two point-lookups: `blocks(A,B)` and `blocks(B,A)`. Both are O(1) on the **same table** with swapped arguments — no mirror needed.
+
+---
+
+## Redis Cache Strategy
+
+| Key | Type | Written by | Read by |
+|---|---|---|---|
+| `sg:following:v1:{id}` | Set | Follow / Unfollow / Block | Kafka downstream engines (SINTER for friend detection) |
+| `sg:blocks:v1:{id}` | Set | Block / Unblock | (future: fast gate check in read path) |
+| `sg:followers_count:v1:{id}` | String | Follow / Unfollow / Block | `GetRelationStatus` query |
+| `sg:following_count:v1:{id}` | String | Follow / Unfollow / Block | `GetRelationStatus` query |
+
+### Why Sets for `following` but counters for `followers`?
+
+Outbound follows are bounded for all users (max tens of thousands). Inbound follows are unbounded for celebrity profiles (millions). Materializing the full inbound set would exhaust Redis memory. A INCR/DECR counter satisfies count reads with O(1) space.
+
+### Mutual-follow (friendship) derivation
+
+```
+IsFriend(A, B) =
+    SISMEMBER sg:following:v1:{A} {B}   -- A follows B
+    AND
+    SISMEMBER sg:following:v1:{B} {A}   -- B follows A
+```
+
+No dedicated `friends` table exists. Derivation is computed via Redis SISMEMBER (O(1)) or SINTER for batch mutual-follows. This prevents dual-write desynchronization during unfollow/block events.
+
+---
+
+## Domain Invariants
+
+| Invariant | Enforced in |
+|---|---|
+| A profile cannot follow itself | `FollowProfileHandler` (pre-aggregate check) |
+| A profile cannot block itself | `BlockProfileHandler` (pre-aggregate check) |
+| Block-gate: follow rejected if any block exists (either direction) | `Relation::follow()` |
+| Re-follow rejected if already following | `Relation::follow()` |
+| Re-block rejected if already blocked | `Relation::block()` |
+| Block severs existing follows in both directions | `Relation::block()` → returns `SeveredFollows` |
+| Unblock does not restore severed follows | Intentional; user must re-follow explicitly |
+
+---
+
+## Kafka Events
+
+| Event | Topic | Key | Subscribers |
+|---|---|---|---|
+| `ProfileFollowed` | `social-graph.followed` | `{actor}:{target}` | Timeline fan-out, notification service |
+| `ProfileUnfollowed` | `social-graph.unfollowed` | `{actor}:{target}` | Timeline pruning |
+| `ProfileBlocked` | `social-graph.blocked` | `{actor}:{target}` | Content filtering, notification suppression |
+| `ProfileUnblocked` | — | — | Not published (no downstream fan-out needed) |
+
+---
+
+## Error Catalogue
+
+| Code | Variant | HTTP | Retryable |
+|---|---|---|---|
+| SGR-1001 | AlreadyFollowing | 409 | No |
+| SGR-1002 | NotFollowing | 422 | No |
+| SGR-1003 | AlreadyBlocked | 409 | No |
+| SGR-1004 | NotBlocked | 422 | No |
+| SGR-2001 | SelfInteraction | 422 | No |
+| SGR-2002 | BlockGateDenied | 422 | No |
+| SGR-9001 | DomainViolation | 422 | No |
+| SGR-9002 | InvalidProfileId | 422 | No |
+| SDB-\* | Storage (ScyllaDB) | var | var |
+| RDB-\* | Cache (Redis) | 500 | var |
+| VAL-\* | Validation | 422 | No |
+
+---
+
+## gRPC Service Interface
+
+```protobuf
+service SocialGraphService {
+    // Commands
+    rpc Follow(FollowRequest)       returns (CommandResponse);
+    rpc Unfollow(UnfollowRequest)   returns (CommandResponse);
+    rpc Block(BlockRequest)         returns (CommandResponse);
+    rpc Unblock(UnblockRequest)     returns (CommandResponse);
+
+    // Queries
+    rpc GetRelationStatus(GetRelationStatusRequest) returns (RelationStatusView);
+    rpc ListFollowers(ListFollowersRequest)         returns (ListFollowersResponse);
+    rpc ListFollowing(ListFollowingRequest)         returns (ListFollowingResponse);
+    rpc ListBlocks(ListBlocksRequest)               returns (ListBlocksResponse);
+}
+```
+
+`RelationStatus` enum values (from actor's perspective):
+
+| Value | Meaning |
+|---|---|
+| `NONE` | No relationship |
+| `FOLLOWING` | Actor follows target only |
+| `FOLLOWED_BY` | Target follows actor only |
+| `MUTUAL` | Both follow each other (implicit friendship) |
+| `BLOCKING` | Actor has blocked target |
+| `BLOCKED_BY` | Target has blocked actor |
+
+---
+
+## Running Migrations
+
+```bash
+# Apply in order using any CQL client (cqlsh, astra, etc.)
+cqlsh -f migrations/0001_create_keyspace.cql
+cqlsh -f migrations/0002_create_followers_table.cql
+cqlsh -f migrations/0003_create_following_table.cql
+cqlsh -f migrations/0004_create_follow_status_table.cql
+cqlsh -f migrations/0005_create_blocks_table.cql
+```

--- a/crates/services/social-graph/build.rs
+++ b/crates/services/social-graph/build.rs
@@ -1,0 +1,14 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(false)
+        .compile_protos(
+            &[
+                "proto/social_graph/v1/enums.proto",
+                "proto/social_graph/v1/messages.proto",
+                "proto/social_graph/v1/service.proto",
+            ],
+            &["proto/"],
+        )?;
+    Ok(())
+}

--- a/crates/services/social-graph/migrations/0001_create_keyspace.cql
+++ b/crates/services/social-graph/migrations/0001_create_keyspace.cql
@@ -1,0 +1,3 @@
+CREATE KEYSPACE IF NOT EXISTS social_graph
+    WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3}
+    AND durable_writes = true;

--- a/crates/services/social-graph/migrations/0002_create_followers_table.cql
+++ b/crates/services/social-graph/migrations/0002_create_followers_table.cql
@@ -1,0 +1,18 @@
+-- Fan-in adjacency list: "Who follows profile X?"
+--
+-- Partition key  : followee_id  — routes all followers of X to the same ScyllaDB partition.
+-- Clustering key : followed_at DESC, follower_id ASC
+--   • DESC on followed_at ensures a LIMIT N scan always returns the N most-recent followers
+--     without a coordinator-side sort.
+--   • follower_id provides a deterministic tie-breaker when two followers arrive within the
+--     same millisecond (prevents silent row collisions).
+--
+-- DELETE requirement: callers must supply the full clustering key (followed_at + follower_id).
+-- The follow_status table is the canonical store for followed_at — see migration 0004.
+CREATE TABLE IF NOT EXISTS social_graph.followers (
+    followee_id   uuid,
+    followed_at   timestamp,
+    follower_id   uuid,
+    PRIMARY KEY (followee_id, followed_at, follower_id)
+) WITH CLUSTERING ORDER BY (followed_at DESC, follower_id ASC)
+  AND compression = {'sstable_compression': 'LZ4Compressor'};

--- a/crates/services/social-graph/migrations/0003_create_following_table.cql
+++ b/crates/services/social-graph/migrations/0003_create_following_table.cql
@@ -1,0 +1,17 @@
+-- Fan-out adjacency list: "Who does profile X follow?"
+--
+-- Symmetric denormalization of the followers table. The dual write (INSERT into both
+-- followers and following per follow event) is the deliberate ScyllaDB trade-off that
+-- eliminates ALLOW FILTERING on both read directions.
+--
+-- Partition key  : follower_id  — routes all follows of X to the same partition.
+-- Clustering key : followed_at DESC, followee_id ASC
+--   • Same rationale as followers: recent-first pagination with O(1) LIMIT.
+--   • followee_id tie-breaks within the same millisecond.
+CREATE TABLE IF NOT EXISTS social_graph.following (
+    follower_id   uuid,
+    followed_at   timestamp,
+    followee_id   uuid,
+    PRIMARY KEY (follower_id, followed_at, followee_id)
+) WITH CLUSTERING ORDER BY (followed_at DESC, followee_id ASC)
+  AND compression = {'sstable_compression': 'LZ4Compressor'};

--- a/crates/services/social-graph/migrations/0004_create_follow_status_table.cql
+++ b/crates/services/social-graph/migrations/0004_create_follow_status_table.cql
@@ -1,0 +1,21 @@
+-- Point-lookup index and deletion-key store for follow relationships.
+--
+-- Purpose 1 — Existence check: "Does profile A follow profile B?"
+--   SELECT followed_at FROM social_graph.follow_status
+--   WHERE follower_id = A AND followee_id = B;
+--   O(1) by partition + full clustering key.
+--
+-- Purpose 2 — Deletion-key retrieval: ScyllaDB DELETE requires the full clustering key.
+--   The followers and following tables include followed_at in their clustering key, so
+--   unfollow and block-sever operations must know this timestamp before issuing DELETE.
+--   This table is the canonical source for that value — no read-before-write on the
+--   adjacency list tables is ever needed.
+--
+-- Partition key  : follower_id
+-- Clustering key : followee_id  (single column; default ASC)
+CREATE TABLE IF NOT EXISTS social_graph.follow_status (
+    follower_id   uuid,
+    followee_id   uuid,
+    followed_at   timestamp,
+    PRIMARY KEY (follower_id, followee_id)
+) WITH compression = {'sstable_compression': 'LZ4Compressor'};

--- a/crates/services/social-graph/migrations/0005_create_blocks_table.cql
+++ b/crates/services/social-graph/migrations/0005_create_blocks_table.cql
@@ -1,0 +1,22 @@
+-- Block adjacency list and point-lookup table.
+--
+-- A single table serves three access patterns without a mirror:
+--   1. "Has A blocked B?"  — SELECT WHERE blocker_id = A AND blockee_id = B  (O(1))
+--   2. "Has B blocked A?"  — SELECT WHERE blocker_id = B AND blockee_id = A  (O(1))
+--   3. "List all profiles A has blocked" — full partition scan on blocker_id = A
+--
+-- Pattern 1 and 2 are the block-gate checks performed during FollowProfile commands.
+-- Both are O(1) point lookups on the same table with swapped arguments — no mirror
+-- (blocked_by) table is needed.
+--
+-- "Who blocked me?" is intentionally not exposed to end-users; the service only
+-- uses the two-direction gate check (patterns 1+2) for enforcement.
+--
+-- Partition key  : blocker_id
+-- Clustering key : blockee_id  (default ASC — paginates block lists in UUID order)
+CREATE TABLE IF NOT EXISTS social_graph.blocks (
+    blocker_id    uuid,
+    blockee_id    uuid,
+    blocked_at    timestamp,
+    PRIMARY KEY (blocker_id, blockee_id)
+) WITH compression = {'sstable_compression': 'LZ4Compressor'};

--- a/crates/services/social-graph/proto/social_graph/v1/enums.proto
+++ b/crates/services/social-graph/proto/social_graph/v1/enums.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package social_graph.v1;
+
+option java_package = "com.coreplatform.socialgraph.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/social-graph/v1;socialgraphv1";
+
+// The combined relationship status between an actor and a target profile,
+// as observed from the actor's point of view.
+//
+// Invariants enforced by the domain layer:
+//   - Block states and follow states are mutually exclusive: a block severs
+//     any existing follow in both directions and prevents future follows.
+//   - MUTUAL_FOLLOW is the implicit "friendship" state; no dedicated table exists.
+enum RelationStatus {
+    RELATION_STATUS_UNSPECIFIED = 0;
+    // No relationship exists between actor and target.
+    RELATION_STATUS_NONE        = 1;
+    // Actor follows target; target does not follow actor back.
+    RELATION_STATUS_FOLLOWING   = 2;
+    // Target follows actor; actor does not follow target back.
+    RELATION_STATUS_FOLLOWED_BY = 3;
+    // Both profiles follow each other (implicit friendship).
+    RELATION_STATUS_MUTUAL      = 4;
+    // Actor has blocked target. No follow is possible in either direction.
+    RELATION_STATUS_BLOCKING    = 5;
+    // Target has blocked actor. No follow is possible in either direction.
+    RELATION_STATUS_BLOCKED_BY  = 6;
+}

--- a/crates/services/social-graph/proto/social_graph/v1/messages.proto
+++ b/crates/services/social-graph/proto/social_graph/v1/messages.proto
@@ -1,0 +1,108 @@
+syntax = "proto3";
+
+package social_graph.v1;
+
+import "social_graph/v1/enums.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.coreplatform.socialgraph.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/social-graph/v1;socialgraphv1";
+
+// ── Read models ───────────────────────────────────────────────────────────────
+
+// The full relationship context between actor and target.
+// Returned by GetRelationStatus.
+message RelationStatusView {
+    string         actor_id               = 1;
+    string         target_id              = 2;
+    RelationStatus status                 = 3;
+    // Follower and following counts are for the target profile.
+    int64          target_followers_count = 4;
+    int64          target_following_count = 5;
+}
+
+// A lightweight summary of one edge in an adjacency list.
+// Used in paginated follower/following list responses.
+message EdgeSummary {
+    // The profile on the other end of the edge.
+    // In ListFollowers responses: the follower_id.
+    // In ListFollowing responses: the followee_id.
+    string                    profile_id  = 1;
+    google.protobuf.Timestamp followed_at = 2;
+}
+
+// A lightweight summary of one block edge.
+message BlockSummary {
+    string                    blockee_id  = 1;
+    google.protobuf.Timestamp blocked_at  = 2;
+}
+
+// Generic acknowledge response for all mutating RPCs.
+message CommandResponse {
+    bool   success   = 1;
+    string actor_id  = 2;
+    string target_id = 3;
+}
+
+// ── Command request messages ──────────────────────────────────────────────────
+
+message FollowRequest {
+    string actor_id  = 1;
+    string target_id = 2;
+}
+
+message UnfollowRequest {
+    string actor_id  = 1;
+    string target_id = 2;
+}
+
+message BlockRequest {
+    string actor_id  = 1;
+    string target_id = 2;
+}
+
+message UnblockRequest {
+    string actor_id  = 1;
+    string target_id = 2;
+}
+
+// ── Query request / response messages ────────────────────────────────────────
+
+message GetRelationStatusRequest {
+    string actor_id  = 1;
+    string target_id = 2;
+}
+
+message ListFollowersRequest {
+    string followee_id = 1;
+    int32  limit       = 2;
+    string page_token  = 3;
+}
+
+message ListFollowersResponse {
+    repeated EdgeSummary followers        = 1;
+    string               next_page_token  = 2;
+}
+
+message ListFollowingRequest {
+    string follower_id = 1;
+    int32  limit       = 2;
+    string page_token  = 3;
+}
+
+message ListFollowingResponse {
+    repeated EdgeSummary following        = 1;
+    string               next_page_token  = 2;
+}
+
+message ListBlocksRequest {
+    string blocker_id  = 1;
+    int32  limit       = 2;
+    string page_token  = 3;
+}
+
+message ListBlocksResponse {
+    repeated BlockSummary blocks          = 1;
+    string                next_page_token = 2;
+}

--- a/crates/services/social-graph/proto/social_graph/v1/service.proto
+++ b/crates/services/social-graph/proto/social_graph/v1/service.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package social_graph.v1;
+
+import "social_graph/v1/enums.proto";
+import "social_graph/v1/messages.proto";
+
+option java_package = "com.coreplatform.socialgraph.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/social-graph/v1;socialgraphv1";
+
+// SocialGraphService owns all directional relationships between profiles.
+//
+// SRP guarantee: this service operates exclusively on opaque ProfileId (UUIDv7)
+// primitives. It has no knowledge of profile metadata (handles, bios, avatars).
+// Social graph concerns must never bleed into services/profile or services/account.
+//
+// Supported relation kinds: Follow, Unfollow, Block, Unblock.
+//
+// Graph invariants enforced by this service:
+//   1. Self-interaction is rejected (a profile cannot follow or block itself).
+//   2. A block bi-directionally severs any existing follow and prevents future follows.
+//   3. Mutual follows (A→B and B→A) are implicitly "friends" — no dedicated table.
+//
+// All mutating RPCs (commands) return CommandResponse.
+// All read RPCs (queries) return typed view or paginated response messages.
+service SocialGraphService {
+
+    // ── Commands ──────────────────────────────────────────────────────────────
+
+    // Record that actor follows target.
+    // Rejected if a block exists in either direction, or if actor == target.
+    rpc Follow(FollowRequest) returns (CommandResponse);
+
+    // Remove an existing follow from actor to target.
+    // Rejected if no follow exists.
+    rpc Unfollow(UnfollowRequest) returns (CommandResponse);
+
+    // Record that actor blocks target.
+    // Severs any existing follow between them (in both directions).
+    // Rejected if actor == target or if actor already blocks target.
+    rpc Block(BlockRequest) returns (CommandResponse);
+
+    // Remove an existing block issued by actor against target.
+    // Does not restore severed follows.
+    rpc Unblock(UnblockRequest) returns (CommandResponse);
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    // Returns the full bidirectional relationship context between actor and target,
+    // plus the target's follower/following counts.
+    rpc GetRelationStatus(GetRelationStatusRequest) returns (RelationStatusView);
+
+    // Paginated list of profiles that follow the given profile (fan-in).
+    rpc ListFollowers(ListFollowersRequest) returns (ListFollowersResponse);
+
+    // Paginated list of profiles that the given profile follows (fan-out).
+    rpc ListFollowing(ListFollowingRequest) returns (ListFollowingResponse);
+
+    // Paginated list of profiles blocked by the given profile.
+    rpc ListBlocks(ListBlocksRequest) returns (ListBlocksResponse);
+}

--- a/crates/services/social-graph/src/application/command/block_profile.rs
+++ b/crates/services/social-graph/src/application/command/block_profile.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use cqrs::{Command, CommandHandler, Envelope};
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::port::{EventPublisher, SocialGraphCache, SocialGraphRepository};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct BlockProfileCommand {
+    pub actor_id:  String,
+    pub target_id: String,
+}
+
+impl Command for BlockProfileCommand {}
+
+impl Validate for BlockProfileCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        let mut v = Vec::new();
+        if self.actor_id.trim().is_empty() {
+            v.push(FieldViolation::new("actor_id", "VAL-4001", "actor_id must not be empty"));
+        }
+        if self.target_id.trim().is_empty() {
+            v.push(FieldViolation::new("target_id", "VAL-4002", "target_id must not be empty"));
+        }
+        if v.is_empty() { Ok(()) } else { Err(v) }
+    }
+}
+
+pub struct BlockProfileHandler {
+    repo:      Arc<dyn SocialGraphRepository>,
+    cache:     Arc<dyn SocialGraphCache>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl BlockProfileHandler {
+    pub fn new(
+        repo:      Arc<dyn SocialGraphRepository>,
+        cache:     Arc<dyn SocialGraphCache>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { repo, cache, publisher }
+    }
+}
+
+impl CommandHandler<BlockProfileCommand> for BlockProfileHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<BlockProfileCommand>,
+    ) -> Result<(), Self::Error> {
+        let cmd = &envelope.payload;
+
+        let actor_id  = ProfileId::try_from(cmd.actor_id.as_str())?;
+        let target_id = ProfileId::try_from(cmd.target_id.as_str())?;
+
+        if actor_id == target_id {
+            return Err(SocialGraphError::SelfInteraction);
+        }
+
+        let mut relation = self.repo.load_relation(&actor_id, &target_id).await?;
+
+        // `block()` returns which follows are severed (with their timestamps).
+        let severed = relation.block()?;
+        let now     = chrono::Utc::now();
+
+        // Persist the block first, then sever any existing follows in parallel.
+        self.repo.persist_block(&actor_id, &target_id, now).await?;
+
+        let (r1, r2) = tokio::join!(
+            async {
+                if let Some(ts) = severed.actor_to_target {
+                    self.repo.delete_follow(&actor_id, &target_id, ts).await?;
+                    let _ = self.cache.remove_following(&actor_id, &target_id).await;
+                    let _ = self.cache.decr_followers_count(&target_id).await;
+                    let _ = self.cache.decr_following_count(&actor_id).await;
+                }
+                Ok::<(), SocialGraphError>(())
+            },
+            async {
+                if let Some(ts) = severed.target_to_actor {
+                    self.repo.delete_follow(&target_id, &actor_id, ts).await?;
+                    let _ = self.cache.remove_following(&target_id, &actor_id).await;
+                    let _ = self.cache.decr_followers_count(&actor_id).await;
+                    let _ = self.cache.decr_following_count(&target_id).await;
+                }
+                Ok::<(), SocialGraphError>(())
+            },
+        );
+        r1?;
+        r2?;
+
+        let _ = self.cache.add_block(&actor_id, &target_id).await;
+
+        for event in relation.take_events() {
+            let _ = self.publisher.publish(&event).await;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/services/social-graph/src/application/command/follow_profile.rs
+++ b/crates/services/social-graph/src/application/command/follow_profile.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use cqrs::{Command, CommandHandler, Envelope};
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::port::{EventPublisher, SocialGraphCache, SocialGraphRepository};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct FollowProfileCommand {
+    pub actor_id:  String,
+    pub target_id: String,
+}
+
+impl Command for FollowProfileCommand {}
+
+impl Validate for FollowProfileCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        let mut v = Vec::new();
+        if self.actor_id.trim().is_empty() {
+            v.push(FieldViolation::new("actor_id", "VAL-4001", "actor_id must not be empty"));
+        }
+        if self.target_id.trim().is_empty() {
+            v.push(FieldViolation::new("target_id", "VAL-4002", "target_id must not be empty"));
+        }
+        if v.is_empty() { Ok(()) } else { Err(v) }
+    }
+}
+
+pub struct FollowProfileHandler {
+    repo:      Arc<dyn SocialGraphRepository>,
+    cache:     Arc<dyn SocialGraphCache>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl FollowProfileHandler {
+    pub fn new(
+        repo:      Arc<dyn SocialGraphRepository>,
+        cache:     Arc<dyn SocialGraphCache>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { repo, cache, publisher }
+    }
+}
+
+impl CommandHandler<FollowProfileCommand> for FollowProfileHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<FollowProfileCommand>,
+    ) -> Result<(), Self::Error> {
+        let cmd = &envelope.payload;
+
+        let actor_id  = ProfileId::try_from(cmd.actor_id.as_str())?;
+        let target_id = ProfileId::try_from(cmd.target_id.as_str())?;
+
+        if actor_id == target_id {
+            return Err(SocialGraphError::SelfInteraction);
+        }
+
+        // Load full bidirectional context (4 concurrent ScyllaDB point-lookups).
+        let mut relation = self.repo.load_relation(&actor_id, &target_id).await?;
+
+        // Domain invariant enforcement (block-gate + idempotency guard).
+        let followed_at = relation.follow()?;
+
+        // Persist the follow edge across the three adjacency tables.
+        self.repo.persist_follow(&actor_id, &target_id, followed_at).await?;
+
+        // Update Redis side-effects (best-effort; errors are logged, not surfaced).
+        let _ = self.cache.add_following(&actor_id, &target_id).await;
+        let _ = self.cache.incr_followers_count(&target_id).await;
+        let _ = self.cache.incr_following_count(&actor_id).await;
+
+        // Publish domain event to Kafka for downstream timeline fan-out engines.
+        for event in relation.take_events() {
+            let _ = self.publisher.publish(&event).await;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/services/social-graph/src/application/command/mod.rs
+++ b/crates/services/social-graph/src/application/command/mod.rs
@@ -1,0 +1,9 @@
+pub mod block_profile;
+pub mod follow_profile;
+pub mod unblock_profile;
+pub mod unfollow_profile;
+
+pub use block_profile::{BlockProfileCommand, BlockProfileHandler};
+pub use follow_profile::{FollowProfileCommand, FollowProfileHandler};
+pub use unblock_profile::{UnblockProfileCommand, UnblockProfileHandler};
+pub use unfollow_profile::{UnfollowProfileCommand, UnfollowProfileHandler};

--- a/crates/services/social-graph/src/application/command/unblock_profile.rs
+++ b/crates/services/social-graph/src/application/command/unblock_profile.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use cqrs::{Command, CommandHandler, Envelope};
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::port::{EventPublisher, SocialGraphCache, SocialGraphRepository};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct UnblockProfileCommand {
+    pub actor_id:  String,
+    pub target_id: String,
+}
+
+impl Command for UnblockProfileCommand {}
+
+impl Validate for UnblockProfileCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        let mut v = Vec::new();
+        if self.actor_id.trim().is_empty() {
+            v.push(FieldViolation::new("actor_id", "VAL-4001", "actor_id must not be empty"));
+        }
+        if self.target_id.trim().is_empty() {
+            v.push(FieldViolation::new("target_id", "VAL-4002", "target_id must not be empty"));
+        }
+        if v.is_empty() { Ok(()) } else { Err(v) }
+    }
+}
+
+pub struct UnblockProfileHandler {
+    repo:      Arc<dyn SocialGraphRepository>,
+    cache:     Arc<dyn SocialGraphCache>,
+    #[allow(dead_code)]
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl UnblockProfileHandler {
+    pub fn new(
+        repo:      Arc<dyn SocialGraphRepository>,
+        cache:     Arc<dyn SocialGraphCache>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { repo, cache, publisher }
+    }
+}
+
+impl CommandHandler<UnblockProfileCommand> for UnblockProfileHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<UnblockProfileCommand>,
+    ) -> Result<(), Self::Error> {
+        let cmd = &envelope.payload;
+
+        let actor_id  = ProfileId::try_from(cmd.actor_id.as_str())?;
+        let target_id = ProfileId::try_from(cmd.target_id.as_str())?;
+
+        let mut relation = self.repo.load_relation(&actor_id, &target_id).await?;
+
+        // Domain guard: must be blocking (returns NotBlocked if not).
+        relation.unblock()?;
+
+        self.repo.delete_block(&actor_id, &target_id).await?;
+
+        let _ = self.cache.remove_block(&actor_id, &target_id).await;
+
+        // ProfileUnblocked is intentionally not published to Kafka.
+        // Unblocking has no downstream fan-out consequence for timeline engines.
+        let _ = relation.take_events();
+
+        Ok(())
+    }
+}

--- a/crates/services/social-graph/src/application/command/unfollow_profile.rs
+++ b/crates/services/social-graph/src/application/command/unfollow_profile.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use cqrs::{Command, CommandHandler, Envelope};
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::port::{EventPublisher, SocialGraphCache, SocialGraphRepository};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct UnfollowProfileCommand {
+    pub actor_id:  String,
+    pub target_id: String,
+}
+
+impl Command for UnfollowProfileCommand {}
+
+impl Validate for UnfollowProfileCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        let mut v = Vec::new();
+        if self.actor_id.trim().is_empty() {
+            v.push(FieldViolation::new("actor_id", "VAL-4001", "actor_id must not be empty"));
+        }
+        if self.target_id.trim().is_empty() {
+            v.push(FieldViolation::new("target_id", "VAL-4002", "target_id must not be empty"));
+        }
+        if v.is_empty() { Ok(()) } else { Err(v) }
+    }
+}
+
+pub struct UnfollowProfileHandler {
+    repo:      Arc<dyn SocialGraphRepository>,
+    cache:     Arc<dyn SocialGraphCache>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl UnfollowProfileHandler {
+    pub fn new(
+        repo:      Arc<dyn SocialGraphRepository>,
+        cache:     Arc<dyn SocialGraphCache>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { repo, cache, publisher }
+    }
+}
+
+impl CommandHandler<UnfollowProfileCommand> for UnfollowProfileHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<UnfollowProfileCommand>,
+    ) -> Result<(), Self::Error> {
+        let cmd = &envelope.payload;
+
+        let actor_id  = ProfileId::try_from(cmd.actor_id.as_str())?;
+        let target_id = ProfileId::try_from(cmd.target_id.as_str())?;
+
+        let mut relation = self.repo.load_relation(&actor_id, &target_id).await?;
+
+        // `unfollow()` returns the `followed_at` timestamp needed for the DELETE.
+        let followed_at = relation.unfollow()?;
+
+        // Triple DELETE: follow_status + following + followers.
+        self.repo.delete_follow(&actor_id, &target_id, followed_at).await?;
+
+        let _ = self.cache.remove_following(&actor_id, &target_id).await;
+        let _ = self.cache.decr_followers_count(&target_id).await;
+        let _ = self.cache.decr_following_count(&actor_id).await;
+
+        for event in relation.take_events() {
+            let _ = self.publisher.publish(&event).await;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/services/social-graph/src/application/mod.rs
+++ b/crates/services/social-graph/src/application/mod.rs
@@ -1,0 +1,3 @@
+pub mod command;
+pub mod port;
+pub mod query;

--- a/crates/services/social-graph/src/application/port/event_publisher.rs
+++ b/crates/services/social-graph/src/application/port/event_publisher.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+
+use crate::domain::event::DomainEvent;
+use crate::error::SocialGraphError;
+
+/// Outbound Kafka event publisher port.
+///
+/// Implemented by [`crate::infrastructure::publisher::kafka_event_publisher::KafkaEventPublisher`].
+///
+/// # Topic mapping
+///
+/// | Event             | Kafka topic                  | Key               |
+/// |-------------------|------------------------------|-------------------|
+/// | ProfileFollowed   | `social-graph.followed`      | `{actor}:{target}`|
+/// | ProfileUnfollowed | `social-graph.unfollowed`    | `{actor}:{target}`|
+/// | ProfileBlocked    | `social-graph.blocked`       | `{actor}:{target}`|
+///
+/// `ProfileUnblocked` is intentionally not published downstream. Unblocking is
+/// a user-local operation with no fan-out consequence for timeline engines.
+#[async_trait]
+pub trait EventPublisher: Send + Sync + 'static {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), SocialGraphError>;
+}

--- a/crates/services/social-graph/src/application/port/mod.rs
+++ b/crates/services/social-graph/src/application/port/mod.rs
@@ -1,0 +1,7 @@
+pub mod event_publisher;
+pub mod social_graph_cache;
+pub mod social_graph_repository;
+
+pub use event_publisher::EventPublisher;
+pub use social_graph_cache::{RelationCounts, SocialGraphCache};
+pub use social_graph_repository::SocialGraphRepository;

--- a/crates/services/social-graph/src/application/port/social_graph_cache.rs
+++ b/crates/services/social-graph/src/application/port/social_graph_cache.rs
@@ -1,0 +1,94 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+/// Follower and following counts for a single profile, read from Redis.
+///
+/// These counters are the only counts maintained in-process.
+/// ScyllaDB COUNT(*) over large partitions is prohibitively expensive for
+/// high-traffic profiles — Redis INCR/DECR is the authoritative counter store.
+#[derive(Debug, Clone, Default)]
+pub struct RelationCounts {
+    /// Total number of profiles following this profile.
+    pub followers: i64,
+    /// Total number of profiles this profile follows.
+    pub following: i64,
+}
+
+/// Redis cache port for the social graph.
+///
+/// # Key namespace
+///
+/// | Key pattern                           | Type   | Purpose                         |
+/// |---------------------------------------|--------|---------------------------------|
+/// | `sg:following:v1:{profile_id}`        | Set    | UUIDs of profiles this ID follows|
+/// | `sg:blocks:v1:{profile_id}`           | Set    | UUIDs this ID has blocked       |
+/// | `sg:followers_count:v1:{profile_id}`  | String | Follower counter (INCR/DECR)    |
+/// | `sg:following_count:v1:{profile_id}`  | String | Following counter (INCR/DECR)   |
+///
+/// # Why Sets for `following` but Strings for `followers`
+///
+/// Outbound follows are bounded for all normal users (max tens of thousands).
+/// Inbound follows are unbounded for celebrities (millions). Materialising the
+/// full inbound set in Redis would exhaust memory on high-follower accounts.
+/// A counter satisfies the read need with O(1) space.
+///
+/// # Cache miss semantics
+///
+/// All methods are best-effort: callers must not treat a cache error as a
+/// domain error. Failures are logged and swallowed at the handler level so
+/// a Redis outage degrades to slower ScyllaDB reads, never a user-visible error.
+#[async_trait]
+pub trait SocialGraphCache: Send + Sync + 'static {
+    // ── Following set operations ──────────────────────────────────────────────
+
+    /// SADD `sg:following:v1:{follower}` `{followee}`.
+    async fn add_following(
+        &self,
+        follower_id: &ProfileId,
+        followee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError>;
+
+    /// SREM `sg:following:v1:{follower}` `{followee}`.
+    async fn remove_following(
+        &self,
+        follower_id: &ProfileId,
+        followee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError>;
+
+    // ── Block set operations ──────────────────────────────────────────────────
+
+    /// SADD `sg:blocks:v1:{blocker}` `{blockee}`.
+    async fn add_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError>;
+
+    /// SREM `sg:blocks:v1:{blocker}` `{blockee}`.
+    async fn remove_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError>;
+
+    // ── Counter operations ────────────────────────────────────────────────────
+
+    /// INCR `sg:followers_count:v1:{profile_id}`.
+    async fn incr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;
+
+    /// DECR `sg:followers_count:v1:{profile_id}` (floor at 0).
+    async fn decr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;
+
+    /// INCR `sg:following_count:v1:{profile_id}`.
+    async fn incr_following_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;
+
+    /// DECR `sg:following_count:v1:{profile_id}` (floor at 0).
+    async fn decr_following_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;
+
+    /// GET both counter keys for a profile in a single call.
+    ///
+    /// Returns zero for keys that do not exist (cold cache after Redis restart).
+    async fn get_counts(&self, profile_id: &ProfileId) -> Result<RelationCounts, SocialGraphError>;
+}

--- a/crates/services/social-graph/src/application/port/social_graph_repository.rs
+++ b/crates/services/social-graph/src/application/port/social_graph_repository.rs
@@ -1,0 +1,94 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::domain::aggregate::Relation;
+use crate::domain::entity::{BlockEdge, FollowEdge};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+/// Persistence port for the social graph.
+///
+/// All methods are point-lookups or narrow partition scans — no ALLOW FILTERING.
+/// The four ScyllaDB tables (followers, following, follow_status, blocks) are
+/// partitioned to guarantee O(1) single-row access and O(page) list scans.
+#[async_trait]
+pub trait SocialGraphRepository: Send + Sync + 'static {
+    /// Loads the full bidirectional relationship context for `(actor, target)`.
+    ///
+    /// Fires four concurrent ScyllaDB point-lookups:
+    ///   1. `follow_status` WHERE `follower = actor  AND followee = target`
+    ///   2. `follow_status` WHERE `follower = target AND followee = actor`
+    ///   3. `blocks`        WHERE `blocker  = actor  AND blockee  = target`
+    ///   4. `blocks`        WHERE `blocker  = target AND blockee  = actor`
+    async fn load_relation(
+        &self,
+        actor_id:  &ProfileId,
+        target_id: &ProfileId,
+    ) -> Result<Relation, SocialGraphError>;
+
+    /// Writes a follow edge across three tables atomically as an unlogged batch:
+    ///   - `following`     INSERT (follower_id, followed_at, followee_id)
+    ///   - `followers`     INSERT (followee_id, followed_at, follower_id)
+    ///   - `follow_status` INSERT (follower_id, followee_id, followed_at)
+    async fn persist_follow(
+        &self,
+        actor_id:    &ProfileId,
+        target_id:   &ProfileId,
+        followed_at: DateTime<Utc>,
+    ) -> Result<(), SocialGraphError>;
+
+    /// Deletes a follow edge from three tables.
+    ///
+    /// `followed_at` must be provided by the caller (obtained from `load_relation`)
+    /// because ScyllaDB requires the full clustering key for a targeted DELETE.
+    async fn delete_follow(
+        &self,
+        actor_id:    &ProfileId,
+        target_id:   &ProfileId,
+        followed_at: DateTime<Utc>,
+    ) -> Result<(), SocialGraphError>;
+
+    /// Writes a block record to the `blocks` table.
+    async fn persist_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+        blocked_at: DateTime<Utc>,
+    ) -> Result<(), SocialGraphError>;
+
+    /// Deletes a block record from the `blocks` table.
+    async fn delete_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError>;
+
+    /// Paginated scan of the `followers` table (fan-in adjacency list).
+    ///
+    /// Page token encodes the `followed_at` millisecond timestamp of the last
+    /// row returned. Absent on first page; present when `returned == limit`.
+    async fn list_followers(
+        &self,
+        followee_id: &ProfileId,
+        limit:       i32,
+        page_token:  Option<&str>,
+    ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError>;
+
+    /// Paginated scan of the `following` table (fan-out adjacency list).
+    async fn list_following(
+        &self,
+        follower_id: &ProfileId,
+        limit:       i32,
+        page_token:  Option<&str>,
+    ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError>;
+
+    /// Paginated scan of the `blocks` table for a given blocker.
+    ///
+    /// Page token encodes the UUID string of the last `blockee_id` returned.
+    async fn list_blocks(
+        &self,
+        blocker_id: &ProfileId,
+        limit:      i32,
+        page_token: Option<&str>,
+    ) -> Result<(Vec<BlockEdge>, Option<String>), SocialGraphError>;
+}

--- a/crates/services/social-graph/src/application/query/get_relation_status.rs
+++ b/crates/services/social-graph/src/application/query/get_relation_status.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::{RelationCounts, SocialGraphCache, SocialGraphRepository};
+use crate::domain::value_object::{ProfileId, RelationStatus};
+use crate::error::SocialGraphError;
+
+/// Query: retrieve the full bidirectional relationship status between two profiles,
+/// together with the target profile's follower and following counts.
+///
+/// Read path:
+///   1. ScyllaDB `load_relation` (4 concurrent point-lookups) → follow/block state.
+///   2. Redis `get_counts` → target's follower/following counters.
+///
+/// ScyllaDB is the authoritative source for relationship state. Redis serves
+/// the counts, which degrade gracefully to zero on cold cache (Redis restart).
+#[derive(Debug, Clone)]
+pub struct GetRelationStatusQuery {
+    pub actor_id:  String,
+    pub target_id: String,
+}
+
+impl Query for GetRelationStatusQuery {
+    type Response = RelationStatusView;
+}
+
+#[derive(Debug, Clone)]
+pub struct RelationStatusView {
+    pub actor_id:               ProfileId,
+    pub target_id:              ProfileId,
+    pub status:                 RelationStatus,
+    pub target_followers_count: i64,
+    pub target_following_count: i64,
+}
+
+pub struct GetRelationStatusHandler {
+    repo:  Arc<dyn SocialGraphRepository>,
+    cache: Arc<dyn SocialGraphCache>,
+}
+
+impl GetRelationStatusHandler {
+    pub fn new(repo: Arc<dyn SocialGraphRepository>, cache: Arc<dyn SocialGraphCache>) -> Self {
+        Self { repo, cache }
+    }
+}
+
+impl QueryHandler<GetRelationStatusQuery> for GetRelationStatusHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<GetRelationStatusQuery>,
+    ) -> Result<RelationStatusView, Self::Error> {
+        let q = &envelope.payload;
+
+        let actor_id  = ProfileId::try_from(q.actor_id.as_str())?;
+        let target_id = ProfileId::try_from(q.target_id.as_str())?;
+
+        // Fire ScyllaDB and Redis queries concurrently.
+        let (relation, counts) = tokio::join!(
+            self.repo.load_relation(&actor_id, &target_id),
+            self.cache.get_counts(&target_id),
+        );
+
+        let relation = relation?;
+        let counts: RelationCounts = counts.unwrap_or_default();
+
+        Ok(RelationStatusView {
+            actor_id,
+            target_id,
+            status:                 relation.status(),
+            target_followers_count: counts.followers,
+            target_following_count: counts.following,
+        })
+    }
+}

--- a/crates/services/social-graph/src/application/query/list_blocks.rs
+++ b/crates/services/social-graph/src/application/query/list_blocks.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::SocialGraphRepository;
+use crate::domain::entity::BlockEdge;
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct ListBlocksQuery {
+    pub blocker_id: String,
+    pub limit:      u32,
+    pub page_token: Option<String>,
+}
+
+impl Query for ListBlocksQuery {
+    type Response = (Vec<BlockEdge>, Option<String>);
+}
+
+pub struct ListBlocksHandler {
+    repo: Arc<dyn SocialGraphRepository>,
+}
+
+impl ListBlocksHandler {
+    pub fn new(repo: Arc<dyn SocialGraphRepository>) -> Self {
+        Self { repo }
+    }
+}
+
+impl QueryHandler<ListBlocksQuery> for ListBlocksHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<ListBlocksQuery>,
+    ) -> Result<(Vec<BlockEdge>, Option<String>), Self::Error> {
+        let q = &envelope.payload;
+
+        let blocker_id = ProfileId::try_from(q.blocker_id.as_str())?;
+        let limit      = q.limit.clamp(1, 100) as i32;
+
+        self.repo.list_blocks(&blocker_id, limit, q.page_token.as_deref()).await
+    }
+}

--- a/crates/services/social-graph/src/application/query/list_followers.rs
+++ b/crates/services/social-graph/src/application/query/list_followers.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::SocialGraphRepository;
+use crate::domain::entity::FollowEdge;
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct ListFollowersQuery {
+    pub followee_id: String,
+    pub limit:       u32,
+    pub page_token:  Option<String>,
+}
+
+impl Query for ListFollowersQuery {
+    type Response = (Vec<FollowEdge>, Option<String>);
+}
+
+pub struct ListFollowersHandler {
+    repo: Arc<dyn SocialGraphRepository>,
+}
+
+impl ListFollowersHandler {
+    pub fn new(repo: Arc<dyn SocialGraphRepository>) -> Self {
+        Self { repo }
+    }
+}
+
+impl QueryHandler<ListFollowersQuery> for ListFollowersHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<ListFollowersQuery>,
+    ) -> Result<(Vec<FollowEdge>, Option<String>), Self::Error> {
+        let q = &envelope.payload;
+
+        let followee_id = ProfileId::try_from(q.followee_id.as_str())?;
+        let limit       = q.limit.clamp(1, 100) as i32;
+
+        self.repo.list_followers(&followee_id, limit, q.page_token.as_deref()).await
+    }
+}

--- a/crates/services/social-graph/src/application/query/list_following.rs
+++ b/crates/services/social-graph/src/application/query/list_following.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::SocialGraphRepository;
+use crate::domain::entity::FollowEdge;
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+#[derive(Debug, Clone)]
+pub struct ListFollowingQuery {
+    pub follower_id: String,
+    pub limit:       u32,
+    pub page_token:  Option<String>,
+}
+
+impl Query for ListFollowingQuery {
+    type Response = (Vec<FollowEdge>, Option<String>);
+}
+
+pub struct ListFollowingHandler {
+    repo: Arc<dyn SocialGraphRepository>,
+}
+
+impl ListFollowingHandler {
+    pub fn new(repo: Arc<dyn SocialGraphRepository>) -> Self {
+        Self { repo }
+    }
+}
+
+impl QueryHandler<ListFollowingQuery> for ListFollowingHandler {
+    type Error = SocialGraphError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<ListFollowingQuery>,
+    ) -> Result<(Vec<FollowEdge>, Option<String>), Self::Error> {
+        let q = &envelope.payload;
+
+        let follower_id = ProfileId::try_from(q.follower_id.as_str())?;
+        let limit       = q.limit.clamp(1, 100) as i32;
+
+        self.repo.list_following(&follower_id, limit, q.page_token.as_deref()).await
+    }
+}

--- a/crates/services/social-graph/src/application/query/mod.rs
+++ b/crates/services/social-graph/src/application/query/mod.rs
@@ -1,0 +1,9 @@
+pub mod get_relation_status;
+pub mod list_blocks;
+pub mod list_followers;
+pub mod list_following;
+
+pub use get_relation_status::{GetRelationStatusQuery, GetRelationStatusHandler};
+pub use list_blocks::{ListBlocksQuery, ListBlocksHandler};
+pub use list_followers::{ListFollowersQuery, ListFollowersHandler};
+pub use list_following::{ListFollowingQuery, ListFollowingHandler};

--- a/crates/services/social-graph/src/domain/aggregate/mod.rs
+++ b/crates/services/social-graph/src/domain/aggregate/mod.rs
@@ -1,0 +1,3 @@
+pub mod relation;
+
+pub use relation::{Relation, RelationContext, SeveredFollows};

--- a/crates/services/social-graph/src/domain/aggregate/relation.rs
+++ b/crates/services/social-graph/src/domain/aggregate/relation.rs
@@ -1,0 +1,225 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::event::{
+    DomainEvent, ProfileBlocked, ProfileFollowed, ProfileUnblocked, ProfileUnfollowed,
+};
+use crate::domain::value_object::{ProfileId, RelationStatus};
+use crate::error::SocialGraphError;
+
+/// The timestamps of follow edges severed by a block operation.
+///
+/// Returned by [`Relation::block`] so the command handler knows exactly which
+/// ScyllaDB DELETEs and Redis SREMs to issue without re-querying the database.
+#[derive(Debug, Clone)]
+pub struct SeveredFollows {
+    /// `Some(ts)` if the actor→target follow was severed; `ts` is `followed_at`
+    /// needed to delete the clustering row from `followers` and `following`.
+    pub actor_to_target: Option<DateTime<Utc>>,
+    /// `Some(ts)` if the target→actor follow was severed.
+    pub target_to_actor: Option<DateTime<Utc>>,
+}
+
+/// The raw bidirectional context used to reconstruct a [`Relation`].
+///
+/// Populated by [`SocialGraphRepository::load_relation`].
+pub struct RelationContext {
+    pub actor_follows_target_since:  Option<DateTime<Utc>>,
+    pub target_follows_actor_since:  Option<DateTime<Utc>>,
+    pub actor_blocks_target:         bool,
+    pub target_blocks_actor:         bool,
+}
+
+/// Aggregate root for the bidirectional relationship between two profiles.
+///
+/// Enforces all social-graph invariants before any persistence call is made:
+///   1. Self-interaction guard (actor == target is rejected at the handler level).
+///   2. Block-gate: a follow is rejected if a block exists in either direction.
+///   3. Idempotency guards: re-follow and re-block return domain errors.
+///   4. Block-sever: `block()` automatically computes which existing follows
+///      must be deleted, returning their timestamps as [`SeveredFollows`].
+///
+/// # Event sourcing
+///
+/// Domain events are accumulated in `pending_events` and drained by the command
+/// handler after persistence succeeds. The handler owns the publish-or-discard
+/// decision; the aggregate never publishes directly.
+pub struct Relation {
+    actor_id:  ProfileId,
+    target_id: ProfileId,
+
+    /// `None` = actor does not follow target.
+    /// `Some(ts)` = actor follows target since `ts` (needed for DELETE key).
+    actor_follows_target_since: Option<DateTime<Utc>>,
+
+    /// `None` = target does not follow actor.
+    /// `Some(ts)` = target follows actor since `ts`.
+    target_follows_actor_since: Option<DateTime<Utc>>,
+
+    actor_blocks_target: bool,
+    target_blocks_actor: bool,
+
+    pending_events: Vec<DomainEvent>,
+}
+
+impl Relation {
+    pub fn from_context(
+        actor_id:  ProfileId,
+        target_id: ProfileId,
+        ctx: RelationContext,
+    ) -> Self {
+        Self {
+            actor_id,
+            target_id,
+            actor_follows_target_since: ctx.actor_follows_target_since,
+            target_follows_actor_since: ctx.target_follows_actor_since,
+            actor_blocks_target:        ctx.actor_blocks_target,
+            target_blocks_actor:        ctx.target_blocks_actor,
+            pending_events:             Vec::new(),
+        }
+    }
+
+    // ── Commands ──────────────────────────────────────────────────────────────
+
+    /// Records that the actor follows the target.
+    ///
+    /// # Errors
+    ///
+    /// - [`SocialGraphError::AlreadyFollowing`] if the follow already exists.
+    /// - [`SocialGraphError::BlockGateDenied`] if a block exists in either direction.
+    pub fn follow(&mut self) -> Result<DateTime<Utc>, SocialGraphError> {
+        if self.actor_blocks_target || self.target_blocks_actor {
+            return Err(SocialGraphError::BlockGateDenied {
+                actor_id:  self.actor_id.as_str(),
+                target_id: self.target_id.as_str(),
+            });
+        }
+        if self.actor_follows_target_since.is_some() {
+            return Err(SocialGraphError::AlreadyFollowing {
+                actor_id:  self.actor_id.as_str(),
+                target_id: self.target_id.as_str(),
+            });
+        }
+        let now = Utc::now();
+        self.actor_follows_target_since = Some(now);
+        self.pending_events.push(DomainEvent::ProfileFollowed(ProfileFollowed {
+            actor_id:    self.actor_id,
+            target_id:   self.target_id,
+            followed_at: now,
+        }));
+        Ok(now)
+    }
+
+    /// Removes the actor→target follow.
+    ///
+    /// # Errors
+    ///
+    /// - [`SocialGraphError::NotFollowing`] if no follow exists.
+    pub fn unfollow(&mut self) -> Result<DateTime<Utc>, SocialGraphError> {
+        let followed_at = self.actor_follows_target_since.ok_or_else(|| {
+            SocialGraphError::NotFollowing {
+                actor_id:  self.actor_id.as_str(),
+                target_id: self.target_id.as_str(),
+            }
+        })?;
+        self.actor_follows_target_since = None;
+        self.pending_events.push(DomainEvent::ProfileUnfollowed(ProfileUnfollowed {
+            actor_id:      self.actor_id,
+            target_id:     self.target_id,
+            unfollowed_at: Utc::now(),
+        }));
+        Ok(followed_at)
+    }
+
+    /// Records that the actor blocks the target, severs any existing follows
+    /// in both directions, and returns the timestamps of severed edges.
+    ///
+    /// # Errors
+    ///
+    /// - [`SocialGraphError::AlreadyBlocked`] if the block already exists.
+    pub fn block(&mut self) -> Result<SeveredFollows, SocialGraphError> {
+        if self.actor_blocks_target {
+            return Err(SocialGraphError::AlreadyBlocked {
+                actor_id:  self.actor_id.as_str(),
+                target_id: self.target_id.as_str(),
+            });
+        }
+        let severed = SeveredFollows {
+            actor_to_target: self.actor_follows_target_since.take(),
+            target_to_actor: self.target_follows_actor_since.take(),
+        };
+        self.actor_blocks_target = true;
+        let now = Utc::now();
+        self.pending_events.push(DomainEvent::ProfileBlocked(ProfileBlocked {
+            actor_id:              self.actor_id,
+            target_id:             self.target_id,
+            blocked_at:            now,
+            severed_actor_follow:  severed.actor_to_target.is_some(),
+            severed_target_follow: severed.target_to_actor.is_some(),
+        }));
+        Ok(severed)
+    }
+
+    /// Removes the block that the actor placed on the target.
+    ///
+    /// Does not restore severed follows (the user must re-follow explicitly).
+    ///
+    /// # Errors
+    ///
+    /// - [`SocialGraphError::NotBlocked`] if no block exists.
+    pub fn unblock(&mut self) -> Result<(), SocialGraphError> {
+        if !self.actor_blocks_target {
+            return Err(SocialGraphError::NotBlocked {
+                actor_id:  self.actor_id.as_str(),
+                target_id: self.target_id.as_str(),
+            });
+        }
+        self.actor_blocks_target = false;
+        self.pending_events.push(DomainEvent::ProfileUnblocked(ProfileUnblocked {
+            actor_id:     self.actor_id,
+            target_id:    self.target_id,
+            unblocked_at: Utc::now(),
+        }));
+        Ok(())
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────────
+
+    pub fn status(&self) -> RelationStatus {
+        if self.actor_blocks_target {
+            return RelationStatus::Blocking;
+        }
+        if self.target_blocks_actor {
+            return RelationStatus::BlockedBy;
+        }
+        match (
+            self.actor_follows_target_since.is_some(),
+            self.target_follows_actor_since.is_some(),
+        ) {
+            (true,  true)  => RelationStatus::MutualFollow,
+            (true,  false) => RelationStatus::Following,
+            (false, true)  => RelationStatus::FollowedBy,
+            (false, false) => RelationStatus::None,
+        }
+    }
+
+    pub fn actor_follows_target_since(&self) -> Option<DateTime<Utc>> {
+        self.actor_follows_target_since
+    }
+
+    pub fn target_follows_actor_since(&self) -> Option<DateTime<Utc>> {
+        self.target_follows_actor_since
+    }
+
+    pub fn actor_blocks_target(&self) -> bool {
+        self.actor_blocks_target
+    }
+
+    pub fn target_blocks_actor(&self) -> bool {
+        self.target_blocks_actor
+    }
+
+    /// Drains and returns all accumulated domain events.
+    pub fn take_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+}

--- a/crates/services/social-graph/src/domain/entity/block_edge.rs
+++ b/crates/services/social-graph/src/domain/entity/block_edge.rs
@@ -1,0 +1,10 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::value_object::ProfileId;
+
+/// A single directed block edge as returned by block-list queries.
+#[derive(Debug, Clone)]
+pub struct BlockEdge {
+    pub blockee_id: ProfileId,
+    pub blocked_at: DateTime<Utc>,
+}

--- a/crates/services/social-graph/src/domain/entity/follow_edge.rs
+++ b/crates/services/social-graph/src/domain/entity/follow_edge.rs
@@ -1,0 +1,13 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::value_object::ProfileId;
+
+/// A single directed follow edge as returned by adjacency-list queries.
+///
+/// In `list_followers` results: `profile_id` is the follower.
+/// In `list_following` results: `profile_id` is the followee.
+#[derive(Debug, Clone)]
+pub struct FollowEdge {
+    pub profile_id:  ProfileId,
+    pub followed_at: DateTime<Utc>,
+}

--- a/crates/services/social-graph/src/domain/entity/mod.rs
+++ b/crates/services/social-graph/src/domain/entity/mod.rs
@@ -1,0 +1,5 @@
+pub mod block_edge;
+pub mod follow_edge;
+
+pub use block_edge::BlockEdge;
+pub use follow_edge::FollowEdge;

--- a/crates/services/social-graph/src/domain/event/mod.rs
+++ b/crates/services/social-graph/src/domain/event/mod.rs
@@ -1,0 +1,17 @@
+pub mod profile_blocked;
+pub mod profile_followed;
+pub mod profile_unblocked;
+pub mod profile_unfollowed;
+
+pub use profile_blocked::ProfileBlocked;
+pub use profile_followed::ProfileFollowed;
+pub use profile_unblocked::ProfileUnblocked;
+pub use profile_unfollowed::ProfileUnfollowed;
+
+#[derive(Debug, Clone)]
+pub enum DomainEvent {
+    ProfileFollowed(ProfileFollowed),
+    ProfileUnfollowed(ProfileUnfollowed),
+    ProfileBlocked(ProfileBlocked),
+    ProfileUnblocked(ProfileUnblocked),
+}

--- a/crates/services/social-graph/src/domain/event/profile_blocked.rs
+++ b/crates/services/social-graph/src/domain/event/profile_blocked.rs
@@ -1,0 +1,15 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::ProfileId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileBlocked {
+    pub actor_id:   ProfileId,
+    pub target_id:  ProfileId,
+    pub blocked_at: DateTime<Utc>,
+    /// True if the block severed an existing actor→target follow.
+    pub severed_actor_follow:  bool,
+    /// True if the block severed an existing target→actor follow.
+    pub severed_target_follow: bool,
+}

--- a/crates/services/social-graph/src/domain/event/profile_followed.rs
+++ b/crates/services/social-graph/src/domain/event/profile_followed.rs
@@ -1,0 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::ProfileId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileFollowed {
+    pub actor_id:    ProfileId,
+    pub target_id:   ProfileId,
+    pub followed_at: DateTime<Utc>,
+}

--- a/crates/services/social-graph/src/domain/event/profile_unblocked.rs
+++ b/crates/services/social-graph/src/domain/event/profile_unblocked.rs
@@ -1,0 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::ProfileId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileUnblocked {
+    pub actor_id:     ProfileId,
+    pub target_id:    ProfileId,
+    pub unblocked_at: DateTime<Utc>,
+}

--- a/crates/services/social-graph/src/domain/event/profile_unfollowed.rs
+++ b/crates/services/social-graph/src/domain/event/profile_unfollowed.rs
@@ -1,0 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::ProfileId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileUnfollowed {
+    pub actor_id:      ProfileId,
+    pub target_id:     ProfileId,
+    pub unfollowed_at: DateTime<Utc>,
+}

--- a/crates/services/social-graph/src/domain/mod.rs
+++ b/crates/services/social-graph/src/domain/mod.rs
@@ -1,0 +1,4 @@
+pub mod aggregate;
+pub mod entity;
+pub mod event;
+pub mod value_object;

--- a/crates/services/social-graph/src/domain/value_object/mod.rs
+++ b/crates/services/social-graph/src/domain/value_object/mod.rs
@@ -1,0 +1,7 @@
+pub mod profile_id;
+pub mod relation_kind;
+pub mod relation_status;
+
+pub use profile_id::ProfileId;
+pub use relation_kind::RelationKind;
+pub use relation_status::RelationStatus;

--- a/crates/services/social-graph/src/domain/value_object/profile_id.rs
+++ b/crates/services/social-graph/src/domain/value_object/profile_id.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::SocialGraphError;
+
+/// Opaque identifier for a profile within the social-graph bounded context.
+///
+/// This service treats profiles as pure UUIDv7 primitives. It has no knowledge
+/// of handles, display names, or any other metadata — those are the responsibility
+/// of services/profile. SRP is maintained by never importing the profile crate here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProfileId(Uuid);
+
+impl ProfileId {
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl TryFrom<&str> for ProfileId {
+    type Error = SocialGraphError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| SocialGraphError::InvalidProfileId(s.to_owned()))
+    }
+}
+
+impl std::fmt::Display for ProfileId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/crates/services/social-graph/src/domain/value_object/relation_kind.rs
+++ b/crates/services/social-graph/src/domain/value_object/relation_kind.rs
@@ -1,0 +1,6 @@
+/// The type of a directed edge in the social graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationKind {
+    Follow,
+    Block,
+}

--- a/crates/services/social-graph/src/domain/value_object/relation_status.rs
+++ b/crates/services/social-graph/src/domain/value_object/relation_status.rs
@@ -1,0 +1,23 @@
+/// The combined relationship status between an actor and a target profile,
+/// observed from the actor's point of view.
+///
+/// # Invariants
+///
+/// Block states and follow states are mutually exclusive. A block severs any
+/// existing follow in both directions and prevents new follows, so `Blocking`
+/// and `BlockedBy` can never coexist with any follow-based variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationStatus {
+    /// No relationship exists between actor and target.
+    None,
+    /// Actor follows target; target does not follow actor back.
+    Following,
+    /// Target follows actor; actor does not follow target.
+    FollowedBy,
+    /// Both profiles follow each other (implicit "friendship").
+    MutualFollow,
+    /// Actor has blocked target.
+    Blocking,
+    /// Target has blocked actor.
+    BlockedBy,
+}

--- a/crates/services/social-graph/src/error.rs
+++ b/crates/services/social-graph/src/error.rs
@@ -1,0 +1,153 @@
+use error::{AppError, Severity};
+use http::StatusCode;
+use thiserror::Error;
+
+/// Canonical domain and application error type for the social-graph microservice.
+///
+/// ## Error code catalogue
+///
+/// | Code     | Variant               | HTTP | Severity | Retryable |
+/// |----------|-----------------------|------|----------|-----------|
+/// | SGR-1001 | AlreadyFollowing      | 409  | Low      | No        |
+/// | SGR-1002 | NotFollowing          | 422  | Low      | No        |
+/// | SGR-1003 | AlreadyBlocked        | 409  | Low      | No        |
+/// | SGR-1004 | NotBlocked            | 422  | Low      | No        |
+/// | SGR-2001 | SelfInteraction       | 422  | Low      | No        |
+/// | SGR-2002 | BlockGateDenied       | 422  | Medium   | No        |
+/// | SGR-9001 | DomainViolation       | 422  | Medium   | No        |
+/// | SGR-9002 | InvalidProfileId      | 422  | Low      | No        |
+/// | SDB-*    | Storage (delegated)   | var  | var      | var       |
+/// | RDB-*    | Cache (delegated)     | 500  | var      | var       |
+/// | VAL-*    | Validation (delegated)| 422  | Low      | No        |
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SocialGraphError {
+    // ── Infrastructure delegates ───────────────────────────────────────────────
+
+    #[error(transparent)]
+    Storage(#[from] scylla_storage::ScyllaStorageError),
+
+    #[error(transparent)]
+    Cache(#[from] redis_storage::RedisStorageError),
+
+    #[error(transparent)]
+    Validation(#[from] validation::ValidationError),
+
+    // ── Follow state (SGR-1xxx) ───────────────────────────────────────────────
+
+    #[error("profile '{actor_id}' already follows '{target_id}'")]
+    AlreadyFollowing { actor_id: String, target_id: String },
+
+    #[error("profile '{actor_id}' does not follow '{target_id}'")]
+    NotFollowing { actor_id: String, target_id: String },
+
+    // ── Block state (SGR-1xxx continued) ─────────────────────────────────────
+
+    #[error("profile '{actor_id}' has already blocked '{target_id}'")]
+    AlreadyBlocked { actor_id: String, target_id: String },
+
+    #[error("profile '{actor_id}' has not blocked '{target_id}'")]
+    NotBlocked { actor_id: String, target_id: String },
+
+    // ── Graph invariants (SGR-2xxx) ───────────────────────────────────────────
+
+    #[error("a profile cannot follow or block itself")]
+    SelfInteraction,
+
+    #[error("follow rejected: a block relationship exists between '{actor_id}' and '{target_id}'")]
+    BlockGateDenied { actor_id: String, target_id: String },
+
+    // ── Domain parse errors (SGR-9xxx) ────────────────────────────────────────
+
+    #[error("domain invariant violated on '{field}': {message}")]
+    DomainViolation { field: String, message: String },
+
+    #[error("invalid profile ID: '{0}'")]
+    InvalidProfileId(String),
+}
+
+impl AppError for SocialGraphError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            SocialGraphError::Storage(e)    => e.error_code(),
+            SocialGraphError::Cache(e)      => e.error_code(),
+            SocialGraphError::Validation(e) => e.error_code(),
+
+            SocialGraphError::AlreadyFollowing { .. } => "SGR-1001",
+            SocialGraphError::NotFollowing { .. }     => "SGR-1002",
+            SocialGraphError::AlreadyBlocked { .. }   => "SGR-1003",
+            SocialGraphError::NotBlocked { .. }       => "SGR-1004",
+
+            SocialGraphError::SelfInteraction           => "SGR-2001",
+            SocialGraphError::BlockGateDenied { .. }    => "SGR-2002",
+
+            SocialGraphError::DomainViolation { .. } => "SGR-9001",
+            SocialGraphError::InvalidProfileId(_)    => "SGR-9002",
+        }
+    }
+
+    fn http_status(&self) -> StatusCode {
+        match self {
+            SocialGraphError::Storage(e)    => e.http_status(),
+            SocialGraphError::Cache(e)      => e.http_status(),
+            SocialGraphError::Validation(e) => e.http_status(),
+
+            SocialGraphError::AlreadyFollowing { .. }
+            | SocialGraphError::AlreadyBlocked { .. } => StatusCode::CONFLICT,
+
+            SocialGraphError::NotFollowing { .. }
+            | SocialGraphError::NotBlocked { .. }
+            | SocialGraphError::SelfInteraction
+            | SocialGraphError::BlockGateDenied { .. }
+            | SocialGraphError::DomainViolation { .. }
+            | SocialGraphError::InvalidProfileId(_) => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            SocialGraphError::Storage(e)    => e.severity(),
+            SocialGraphError::Cache(e)      => e.severity(),
+            SocialGraphError::Validation(e) => e.severity(),
+
+            SocialGraphError::BlockGateDenied { .. }
+            | SocialGraphError::DomainViolation { .. } => Severity::Medium,
+
+            _ => Severity::Low,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            SocialGraphError::Storage(e) => e.is_retryable(),
+            SocialGraphError::Cache(e)   => e.is_retryable(),
+            _                            => false,
+        }
+    }
+
+    fn category(&self) -> &'static str {
+        match self {
+            SocialGraphError::Storage(e)    => e.category(),
+            SocialGraphError::Cache(e)      => e.category(),
+            SocialGraphError::Validation(e) => e.category(),
+            _                               => "SGR",
+        }
+    }
+
+    fn user_facing_message(&self) -> &'static str {
+        match self {
+            SocialGraphError::Storage(e)    => e.user_facing_message(),
+            SocialGraphError::Cache(e)      => e.user_facing_message(),
+            SocialGraphError::Validation(e) => e.user_facing_message(),
+
+            SocialGraphError::AlreadyFollowing { .. } => "You are already following this profile.",
+            SocialGraphError::NotFollowing { .. }     => "You are not following this profile.",
+            SocialGraphError::AlreadyBlocked { .. }   => "You have already blocked this profile.",
+            SocialGraphError::NotBlocked { .. }       => "You have not blocked this profile.",
+            SocialGraphError::SelfInteraction          => "A profile cannot follow or block itself.",
+            SocialGraphError::BlockGateDenied { .. }   => "A block relationship prevents this follow.",
+            SocialGraphError::DomainViolation { .. }   => "A domain constraint was violated.",
+            SocialGraphError::InvalidProfileId(_)      => "The provided profile ID is not valid.",
+        }
+    }
+}

--- a/crates/services/social-graph/src/infrastructure/cache/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/cache/mod.rs
@@ -1,0 +1,3 @@
+pub mod redis_social_graph_cache;
+
+pub use redis_social_graph_cache::RedisSocialGraphCache;

--- a/crates/services/social-graph/src/infrastructure/cache/redis_social_graph_cache.rs
+++ b/crates/services/social-graph/src/infrastructure/cache/redis_social_graph_cache.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fred::interfaces::{KeysInterface as _, SetsInterface as _};
+
+use redis_storage::{RedisClient, RedisStorageError};
+
+use crate::application::port::{RelationCounts, SocialGraphCache};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+
+// ── Key builders ──────────────────────────────────────────────────────────────
+
+fn following_key(profile_id: &ProfileId) -> String {
+    format!("sg:following:v1:{profile_id}")
+}
+
+fn blocks_key(profile_id: &ProfileId) -> String {
+    format!("sg:blocks:v1:{profile_id}")
+}
+
+fn followers_count_key(profile_id: &ProfileId) -> String {
+    format!("sg:followers_count:v1:{profile_id}")
+}
+
+fn following_count_key(profile_id: &ProfileId) -> String {
+    format!("sg:following_count:v1:{profile_id}")
+}
+
+// ── Error helper ──────────────────────────────────────────────────────────────
+
+fn redis_err(e: fred::error::Error) -> SocialGraphError {
+    SocialGraphError::Cache(RedisStorageError::from(e))
+}
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+pub struct RedisSocialGraphCache {
+    client: Arc<RedisClient>,
+}
+
+impl RedisSocialGraphCache {
+    pub fn new(client: Arc<RedisClient>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl SocialGraphCache for RedisSocialGraphCache {
+    // ── Following set operations ──────────────────────────────────────────────
+
+    async fn add_following(
+        &self,
+        follower_id: &ProfileId,
+        followee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError> {
+        let key    = following_key(follower_id);
+        let member = followee_id.as_str();
+        self.client
+            .sadd::<i64, _, _>(&key, member)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    async fn remove_following(
+        &self,
+        follower_id: &ProfileId,
+        followee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError> {
+        let key    = following_key(follower_id);
+        let member = followee_id.as_str();
+        self.client
+            .srem::<i64, _, _>(&key, member)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    // ── Block set operations ──────────────────────────────────────────────────
+
+    async fn add_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError> {
+        let key    = blocks_key(blocker_id);
+        let member = blockee_id.as_str();
+        self.client
+            .sadd::<i64, _, _>(&key, member)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    async fn remove_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError> {
+        let key    = blocks_key(blocker_id);
+        let member = blockee_id.as_str();
+        self.client
+            .srem::<i64, _, _>(&key, member)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    // ── Counter operations ────────────────────────────────────────────────────
+
+    async fn incr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {
+        let key = followers_count_key(profile_id);
+        self.client.incr::<i64, _>(&key).await.map_err(redis_err)?;
+        Ok(())
+    }
+
+    async fn decr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {
+        let key   = followers_count_key(profile_id);
+        let value: i64 = self.client.decr(&key).await.map_err(redis_err)?;
+        // Clamp at zero: a decrement below zero signals a consistency gap.
+        if value < 0 {
+            let _ = self.client.set::<(), _, _>(&key, 0i64, None, None, false).await;
+        }
+        Ok(())
+    }
+
+    async fn incr_following_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {
+        let key = following_count_key(profile_id);
+        self.client.incr::<i64, _>(&key).await.map_err(redis_err)?;
+        Ok(())
+    }
+
+    async fn decr_following_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {
+        let key   = following_count_key(profile_id);
+        let value: i64 = self.client.decr(&key).await.map_err(redis_err)?;
+        if value < 0 {
+            let _ = self.client.set::<(), _, _>(&key, 0i64, None, None, false).await;
+        }
+        Ok(())
+    }
+
+    async fn get_counts(&self, profile_id: &ProfileId) -> Result<RelationCounts, SocialGraphError> {
+        let fk = followers_count_key(profile_id);
+        let gk = following_count_key(profile_id);
+
+        let (r_followers, r_following) = tokio::join!(
+            self.client.get::<Option<i64>, _>(&fk),
+            self.client.get::<Option<i64>, _>(&gk),
+        );
+
+        Ok(RelationCounts {
+            followers: r_followers.map_err(redis_err)?.unwrap_or(0),
+            following: r_following.map_err(redis_err)?.unwrap_or(0),
+        })
+    }
+}

--- a/crates/services/social-graph/src/infrastructure/grpc/handler/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/grpc/handler/mod.rs
@@ -1,0 +1,3 @@
+pub mod social_graph_service_handler;
+
+pub use social_graph_service_handler::SocialGraphServiceHandler;

--- a/crates/services/social-graph/src/infrastructure/grpc/handler/social_graph_service_handler.rs
+++ b/crates/services/social-graph/src/infrastructure/grpc/handler/social_graph_service_handler.rs
@@ -1,0 +1,293 @@
+use chrono::{DateTime, Utc};
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+use cqrs::{CommandBus, Envelope, QueryBus};
+
+use crate::application::command::{
+    BlockProfileCommand, FollowProfileCommand, UnblockProfileCommand, UnfollowProfileCommand,
+};
+use crate::application::query::{
+    GetRelationStatusQuery, ListBlocksQuery, ListFollowersQuery, ListFollowingQuery,
+};
+use crate::application::query::get_relation_status::RelationStatusView;
+use crate::domain::entity::{BlockEdge, FollowEdge};
+use crate::domain::value_object::RelationStatus;
+
+// ── Proto inclusion ───────────────────────────────────────────────────────────
+
+pub mod proto {
+    tonic::include_proto!("social_graph.v1");
+}
+
+pub use proto::social_graph_service_server::SocialGraphServiceServer;
+
+/// gRPC handler for the SocialGraph service.
+///
+/// Bridges Protobuf RPCs to CQRS command/query envelopes and back.
+/// Zero domain logic lives here — all invariant enforcement is in the
+/// domain aggregate and command handlers.
+pub struct SocialGraphServiceHandler<CB, QB>
+where
+    CB: CommandBus + Send + Sync + 'static,
+    QB: QueryBus + Send + Sync + 'static,
+{
+    command_bus: CB,
+    query_bus:   QB,
+}
+
+impl<CB, QB> SocialGraphServiceHandler<CB, QB>
+where
+    CB: CommandBus + Send + Sync + 'static,
+    QB: QueryBus + Send + Sync + 'static,
+{
+    pub fn new(command_bus: CB, query_bus: QB) -> Self {
+        Self { command_bus, query_bus }
+    }
+
+    fn ok_response(actor_id: &str, target_id: &str) -> Response<proto::CommandResponse> {
+        Response::new(proto::CommandResponse {
+            success:   true,
+            actor_id:  actor_id.to_owned(),
+            target_id: target_id.to_owned(),
+        })
+    }
+}
+
+// ── Command implementations ───────────────────────────────────────────────────
+
+impl<CB, QB> SocialGraphServiceHandler<CB, QB>
+where
+    CB: CommandBus + Send + Sync + 'static,
+    QB: QueryBus + Send + Sync + 'static,
+{
+    pub async fn follow(
+        &self,
+        request: Request<proto::FollowRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = FollowProfileCommand {
+            actor_id:  req.actor_id.clone(),
+            target_id: req.target_id.clone(),
+        };
+        self.command_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), cmd))
+            .await
+            .map(|_| Self::ok_response(&req.actor_id, &req.target_id))
+            .map_err(cqrs_to_status)
+    }
+
+    pub async fn unfollow(
+        &self,
+        request: Request<proto::UnfollowRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = UnfollowProfileCommand {
+            actor_id:  req.actor_id.clone(),
+            target_id: req.target_id.clone(),
+        };
+        self.command_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), cmd))
+            .await
+            .map(|_| Self::ok_response(&req.actor_id, &req.target_id))
+            .map_err(cqrs_to_status)
+    }
+
+    pub async fn block(
+        &self,
+        request: Request<proto::BlockRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = BlockProfileCommand {
+            actor_id:  req.actor_id.clone(),
+            target_id: req.target_id.clone(),
+        };
+        self.command_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), cmd))
+            .await
+            .map(|_| Self::ok_response(&req.actor_id, &req.target_id))
+            .map_err(cqrs_to_status)
+    }
+
+    pub async fn unblock(
+        &self,
+        request: Request<proto::UnblockRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = UnblockProfileCommand {
+            actor_id:  req.actor_id.clone(),
+            target_id: req.target_id.clone(),
+        };
+        self.command_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), cmd))
+            .await
+            .map(|_| Self::ok_response(&req.actor_id, &req.target_id))
+            .map_err(cqrs_to_status)
+    }
+}
+
+// ── Query implementations ─────────────────────────────────────────────────────
+
+impl<CB, QB> SocialGraphServiceHandler<CB, QB>
+where
+    CB: CommandBus + Send + Sync + 'static,
+    QB: QueryBus + Send + Sync + 'static,
+{
+    pub async fn get_relation_status(
+        &self,
+        request: Request<proto::GetRelationStatusRequest>,
+    ) -> Result<Response<proto::RelationStatusView>, Status> {
+        let req = request.into_inner();
+        let query = GetRelationStatusQuery {
+            actor_id:  req.actor_id,
+            target_id: req.target_id,
+        };
+        let view: RelationStatusView = self
+            .query_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(cqrs_to_status)?;
+
+        Ok(Response::new(relation_status_view_to_proto(view)))
+    }
+
+    pub async fn list_followers(
+        &self,
+        request: Request<proto::ListFollowersRequest>,
+    ) -> Result<Response<proto::ListFollowersResponse>, Status> {
+        let req   = request.into_inner();
+        let limit = req.limit.clamp(1, 100) as u32;
+        let query = ListFollowersQuery {
+            followee_id: req.followee_id,
+            limit,
+            page_token: Some(req.page_token).filter(|s| !s.is_empty()),
+        };
+        let (edges, next): (Vec<FollowEdge>, Option<String>) = self
+            .query_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(cqrs_to_status)?;
+
+        Ok(Response::new(proto::ListFollowersResponse {
+            followers:       edges.into_iter().map(follow_edge_to_proto).collect(),
+            next_page_token: next.unwrap_or_default(),
+        }))
+    }
+
+    pub async fn list_following(
+        &self,
+        request: Request<proto::ListFollowingRequest>,
+    ) -> Result<Response<proto::ListFollowingResponse>, Status> {
+        let req   = request.into_inner();
+        let limit = req.limit.clamp(1, 100) as u32;
+        let query = ListFollowingQuery {
+            follower_id: req.follower_id,
+            limit,
+            page_token: Some(req.page_token).filter(|s| !s.is_empty()),
+        };
+        let (edges, next): (Vec<FollowEdge>, Option<String>) = self
+            .query_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(cqrs_to_status)?;
+
+        Ok(Response::new(proto::ListFollowingResponse {
+            following:       edges.into_iter().map(follow_edge_to_proto).collect(),
+            next_page_token: next.unwrap_or_default(),
+        }))
+    }
+
+    pub async fn list_blocks(
+        &self,
+        request: Request<proto::ListBlocksRequest>,
+    ) -> Result<Response<proto::ListBlocksResponse>, Status> {
+        let req   = request.into_inner();
+        let limit = req.limit.clamp(1, 100) as u32;
+        let query = ListBlocksQuery {
+            blocker_id: req.blocker_id,
+            limit,
+            page_token: Some(req.page_token).filter(|s| !s.is_empty()),
+        };
+        let (edges, next): (Vec<BlockEdge>, Option<String>) = self
+            .query_bus
+            .dispatch(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(cqrs_to_status)?;
+
+        Ok(Response::new(proto::ListBlocksResponse {
+            blocks:          edges.into_iter().map(block_edge_to_proto).collect(),
+            next_page_token: next.unwrap_or_default(),
+        }))
+    }
+}
+
+// ── Proto conversion helpers ──────────────────────────────────────────────────
+
+fn dt_to_ts(dt: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: dt.timestamp(),
+        nanos:   dt.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn relation_status_to_i32(s: RelationStatus) -> i32 {
+    match s {
+        RelationStatus::None        => 1,
+        RelationStatus::Following   => 2,
+        RelationStatus::FollowedBy  => 3,
+        RelationStatus::MutualFollow => 4,
+        RelationStatus::Blocking    => 5,
+        RelationStatus::BlockedBy   => 6,
+    }
+}
+
+fn relation_status_view_to_proto(v: RelationStatusView) -> proto::RelationStatusView {
+    proto::RelationStatusView {
+        actor_id:               v.actor_id.as_str(),
+        target_id:              v.target_id.as_str(),
+        status:                 relation_status_to_i32(v.status),
+        target_followers_count: v.target_followers_count,
+        target_following_count: v.target_following_count,
+    }
+}
+
+fn follow_edge_to_proto(e: FollowEdge) -> proto::EdgeSummary {
+    proto::EdgeSummary {
+        profile_id:  e.profile_id.as_str(),
+        followed_at: Some(dt_to_ts(e.followed_at)),
+    }
+}
+
+fn block_edge_to_proto(e: BlockEdge) -> proto::BlockSummary {
+    proto::BlockSummary {
+        blockee_id: e.blockee_id.as_str(),
+        blocked_at: Some(dt_to_ts(e.blocked_at)),
+    }
+}
+
+// ── Error mapping ─────────────────────────────────────────────────────────────
+
+pub fn cqrs_to_status(err: cqrs::error::CqrsError) -> Status {
+    use cqrs::error::CqrsError;
+    match err {
+        CqrsError::HandlerNotFound { type_name } => {
+            Status::unimplemented(format!("no handler registered for {type_name}"))
+        }
+        CqrsError::DuplicateRegistration { type_name } => {
+            Status::internal(format!("duplicate handler for {type_name}"))
+        }
+        CqrsError::Handler(boxed) => {
+            use error::AppError as _;
+            let msg      = boxed.to_string();
+            let retryable = boxed.is_retryable();
+            match boxed.http_status().as_u16() {
+                404 => Status::not_found(msg),
+                409 if retryable => Status::aborted(msg),
+                409 => Status::already_exists(msg),
+                400 | 422 => Status::failed_precondition(msg),
+                503 | 502 => Status::unavailable(msg),
+                _         => Status::internal(msg),
+            }
+        }
+    }
+}

--- a/crates/services/social-graph/src/infrastructure/grpc/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/grpc/mod.rs
@@ -1,0 +1,2 @@
+pub mod handler;
+pub mod server;

--- a/crates/services/social-graph/src/infrastructure/grpc/server.rs
+++ b/crates/services/social-graph/src/infrastructure/grpc/server.rs
@@ -1,0 +1,73 @@
+use tonic::{Request, Response, Status};
+
+use cqrs::{CommandBus, QueryBus};
+
+use super::handler::social_graph_service_handler::{proto, SocialGraphServiceHandler};
+use proto::social_graph_service_server::SocialGraphService;
+
+#[tonic::async_trait]
+impl<CB, QB> SocialGraphService for SocialGraphServiceHandler<CB, QB>
+where
+    CB: CommandBus + Send + Sync + 'static,
+    QB: QueryBus + Send + Sync + 'static,
+{
+    // ── Commands ──────────────────────────────────────────────────────────────
+
+    async fn follow(
+        &self,
+        request: Request<proto::FollowRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        self.follow(request).await
+    }
+
+    async fn unfollow(
+        &self,
+        request: Request<proto::UnfollowRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        self.unfollow(request).await
+    }
+
+    async fn block(
+        &self,
+        request: Request<proto::BlockRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        self.block(request).await
+    }
+
+    async fn unblock(
+        &self,
+        request: Request<proto::UnblockRequest>,
+    ) -> Result<Response<proto::CommandResponse>, Status> {
+        self.unblock(request).await
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    async fn get_relation_status(
+        &self,
+        request: Request<proto::GetRelationStatusRequest>,
+    ) -> Result<Response<proto::RelationStatusView>, Status> {
+        self.get_relation_status(request).await
+    }
+
+    async fn list_followers(
+        &self,
+        request: Request<proto::ListFollowersRequest>,
+    ) -> Result<Response<proto::ListFollowersResponse>, Status> {
+        self.list_followers(request).await
+    }
+
+    async fn list_following(
+        &self,
+        request: Request<proto::ListFollowingRequest>,
+    ) -> Result<Response<proto::ListFollowingResponse>, Status> {
+        self.list_following(request).await
+    }
+
+    async fn list_blocks(
+        &self,
+        request: Request<proto::ListBlocksRequest>,
+    ) -> Result<Response<proto::ListBlocksResponse>, Status> {
+        self.list_blocks(request).await
+    }
+}

--- a/crates/services/social-graph/src/infrastructure/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/mod.rs
@@ -1,0 +1,4 @@
+pub mod cache;
+pub mod grpc;
+pub mod persistence;
+pub mod publisher;

--- a/crates/services/social-graph/src/infrastructure/persistence/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,4 @@
+pub mod model;
+pub mod scylla_social_graph_repository;
+
+pub use scylla_social_graph_repository::ScyllaSocialGraphRepository;

--- a/crates/services/social-graph/src/infrastructure/persistence/model/block_row.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/model/block_row.rs
@@ -1,0 +1,13 @@
+use scylla::value::CqlTimestamp;
+use scylla::DeserializeRow;
+use uuid::Uuid;
+
+/// Positional deserialization target for rows from the `blocks` table.
+///
+/// SELECT must emit `(blockee_id, blocked_at)` in this order.
+#[derive(DeserializeRow)]
+#[scylla(flavor = "enforce_order")]
+pub struct BlockRow {
+    pub blockee_id: Uuid,
+    pub blocked_at: CqlTimestamp,
+}

--- a/crates/services/social-graph/src/infrastructure/persistence/model/follow_row.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/model/follow_row.rs
@@ -1,0 +1,16 @@
+use scylla::value::CqlTimestamp;
+use scylla::DeserializeRow;
+use uuid::Uuid;
+
+/// Positional deserialization target for rows from the `followers` and `following` tables.
+///
+/// SELECT must always emit `(profile_id_column, followed_at)` in this order.
+/// `enforce_order` matches fields by position rather than by column name, so the
+/// same struct serves both tables regardless of whether the first column is named
+/// `follower_id` or `followee_id`.
+#[derive(DeserializeRow)]
+#[scylla(flavor = "enforce_order")]
+pub struct FollowRow {
+    pub profile_id:  Uuid,
+    pub followed_at: CqlTimestamp,
+}

--- a/crates/services/social-graph/src/infrastructure/persistence/model/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/model/mod.rs
@@ -1,0 +1,5 @@
+pub mod block_row;
+pub mod follow_row;
+
+pub use block_row::BlockRow;
+pub use follow_row::FollowRow;

--- a/crates/services/social-graph/src/infrastructure/persistence/scylla_social_graph_repository.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/scylla_social_graph_repository.rs
@@ -1,0 +1,576 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chrono::{TimeZone, Utc};
+use scylla::observability::history::HistoryListener;
+use scylla::statement::unprepared::Statement;
+use scylla::value::CqlTimestamp;
+use scylla::DeserializeRow;
+use uuid::Uuid;
+
+use scylla_storage::{ProfileKind as ScyllaProfileKind, ScyllaClient, ScyllaStorageError};
+
+use crate::application::port::SocialGraphRepository;
+use crate::domain::aggregate::{Relation, RelationContext};
+use crate::domain::entity::{BlockEdge, FollowEdge};
+use crate::domain::value_object::ProfileId;
+use crate::error::SocialGraphError;
+use crate::infrastructure::persistence::model::{BlockRow, FollowRow};
+
+// ── Page-token types ──────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct FollowPageToken {
+    followed_at_ms: i64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BlockPageToken {
+    last_blockee_id: String,
+}
+
+// ── Error helpers ─────────────────────────────────────────────────────────────
+
+fn scylla_err(e: scylla::errors::ExecutionError) -> SocialGraphError {
+    SocialGraphError::Storage(ScyllaStorageError::from(e))
+}
+
+fn row_err(ctx: &'static str, e: impl ToString) -> SocialGraphError {
+    SocialGraphError::DomainViolation {
+        field:   ctx.to_owned(),
+        message: e.to_string(),
+    }
+}
+
+fn token_err(field: &'static str, msg: &'static str) -> SocialGraphError {
+    SocialGraphError::DomainViolation {
+        field:   field.to_owned(),
+        message: msg.to_owned(),
+    }
+}
+
+// ── Repository ────────────────────────────────────────────────────────────────
+
+pub struct ScyllaSocialGraphRepository {
+    client: Arc<ScyllaClient>,
+}
+
+impl ScyllaSocialGraphRepository {
+    pub fn new(client: Arc<ScyllaClient>) -> Self {
+        Self { client }
+    }
+
+    fn fast_stmt(&self, cql: &str) -> Statement {
+        let mut s = Statement::new(cql);
+        s.set_execution_profile_handle(Some(
+            self.client
+                .profiles
+                .get(ScyllaProfileKind::Fast)
+                .clone()
+                .into_handle_with_label("fast".to_string()),
+        ));
+        s.set_history_listener(
+            Arc::clone(&self.client.history_listener) as Arc<dyn HistoryListener>,
+        );
+        s
+    }
+
+    fn strict_stmt(&self, cql: &str) -> Statement {
+        let mut s = Statement::new(cql);
+        s.set_execution_profile_handle(Some(
+            self.client
+                .profiles
+                .get(ScyllaProfileKind::Strict)
+                .clone()
+                .into_handle_with_label("strict".to_string()),
+        ));
+        s.set_history_listener(
+            Arc::clone(&self.client.history_listener) as Arc<dyn HistoryListener>,
+        );
+        s
+    }
+
+    fn dt_ms(dt: chrono::DateTime<Utc>) -> CqlTimestamp {
+        CqlTimestamp(dt.timestamp_millis())
+    }
+
+    fn ms_to_dt(ms: i64) -> Result<chrono::DateTime<Utc>, SocialGraphError> {
+        Utc.timestamp_millis_opt(ms).single().ok_or_else(|| SocialGraphError::DomainViolation {
+            field:   "timestamp".to_owned(),
+            message: format!("invalid millisecond timestamp: {ms}"),
+        })
+    }
+
+    // ── Point-lookup helpers used by load_relation ────────────────────────────
+
+    async fn get_follow_since(
+        &self,
+        follower_id: &ProfileId,
+        followee_id: &ProfileId,
+    ) -> Result<Option<chrono::DateTime<Utc>>, SocialGraphError> {
+        #[derive(DeserializeRow)]
+        struct Row { followed_at: CqlTimestamp }
+
+        let stmt = self.fast_stmt(
+            "SELECT followed_at FROM social_graph.follow_status \
+             WHERE follower_id = ? AND followee_id = ?",
+        );
+        let result = self
+            .client
+            .session
+            .execute_unpaged(stmt, (follower_id.as_uuid(), followee_id.as_uuid()))
+            .await
+            .map_err(scylla_err)?;
+
+        let row = result
+            .into_rows_result()
+            .map_err(|e| row_err("get_follow_since:rows", e))?
+            .maybe_first_row::<Row>()
+            .map_err(|e| row_err("get_follow_since:deser", e))?;
+
+        row.map(|r| Self::ms_to_dt(r.followed_at.0)).transpose()
+    }
+
+    async fn get_block_exists(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<bool, SocialGraphError> {
+        #[derive(DeserializeRow)]
+        #[allow(dead_code)]
+        struct Row { blocked_at: CqlTimestamp }
+
+        let stmt = self.fast_stmt(
+            "SELECT blocked_at FROM social_graph.blocks \
+             WHERE blocker_id = ? AND blockee_id = ?",
+        );
+        let result = self
+            .client
+            .session
+            .execute_unpaged(stmt, (blocker_id.as_uuid(), blockee_id.as_uuid()))
+            .await
+            .map_err(scylla_err)?;
+
+        let row = result
+            .into_rows_result()
+            .map_err(|e| row_err("get_block_exists:rows", e))?
+            .maybe_first_row::<Row>()
+            .map_err(|e| row_err("get_block_exists:deser", e))?;
+
+        Ok(row.is_some())
+    }
+}
+
+#[async_trait]
+impl SocialGraphRepository for ScyllaSocialGraphRepository {
+    // ── load_relation ─────────────────────────────────────────────────────────
+
+    async fn load_relation(
+        &self,
+        actor_id:  &ProfileId,
+        target_id: &ProfileId,
+    ) -> Result<Relation, SocialGraphError> {
+        // Fire four concurrent O(1) ScyllaDB point-lookups.
+        let (r1, r2, r3, r4) = tokio::join!(
+            self.get_follow_since(actor_id, target_id),
+            self.get_follow_since(target_id, actor_id),
+            self.get_block_exists(actor_id, target_id),
+            self.get_block_exists(target_id, actor_id),
+        );
+
+        Ok(Relation::from_context(
+            *actor_id,
+            *target_id,
+            RelationContext {
+                actor_follows_target_since: r1?,
+                target_follows_actor_since: r2?,
+                actor_blocks_target:        r3?,
+                target_blocks_actor:        r4?,
+            },
+        ))
+    }
+
+    // ── persist_follow ────────────────────────────────────────────────────────
+
+    async fn persist_follow(
+        &self,
+        actor_id:    &ProfileId,
+        target_id:   &ProfileId,
+        followed_at: chrono::DateTime<Utc>,
+    ) -> Result<(), SocialGraphError> {
+        let ts = Self::dt_ms(followed_at);
+
+        // Write follow_status first (it is the canonical deletion-key store).
+        let stmt_status = self.strict_stmt(
+            "INSERT INTO social_graph.follow_status \
+             (follower_id, followee_id, followed_at) VALUES (?, ?, ?)",
+        );
+        self.client
+            .session
+            .execute_unpaged(stmt_status, (actor_id.as_uuid(), target_id.as_uuid(), ts))
+            .await
+            .map_err(scylla_err)?;
+
+        // Write both adjacency tables concurrently.
+        let (r_following, r_followers) = tokio::join!(
+            async {
+                let stmt = self.strict_stmt(
+                    "INSERT INTO social_graph.following \
+                     (follower_id, followed_at, followee_id) VALUES (?, ?, ?)",
+                );
+                self.client
+                    .session
+                    .execute_unpaged(stmt, (actor_id.as_uuid(), ts, target_id.as_uuid()))
+                    .await
+                    .map_err(scylla_err)
+            },
+            async {
+                let stmt = self.strict_stmt(
+                    "INSERT INTO social_graph.followers \
+                     (followee_id, followed_at, follower_id) VALUES (?, ?, ?)",
+                );
+                self.client
+                    .session
+                    .execute_unpaged(stmt, (target_id.as_uuid(), ts, actor_id.as_uuid()))
+                    .await
+                    .map_err(scylla_err)
+            },
+        );
+        r_following?;
+        r_followers?;
+
+        Ok(())
+    }
+
+    // ── delete_follow ─────────────────────────────────────────────────────────
+
+    async fn delete_follow(
+        &self,
+        actor_id:    &ProfileId,
+        target_id:   &ProfileId,
+        followed_at: chrono::DateTime<Utc>,
+    ) -> Result<(), SocialGraphError> {
+        let ts = Self::dt_ms(followed_at);
+
+        // Delete follow_status first.
+        let stmt_status = self.strict_stmt(
+            "DELETE FROM social_graph.follow_status \
+             WHERE follower_id = ? AND followee_id = ?",
+        );
+        self.client
+            .session
+            .execute_unpaged(stmt_status, (actor_id.as_uuid(), target_id.as_uuid()))
+            .await
+            .map_err(scylla_err)?;
+
+        // Delete both adjacency rows concurrently.
+        let (r_following, r_followers) = tokio::join!(
+            async {
+                let stmt = self.strict_stmt(
+                    "DELETE FROM social_graph.following \
+                     WHERE follower_id = ? AND followed_at = ? AND followee_id = ?",
+                );
+                self.client
+                    .session
+                    .execute_unpaged(stmt, (actor_id.as_uuid(), ts, target_id.as_uuid()))
+                    .await
+                    .map_err(scylla_err)
+            },
+            async {
+                let stmt = self.strict_stmt(
+                    "DELETE FROM social_graph.followers \
+                     WHERE followee_id = ? AND followed_at = ? AND follower_id = ?",
+                );
+                self.client
+                    .session
+                    .execute_unpaged(stmt, (target_id.as_uuid(), ts, actor_id.as_uuid()))
+                    .await
+                    .map_err(scylla_err)
+            },
+        );
+        r_following?;
+        r_followers?;
+
+        Ok(())
+    }
+
+    // ── persist_block ─────────────────────────────────────────────────────────
+
+    async fn persist_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+        blocked_at: chrono::DateTime<Utc>,
+    ) -> Result<(), SocialGraphError> {
+        let stmt = self.strict_stmt(
+            "INSERT INTO social_graph.blocks \
+             (blocker_id, blockee_id, blocked_at) VALUES (?, ?, ?)",
+        );
+        self.client
+            .session
+            .execute_unpaged(
+                stmt,
+                (blocker_id.as_uuid(), blockee_id.as_uuid(), Self::dt_ms(blocked_at)),
+            )
+            .await
+            .map_err(scylla_err)?;
+        Ok(())
+    }
+
+    // ── delete_block ──────────────────────────────────────────────────────────
+
+    async fn delete_block(
+        &self,
+        blocker_id: &ProfileId,
+        blockee_id: &ProfileId,
+    ) -> Result<(), SocialGraphError> {
+        let stmt = self.strict_stmt(
+            "DELETE FROM social_graph.blocks \
+             WHERE blocker_id = ? AND blockee_id = ?",
+        );
+        self.client
+            .session
+            .execute_unpaged(stmt, (blocker_id.as_uuid(), blockee_id.as_uuid()))
+            .await
+            .map_err(scylla_err)?;
+        Ok(())
+    }
+
+    // ── list_followers ────────────────────────────────────────────────────────
+
+    async fn list_followers(
+        &self,
+        followee_id: &ProfileId,
+        limit:       i32,
+        page_token:  Option<&str>,
+    ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError> {
+        let limit = limit.clamp(1, 100) as i64;
+        let token = decode_follow_token(page_token)?;
+
+        let rows: Vec<FollowRow> = if let Some(ref tok) = token {
+            let stmt = self.fast_stmt(
+                "SELECT follower_id, followed_at FROM social_graph.followers \
+                 WHERE followee_id = ? AND followed_at < ? LIMIT ?",
+            );
+            self.client
+                .session
+                .execute_unpaged(
+                    stmt,
+                    (followee_id.as_uuid(), CqlTimestamp(tok.followed_at_ms), limit),
+                )
+                .await
+                .map_err(scylla_err)?
+                .into_rows_result()
+                .map_err(|e| row_err("list_followers:rows", e))?
+                .rows::<FollowRow>()
+                .map_err(|e| row_err("list_followers:iter", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| row_err("list_followers:deser", e))?
+        } else {
+            let stmt = self.fast_stmt(
+                "SELECT follower_id, followed_at FROM social_graph.followers \
+                 WHERE followee_id = ? LIMIT ?",
+            );
+            self.client
+                .session
+                .execute_unpaged(stmt, (followee_id.as_uuid(), limit))
+                .await
+                .map_err(scylla_err)?
+                .into_rows_result()
+                .map_err(|e| row_err("list_followers:rows", e))?
+                .rows::<FollowRow>()
+                .map_err(|e| row_err("list_followers:iter", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| row_err("list_followers:deser", e))?
+        };
+
+        build_follow_page(rows, limit)
+    }
+
+    // ── list_following ────────────────────────────────────────────────────────
+
+    async fn list_following(
+        &self,
+        follower_id: &ProfileId,
+        limit:       i32,
+        page_token:  Option<&str>,
+    ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError> {
+        let limit = limit.clamp(1, 100) as i64;
+        let token = decode_follow_token(page_token)?;
+
+        let rows: Vec<FollowRow> = if let Some(ref tok) = token {
+            let stmt = self.fast_stmt(
+                "SELECT followee_id, followed_at FROM social_graph.following \
+                 WHERE follower_id = ? AND followed_at < ? LIMIT ?",
+            );
+            self.client
+                .session
+                .execute_unpaged(
+                    stmt,
+                    (follower_id.as_uuid(), CqlTimestamp(tok.followed_at_ms), limit),
+                )
+                .await
+                .map_err(scylla_err)?
+                .into_rows_result()
+                .map_err(|e| row_err("list_following:rows", e))?
+                .rows::<FollowRow>()
+                .map_err(|e| row_err("list_following:iter", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| row_err("list_following:deser", e))?
+        } else {
+            let stmt = self.fast_stmt(
+                "SELECT followee_id, followed_at FROM social_graph.following \
+                 WHERE follower_id = ? LIMIT ?",
+            );
+            self.client
+                .session
+                .execute_unpaged(stmt, (follower_id.as_uuid(), limit))
+                .await
+                .map_err(scylla_err)?
+                .into_rows_result()
+                .map_err(|e| row_err("list_following:rows", e))?
+                .rows::<FollowRow>()
+                .map_err(|e| row_err("list_following:iter", e))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| row_err("list_following:deser", e))?
+        };
+
+        build_follow_page(rows, limit)
+    }
+
+    // ── list_blocks ───────────────────────────────────────────────────────────
+
+    async fn list_blocks(
+        &self,
+        blocker_id: &ProfileId,
+        limit:      i32,
+        page_token: Option<&str>,
+    ) -> Result<(Vec<BlockEdge>, Option<String>), SocialGraphError> {
+        let limit = limit.clamp(1, 100) as i64;
+
+        let token: Option<BlockPageToken> = page_token
+            .map(|t| {
+                let bytes = URL_SAFE_NO_PAD
+                    .decode(t)
+                    .map_err(|_| token_err("page_token", "invalid base64 encoding"))?;
+                serde_json::from_slice(&bytes)
+                    .map_err(|_| token_err("page_token", "invalid block page token format"))
+            })
+            .transpose()?;
+
+        let rows_result = if let Some(ref tok) = token {
+            let last_id = Uuid::parse_str(&tok.last_blockee_id).map_err(|_| {
+                token_err("page_token.last_blockee_id", "invalid UUID in block page token")
+            })?;
+            let stmt = self.fast_stmt(
+                "SELECT blockee_id, blocked_at FROM social_graph.blocks \
+                 WHERE blocker_id = ? AND blockee_id > ? LIMIT ?",
+            );
+            self.client
+                .session
+                .execute_unpaged(stmt, (blocker_id.as_uuid(), last_id, limit))
+                .await
+                .map_err(scylla_err)?
+                .into_rows_result()
+                .map_err(|e| row_err("list_blocks:rows", e))?
+        } else {
+            let stmt = self.fast_stmt(
+                "SELECT blockee_id, blocked_at FROM social_graph.blocks \
+                 WHERE blocker_id = ? LIMIT ?",
+            );
+            self.client
+                .session
+                .execute_unpaged(stmt, (blocker_id.as_uuid(), limit))
+                .await
+                .map_err(scylla_err)?
+                .into_rows_result()
+                .map_err(|e| row_err("list_blocks:rows", e))?
+        };
+
+        let rows: Vec<BlockRow> = rows_result
+            .rows::<BlockRow>()
+            .map_err(|e| row_err("list_blocks:iter", e))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| row_err("list_blocks:deser", e))?;
+
+        let total = rows.len();
+        let mut edges = Vec::with_capacity(total);
+        let mut last_blockee_id = String::new();
+
+        for row in &rows {
+            last_blockee_id = row.blockee_id.to_string();
+            let blocked_at = Utc
+                .timestamp_millis_opt(row.blocked_at.0)
+                .single()
+                .ok_or_else(|| SocialGraphError::DomainViolation {
+                    field:   "blocked_at".to_owned(),
+                    message: format!("invalid timestamp {}", row.blocked_at.0),
+                })?;
+            edges.push(BlockEdge {
+                blockee_id: ProfileId::from_uuid(row.blockee_id),
+                blocked_at,
+            });
+        }
+
+        let next_token = if total == limit as usize {
+            let tok  = BlockPageToken { last_blockee_id };
+            let json = serde_json::to_vec(&tok).unwrap_or_default();
+            Some(URL_SAFE_NO_PAD.encode(json))
+        } else {
+            None
+        };
+
+        Ok((edges, next_token))
+    }
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+fn decode_follow_token(
+    page_token: Option<&str>,
+) -> Result<Option<FollowPageToken>, SocialGraphError> {
+    page_token
+        .map(|t| {
+            let bytes = URL_SAFE_NO_PAD
+                .decode(t)
+                .map_err(|_| token_err("page_token", "invalid base64 encoding"))?;
+            serde_json::from_slice(&bytes)
+                .map_err(|_| token_err("page_token", "invalid follow page token format"))
+        })
+        .transpose()
+}
+
+fn build_follow_page(
+    rows:  Vec<FollowRow>,
+    limit: i64,
+) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError> {
+    let total = rows.len();
+    let mut edges = Vec::with_capacity(total);
+    let mut last_followed_at_ms = 0i64;
+
+    for row in &rows {
+        last_followed_at_ms = row.followed_at.0;
+        let followed_at = Utc
+            .timestamp_millis_opt(row.followed_at.0)
+            .single()
+            .ok_or_else(|| SocialGraphError::DomainViolation {
+                field:   "followed_at".to_owned(),
+                message: format!("invalid timestamp {}", row.followed_at.0),
+            })?;
+        edges.push(FollowEdge {
+            profile_id:  ProfileId::from_uuid(row.profile_id),
+            followed_at,
+        });
+    }
+
+    let next_token = if total == limit as usize {
+        let tok  = FollowPageToken { followed_at_ms: last_followed_at_ms };
+        let json = serde_json::to_vec(&tok).unwrap_or_default();
+        Some(URL_SAFE_NO_PAD.encode(json))
+    } else {
+        None
+    };
+
+    Ok((edges, next_token))
+}

--- a/crates/services/social-graph/src/infrastructure/publisher/kafka_event_publisher.rs
+++ b/crates/services/social-graph/src/infrastructure/publisher/kafka_event_publisher.rs
@@ -1,0 +1,82 @@
+use async_trait::async_trait;
+use transport::{
+    error::TransportError,
+    kafka::{envelope::EventEnvelope, producer::handle::KafkaProducerHandle},
+};
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::{DomainEvent, ProfileBlocked, ProfileFollowed, ProfileUnfollowed};
+use crate::error::SocialGraphError;
+
+const TOPIC_FOLLOWED:   &str = "social-graph.followed";
+const TOPIC_UNFOLLOWED: &str = "social-graph.unfollowed";
+const TOPIC_BLOCKED:    &str = "social-graph.blocked";
+
+fn transport_err(e: TransportError) -> SocialGraphError {
+    SocialGraphError::DomainViolation {
+        field:   "kafka".to_owned(),
+        message: e.to_string(),
+    }
+}
+
+pub struct KafkaEventPublisher {
+    producer: KafkaProducerHandle,
+}
+
+impl KafkaEventPublisher {
+    pub fn new(producer: KafkaProducerHandle) -> Self {
+        Self { producer }
+    }
+}
+
+#[async_trait]
+impl EventPublisher for KafkaEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), SocialGraphError> {
+        match event {
+            DomainEvent::ProfileFollowed(e) => publish_followed(&self.producer, e).await,
+            DomainEvent::ProfileUnfollowed(e) => publish_unfollowed(&self.producer, e).await,
+            DomainEvent::ProfileBlocked(e) => publish_blocked(&self.producer, e).await,
+            // ProfileUnblocked is not published downstream per the interface contract.
+            DomainEvent::ProfileUnblocked(_) => Ok(()),
+        }
+    }
+}
+
+async fn publish_followed(
+    producer: &KafkaProducerHandle,
+    event:    &ProfileFollowed,
+) -> Result<(), SocialGraphError> {
+    let key      = format!("{}:{}", event.actor_id, event.target_id);
+    let envelope = EventEnvelope::new(TOPIC_FOLLOWED, key, event.clone())
+        .with_header("event_type", "ProfileFollowed")
+        .with_header("actor_id",   event.actor_id.as_str())
+        .with_header("target_id",  event.target_id.as_str());
+
+    producer.publish(envelope).await.map_err(transport_err)
+}
+
+async fn publish_unfollowed(
+    producer: &KafkaProducerHandle,
+    event:    &ProfileUnfollowed,
+) -> Result<(), SocialGraphError> {
+    let key      = format!("{}:{}", event.actor_id, event.target_id);
+    let envelope = EventEnvelope::new(TOPIC_UNFOLLOWED, key, event.clone())
+        .with_header("event_type", "ProfileUnfollowed")
+        .with_header("actor_id",   event.actor_id.as_str())
+        .with_header("target_id",  event.target_id.as_str());
+
+    producer.publish(envelope).await.map_err(transport_err)
+}
+
+async fn publish_blocked(
+    producer: &KafkaProducerHandle,
+    event:    &ProfileBlocked,
+) -> Result<(), SocialGraphError> {
+    let key      = format!("{}:{}", event.actor_id, event.target_id);
+    let envelope = EventEnvelope::new(TOPIC_BLOCKED, key, event.clone())
+        .with_header("event_type", "ProfileBlocked")
+        .with_header("actor_id",   event.actor_id.as_str())
+        .with_header("target_id",  event.target_id.as_str());
+
+    producer.publish(envelope).await.map_err(transport_err)
+}

--- a/crates/services/social-graph/src/infrastructure/publisher/mod.rs
+++ b/crates/services/social-graph/src/infrastructure/publisher/mod.rs
@@ -1,0 +1,3 @@
+pub mod kafka_event_publisher;
+
+pub use kafka_event_publisher::KafkaEventPublisher;

--- a/crates/services/social-graph/src/lib.rs
+++ b/crates/services/social-graph/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod application;
+pub mod domain;
+pub mod error;
+pub mod infrastructure;


### PR DESCRIPTION
…service

Introduces crates/services/social-graph, the third core pillar of the platform. Owns all directional Follow/Unfollow/Block/Unblock relationships between opaque ProfileId (UUIDv7) primitives with strict SRP — zero profile metadata knowledge.

ScyllaDB schema (4 tables, keyspace social_graph):
- followers / following: symmetric denormalized adjacency lists for O(1) fan-in and fan-out reads without ALLOW FILTERING
- follow_status: point-lookup index storing followed_at timestamps required for targeted clustering-key DELETEs on unfollow and block-sever operations
- blocks: single table covering both directions via swapped-argument point-lookups; no blocked_by mirror needed

Redis cache strategy:
- sg:following:v1:{id} Set for outbound edges (SADD/SREM, bounded per user)
- sg:blocks:v1:{id} Set for issued blocks
- sg:followers_count/sg:following_count String counters (INCR/DECR, zero-clamped)
- Mutual-follow (friendship) derived via SISMEMBER on both following sets; no dedicated friends table to prevent dual-write desynchronization on unfollow

Domain aggregate Relation:
- Loaded via 4 concurrent ScyllaDB point-lookups (tokio::join!)
- Enforces: self-interaction guard, block-gate on follow, re-follow/re-block idempotency, block-sever returning SeveredFollows with deletion timestamps
- Command handlers update Redis as best-effort side-effects after ScyllaDB writes

Kafka outbound events: social-graph.followed / .unfollowed / .blocked ProfileUnblocked intentionally not published (no downstream fan-out consequence)

Error codes: SGR-1001..SGR-1004 (state), SGR-2001..SGR-2002 (invariants), SGR-9001..SGR-9002 (parse/domain), delegating SDB-*/RDB-*/VAL-* to shared crates