### PR TITLE
refactor(workspace): centralize internal deps via workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,14 +36,24 @@ repository = "https://github.com/ton-repo/projet"
 description = "core-platform repo"
 
 [workspace.dependencies]
-error = { path = "crates/shared/error" }
-resilience = { path = "crates/shared/resilience" }
-validate-core = { path = "crates/shared/validate-core" }
-validation = { path = "crates/shared/validation" }
-postgres-storage = { path = "crates/shared/storage/postgres" }
-scylla-storage = { path = "crates/shared/storage/scylla" }
-redis-storage = { path = "crates/shared/storage/redis" }
-test-support = { path = "crates/shared/test-support" }
+# ── Internal shared crates ────────────────────────────────────────────────────
+# Single source of truth for every intra-workspace path. Member crates reference
+# these with `{ workspace = true }` so paths live in exactly one place.
+# NB: the `postgres` crate is exposed under the `postgres-storage` key (via
+# `package`) to avoid colliding with the crates.io `postgres` crate and to keep
+# the naming symmetric with `scylla-storage` / `redis-storage`.
+error            = { path = "crates/shared/error" }
+resilience       = { path = "crates/shared/resilience" }
+telemetry        = { path = "crates/shared/telemetry" }
+transport        = { path = "crates/shared/transport" }
+cqrs             = { path = "crates/shared/cqrs" }
+auth-context     = { path = "crates/shared/auth-context" }
+validate-core    = { path = "crates/shared/validate-core" }
+validation       = { path = "crates/shared/validation" }
+postgres-storage = { path = "crates/shared/storage/postgres", package = "postgres" }
+scylla-storage   = { path = "crates/shared/storage/scylla" }
+redis-storage    = { path = "crates/shared/storage/redis" }
+test-support     = { path = "crates/shared/test-support" }
 
 
 # Communs

--- a/crates/services/account/Cargo.toml
+++ b/crates/services/account/Cargo.toml
@@ -8,17 +8,17 @@ repository.workspace = true
 description = "Account microservice — complete lifecycle management for physical persons on the platform."
 
 [dependencies]
-# ── Shared platform infrastructure (workspace keys) ───────────────────────────
+# ── Shared platform infrastructure ────────────────────────────────────────────
 error            = { workspace = true }
 validate-core    = { workspace = true }
 validation       = { workspace = true }
-postgres-storage = { path = "../../shared/storage/postgres", package = "postgres" }
+postgres-storage = { workspace = true }
 
-# ── Shared platform crates (path — not yet registered as workspace keys) ──────
-cqrs         = { path = "../../shared/cqrs" }
-auth-context = { path = "../../shared/auth-context" }
-telemetry    = { path = "../../shared/telemetry" }
-transport    = { path = "../../shared/transport" }
+# ── Shared platform crates ────────────────────────────────────────────────────
+cqrs         = { workspace = true }
+auth-context = { workspace = true }
+telemetry    = { workspace = true }
+transport    = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/chat/Cargo.toml
+++ b/crates/services/chat/Cargo.toml
@@ -11,11 +11,11 @@ description = "Chat microservice — unified Conversation layer (Group mesh + Ch
 error          = { workspace = true }
 validate-core  = { workspace = true }
 validation     = { workspace = true }
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage  = { path = "../../shared/storage/redis",  package = "redis-storage" }
-cqrs           = { path = "../../shared/cqrs" }
-telemetry      = { path = "../../shared/telemetry" }
-transport      = { path = "../../shared/transport" }
+scylla-storage = { workspace = true }
+redis-storage  = { workspace = true }
+cqrs           = { workspace = true }
+telemetry      = { workspace = true }
+transport      = { workspace = true }
 
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }
@@ -67,7 +67,7 @@ uuid                   = { workspace = true }
 chrono                 = { workspace = true }
 tonic                  = { workspace = true }
 
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage  = { path = "../../shared/storage/redis",  package = "redis-storage" }
-transport      = { path = "../../shared/transport" }
-cqrs           = { path = "../../shared/cqrs" }
+scylla-storage = { workspace = true }
+redis-storage  = { workspace = true }
+transport      = { workspace = true }
+cqrs           = { workspace = true }

--- a/crates/services/comment/Cargo.toml
+++ b/crates/services/comment/Cargo.toml
@@ -11,10 +11,10 @@ description = "Comment microservice — 1-level threaded comment engine with GIF
 error          = { workspace = true }
 validate-core  = { workspace = true }
 validation     = { workspace = true }
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-cqrs           = { path = "../../shared/cqrs" }
-telemetry      = { path = "../../shared/telemetry" }
-transport      = { path = "../../shared/transport" }
+scylla-storage = { workspace = true }
+cqrs           = { workspace = true }
+telemetry      = { workspace = true }
+transport      = { workspace = true }
 
 tokio        = { workspace = true }
 async-trait  = { workspace = true }

--- a/crates/services/engagement/Cargo.toml
+++ b/crates/services/engagement/Cargo.toml
@@ -11,11 +11,11 @@ description = "Engagement microservice — weighted reaction scoring engine with
 error          = { workspace = true }
 validate-core  = { workspace = true }
 validation     = { workspace = true }
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage  = { path = "../../shared/storage/redis",  package = "redis-storage" }
-cqrs           = { path = "../../shared/cqrs" }
-telemetry      = { path = "../../shared/telemetry" }
-transport      = { path = "../../shared/transport" }
+scylla-storage = { workspace = true }
+redis-storage  = { workspace = true }
+cqrs           = { workspace = true }
+telemetry      = { workspace = true }
+transport      = { workspace = true }
 
 tokio        = { workspace = true }
 futures      = { workspace = true }

--- a/crates/services/geo-discovery/Cargo.toml
+++ b/crates/services/geo-discovery/Cargo.toml
@@ -11,11 +11,11 @@ description = "Geo-discovery microservice — H3 spatial indexing engine with Re
 error          = { workspace = true }
 validate-core  = { workspace = true }
 validation     = { workspace = true }
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage  = { path = "../../shared/storage/redis",  package = "redis-storage" }
-cqrs           = { path = "../../shared/cqrs" }
-telemetry      = { path = "../../shared/telemetry" }
-transport      = { path = "../../shared/transport" }
+scylla-storage = { workspace = true }
+redis-storage  = { workspace = true }
+cqrs           = { workspace = true }
+telemetry      = { workspace = true }
+transport      = { workspace = true }
 
 tokio        = { workspace = true }
 futures      = { workspace = true }

--- a/crates/services/notification/Cargo.toml
+++ b/crates/services/notification/Cargo.toml
@@ -11,11 +11,11 @@ description = "Notification microservice — semantic event ingestion, ScyllaDB 
 error          = { workspace = true }
 validate-core  = { workspace = true }
 validation     = { workspace = true }
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage  = { path = "../../shared/storage/redis",  package = "redis-storage" }
-cqrs           = { path = "../../shared/cqrs" }
-telemetry      = { path = "../../shared/telemetry" }
-transport      = { path = "../../shared/transport" }
+scylla-storage = { workspace = true }
+redis-storage  = { workspace = true }
+cqrs           = { workspace = true }
+telemetry      = { workspace = true }
+transport      = { workspace = true }
 
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/services/post/Cargo.toml
+++ b/crates/services/post/Cargo.toml
@@ -11,11 +11,11 @@ description = "Post microservice — multi-format media content production pilla
 error            = { workspace = true }
 validate-core    = { workspace = true }
 validation       = { workspace = true }
-scylla-storage   = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-cqrs         = { path = "../../shared/cqrs" }
-auth-context = { path = "../../shared/auth-context" }
-telemetry    = { path = "../../shared/telemetry" }
-transport    = { path = "../../shared/transport" }
+scylla-storage   = { workspace = true }
+cqrs         = { workspace = true }
+auth-context = { workspace = true }
+telemetry    = { workspace = true }
+transport    = { workspace = true }
 tokio        = { workspace = true }
 futures      = { workspace = true }
 async-trait  = { workspace = true }

--- a/crates/services/profile/Cargo.toml
+++ b/crates/services/profile/Cargo.toml
@@ -12,14 +12,14 @@ description = "Profile microservice — public identity metadata layer for hyper
 error            = { workspace = true }
 validate-core    = { workspace = true }
 validation       = { workspace = true }
-scylla-storage   = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage    = { path = "../../shared/storage/redis", package = "redis-storage" }
+scylla-storage   = { workspace = true }
+redis-storage    = { workspace = true }
 
 # ── Shared platform crates ────────────────────────────────────────────────────
-cqrs         = { path = "../../shared/cqrs" }
-auth-context = { path = "../../shared/auth-context" }
-telemetry    = { path = "../../shared/telemetry" }
-transport    = { path = "../../shared/transport" }
+cqrs         = { workspace = true }
+auth-context = { workspace = true }
+telemetry    = { workspace = true }
+transport    = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/social-graph/Cargo.toml
+++ b/crates/services/social-graph/Cargo.toml
@@ -12,14 +12,14 @@ description = "Social-graph microservice — directional follow/block relationsh
 error            = { workspace = true }
 validate-core    = { workspace = true }
 validation       = { workspace = true }
-scylla-storage   = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage    = { path = "../../shared/storage/redis", package = "redis-storage" }
+scylla-storage   = { workspace = true }
+redis-storage    = { workspace = true }
 
 # ── Shared platform crates ────────────────────────────────────────────────────
-cqrs         = { path = "../../shared/cqrs" }
-auth-context = { path = "../../shared/auth-context" }
-telemetry    = { path = "../../shared/telemetry" }
-transport    = { path = "../../shared/transport" }
+cqrs         = { workspace = true }
+auth-context = { workspace = true }
+telemetry    = { workspace = true }
+transport    = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/timeline/Cargo.toml
+++ b/crates/services/timeline/Cargo.toml
@@ -12,11 +12,11 @@ description = "Timeline microservice — hybrid fan-out-on-write / fan-out-on-re
 error          = { workspace = true }
 validate-core  = { workspace = true }
 validation     = { workspace = true }
-scylla-storage = { path = "../../shared/storage/scylla", package = "scylla-storage" }
-redis-storage  = { path = "../../shared/storage/redis",  package = "redis-storage" }
-cqrs           = { path = "../../shared/cqrs" }
-telemetry      = { path = "../../shared/telemetry" }
-transport      = { path = "../../shared/transport" }
+scylla-storage = { workspace = true }
+redis-storage  = { workspace = true }
+cqrs           = { workspace = true }
+telemetry      = { workspace = true }
+transport      = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/shared/auth-context/Cargo.toml
+++ b/crates/shared/auth-context/Cargo.toml
@@ -13,7 +13,7 @@ cqrs-integration  = ["dep:cqrs"]
 
 [dependencies]
 # Intra-workspace
-cqrs = { path = "../cqrs", optional = true }
+cqrs = { workspace = true, optional = true }
 
 # Async runtime
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/shared/validation/Cargo.toml
+++ b/crates/shared/validation/Cargo.toml
@@ -10,7 +10,7 @@ description           = "Tower-inspired ValidationLayer middleware, field-level 
 [dependencies]
 # Intra-workspace
 validate-core = { workspace = true }
-cqrs          = { path = "../cqrs" }
+cqrs          = { workspace = true }
 error         = { workspace = true }
 
 # Error ergonomics


### PR DESCRIPTION
Register every intra-workspace crate in [workspace.dependencies] as the single source of truth for paths, and switch all member crates from brittle relative `path = "../.."` references to `{ workspace = true }`.

Root Cargo.toml:
- Add the 4 previously-unregistered internal crates: telemetry, transport, cqrs, auth-context.
- Fix the postgres-storage key to carry `package = "postgres"` (the crate's package name differs from the key), so it resolves as a workspace dependency and avoids colliding with the crates.io `postgres` crate.

Members:
- cqrs (validation), cqrs (auth-context, optional preserved), and all 10 services now reference shared crates with `{ workspace = true }`, including chat's dev-dependencies.

Verified the full dependency graph resolves via `cargo metadata`.