### PR TITLE
feat(telemetry): live log-filter dial via [telemetry] (Step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4372,6 +4372,7 @@ name = "telemetry"
 version = "0.1.0"
 dependencies = [
  "axum 0.8.8",
+ "infra-config",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",

--- a/crates/shared/infra-config/examples/infrastructure.toml
+++ b/crates/shared/infra-config/examples/infrastructure.toml
@@ -109,3 +109,13 @@ on_backend_error = "fail_open"
 [traffic.bindings]
 "/post.PostService/CreatePost"      = "write-tight"
 "/timeline.TimelineService/GetFeed" = "standard"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Telemetry — a *singleton* section (no profiles/bindings). When present, log_filter
+# is the source of truth at boot (overriding RUST_LOG/default) and hot-reloads: an
+# SRE can raise verbosity mid-incident by editing this, with no redeploy. Requires
+# the binary to wire telemetry's reload handle (InfraRegistry::with_log_control).
+# ══════════════════════════════════════════════════════════════════════════════
+[telemetry]
+log_filter = "info,post=debug,tower=warn"

--- a/crates/shared/infra-config/src/infra.rs
+++ b/crates/shared/infra-config/src/infra.rs
@@ -7,7 +7,8 @@ use tracing::warn;
 
 use crate::{
     cache::CacheRegistry, error::ConfigError, reload::Reloadable, registry::ResilienceRegistry,
-    schema::InfrastructureConfig, traffic::TrafficRegistry,
+    schema::InfrastructureConfig, telemetry::{LogFilterControl, TelemetrySection},
+    traffic::TrafficRegistry,
 };
 
 /// Owns one resolved registry per `infrastructure.toml` section and presents them as a
@@ -28,6 +29,11 @@ pub struct InfraRegistry {
     resilience: Arc<ResilienceRegistry>,
     cache: Option<Arc<CacheRegistry>>,
     traffic: Option<Arc<TrafficRegistry>>,
+    /// The `[telemetry]` section from boot config (the filter to apply once a control is
+    /// attached). The live filter lives inside the tracing subscriber, swapped via the control.
+    telemetry: Option<TelemetrySection>,
+    /// Drives the process-global log filter; attached by the binary after `telemetry::init`.
+    log_control: Option<Arc<dyn LogFilterControl>>,
 }
 
 impl InfraRegistry {
@@ -46,7 +52,26 @@ impl InfraRegistry {
             None => None,
         };
 
-        Ok(Self { resilience, cache, traffic })
+        Ok(Self { resilience, cache, traffic, telemetry: config.telemetry, log_control: None })
+    }
+
+    /// Attaches the log-filter control (from `telemetry::init`) and **applies the boot
+    /// `[telemetry]` filter immediately** — making the ConfigMap the source of truth over the
+    /// env/default bootstrap. A bad boot filter fails loud here (caught at deploy).
+    ///
+    /// Call once, after `from_config` and before sharing the registry / starting the watcher.
+    pub fn with_log_control(
+        mut self,
+        control: Arc<dyn LogFilterControl>,
+    ) -> Result<Self, ConfigError> {
+        if let Some(section) = &self.telemetry {
+            control
+                .validate_filter(&section.log_filter)
+                .and_then(|()| control.set_filter(&section.log_filter))
+                .map_err(ConfigError::validation)?;
+        }
+        self.log_control = Some(control);
+        Ok(self)
     }
 
     /// Shared resilience registry (always present).
@@ -70,6 +95,13 @@ impl InfraRegistry {
     pub fn apply(&self, config: InfrastructureConfig) -> Result<(), ConfigError> {
         config.validate()?;
 
+        // Fail-closed pre-check: the log filter is the one section whose *syntax* lives
+        // behind the control, so validate it here (before any swap) to keep the reload
+        // all-or-nothing — a bad directive rejects the whole document.
+        if let (Some(control), Some(section)) = (&self.log_control, &config.telemetry) {
+            control.validate_filter(&section.log_filter).map_err(ConfigError::validation)?;
+        }
+
         self.resilience.apply_section(config.resilience)?;
 
         match (&self.cache, config.cache) {
@@ -91,6 +123,21 @@ impl InfraRegistry {
             (None, Some(_)) => warn!(
                 "[traffic] section added at runtime — ignored (adding a section requires a restart)"
             ),
+            (None, None) => {}
+        }
+
+        // Telemetry: swap the live log filter (already validated above, so this won't fail
+        // on syntax). A configured section with no control attached is a wiring gap — warn.
+        match (&self.log_control, config.telemetry) {
+            (Some(control), Some(section)) => {
+                control.set_filter(&section.log_filter).map_err(ConfigError::validation)?;
+            }
+            (Some(_), None) => {
+                warn!("[telemetry] section removed from reloaded config — keeping current filter")
+            }
+            (None, Some(_)) => {
+                warn!("[telemetry] section present but no log control attached — ignored")
+            }
             (None, None) => {}
         }
 

--- a/crates/shared/infra-config/src/lib.rs
+++ b/crates/shared/infra-config/src/lib.rs
@@ -27,6 +27,7 @@ pub mod infra;
 pub mod registry;
 pub mod reload;
 pub mod schema;
+pub mod telemetry;
 pub mod traffic;
 pub mod watcher;
 
@@ -37,5 +38,6 @@ pub use infra::InfraRegistry;
 pub use registry::ResilienceRegistry;
 pub use reload::Reloadable;
 pub use schema::{InfrastructureConfig, ResilienceSection};
+pub use telemetry::{LogFilterControl, TelemetrySection};
 pub use traffic::{TrafficRegistry, TrafficSection};
 pub use watcher::{load_from_path, spawn_watcher};

--- a/crates/shared/infra-config/src/schema.rs
+++ b/crates/shared/infra-config/src/schema.rs
@@ -20,7 +20,8 @@ use resilience::{retry::backoff::spec::BackoffSpec, ResilienceProfileSpec};
 use serde::Deserialize;
 
 use crate::{
-    cache::CacheSection, catalog::validate_bindings, error::ConfigError, traffic::TrafficSection,
+    cache::CacheSection, catalog::validate_bindings, error::ConfigError,
+    telemetry::TelemetrySection, traffic::TrafficSection,
 };
 
 /// Top-level `infrastructure.toml` document.
@@ -39,6 +40,10 @@ pub struct InfrastructureConfig {
     /// Externalized ingress rate-limit profiles. Absent in deployments that don't use them.
     #[serde(default)]
     pub traffic: Option<TrafficSection>,
+
+    /// Externalized log/observability control. Absent → boot logging behaviour is unchanged.
+    #[serde(default)]
+    pub telemetry: Option<TelemetrySection>,
 }
 
 impl InfrastructureConfig {
@@ -51,6 +56,9 @@ impl InfrastructureConfig {
         }
         if let Some(traffic) = &self.traffic {
             traffic.validate()?;
+        }
+        if let Some(telemetry) = &self.telemetry {
+            telemetry.validate()?;
         }
         Ok(())
     }

--- a/crates/shared/infra-config/src/telemetry.rs
+++ b/crates/shared/infra-config/src/telemetry.rs
@@ -1,0 +1,52 @@
+//! The `[telemetry]` section: a *singleton* (non-catalog) tenant for live log control.
+//!
+//! Unlike `[resilience]`/`[cache]`/`[traffic]` — which are per-key catalogs — telemetry is
+//! process-global: one log-filter directive, no profiles or bindings. So this section is a
+//! flat struct, and `InfraRegistry` drives it through a [`LogFilterControl`] handle rather
+//! than a registry of profiles.
+//!
+//! ```toml
+//! [telemetry]
+//! log_filter = "info,post=debug,tower=warn"
+//! ```
+
+use serde::Deserialize;
+
+use crate::error::ConfigError;
+
+/// Drives the process-global log filter.
+///
+/// Implemented by the telemetry layer's reload handle (behind telemetry's `infra-config`
+/// feature) and wired into [`InfraRegistry`](crate::InfraRegistry) by the serving binary.
+/// Kept here, dependency-light, so `infra-config` needs no `tracing-subscriber`: filter
+/// *syntax* knowledge lives entirely in the implementation.
+pub trait LogFilterControl: Send + Sync {
+    /// Parse-check a directive **without** applying it — used for fail-closed pre-validation
+    /// so a bad filter rejects the whole reload before anything is swapped.
+    fn validate_filter(&self, directives: &str) -> Result<(), String>;
+
+    /// Parse and lock-free-swap the live filter. Implementations keep the previous filter on
+    /// error, so logging can never be left broken.
+    fn set_filter(&self, directives: &str) -> Result<(), String>;
+}
+
+/// The `[telemetry]` section — a singleton: one process-global log filter.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TelemetrySection {
+    /// `tracing_subscriber` `EnvFilter` directive, e.g. `"info,post=debug"`. When present,
+    /// this is the source of truth at boot (overriding `RUST_LOG`/default) and the value the
+    /// watcher hot-reloads.
+    pub log_filter: String,
+}
+
+impl TelemetrySection {
+    /// Structural validation only. Directive *syntax* is checked via
+    /// [`LogFilterControl::validate_filter`] (where `tracing-subscriber` lives), so it can
+    /// participate in the cross-section fail-closed pre-check without pulling that dep here.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.log_filter.trim().is_empty() {
+            return Err(ConfigError::validation("[telemetry] log_filter must not be empty"));
+        }
+        Ok(())
+    }
+}

--- a/crates/shared/infra-config/tests/telemetry.rs
+++ b/crates/shared/infra-config/tests/telemetry.rs
@@ -1,0 +1,95 @@
+//! `[telemetry]` tenant: boot apply, hot-reload, and fail-closed via a fake control.
+
+use std::sync::{Arc, Mutex};
+
+use infra_config::{InfraRegistry, InfrastructureConfig, LogFilterControl, Reloadable};
+
+/// Records applied filters; optionally rejects any directive containing a marker substring
+/// (stands in for telemetry's real parse-check).
+#[derive(Default)]
+struct FakeControl {
+    applied: Mutex<Vec<String>>,
+    reject_marker: Mutex<Option<String>>,
+}
+
+impl LogFilterControl for FakeControl {
+    fn validate_filter(&self, directives: &str) -> Result<(), String> {
+        match self.reject_marker.lock().unwrap().as_deref() {
+            Some(marker) if directives.contains(marker) => Err(format!("invalid filter: {directives}")),
+            _ => Ok(()),
+        }
+    }
+    fn set_filter(&self, directives: &str) -> Result<(), String> {
+        self.applied.lock().unwrap().push(directives.to_owned());
+        Ok(())
+    }
+}
+
+const BASE: &str = r#"
+[resilience]
+default_profile = "standard"
+[resilience.profiles.standard]
+timeout = { duration_ms = 10000 }
+circuit_breaker = { failure_threshold = 5, success_threshold = 2, open_duration_ms = 30000, half_open_max_calls = 1 }
+retry = { max_attempts = 3, backoff = { kind = "exponential", base_ms = 50, max_ms = 10000, jitter = "full" } }
+
+[telemetry]
+log_filter = "info,post=debug"
+"#;
+
+fn registry(control: Arc<FakeControl>) -> InfraRegistry {
+    let cfg = InfrastructureConfig::from_toml(BASE).unwrap();
+    let control: Arc<dyn LogFilterControl> = control;
+    InfraRegistry::from_config(cfg).unwrap().with_log_control(control).unwrap()
+}
+
+#[test]
+fn boot_applies_configured_filter() {
+    let control = Arc::new(FakeControl::default());
+    let _reg = registry(Arc::clone(&control));
+    assert_eq!(control.applied.lock().unwrap().as_slice(), &["info,post=debug".to_string()]);
+}
+
+#[test]
+fn hot_reload_applies_new_filter() {
+    let control = Arc::new(FakeControl::default());
+    let reg = registry(Arc::clone(&control));
+
+    let next = BASE.replace("info,post=debug", "warn,post=trace");
+    reg.reload(&next).unwrap();
+
+    assert_eq!(control.applied.lock().unwrap().last().unwrap(), "warn,post=trace");
+}
+
+#[test]
+fn bad_filter_rejects_whole_reload() {
+    let control = Arc::new(FakeControl::default());
+    *control.reject_marker.lock().unwrap() = Some("BADFILTER".to_string());
+    let reg = registry(Arc::clone(&control));
+
+    let applied_before = control.applied.lock().unwrap().len();
+    let bad = BASE.replace("info,post=debug", "BADFILTER");
+    let err = reg.reload(&bad).unwrap_err();
+
+    assert!(err.to_string().contains("invalid filter"), "got: {err}");
+    // Fail-closed: set_filter was never called for the rejected push.
+    assert_eq!(control.applied.lock().unwrap().len(), applied_before);
+}
+
+#[test]
+fn telemetry_section_is_optional() {
+    let resilience_only = r#"
+[resilience]
+default_profile = "standard"
+[resilience.profiles.standard]
+timeout = { duration_ms = 10000 }
+circuit_breaker = { failure_threshold = 5, success_threshold = 2, open_duration_ms = 30000, half_open_max_calls = 1 }
+retry = { max_attempts = 3, backoff = { kind = "exponential", base_ms = 50, max_ms = 10000, jitter = "full" } }
+"#;
+    let control = Arc::new(FakeControl::default());
+    let cfg = InfrastructureConfig::from_toml(resilience_only).unwrap();
+    let dyn_control: Arc<dyn LogFilterControl> = Arc::clone(&control) as _;
+    let _reg = InfraRegistry::from_config(cfg).unwrap().with_log_control(dyn_control).unwrap();
+    // No [telemetry] section → nothing applied at boot.
+    assert!(control.applied.lock().unwrap().is_empty());
+}

--- a/crates/shared/telemetry/Cargo.toml
+++ b/crates/shared/telemetry/Cargo.toml
@@ -31,6 +31,12 @@ prometheus = { version = "0.13", features = ["process"], optional = true }
 # HTTP route for GET /metrics
 axum = { workspace = true, optional = true }
 
+# Optional bridge to the externalized config layer for hot-reloadable log filtering.
+# Off by default so log-only consumers never pull `infra-config`.
+infra-config = { workspace = true, optional = true }
+
 [features]
 default = ["prometheus-exporter"]
 prometheus-exporter = ["dep:opentelemetry-prometheus", "dep:prometheus", "dep:axum"]
+# Implements `infra_config::LogFilterControl` for the log reload handle.
+infra-config = ["dep:infra-config"]

--- a/crates/shared/telemetry/src/guard.rs
+++ b/crates/shared/telemetry/src/guard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use opentelemetry_sdk::trace::TracerProvider;
 use tracing_appender::non_blocking::WorkerGuard;
 
+use crate::log::LogReloadHandle;
 use crate::metrics::{exporter::PrometheusHandle, layer::MetricsPipeline};
 
 /// Lifetime anchor for the entire telemetry pipeline.
@@ -40,6 +41,8 @@ pub struct TelemetryGuard {
     tracer_provider: TracerProvider,
     /// Holds the metrics pipeline; shutdown flushes the meter provider.
     metrics_pipeline: MetricsPipeline,
+    /// Hot-swaps the live log filter; handed to the config layer for runtime control.
+    log_reloader: LogReloadHandle,
 }
 
 impl TelemetryGuard {
@@ -47,12 +50,21 @@ impl TelemetryGuard {
         log_guard: WorkerGuard,
         tracer_provider: TracerProvider,
         metrics_pipeline: MetricsPipeline,
+        log_reloader: LogReloadHandle,
     ) -> Self {
         Self {
             _log_guard: log_guard,
             tracer_provider,
             metrics_pipeline,
+            log_reloader,
         }
+    }
+
+    /// Returns a cloneable handle for hot-swapping the log filter at runtime. Hand it to
+    /// `InfraRegistry::with_log_control` (with telemetry's `infra-config` feature enabled) so
+    /// an `infrastructure.toml` `[telemetry]` change drives the live filter with no redeploy.
+    pub fn log_reloader(&self) -> LogReloadHandle {
+        self.log_reloader.clone()
     }
 
     /// Returns a cheaply cloneable handle to the Prometheus registry.

--- a/crates/shared/telemetry/src/init.rs
+++ b/crates/shared/telemetry/src/init.rs
@@ -1,6 +1,8 @@
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter};
 
-use crate::{config::TelemetryConfig, error::TelemetryError, guard::TelemetryGuard};
+use crate::{
+    config::TelemetryConfig, error::TelemetryError, guard::TelemetryGuard, log::LogReloadHandle,
+};
 
 /// Initialises the full observability pipeline and returns a [`TelemetryGuard`].
 ///
@@ -31,15 +33,26 @@ pub fn init(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
 
     let metrics_pipeline = crate::metrics::layer::init_metrics_pipeline(&config.metrics)?;
 
+    // Bootstrap filter from RUST_LOG / default. When an `infrastructure.toml` `[telemetry]`
+    // section is wired in, the binary overrides this immediately after init (ConfigMap is the
+    // source of truth); absent that, this remains the live filter.
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(&config.log.default_filter));
 
+    // Wrap the (base) filter in a reload layer so its directive can be hot-swapped at runtime.
+    let (filter_layer, reload_handle) = reload::Layer::new(env_filter);
+
     tracing_subscriber::registry()
-        .with(env_filter)
+        .with(filter_layer)
         .with(log_layer)
         .with(trace_layer)
         .try_init()
         .map_err(|e| TelemetryError::SubscriberInit(e.to_string()))?;
 
-    Ok(TelemetryGuard::new(log_guard, tracer_provider, metrics_pipeline))
+    Ok(TelemetryGuard::new(
+        log_guard,
+        tracer_provider,
+        metrics_pipeline,
+        LogReloadHandle::new(reload_handle),
+    ))
 }

--- a/crates/shared/telemetry/src/lib.rs
+++ b/crates/shared/telemetry/src/lib.rs
@@ -17,3 +17,4 @@ pub use config::TelemetryConfig;
 pub use error::TelemetryError;
 pub use guard::TelemetryGuard;
 pub use init::init;
+pub use log::LogReloadHandle;

--- a/crates/shared/telemetry/src/log/mod.rs
+++ b/crates/shared/telemetry/src/log/mod.rs
@@ -1,5 +1,7 @@
 pub mod config;
 pub mod layer;
+pub mod reload;
 
 pub use config::*;
 pub use layer::*;
+pub use reload::LogReloadHandle;

--- a/crates/shared/telemetry/src/log/reload.rs
+++ b/crates/shared/telemetry/src/log/reload.rs
@@ -1,0 +1,78 @@
+//! Runtime hot-swap of the global log-filter directive.
+//!
+//! The `EnvFilter` is installed as the base layer on the `Registry`, so its reload handle
+//! has a *nameable* type (`reload::Handle<EnvFilter, Registry>`) — no type erasure needed.
+//! [`LogReloadHandle`] wraps it with parse-checked, string-in/string-out methods so callers
+//! (and the externalized config layer) never touch `tracing-subscriber` types directly.
+
+use tracing_subscriber::{reload, EnvFilter, Registry};
+
+/// Cheap, cloneable handle to hot-swap the process-global log filter at runtime.
+///
+/// Obtain it from [`TelemetryGuard::log_reloader`](crate::TelemetryGuard::log_reloader).
+#[derive(Clone)]
+pub struct LogReloadHandle {
+    handle: reload::Handle<EnvFilter, Registry>,
+}
+
+impl LogReloadHandle {
+    pub(crate) fn new(handle: reload::Handle<EnvFilter, Registry>) -> Self {
+        Self { handle }
+    }
+
+    /// Parse-check a directive (e.g. `"info,post=debug"`) without applying it.
+    pub fn validate(&self, directives: &str) -> Result<(), String> {
+        EnvFilter::try_new(directives).map(|_| ()).map_err(|e| e.to_string())
+    }
+
+    /// Parse and lock-free-swap the live filter. On a parse error the previous filter is
+    /// kept, so logging is never left broken.
+    pub fn reload(&self, directives: &str) -> Result<(), String> {
+        let filter = EnvFilter::try_new(directives).map_err(|e| e.to_string())?;
+        self.handle.reload(filter).map_err(|e| e.to_string())
+    }
+}
+
+/// Bridges the reload handle to the externalized-config layer's control trait, so an
+/// `infrastructure.toml` `[telemetry]` change drives the live filter. Gated so a service
+/// that only wants logging never pulls `infra-config` (mirrors `auth-context`'s
+/// `cqrs-integration` feature).
+#[cfg(feature = "infra-config")]
+impl infra_config::LogFilterControl for LogReloadHandle {
+    fn validate_filter(&self, directives: &str) -> Result<(), String> {
+        self.validate(directives)
+    }
+
+    fn set_filter(&self, directives: &str) -> Result<(), String> {
+        self.reload(directives)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// A `LogReloadHandle` over a local (non-global) subscriber. The subscriber is returned
+    /// so it stays alive — the handle swaps the filter inside it.
+    fn handle() -> (impl tracing::Subscriber, LogReloadHandle) {
+        let (layer, h) = reload::Layer::new(EnvFilter::new("info"));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        (subscriber, LogReloadHandle::new(h))
+    }
+
+    #[test]
+    fn validate_accepts_good_and_rejects_bad() {
+        let (_sub, h) = handle();
+        assert!(h.validate("info,post=debug,tower=warn").is_ok());
+        assert!(h.validate("post=notalevel").is_err());
+    }
+
+    #[test]
+    fn reload_swaps_good_and_keeps_previous_on_bad() {
+        let (_sub, h) = handle();
+        assert!(h.reload("debug,post=trace").is_ok());
+        // A malformed directive is rejected; the previous filter stays live.
+        assert!(h.reload("post=notalevel").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **`[telemetry]` section** to the externalized-config layer with its first dial: a **live log-filter** that hot-reloads via `tracing_subscriber::reload`. An `infrastructure.toml` change now raises log verbosity (`info → info,post=debug`) with **no redeploy** — closing the original audit finding that a restart was required (and would lose the incident repro).

> **Stacked on #434** (`feat/infra-config-traffic-arc`) — this branch builds on the generalized `infra-config`. Review #434 first; retarget to `develop` once it merges.

## What's in here

- **telemetry**: the base `EnvFilter` is wrapped in `reload::Layer`; `TelemetryGuard::log_reloader()` exposes a cloneable `LogReloadHandle` (`validate` / `reload`, previous filter kept on parse error). The handle type is nameable because the filter is the base layer on `Registry` — no type erasure. Optional, off-by-default `infra-config` feature impls `LogFilterControl` (mirrors `auth-context`'s `cqrs-integration`), so log-only consumers never pull `infra-config`.
- **infra-config**: `[telemetry]` is the first **singleton** section (no catalog/bindings). `LogFilterControl` trait kept dependency-light (no `tracing-subscriber` here — filter syntax lives in the impl). `InfraRegistry::with_log_control` applies the configured filter at boot (**ConfigMap is the source of truth** over `RUST_LOG`/default; bad boot filter fails loud) and hot-reloads it **fail-closed across sections** (a bad directive rejects the whole document; the live filter is never left broken).

## Design decisions (confirmed)

- **Boundary**: feature-gated trait impl in telemetry — keeps both crate dependency trees lean.
- **Precedence**: `[telemetry]` present → it owns boot + hot-reload; absent → today's behavior unchanged (opt-in, like every other section).
- **Scope**: log filter only. Trace sampling is Step 2 (needs a custom dynamic `Sampler` — the SDK bakes the sampler at provider build). Log *format* stays boot-time.

## Testing

- telemetry: reload-handle unit tests (validate good/bad; reload swaps, keeps previous on bad), both feature modes.
- infra-config: boot apply, hot-reload, fail-closed (bad filter rejects the whole reload), optional section.
- `cargo check --workspace` clean; clippy clean for new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
