### PR TITLE
feat(telemetry): dynamic trace-sampling dial + unified TelemetryControl (Step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
 name = "telemetry"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "axum 0.8.8",
  "infra-config",
  "opentelemetry",

--- a/crates/shared/infra-config/README.md
+++ b/crates/shared/infra-config/README.md
@@ -127,7 +127,96 @@ let channel = GrpcClientBuilder::new(
 let app = profile::app::App::build(backends, registry.cache().expect("[cache] configured")).await?;
 ```
 
-A resilience-only deployment can drive the same watcher with `Arc<ResilienceRegistry>` directly — both implement `Reloadable`. See [`examples/infrastructure.toml`](examples/infrastructure.toml) for the full `[resilience]` + `[cache]` catalogs and bindings.
+A resilience-only deployment can drive the same watcher with `Arc<ResilienceRegistry>` directly — both implement `Reloadable`. See [`examples/infrastructure.toml`](examples/infrastructure.toml) for the full catalogs and bindings.
+
+---
+
+## 🚀 Binary bootstrap — rollout checklist
+
+`infra-config` is pure composition; the **serving binary** owns activation. Wire it once at
+boot, in this order:
+
+1. **`telemetry::init` first** — before any `tracing` macro. Keep the `TelemetryGuard` alive
+   for the whole process. Enable telemetry's `infra-config` feature so its control handle
+   implements [`TelemetryControl`].
+2. **Load + resolve** the document (`load_from_path` → `InfraRegistry::from_config`).
+3. **Attach the telemetry control** (`with_telemetry_control`) — applies the `[telemetry]`
+   dials at boot (ConfigMap is the source of truth over `RUST_LOG`/env); a bad boot value
+   fails loud here.
+4. **`spawn_watcher`** — one watcher drives every section; **keep the returned guard alive**.
+5. **Hand each section to its consumer**: `resilience()` → gRPC client builder; `cache()` →
+   each service's `App::build`; `traffic()` → the gRPC server.
+6. **Server-side rate limiting**: `GrpcServerBuilder::with_traffic(traffic)`, plus
+   `with_traffic_backend(...)` **only if** a profile uses `mode = "distributed"`.
+7. **Prune loops**: spawn periodic `traffic.prune_all()` and (distributed) `backend.prune(lease_ms)`
+   to bound memory for unbounded `per_caller` keyspaces.
+8. **Keep `_telemetry` and `_watcher` bound** for the process lifetime.
+
+```toml
+# serving binary Cargo.toml
+infra-config  = { workspace = true }
+telemetry     = { workspace = true, features = ["infra-config"] } # enables the control bridge
+traffic-redis = { workspace = true }                              # only for mode = "distributed"
+```
+
+```rust,ignore
+use std::sync::Arc;
+use std::time::Duration;
+use infra_config::{load_from_path, spawn_watcher, InfraRegistry, TelemetryControl};
+
+const CONFIG: &str = "/etc/infra/infrastructure.toml"; // mounted ConfigMap
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // 1. Telemetry first; keep the guard alive. (binary deps telemetry w/ `infra-config`.)
+    let cfg = telemetry::TelemetryConfig::from_env("post-command", env!("CARGO_PKG_VERSION"));
+    let _telemetry = telemetry::init(cfg)?;
+
+    // 2-3. Load, resolve, attach the telemetry control (applies [telemetry] dials at boot).
+    let control: Arc<dyn TelemetryControl> = Arc::new(_telemetry.telemetry_control());
+    let infra = Arc::new(
+        InfraRegistry::from_config(load_from_path(CONFIG.as_ref())?)?
+            .with_telemetry_control(control)?,
+    );
+
+    // 4. One watcher for every section. KEEP IT ALIVE.
+    let _watcher = spawn_watcher(CONFIG.into(), Arc::clone(&infra))?;
+
+    // 5. Cache → service composition root.
+    let app = post::app::App::build(backends, infra.cache().expect("[cache] configured")).await?;
+
+    // 6. gRPC server with ingress rate limiting.
+    let mut server = transport::grpc::server::GrpcServerBuilder::new(Default::default());
+    if let Some(traffic) = infra.traffic() {
+        server = server.with_traffic(Arc::clone(&traffic));
+
+        // Distributed budgets: wire the Redis-lease backend (only if a profile uses it).
+        let backend = Arc::new(traffic_redis::RedisLeaseBackend::new(redis.clone()));
+        server = server.with_traffic_backend(Arc::clone(&backend) as Arc<dyn traffic::QuotaBackend>);
+
+        // 7. Prune loops — bound memory for per_caller keyspaces.
+        let lease_ms = 1_000;
+        tokio::spawn({ let t = Arc::clone(&traffic); async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(60));
+            loop { tick.tick().await; t.prune_all(); }
+        }});
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(60));
+            loop { tick.tick().await; backend.prune(lease_ms); }
+        });
+    }
+
+    server.build()?
+        .add_service(/* PostServiceServer::new(handler) */)
+        .serve("0.0.0.0:50051".parse()?)
+        .await?;
+    Ok(()) // 8. _telemetry + _watcher drop here, at process exit.
+}
+```
+
+> **Incremental adoption:** every section is optional. A binary that only wants resilience +
+> cache skips steps 1/3/6/7; one without distributed profiles skips `with_traffic_backend`
+> and its prune loop. Absent sections leave today's behaviour untouched.
 
 ---
 

--- a/crates/shared/infra-config/examples/infrastructure.toml
+++ b/crates/shared/infra-config/examples/infrastructure.toml
@@ -112,10 +112,13 @@ on_backend_error = "fail_open"
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Telemetry — a *singleton* section (no profiles/bindings). When present, log_filter
-# is the source of truth at boot (overriding RUST_LOG/default) and hot-reloads: an
-# SRE can raise verbosity mid-incident by editing this, with no redeploy. Requires
-# the binary to wire telemetry's reload handle (InfraRegistry::with_log_control).
+# Telemetry — a *singleton* section (no profiles/bindings). Both dials are optional
+# and, when present, are the source of truth at boot (overriding env) and hot-reload:
+# an SRE can raise log verbosity or trace sampling mid-incident by editing this, with
+# no redeploy. Requires the binary to wire telemetry's control handle
+# (InfraRegistry::with_telemetry_control). sampling_ratio uses ParentBased sampling,
+# so a sampled trace stays whole across service hops.
 # ══════════════════════════════════════════════════════════════════════════════
 [telemetry]
-log_filter = "info,post=debug,tower=warn"
+log_filter     = "info,post=debug,tower=warn"
+sampling_ratio = 0.1

--- a/crates/shared/infra-config/src/infra.rs
+++ b/crates/shared/infra-config/src/infra.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 
 use crate::{
     cache::CacheRegistry, error::ConfigError, reload::Reloadable, registry::ResilienceRegistry,
-    schema::InfrastructureConfig, telemetry::{LogFilterControl, TelemetrySection},
+    schema::InfrastructureConfig, telemetry::{TelemetryControl, TelemetrySection},
     traffic::TrafficRegistry,
 };
 
@@ -29,11 +29,12 @@ pub struct InfraRegistry {
     resilience: Arc<ResilienceRegistry>,
     cache: Option<Arc<CacheRegistry>>,
     traffic: Option<Arc<TrafficRegistry>>,
-    /// The `[telemetry]` section from boot config (the filter to apply once a control is
-    /// attached). The live filter lives inside the tracing subscriber, swapped via the control.
+    /// The `[telemetry]` section from boot config (the dials to apply once a control is
+    /// attached). The live state lives inside the tracing subscriber / sampler, swapped via
+    /// the control.
     telemetry: Option<TelemetrySection>,
-    /// Drives the process-global log filter; attached by the binary after `telemetry::init`.
-    log_control: Option<Arc<dyn LogFilterControl>>,
+    /// Drives the process-global telemetry dials; attached by the binary after `telemetry::init`.
+    telemetry_control: Option<Arc<dyn TelemetryControl>>,
 }
 
 impl InfraRegistry {
@@ -52,25 +53,37 @@ impl InfraRegistry {
             None => None,
         };
 
-        Ok(Self { resilience, cache, traffic, telemetry: config.telemetry, log_control: None })
+        Ok(Self {
+            resilience,
+            cache,
+            traffic,
+            telemetry: config.telemetry,
+            telemetry_control: None,
+        })
     }
 
-    /// Attaches the log-filter control (from `telemetry::init`) and **applies the boot
-    /// `[telemetry]` filter immediately** — making the ConfigMap the source of truth over the
-    /// env/default bootstrap. A bad boot filter fails loud here (caught at deploy).
+    /// Attaches the telemetry control (from `telemetry::init`) and **applies the boot
+    /// `[telemetry]` dials immediately** — making the ConfigMap the source of truth over the
+    /// env/default bootstrap. A bad boot filter fails loud here (caught at deploy); the
+    /// sampling range was already validated by `from_config`.
     ///
     /// Call once, after `from_config` and before sharing the registry / starting the watcher.
-    pub fn with_log_control(
+    pub fn with_telemetry_control(
         mut self,
-        control: Arc<dyn LogFilterControl>,
+        control: Arc<dyn TelemetryControl>,
     ) -> Result<Self, ConfigError> {
         if let Some(section) = &self.telemetry {
-            control
-                .validate_filter(&section.log_filter)
-                .and_then(|()| control.set_filter(&section.log_filter))
-                .map_err(ConfigError::validation)?;
+            if let Some(filter) = &section.log_filter {
+                control
+                    .validate_filter(filter)
+                    .and_then(|()| control.set_filter(filter))
+                    .map_err(ConfigError::validation)?;
+            }
+            if let Some(ratio) = section.sampling_ratio {
+                control.set_sampling_ratio(ratio);
+            }
         }
-        self.log_control = Some(control);
+        self.telemetry_control = Some(control);
         Ok(self)
     }
 
@@ -95,11 +108,13 @@ impl InfraRegistry {
     pub fn apply(&self, config: InfrastructureConfig) -> Result<(), ConfigError> {
         config.validate()?;
 
-        // Fail-closed pre-check: the log filter is the one section whose *syntax* lives
+        // Fail-closed pre-check: the log filter is the one telemetry dial whose *syntax* lives
         // behind the control, so validate it here (before any swap) to keep the reload
-        // all-or-nothing — a bad directive rejects the whole document.
-        if let (Some(control), Some(section)) = (&self.log_control, &config.telemetry) {
-            control.validate_filter(&section.log_filter).map_err(ConfigError::validation)?;
+        // all-or-nothing. (The sampling range was already checked by `config.validate()`.)
+        if let (Some(control), Some(TelemetrySection { log_filter: Some(filter), .. })) =
+            (&self.telemetry_control, &config.telemetry)
+        {
+            control.validate_filter(filter).map_err(ConfigError::validation)?;
         }
 
         self.resilience.apply_section(config.resilience)?;
@@ -126,17 +141,23 @@ impl InfraRegistry {
             (None, None) => {}
         }
 
-        // Telemetry: swap the live log filter (already validated above, so this won't fail
-        // on syntax). A configured section with no control attached is a wiring gap — warn.
-        match (&self.log_control, config.telemetry) {
+        // Telemetry: swap the live dials. The filter was syntax-checked above and the
+        // sampling range by `config.validate()`, so neither fails here. A configured section
+        // with no control attached is a wiring gap — warn.
+        match (&self.telemetry_control, config.telemetry) {
             (Some(control), Some(section)) => {
-                control.set_filter(&section.log_filter).map_err(ConfigError::validation)?;
+                if let Some(filter) = &section.log_filter {
+                    control.set_filter(filter).map_err(ConfigError::validation)?;
+                }
+                if let Some(ratio) = section.sampling_ratio {
+                    control.set_sampling_ratio(ratio);
+                }
             }
             (Some(_), None) => {
-                warn!("[telemetry] section removed from reloaded config — keeping current filter")
+                warn!("[telemetry] section removed from reloaded config — keeping current dials")
             }
             (None, Some(_)) => {
-                warn!("[telemetry] section present but no log control attached — ignored")
+                warn!("[telemetry] section present but no telemetry control attached — ignored")
             }
             (None, None) => {}
         }

--- a/crates/shared/infra-config/src/lib.rs
+++ b/crates/shared/infra-config/src/lib.rs
@@ -38,6 +38,6 @@ pub use infra::InfraRegistry;
 pub use registry::ResilienceRegistry;
 pub use reload::Reloadable;
 pub use schema::{InfrastructureConfig, ResilienceSection};
-pub use telemetry::{LogFilterControl, TelemetrySection};
+pub use telemetry::{TelemetryControl, TelemetrySection};
 pub use traffic::{TrafficRegistry, TrafficSection};
 pub use watcher::{load_from_path, spawn_watcher};

--- a/crates/shared/infra-config/src/telemetry.rs
+++ b/crates/shared/infra-config/src/telemetry.rs
@@ -1,51 +1,69 @@
-//! The `[telemetry]` section: a *singleton* (non-catalog) tenant for live log control.
+//! The `[telemetry]` section: a *singleton* (non-catalog) tenant for live observability control.
 //!
 //! Unlike `[resilience]`/`[cache]`/`[traffic]` — which are per-key catalogs — telemetry is
-//! process-global: one log-filter directive, no profiles or bindings. So this section is a
-//! flat struct, and `InfraRegistry` drives it through a [`LogFilterControl`] handle rather
-//! than a registry of profiles.
+//! process-global: one log-filter directive and one trace-sampling ratio, no profiles or
+//! bindings. So this section is a flat struct, and `InfraRegistry` drives it through a single
+//! [`TelemetryControl`] handle rather than a registry of profiles.
 //!
 //! ```toml
 //! [telemetry]
-//! log_filter = "info,post=debug,tower=warn"
+//! log_filter     = "info,post=debug,tower=warn"
+//! sampling_ratio = 0.1   # 0.0 = off, 1.0 = all, mid = head-based ratio
 //! ```
 
 use serde::Deserialize;
 
 use crate::error::ConfigError;
 
-/// Drives the process-global log filter.
+/// Drives the process-global telemetry dials.
 ///
-/// Implemented by the telemetry layer's reload handle (behind telemetry's `infra-config`
+/// Implemented by the telemetry layer's control handle (behind telemetry's `infra-config`
 /// feature) and wired into [`InfraRegistry`](crate::InfraRegistry) by the serving binary.
-/// Kept here, dependency-light, so `infra-config` needs no `tracing-subscriber`: filter
-/// *syntax* knowledge lives entirely in the implementation.
-pub trait LogFilterControl: Send + Sync {
-    /// Parse-check a directive **without** applying it — used for fail-closed pre-validation
-    /// so a bad filter rejects the whole reload before anything is swapped.
+/// Kept here, dependency-light, so `infra-config` needs no `tracing-subscriber`/OTel: the
+/// log-filter *syntax* lives in the implementation, while the sampling *range* is a plain
+/// number validated here (see [`TelemetrySection::validate`]).
+pub trait TelemetryControl: Send + Sync {
+    /// Parse-check a log-filter directive **without** applying it — used for fail-closed
+    /// pre-validation so a bad filter rejects the whole reload before anything is swapped.
     fn validate_filter(&self, directives: &str) -> Result<(), String>;
 
-    /// Parse and lock-free-swap the live filter. Implementations keep the previous filter on
-    /// error, so logging can never be left broken.
+    /// Parse and lock-free-swap the live log filter. Implementations keep the previous filter
+    /// on error, so logging is never left broken.
     fn set_filter(&self, directives: &str) -> Result<(), String>;
+
+    /// Lock-free-swap the live trace-sampling ratio. Infallible: the `[0.0, 1.0]` range is
+    /// validated upstream by [`TelemetrySection::validate`] (and clamped defensively).
+    fn set_sampling_ratio(&self, ratio: f64);
 }
 
-/// The `[telemetry]` section — a singleton: one process-global log filter.
+/// The `[telemetry]` section — a singleton. Both dials are optional, so a deployment can
+/// control either, both, or neither.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TelemetrySection {
     /// `tracing_subscriber` `EnvFilter` directive, e.g. `"info,post=debug"`. When present,
-    /// this is the source of truth at boot (overriding `RUST_LOG`/default) and the value the
-    /// watcher hot-reloads.
-    pub log_filter: String,
+    /// this is the boot source of truth (over `RUST_LOG`/default) and the value hot-reloaded.
+    #[serde(default)]
+    pub log_filter: Option<String>,
+
+    /// Head-based trace-sampling ratio in `[0.0, 1.0]` (`0.0` = off, `1.0` = all). When
+    /// present, the boot source of truth (over the env sampler) and the value hot-reloaded.
+    #[serde(default)]
+    pub sampling_ratio: Option<f64>,
 }
 
 impl TelemetrySection {
-    /// Structural validation only. Directive *syntax* is checked via
-    /// [`LogFilterControl::validate_filter`] (where `tracing-subscriber` lives), so it can
-    /// participate in the cross-section fail-closed pre-check without pulling that dep here.
+    /// Validates both dials: a present `log_filter` must be non-empty (syntax is checked via
+    /// [`TelemetryControl::validate_filter`] where `tracing-subscriber` lives); a present
+    /// `sampling_ratio` must be in `[0.0, 1.0]`. Run in the cross-section fail-closed
+    /// pre-check, so a bad value rejects the whole document before any swap.
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if self.log_filter.trim().is_empty() {
+        if self.log_filter.as_deref().is_some_and(|f| f.trim().is_empty()) {
             return Err(ConfigError::validation("[telemetry] log_filter must not be empty"));
+        }
+        if let Some(ratio) = self.sampling_ratio.filter(|r| !(0.0..=1.0).contains(r)) {
+            return Err(ConfigError::validation(format!(
+                "[telemetry] sampling_ratio {ratio} must be in [0.0, 1.0]"
+            )));
         }
         Ok(())
     }

--- a/crates/shared/infra-config/tests/telemetry.rs
+++ b/crates/shared/infra-config/tests/telemetry.rs
@@ -2,17 +2,18 @@
 
 use std::sync::{Arc, Mutex};
 
-use infra_config::{InfraRegistry, InfrastructureConfig, LogFilterControl, Reloadable};
+use infra_config::{InfraRegistry, InfrastructureConfig, Reloadable, TelemetryControl};
 
-/// Records applied filters; optionally rejects any directive containing a marker substring
+/// Records applied dials; optionally rejects log filters containing a marker substring
 /// (stands in for telemetry's real parse-check).
 #[derive(Default)]
 struct FakeControl {
-    applied: Mutex<Vec<String>>,
+    filters: Mutex<Vec<String>>,
+    ratios: Mutex<Vec<f64>>,
     reject_marker: Mutex<Option<String>>,
 }
 
-impl LogFilterControl for FakeControl {
+impl TelemetryControl for FakeControl {
     fn validate_filter(&self, directives: &str) -> Result<(), String> {
         match self.reject_marker.lock().unwrap().as_deref() {
             Some(marker) if directives.contains(marker) => Err(format!("invalid filter: {directives}")),
@@ -20,8 +21,11 @@ impl LogFilterControl for FakeControl {
         }
     }
     fn set_filter(&self, directives: &str) -> Result<(), String> {
-        self.applied.lock().unwrap().push(directives.to_owned());
+        self.filters.lock().unwrap().push(directives.to_owned());
         Ok(())
+    }
+    fn set_sampling_ratio(&self, ratio: f64) {
+        self.ratios.lock().unwrap().push(ratio);
     }
 }
 
@@ -35,30 +39,42 @@ retry = { max_attempts = 3, backoff = { kind = "exponential", base_ms = 50, max_
 
 [telemetry]
 log_filter = "info,post=debug"
+sampling_ratio = 0.1
 "#;
 
 fn registry(control: Arc<FakeControl>) -> InfraRegistry {
     let cfg = InfrastructureConfig::from_toml(BASE).unwrap();
-    let control: Arc<dyn LogFilterControl> = control;
-    InfraRegistry::from_config(cfg).unwrap().with_log_control(control).unwrap()
+    let control: Arc<dyn TelemetryControl> = control;
+    InfraRegistry::from_config(cfg).unwrap().with_telemetry_control(control).unwrap()
 }
 
 #[test]
-fn boot_applies_configured_filter() {
+fn boot_applies_both_dials() {
     let control = Arc::new(FakeControl::default());
     let _reg = registry(Arc::clone(&control));
-    assert_eq!(control.applied.lock().unwrap().as_slice(), &["info,post=debug".to_string()]);
+    assert_eq!(control.filters.lock().unwrap().as_slice(), &["info,post=debug".to_string()]);
+    assert_eq!(control.ratios.lock().unwrap().as_slice(), &[0.1]);
 }
 
 #[test]
-fn hot_reload_applies_new_filter() {
+fn hot_reload_applies_new_dials() {
     let control = Arc::new(FakeControl::default());
     let reg = registry(Arc::clone(&control));
 
-    let next = BASE.replace("info,post=debug", "warn,post=trace");
+    let next = BASE.replace("info,post=debug", "warn,post=trace").replace("0.1", "1.0");
     reg.reload(&next).unwrap();
 
-    assert_eq!(control.applied.lock().unwrap().last().unwrap(), "warn,post=trace");
+    assert_eq!(control.filters.lock().unwrap().last().unwrap(), "warn,post=trace");
+    assert_eq!(*control.ratios.lock().unwrap().last().unwrap(), 1.0);
+}
+
+#[test]
+fn out_of_range_ratio_rejected_at_validation() {
+    let bad = BASE.replace("sampling_ratio = 0.1", "sampling_ratio = 1.5");
+    // Range is validated in infra-config (no control needed) — fails at parse/from_config.
+    let cfg = InfrastructureConfig::from_toml(&bad).unwrap();
+    let err = InfraRegistry::from_config(cfg).err().expect("expected error");
+    assert!(err.to_string().contains("must be in [0.0, 1.0]"), "got: {err}");
 }
 
 #[test]
@@ -67,29 +83,36 @@ fn bad_filter_rejects_whole_reload() {
     *control.reject_marker.lock().unwrap() = Some("BADFILTER".to_string());
     let reg = registry(Arc::clone(&control));
 
-    let applied_before = control.applied.lock().unwrap().len();
+    let filters_before = control.filters.lock().unwrap().len();
+    let ratios_before = control.ratios.lock().unwrap().len();
     let bad = BASE.replace("info,post=debug", "BADFILTER");
     let err = reg.reload(&bad).unwrap_err();
 
     assert!(err.to_string().contains("invalid filter"), "got: {err}");
-    // Fail-closed: set_filter was never called for the rejected push.
-    assert_eq!(control.applied.lock().unwrap().len(), applied_before);
+    // Fail-closed: neither dial was applied for the rejected push.
+    assert_eq!(control.filters.lock().unwrap().len(), filters_before);
+    assert_eq!(control.ratios.lock().unwrap().len(), ratios_before);
 }
 
 #[test]
-fn telemetry_section_is_optional() {
-    let resilience_only = r#"
+fn dials_are_individually_optional() {
+    let sampling_only = r#"
 [resilience]
 default_profile = "standard"
 [resilience.profiles.standard]
 timeout = { duration_ms = 10000 }
 circuit_breaker = { failure_threshold = 5, success_threshold = 2, open_duration_ms = 30000, half_open_max_calls = 1 }
 retry = { max_attempts = 3, backoff = { kind = "exponential", base_ms = 50, max_ms = 10000, jitter = "full" } }
+
+[telemetry]
+sampling_ratio = 0.5
 "#;
     let control = Arc::new(FakeControl::default());
-    let cfg = InfrastructureConfig::from_toml(resilience_only).unwrap();
-    let dyn_control: Arc<dyn LogFilterControl> = Arc::clone(&control) as _;
-    let _reg = InfraRegistry::from_config(cfg).unwrap().with_log_control(dyn_control).unwrap();
-    // No [telemetry] section → nothing applied at boot.
-    assert!(control.applied.lock().unwrap().is_empty());
+    let cfg = InfrastructureConfig::from_toml(sampling_only).unwrap();
+    let dyn_control: Arc<dyn TelemetryControl> = Arc::clone(&control) as _;
+    let _reg = InfraRegistry::from_config(cfg).unwrap().with_telemetry_control(dyn_control).unwrap();
+
+    // Only the sampling dial was set; no filter was touched.
+    assert!(control.filters.lock().unwrap().is_empty());
+    assert_eq!(control.ratios.lock().unwrap().as_slice(), &[0.5]);
 }

--- a/crates/shared/telemetry/Cargo.toml
+++ b/crates/shared/telemetry/Cargo.toml
@@ -12,6 +12,7 @@ description.workspace = true
 tokio = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
+arc-swap = { workspace = true }
 
 # Logging — non-blocking stdout + structured formatting
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }

--- a/crates/shared/telemetry/README.md
+++ b/crates/shared/telemetry/README.md
@@ -166,9 +166,32 @@ impl TelemetryGuard {
     /// Returns the Prometheus registry handle for mounting GET /metrics.
     /// None when using OTLP metrics or when the `prometheus-exporter` feature is disabled.
     pub fn prometheus_handle(&self) -> Option<Arc<PrometheusHandle>>
+
+    /// Returns the unified, cloneable control handle for hot-swapping the live log filter
+    /// and trace-sampling ratio at runtime. Hand it to `InfraRegistry::with_telemetry_control`
+    /// (requires the `infra-config` feature) so an `infrastructure.toml` `[telemetry]` change
+    /// drives both dials with no redeploy.
+    pub fn telemetry_control(&self) -> TelemetryControlHandle
 }
 
 impl Drop for TelemetryGuard { /* flushes spans → metrics → logs in order */ }
+```
+
+### `TelemetryControlHandle` — the live dials
+
+```rust
+// src/control.rs
+pub struct TelemetryControlHandle { /* opaque, cheap to clone */ }
+
+impl TelemetryControlHandle {
+    pub fn set_log_filter(&self, directives: &str) -> Result<(), String>; // parse-checked
+    pub fn set_sampling_ratio(&self, ratio: f64);                          // clamped to [0,1]
+}
+
+// With `features = ["infra-config"]`, it also implements `infra_config::TelemetryControl`,
+// so the externalized-config watcher drives it. The log filter is wrapped in a
+// `tracing_subscriber::reload` layer; the trace sampler is a `DynamicSampler`
+// (ParentBased(TraceIdRatioBased(ratio)) behind an `ArcSwap`) — neither needs a restart.
 ```
 
 ---
@@ -215,11 +238,34 @@ pub enum TelemetryError {
 ```toml
 [dependencies]
 # Default features enable Prometheus scrape endpoint + Axum route helper.
-telemetry = { path = "crates/shared/telemetry" }
+telemetry = { workspace = true }
 
 # To disable Prometheus (pure OTLP push, removes axum + prometheus deps):
-# telemetry = { path = "crates/shared/telemetry", default-features = false }
+# telemetry = { workspace = true, default-features = false }
+
+# To drive the live log-filter + trace-sampling dials from infrastructure.toml,
+# enable the externalized-config bridge (the serving binary does this):
+# telemetry = { workspace = true, features = ["infra-config"] }
 ```
+
+### Live dials via externalized config
+
+With the `infra-config` feature on, hand the control handle to the registry so an
+`infrastructure.toml` `[telemetry]` change hot-reloads the log filter and trace-sampling
+ratio — the SRE incident lever (raise verbosity / sampling with no redeploy, which would
+lose the repro):
+
+```rust,ignore
+let _telemetry = telemetry::init(cfg)?;                    // keep alive; before any tracing
+
+let control: Arc<dyn infra_config::TelemetryControl> = Arc::new(_telemetry.telemetry_control());
+let infra = infra_config::InfraRegistry::from_config(config)?
+    .with_telemetry_control(control)?;                    // applies [telemetry] dials at boot
+// … spawn_watcher(path, Arc::new(infra)) drives them thereafter.
+```
+
+> See [`infra-config`](../infra-config/README.md#-binary-bootstrap--rollout-checklist) for
+> the full binary bootstrap (telemetry + resilience + cache + traffic) rollout checklist.
 
 ### Standard Bootstrap Pattern
 
@@ -304,8 +350,9 @@ let _guard = telemetry::init(cfg).expect("telemetry init failed");
 | Feature | Default | Adds |
 |---|---|---|
 | `prometheus-exporter` | ✅ enabled | `opentelemetry-prometheus`, `prometheus` (with process metrics), `axum`; exposes `PrometheusHandle` and `metrics_route`. |
+| `infra-config` | ⬜ off | Implements `infra_config::TelemetryControl` for `TelemetryControlHandle`, so an `infrastructure.toml` `[telemetry]` change hot-reloads the log filter and trace-sampling ratio. Pulls `infra-config` — off by default so log/trace-only consumers don't. |
 
-Disable with `default-features = false` to produce a binary with no Prometheus or Axum transitive dependencies.
+Disable `prometheus-exporter` with `default-features = false` to produce a binary with no Prometheus or Axum transitive dependencies.
 
 ### Runtime Requirements
 

--- a/crates/shared/telemetry/src/control.rs
+++ b/crates/shared/telemetry/src/control.rs
@@ -1,0 +1,49 @@
+//! The unified, process-global telemetry control handle.
+
+use crate::log::LogReloadHandle;
+use crate::trace::SamplingHandle;
+
+/// One handle bundling every telemetry dial — the live log filter and the trace-sampling
+/// ratio. Obtain it from [`TelemetryGuard::telemetry_control`](crate::TelemetryGuard::telemetry_control)
+/// and hand it to `InfraRegistry::with_telemetry_control` (with telemetry's `infra-config`
+/// feature enabled) so an `infrastructure.toml` `[telemetry]` change drives both dials with
+/// no redeploy. Cheap to clone; clones share the underlying reload handles.
+#[derive(Clone)]
+pub struct TelemetryControlHandle {
+    log: LogReloadHandle,
+    sampling: SamplingHandle,
+}
+
+impl TelemetryControlHandle {
+    pub(crate) fn new(log: LogReloadHandle, sampling: SamplingHandle) -> Self {
+        Self { log, sampling }
+    }
+
+    /// Hot-swap the log filter directly (string-in, parse-checked).
+    pub fn set_log_filter(&self, directives: &str) -> Result<(), String> {
+        self.log.reload(directives)
+    }
+
+    /// Hot-swap the trace-sampling ratio directly (clamped to `[0.0, 1.0]`).
+    pub fn set_sampling_ratio(&self, ratio: f64) {
+        self.sampling.set(ratio);
+    }
+}
+
+/// Bridges the unified handle to the externalized-config layer, so an `[telemetry]` change
+/// drives both dials. Gated so log/trace-only consumers never pull `infra-config` (mirrors
+/// `auth-context`'s `cqrs-integration` feature).
+#[cfg(feature = "infra-config")]
+impl infra_config::TelemetryControl for TelemetryControlHandle {
+    fn validate_filter(&self, directives: &str) -> Result<(), String> {
+        self.log.validate(directives)
+    }
+
+    fn set_filter(&self, directives: &str) -> Result<(), String> {
+        self.log.reload(directives)
+    }
+
+    fn set_sampling_ratio(&self, ratio: f64) {
+        self.sampling.set(ratio);
+    }
+}

--- a/crates/shared/telemetry/src/guard.rs
+++ b/crates/shared/telemetry/src/guard.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use opentelemetry_sdk::trace::TracerProvider;
 use tracing_appender::non_blocking::WorkerGuard;
 
+use crate::control::TelemetryControlHandle;
 use crate::log::LogReloadHandle;
 use crate::metrics::{exporter::PrometheusHandle, layer::MetricsPipeline};
+use crate::trace::SamplingHandle;
 
 /// Lifetime anchor for the entire telemetry pipeline.
 ///
@@ -41,8 +43,10 @@ pub struct TelemetryGuard {
     tracer_provider: TracerProvider,
     /// Holds the metrics pipeline; shutdown flushes the meter provider.
     metrics_pipeline: MetricsPipeline,
-    /// Hot-swaps the live log filter; handed to the config layer for runtime control.
+    /// Hot-swaps the live log filter.
     log_reloader: LogReloadHandle,
+    /// Hot-swaps the live trace-sampling ratio.
+    sampling_handle: SamplingHandle,
 }
 
 impl TelemetryGuard {
@@ -51,20 +55,24 @@ impl TelemetryGuard {
         tracer_provider: TracerProvider,
         metrics_pipeline: MetricsPipeline,
         log_reloader: LogReloadHandle,
+        sampling_handle: SamplingHandle,
     ) -> Self {
         Self {
             _log_guard: log_guard,
             tracer_provider,
             metrics_pipeline,
             log_reloader,
+            sampling_handle,
         }
     }
 
-    /// Returns a cloneable handle for hot-swapping the log filter at runtime. Hand it to
-    /// `InfraRegistry::with_log_control` (with telemetry's `infra-config` feature enabled) so
-    /// an `infrastructure.toml` `[telemetry]` change drives the live filter with no redeploy.
-    pub fn log_reloader(&self) -> LogReloadHandle {
-        self.log_reloader.clone()
+    /// Returns the unified, cloneable [`TelemetryControlHandle`] for hot-swapping the log
+    /// filter and trace-sampling ratio at runtime. Hand it to
+    /// `InfraRegistry::with_telemetry_control` (with telemetry's `infra-config` feature
+    /// enabled) so an `infrastructure.toml` `[telemetry]` change drives both dials with no
+    /// redeploy.
+    pub fn telemetry_control(&self) -> TelemetryControlHandle {
+        TelemetryControlHandle::new(self.log_reloader.clone(), self.sampling_handle.clone())
     }
 
     /// Returns a cheaply cloneable handle to the Prometheus registry.

--- a/crates/shared/telemetry/src/init.rs
+++ b/crates/shared/telemetry/src/init.rs
@@ -25,7 +25,7 @@ use crate::{
 pub fn init(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
     let (log_layer, log_guard) = crate::log::layer::build_log_layer(&config.log)?;
 
-    let (trace_layer, tracer_provider) = crate::trace::layer::build_trace_layer(
+    let (trace_layer, tracer_provider, sampling_handle) = crate::trace::layer::build_trace_layer(
         &config.trace,
         &config.service_name,
         &config.service_version,
@@ -54,5 +54,6 @@ pub fn init(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
         tracer_provider,
         metrics_pipeline,
         LogReloadHandle::new(reload_handle),
+        sampling_handle,
     ))
 }

--- a/crates/shared/telemetry/src/lib.rs
+++ b/crates/shared/telemetry/src/lib.rs
@@ -6,6 +6,7 @@
 //! lifetime of the process; dropping it flushes all in-flight spans and logs.
 
 pub mod config;
+pub mod control;
 pub mod error;
 pub mod guard;
 pub mod init;
@@ -14,7 +15,9 @@ pub mod metrics;
 pub mod trace;
 
 pub use config::TelemetryConfig;
+pub use control::TelemetryControlHandle;
 pub use error::TelemetryError;
 pub use guard::TelemetryGuard;
 pub use init::init;
 pub use log::LogReloadHandle;
+pub use trace::SamplingHandle;

--- a/crates/shared/telemetry/src/log/reload.rs
+++ b/crates/shared/telemetry/src/log/reload.rs
@@ -33,21 +33,6 @@ impl LogReloadHandle {
     }
 }
 
-/// Bridges the reload handle to the externalized-config layer's control trait, so an
-/// `infrastructure.toml` `[telemetry]` change drives the live filter. Gated so a service
-/// that only wants logging never pulls `infra-config` (mirrors `auth-context`'s
-/// `cqrs-integration` feature).
-#[cfg(feature = "infra-config")]
-impl infra_config::LogFilterControl for LogReloadHandle {
-    fn validate_filter(&self, directives: &str) -> Result<(), String> {
-        self.validate(directives)
-    }
-
-    fn set_filter(&self, directives: &str) -> Result<(), String> {
-        self.reload(directives)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/shared/telemetry/src/trace/dynamic_sampler.rs
+++ b/crates/shared/telemetry/src/trace/dynamic_sampler.rs
@@ -1,0 +1,111 @@
+//! Runtime hot-swap of the trace-sampling ratio.
+//!
+//! The OTel SDK consumes the sampler **by value** at `TracerProvider` build, so it can't be
+//! replaced afterward. We install a [`DynamicSampler`] once that reads the live sampler from
+//! an [`ArcSwap`] on each span — the provider never changes; the ratio behind it does.
+//!
+//! The stored value is the fully-built `ParentBased(TraceIdRatioBased(ratio))`, so the hot
+//! path is a single lock-free load + delegate with **no per-span allocation**; the `Box` is
+//! rebuilt only when the ratio changes (rare). `ParentBased` ensures a child span respects
+//! the upstream sampling decision — traces stay whole across service hops.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use opentelemetry::trace::{Link, SamplingResult, SpanKind, TraceId};
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_sdk::trace::{Sampler, ShouldSample};
+
+/// Builds the parent-respecting, ratio-based sampler for `ratio` (clamped to `[0.0, 1.0]`).
+fn build(ratio: f64) -> Sampler {
+    Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio.clamp(0.0, 1.0))))
+}
+
+/// A [`ShouldSample`] whose effective ratio is hot-swappable. Install it on the
+/// `TracerProvider`; reconfigure it through the [`SamplingHandle`] it hands out.
+#[derive(Debug, Clone)]
+pub struct DynamicSampler {
+    inner: Arc<ArcSwap<Sampler>>,
+}
+
+impl DynamicSampler {
+    /// Creates a sampler starting at `ratio` (`0.0` = off, `1.0` = all).
+    pub fn new(ratio: f64) -> Self {
+        Self { inner: Arc::new(ArcSwap::from_pointee(build(ratio))) }
+    }
+
+    /// A cloneable handle that swaps this sampler's ratio at runtime. All clones — and the
+    /// installed sampler — share the same `ArcSwap`, so a swap reconfigures the live provider.
+    pub fn handle(&self) -> SamplingHandle {
+        SamplingHandle { inner: Arc::clone(&self.inner) }
+    }
+}
+
+impl ShouldSample for DynamicSampler {
+    fn should_sample(
+        &self,
+        parent_context: Option<&Context>,
+        trace_id: TraceId,
+        name: &str,
+        span_kind: &SpanKind,
+        attributes: &[KeyValue],
+        links: &[Link],
+    ) -> SamplingResult {
+        self.inner
+            .load()
+            .should_sample(parent_context, trace_id, name, span_kind, attributes, links)
+    }
+}
+
+/// Hot-swaps the live trace-sampling ratio.
+#[derive(Clone)]
+pub struct SamplingHandle {
+    inner: Arc<ArcSwap<Sampler>>,
+}
+
+impl SamplingHandle {
+    /// Sets the head-based ratio (clamped to `[0.0, 1.0]`). Lock-free; observed by the next
+    /// root span. `ParentBased` is preserved, so child spans keep following their parent.
+    pub fn set(&self, ratio: f64) {
+        self.inner.store(Arc::new(build(ratio)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{SamplingDecision, TraceId};
+
+    fn decide(sampler: &DynamicSampler, tid: u128) -> SamplingDecision {
+        sampler
+            .should_sample(None, TraceId::from_bytes(tid.to_be_bytes()), "span", &SpanKind::Internal, &[], &[])
+            .decision
+    }
+
+    #[test]
+    fn ratio_zero_drops_all_root_spans() {
+        let s = DynamicSampler::new(1.0);
+        s.handle().set(0.0);
+        for tid in 1..50u128 {
+            assert_eq!(decide(&s, tid), SamplingDecision::Drop);
+        }
+    }
+
+    #[test]
+    fn ratio_one_samples_all_root_spans() {
+        let s = DynamicSampler::new(0.0);
+        s.handle().set(1.0);
+        for tid in 1..50u128 {
+            assert_eq!(decide(&s, tid), SamplingDecision::RecordAndSample);
+        }
+    }
+
+    #[test]
+    fn out_of_range_is_clamped() {
+        let s = DynamicSampler::new(0.5);
+        s.handle().set(9.9); // clamps to 1.0
+        assert_eq!(decide(&s, 42), SamplingDecision::RecordAndSample);
+        s.handle().set(-3.0); // clamps to 0.0
+        assert_eq!(decide(&s, 42), SamplingDecision::Drop);
+    }
+}

--- a/crates/shared/telemetry/src/trace/layer.rs
+++ b/crates/shared/telemetry/src/trace/layer.rs
@@ -4,7 +4,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     runtime,
-    trace::{BatchSpanProcessor, Sampler, TracerProvider},
+    trace::{BatchSpanProcessor, TracerProvider},
     Resource,
 };
 use opentelemetry_semantic_conventions::resource as semcov;
@@ -12,7 +12,13 @@ use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::Layer;
 
 use super::config::{SamplingStrategy, TraceConfig};
+use super::dynamic_sampler::{DynamicSampler, SamplingHandle};
 use crate::error::TelemetryError;
+
+/// What [`build_trace_layer`] yields: the tracing layer, the owning provider (for the
+/// guard's flush-on-drop), and the handle that hot-swaps the sampling ratio.
+type TraceLayerBuild<S> =
+    (Box<dyn tracing_subscriber::Layer<S> + Send + Sync>, TracerProvider, SamplingHandle);
 
 /// Builds the OpenTelemetry tracing layer and the owning [`TracerProvider`].
 ///
@@ -25,13 +31,13 @@ use crate::error::TelemetryError;
 ///   └─ BatchSpanProcessor (Tokio async, non-blocking)
 ///       └─ TracerProvider
 ///           └─ Resource { service.name, service.version }
-///           └─ Sampler  { AlwaysOn | AlwaysOff | TraceIdRatio }
+///           └─ DynamicSampler  ParentBased(TraceIdRatioBased(ratio)) — hot-swappable
 /// ```
 pub fn build_trace_layer<S>(
     config: &TraceConfig,
     service_name: &str,
     service_version: &str,
-) -> Result<(Box<dyn Layer<S> + Send + Sync>, TracerProvider), TelemetryError>
+) -> Result<TraceLayerBuild<S>, TelemetryError>
 where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span> + Send + Sync,
 {
@@ -42,7 +48,10 @@ where
         KeyValue::new(semcov::SERVICE_VERSION, service_version.to_string()),
     ]);
 
-    let sampler = sampler_from(&config.sampling)?;
+    // Install a dynamic, parent-respecting sampler initialised from config; keep its handle
+    // so the ratio can be hot-swapped (the SDK bakes the sampler into the provider at build).
+    let sampler = DynamicSampler::new(ratio_from(&config.sampling)?);
+    let sampling_handle = sampler.handle();
 
     let batch = BatchSpanProcessor::builder(exporter, runtime::Tokio).build();
 
@@ -57,18 +66,20 @@ where
     let tracer = provider.tracer(service_name.to_string());
     let layer: Box<dyn Layer<S> + Send + Sync> = Box::new(OpenTelemetryLayer::new(tracer));
 
-    Ok((layer, provider))
+    Ok((layer, provider, sampling_handle))
 }
 
-fn sampler_from(strategy: &SamplingStrategy) -> Result<Sampler, TelemetryError> {
+/// Resolves a boot [`SamplingStrategy`] to a ratio in `[0.0, 1.0]`. `AlwaysOn`/`AlwaysOff`
+/// map to `1.0`/`0.0`; an out-of-range explicit ratio fails loud at boot.
+fn ratio_from(strategy: &SamplingStrategy) -> Result<f64, TelemetryError> {
     match strategy {
-        SamplingStrategy::AlwaysOn => Ok(Sampler::AlwaysOn),
-        SamplingStrategy::AlwaysOff => Ok(Sampler::AlwaysOff),
+        SamplingStrategy::AlwaysOn => Ok(1.0),
+        SamplingStrategy::AlwaysOff => Ok(0.0),
         SamplingStrategy::TraceIdRatio(ratio) => {
             if !(0.0..=1.0).contains(ratio) {
                 return Err(TelemetryError::InvalidSamplingRatio(*ratio));
             }
-            Ok(Sampler::TraceIdRatioBased(*ratio))
+            Ok(*ratio)
         }
     }
 }
@@ -79,39 +90,31 @@ mod tests {
     use crate::error::TelemetryError;
 
     #[test]
-    fn always_on_sampler_succeeds() {
-        sampler_from(&SamplingStrategy::AlwaysOn).unwrap();
+    fn always_on_maps_to_one() {
+        assert_eq!(ratio_from(&SamplingStrategy::AlwaysOn).unwrap(), 1.0);
     }
 
     #[test]
-    fn always_off_sampler_succeeds() {
-        sampler_from(&SamplingStrategy::AlwaysOff).unwrap();
+    fn always_off_maps_to_zero() {
+        assert_eq!(ratio_from(&SamplingStrategy::AlwaysOff).unwrap(), 0.0);
     }
 
     #[test]
-    fn mid_range_ratio_succeeds() {
-        sampler_from(&SamplingStrategy::TraceIdRatio(0.5)).unwrap();
-    }
-
-    #[test]
-    fn zero_ratio_is_valid_boundary() {
-        sampler_from(&SamplingStrategy::TraceIdRatio(0.0)).unwrap();
-    }
-
-    #[test]
-    fn one_ratio_is_valid_boundary() {
-        sampler_from(&SamplingStrategy::TraceIdRatio(1.0)).unwrap();
+    fn ratio_passes_through_in_range() {
+        assert_eq!(ratio_from(&SamplingStrategy::TraceIdRatio(0.5)).unwrap(), 0.5);
+        assert_eq!(ratio_from(&SamplingStrategy::TraceIdRatio(0.0)).unwrap(), 0.0);
+        assert_eq!(ratio_from(&SamplingStrategy::TraceIdRatio(1.0)).unwrap(), 1.0);
     }
 
     #[test]
     fn negative_ratio_returns_invalid_sampling_error() {
-        let err = sampler_from(&SamplingStrategy::TraceIdRatio(-0.1)).unwrap_err();
+        let err = ratio_from(&SamplingStrategy::TraceIdRatio(-0.1)).unwrap_err();
         assert!(matches!(err, TelemetryError::InvalidSamplingRatio(r) if (r - (-0.1)).abs() < f64::EPSILON));
     }
 
     #[test]
     fn ratio_above_one_returns_invalid_sampling_error() {
-        let err = sampler_from(&SamplingStrategy::TraceIdRatio(1.5)).unwrap_err();
+        let err = ratio_from(&SamplingStrategy::TraceIdRatio(1.5)).unwrap_err();
         assert!(matches!(err, TelemetryError::InvalidSamplingRatio(r) if (r - 1.5).abs() < f64::EPSILON));
     }
 }

--- a/crates/shared/telemetry/src/trace/mod.rs
+++ b/crates/shared/telemetry/src/trace/mod.rs
@@ -1,6 +1,8 @@
 pub mod config;
+pub mod dynamic_sampler;
 pub mod exporter;
 pub mod layer;
 
 pub use config::*;
+pub use dynamic_sampler::{DynamicSampler, SamplingHandle};
 pub use layer::*;

--- a/crates/shared/traffic-redis/README.md
+++ b/crates/shared/traffic-redis/README.md
@@ -1,0 +1,55 @@
+# `traffic-redis` — Redis-Lease Distributed Backend for `traffic`
+
+## 🎯 Overview & Service Role
+
+Implements [`traffic::QuotaBackend`](../traffic) so a `mode = "distributed"` rate-limit
+profile enforces a **fleet-global** budget — not just per-replica — **without a Redis
+round-trip per request**. Each replica *leases* a chunk of the global per-window budget and
+serves it locally, only crossing to Redis when its chunk runs out (or to learn the window is
+spent). Backend I/O is therefore amortized over `burst` requests per key per replica.
+
+`transport` depends only on the `QuotaBackend` trait (in pure `traffic`); the serving binary
+injects this implementation, so the transport layer links no Redis.
+
+## 📐 How the lease works
+
+```
+QuotaBackend (trait, in `traffic`)
+ └─ RedisLeaseBackend
+      ├─ LeaseBook    — per-key local lease cache + windowed-budget algorithm (pure)
+      └─ ClaimSource  — atomic "lease N tokens" seam
+           └─ RedisClaimSource — one atomic Lua script (single key → cluster-slot-safe)
+```
+
+- **Window budget** = `ceil(rps × lease_ms / 1000)` global tokens per `lease_ms` window.
+- **Lease chunk** = `burst` (capped at the budget): larger = fewer Redis claims, coarser
+  cross-replica fairness.
+- **Exhausted-window short-circuit**: once a window's global budget is spent it stays spent,
+  so an over-budget flood is served locally — it does **not** hammer Redis.
+- **Failure policy**: a claim failure surfaces as `QuotaError`; the transport layer maps it to
+  the profile's `on_backend_error` (`fail_open` → degrade to the local governor;
+  `fail_closed` → reject). Requests served from an existing lease never touch Redis, so a
+  Redis blip only affects refills.
+
+The pure `LeaseBook` algorithm is unit-tested against an in-memory `ClaimSource`; the live
+Lua path is integration-tested behind a feature gate.
+
+## 🔌 Key API
+
+```rust
+let backend = Arc::new(RedisLeaseBackend::new(redis_client));
+// hand to the gRPC server:
+builder.with_traffic_backend(Arc::clone(&backend) as Arc<dyn traffic::QuotaBackend>);
+// periodic memory bound for per_caller keyspaces:
+backend.prune(lease_ms);
+```
+
+See the [binary rollout checklist](../infra-config/README.md#-binary-bootstrap--rollout-checklist).
+
+## 🛠️ Local Development
+
+```bash
+cargo test -p traffic-redis                                   # hermetic: lease algorithm vs a fake claim source
+cargo test -p traffic-redis --features integration-traffic-redis   # live Redis (needs Docker)
+cargo clippy -p traffic-redis -- -D warnings
+```

--- a/crates/shared/traffic/README.md
+++ b/crates/shared/traffic/README.md
@@ -1,0 +1,60 @@
+# `traffic` — Server-Side Ingress Rate Limiting (pure mechanism)
+
+## 🎯 Overview & Service Role
+
+`traffic` is the **server-side mirror of [`resilience`](../resilience)**: where resilience
+protects a *caller* from a slow/failing downstream (client side), `traffic` protects a
+*server* from too many inbound callers (ingress). Both use the externalized catalog model —
+[`infra-config`](../infra-config) parses the `[traffic]` section and resolves bindings into
+the [`TrafficProfile`] handles this crate produces; the gRPC layer that applies them lives in
+[`transport`](../transport).
+
+This crate is deliberately **transport-agnostic and pure**: it owns the limiter, the config
+types, and a `check(key) -> TrafficDecision` decision — no `tonic`, no `http`, no identity
+plumbing, no Redis.
+
+## 📐 Model
+
+| Knob | Values | Meaning |
+|---|---|---|
+| `rps` / `burst` | `u32` | Sustained rate + bucket capacity (token-bucket / GCRA via `governor`). |
+| `scope` | `per_method` \| `per_caller` | Key dimension. `per_caller` keys on an edge-mesh identity (resolved in `transport`); falls back to per-method when absent. |
+| `mode` | `local` \| `distributed` | `local` = in-process per-replica (fleet limit ≈ rps × replicas). `distributed` = fleet-global budget via a [`QuotaBackend`] (see [`traffic-redis`](../traffic-redis)). |
+| `enforce` | `bool` (default `true`) | `false` = **shadow**: charge the cell and observe the would-throttle, but admit. The observe-before-enforce rollout rail. |
+| `on_backend_error` | `fail_open` \| `fail_closed` | Distributed only: degrade to the local limiter, or reject, when the backend is unreachable. |
+
+- **Config behind `ArcSwap`**: `rps`/`burst`/`scope`/`enforce` hot-reload. A quota change
+  rebuilds the keyed limiter (state reset) **only when `rps`/`burst` actually change**;
+  other changes (e.g. `enforce`) never reset live buckets.
+- **`QuotaBackend`** is the distributed seam (async trait). `local` mode never touches it;
+  the implementation lives in `traffic-redis` so this crate — and `transport` — link no Redis.
+
+## 🔌 Key API
+
+```rust
+let profile: TrafficProfile = registry.profile_for("/post.PostService/CreatePost");
+match profile.check("/post.PostService/CreatePost|alice") {  // key = method[|identity]
+    TrafficDecision::Allow => { /* forward */ }
+    TrafficDecision::Throttle { retry_after } => { /* shed */ }
+}
+profile.prune();        // drop idle keys (bound memory for per_caller)
+profile.quota();        // the global Quota for distributed enforcement
+```
+
+## 📦 Integration
+
+```toml
+traffic = { workspace = true }                 # pure
+# traffic = { workspace = true, features = ["serde"] }   # infra-config enables this to parse [traffic]
+```
+
+Bind profiles to gRPC methods in `[traffic]` and install the layer via
+`GrpcServerBuilder::with_traffic`. See the
+[binary rollout checklist](../infra-config/README.md#-binary-bootstrap--rollout-checklist).
+
+## 🛠️ Local Development
+
+```bash
+cargo test -p traffic            # limiter behaviour (admit/shed, isolation, hot-reload)
+cargo clippy -p traffic -- -D warnings
+```

--- a/crates/shared/transport/README.md
+++ b/crates/shared/transport/README.md
@@ -121,6 +121,10 @@ tonic::Server
 
 ### Activating ingress rate limiting (server)
 
+> For the **full binary bootstrap** (telemetry + resilience + cache + traffic together),
+> see [`infra-config`'s rollout checklist](../infra-config/README.md#-binary-bootstrap--rollout-checklist).
+> The snippet below is the traffic-specific slice.
+
 `TrafficLayer` is always present in the server type but is a no-op until a
 `TrafficRegistry` is supplied. The serving binary wires it once at boot:
 


### PR DESCRIPTION
## Summary

Completes the **`[telemetry]`** section with its second dial: **dynamic trace sampling**. An `infrastructure.toml` change now adjusts the head-based sampling ratio at runtime — an SRE can crank `0.1 → 1.0` mid-incident with **no redeploy** (a restart would lose the repro).

> **Stacked on #435** (`feat/telemetry-log-dial`), which is stacked on #434. Review bottom-up: #434 → #435 → this. Retarget to `develop` as each lands.

## What's in here

- **`DynamicSampler`** bypasses the SDK's build-time sampler immutability via `Arc<ArcSwap<Sampler>>`: `should_sample` loads the live sampler and delegates, with **zero per-span allocation** — the `Box` is rebuilt only when the ratio changes (rare), not per span.
- **ParentBased by design**: the stored sampler is `ParentBased(TraceIdRatioBased(ratio))`, so a child span respects the upstream sampling decision — **traces stay whole across service hops** (no fragmentation). Reuses the SDK's exact ratio math by delegating to the enum rather than reimplementing it.
- **Unified `TelemetryControl`**: `LogFilterControl` is converged into a single process-global `TelemetryControl` (`validate_filter` / `set_filter` / `set_sampling_ratio`). `TelemetryGuard::telemetry_control()` returns one `TelemetryControlHandle` for both dials (replaces `log_reloader()`); the gated impl lives behind telemetry's `infra-config` feature.
- **`[telemetry]` gains `sampling_ratio`** (both dials now individually optional). The `[0.0, 1.0]` range is validated **in `infra-config`** (a plain number — no OTel/tracing dep), fail-closed across the whole reload; `SamplingHandle::set` clamps as defense-in-depth. `with_log_control` → `with_telemetry_control` applies both dials at boot (ConfigMap is the source of truth).

## Testing

- telemetry: `DynamicSampler` (ratio `0.0` → all `Drop`, `1.0` → all `RecordAndSample`, out-of-range clamp); `ratio_from` boot mapping (`AlwaysOn/Off`, in-range, out-of-range fails loud).
- infra-config: boot apply (both dials), hot-reload, individually-optional dials, out-of-range ratio rejected at validation, bad filter rejects the whole reload.
- `cargo check --workspace` clean; clippy clean for new code; both telemetry feature modes build/test.

## The externalized-config initiative is now complete

`[resilience]` · `[cache]` · `[traffic]` (local + distributed) · `[telemetry]` (log filter + trace sampling) — every value the original audit flagged is hot-reloadable via ConfigMap, fail-closed, no redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
