### PR TITLE
feat(platform): unified service-runtime + fleet bootstrap rollout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "account"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "auth-context",
  "chrono",
@@ -19,6 +20,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "service-runtime",
  "sqlx",
  "telemetry",
  "test-support",
@@ -35,6 +37,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "account-server"
+version = "0.1.0"
+dependencies = [
+ "account",
+ "anyhow",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -455,6 +467,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 name = "chat"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "cqrs",
@@ -464,6 +477,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http",
+ "infra-config",
  "once_cell",
  "prost 0.14.4",
  "prost-types",
@@ -473,7 +487,9 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
+ "test-support",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
@@ -490,6 +506,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "chat-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chat",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -510,6 +536,7 @@ dependencies = [
 name = "comment"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -522,6 +549,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -537,6 +565,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "comment-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "comment",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -975,6 +1013,7 @@ dependencies = [
 name = "engagement"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "cqrs",
@@ -991,6 +1030,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -1006,6 +1046,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "engagement-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "engagement",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -1364,6 +1414,7 @@ dependencies = [
 name = "geo-discovery"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "cqrs",
@@ -1381,6 +1432,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -1396,6 +1448,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "geo-discovery-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "geo-discovery",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -2270,6 +2332,7 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 name = "notification"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "cqrs",
@@ -2288,6 +2351,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -2304,6 +2368,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "notification-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "notification",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -2783,6 +2857,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 name = "post"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "auth-context",
  "base64 0.22.1",
@@ -2797,6 +2872,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -2812,6 +2888,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "post-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "post",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -2919,6 +3005,7 @@ dependencies = [
 name = "profile"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "auth-context",
  "base64 0.22.1",
@@ -2937,6 +3024,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -2952,6 +3040,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "profile-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "profile",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -3877,6 +3975,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "service-runtime"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "infra-config",
+ "telemetry",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-health",
+ "tracing",
+ "transport",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +4089,7 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 name = "social-graph"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "auth-context",
  "base64 0.22.1",
@@ -3992,6 +4106,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -4007,6 +4122,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "social-graph-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "service-runtime",
+ "social-graph",
+ "tokio",
 ]
 
 [[package]]
@@ -4371,6 +4496,7 @@ dependencies = [
 name = "telemetry"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "axum 0.8.8",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4536,6 +4662,7 @@ dependencies = [
 name = "timeline"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -4552,6 +4679,7 @@ dependencies = [
  "scylla-storage",
  "serde",
  "serde_json",
+ "service-runtime",
  "telemetry",
  "test-support",
  "thiserror 2.0.18",
@@ -4567,6 +4695,16 @@ dependencies = [
  "uuid",
  "validate-core",
  "validation",
+]
+
+[[package]]
+name = "timeline-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "service-runtime",
+ "timeline",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/shared/validate-core",
     "crates/shared/validation",
     "crates/shared/test-support",
+    "crates/platform/service-runtime",
     "crates/services/account",
     "crates/services/profile",
     "crates/services/social-graph",
@@ -27,6 +28,16 @@ members = [
     "crates/services/notification",
     "crates/services/timeline",
     "crates/services/chat",
+    "crates/apps/chat-server",
+    "crates/apps/profile-server",
+    "crates/apps/social-graph-server",
+    "crates/apps/geo-discovery-server",
+    "crates/apps/notification-server",
+    "crates/apps/post-server",
+    "crates/apps/comment-server",
+    "crates/apps/engagement-server",
+    "crates/apps/account-server",
+    "crates/apps/timeline-server",
 ]
 resolver = "2"
 
@@ -60,6 +71,17 @@ postgres-storage = { path = "crates/shared/storage/postgres", package = "postgre
 scylla-storage   = { path = "crates/shared/storage/scylla" }
 redis-storage    = { path = "crates/shared/storage/redis" }
 test-support     = { path = "crates/shared/test-support" }
+service-runtime  = { path = "crates/platform/service-runtime" }
+account          = { path = "crates/services/account" }
+chat             = { path = "crates/services/chat" }
+profile          = { path = "crates/services/profile" }
+social-graph     = { path = "crates/services/social-graph" }
+post             = { path = "crates/services/post" }
+engagement       = { path = "crates/services/engagement" }
+comment          = { path = "crates/services/comment" }
+geo-discovery    = { path = "crates/services/geo-discovery" }
+notification     = { path = "crates/services/notification" }
+timeline         = { path = "crates/services/timeline" }
 
 
 # Communs

--- a/README.md
+++ b/README.md
@@ -60,34 +60,29 @@ cargo build
 
 # Run tests (unit and integration via testcontainers)
 cargo test
-Local Infrastructure
+```
+
+### Local Infrastructure
+
 To start the necessary dependencies (Postgres, Redis, ScyllaDB, Kafka) for local development:
 
-Bash
+```bash
 docker-compose up -d
-Repository Structure
-backend/gateway/: GraphQL Gateway (BFF).
-
-backend/services/: Entry points for microservices (API Command Servers and Workers).
-
-crates/: Core business logic and infrastructure abstractions.
-
-shared-kernel: Common DDD building blocks.
-
-infra-*: Drivers and technical implementations.
-
-*-test-utils: Specialized testing tools.
-
-common/rust/shared-proto: Generated gRPC contracts.
-
-infrastructure/: Terraform modules, EKS configurations, and ArgoCD manifests.
-
-Roadmap
-[ ] Stabilization of the Bazel build chain.
-
-[ ] Implementation of Sharding at the SQLx layer.
-
-[ ] Extension of the Gamification module.
-
-[ ] Distributed monitoring with OpenTelemetry.
 ```
+
+## Repository Structure
+
+The workspace lives under `crates/`, organised by role:
+
+- **`crates/services/<svc>/`** — domain microservices (DDD + CQRS), **library-only**. Each exposes a composition root (`App::build`) and implements `service_runtime::Service` (`crate::service::<Svc>Service`).
+- **`crates/apps/<svc>-server/`** — thin deployable binaries (one per service). Each `main` is a `service_runtime::serve::<…>(addr)` one-liner.
+- **`crates/platform/service-runtime/`** — the unified fleet bootstrap: telemetry, `infrastructure.toml` load + hot-reload, ingress trace + rate-limit layers, dynamic gRPC health, and graceful shutdown. See its [README](crates/platform/service-runtime/README.md).
+- **`crates/shared/`** — reusable building blocks: `error`, `cqrs`, `auth-context`, `validation`/`validate-core`, the externalized-config stack (`infra-config`, `resilience`, `traffic`, `telemetry`), `transport` (gRPC + Kafka), and storage clients under `crates/shared/storage/{postgres,scylla,redis}`.
+- **`infrastructure/`** — Terraform/Terragrunt modules, EKS configuration, and ArgoCD manifests.
+
+## Roadmap
+
+- [ ] Stabilization of the Bazel build chain (role-tiered crate layout + a shared `contracts/` tier).
+- [ ] Schema-migration runner (`apps/migrator`).
+- [ ] Implementation of Sharding at the SQLx layer.
+- [x] Distributed monitoring with OpenTelemetry — live log-filter and trace-sampling dials via the `[telemetry]` config section.

--- a/crates/apps/account-server/Cargo.toml
+++ b/crates/apps/account-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "account-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the account service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+account         = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/account-server/src/main.rs
+++ b/crates/apps/account-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `account-server` — the deployable account binary.
+
+use std::net::SocketAddr;
+
+use account::service::AccountService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("ACCOUNT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50059".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<AccountService>(addr).await
+}

--- a/crates/apps/chat-server/Cargo.toml
+++ b/crates/apps/chat-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "chat-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the chat service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+chat            = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/chat-server/src/main.rs
+++ b/crates/apps/chat-server/src/main.rs
@@ -1,0 +1,19 @@
+//! `chat-server` — the deployable chat binary.
+//!
+//! Intentionally trivial: all bootstrap (telemetry, config + hot-reload, gRPC
+//! serving, graceful shutdown) lives in [`service_runtime`], and all domain
+//! wiring lives in the `chat` library. Adding a deployable to the fleet is a new
+//! crate this size.
+
+use std::net::SocketAddr;
+
+use chat::service::ChatService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("CHAT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50051".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<ChatService>(addr).await
+}

--- a/crates/apps/comment-server/Cargo.toml
+++ b/crates/apps/comment-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "comment-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the comment service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+comment         = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/comment-server/src/main.rs
+++ b/crates/apps/comment-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `comment-server` — the deployable comment binary.
+
+use std::net::SocketAddr;
+
+use comment::service::CommentService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("COMMENT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50057".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<CommentService>(addr).await
+}

--- a/crates/apps/engagement-server/Cargo.toml
+++ b/crates/apps/engagement-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "engagement-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the engagement service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+engagement      = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/engagement-server/src/main.rs
+++ b/crates/apps/engagement-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `engagement-server` — the deployable engagement binary.
+
+use std::net::SocketAddr;
+
+use engagement::service::EngagementService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("ENGAGEMENT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50058".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<EngagementService>(addr).await
+}

--- a/crates/apps/geo-discovery-server/Cargo.toml
+++ b/crates/apps/geo-discovery-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "geo-discovery-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the geo-discovery service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+geo-discovery   = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/geo-discovery-server/src/main.rs
+++ b/crates/apps/geo-discovery-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `geo-discovery-server` — the deployable geo-discovery binary.
+
+use std::net::SocketAddr;
+
+use geo_discovery::service::GeoDiscoveryService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("GEO_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50054".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<GeoDiscoveryService>(addr).await
+}

--- a/crates/apps/notification-server/Cargo.toml
+++ b/crates/apps/notification-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "notification-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the notification service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+notification    = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/notification-server/src/main.rs
+++ b/crates/apps/notification-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `notification-server` — the deployable notification binary.
+
+use std::net::SocketAddr;
+
+use notification::service::NotificationService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("NOTIFICATION_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50055".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<NotificationService>(addr).await
+}

--- a/crates/apps/post-server/Cargo.toml
+++ b/crates/apps/post-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "post-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the post service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+post            = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/post-server/src/main.rs
+++ b/crates/apps/post-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `post-server` — the deployable post binary.
+
+use std::net::SocketAddr;
+
+use post::service::PostService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("POST_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50056".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<PostService>(addr).await
+}

--- a/crates/apps/profile-server/Cargo.toml
+++ b/crates/apps/profile-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "profile-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the profile service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+profile         = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/profile-server/src/main.rs
+++ b/crates/apps/profile-server/src/main.rs
@@ -1,0 +1,19 @@
+//! `profile-server` — the deployable profile binary.
+//!
+//! Like `chat-server`, intentionally trivial: bootstrap lives in
+//! [`service_runtime`] and domain wiring in the `profile` library. Profile's
+//! inbound account-event consumer is self-spawned during `ProfileService::build`,
+//! so this entrypoint stays a one-liner.
+
+use std::net::SocketAddr;
+
+use profile::service::ProfileService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("PROFILE_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50052".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<ProfileService>(addr).await
+}

--- a/crates/apps/social-graph-server/Cargo.toml
+++ b/crates/apps/social-graph-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "social-graph-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the social-graph service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+social-graph    = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/social-graph-server/src/main.rs
+++ b/crates/apps/social-graph-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `social-graph-server` — the deployable social-graph binary.
+
+use std::net::SocketAddr;
+
+use social_graph::service::SocialGraphService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("SOCIAL_GRAPH_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50053".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<SocialGraphService>(addr).await
+}

--- a/crates/apps/timeline-server/Cargo.toml
+++ b/crates/apps/timeline-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "timeline-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the timeline service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+timeline        = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/timeline-server/src/main.rs
+++ b/crates/apps/timeline-server/src/main.rs
@@ -1,0 +1,14 @@
+//! `timeline-server` — the deployable timeline binary.
+
+use std::net::SocketAddr;
+
+use timeline::service::TimelineService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("TIMELINE_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50060".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<TimelineService>(addr).await
+}

--- a/crates/platform/service-runtime/Cargo.toml
+++ b/crates/platform/service-runtime/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name                 = "service-runtime"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Unified fleet bootstrap: the one boot sequence (telemetry → infra-config + hot-reload → compose → gRPC serve → graceful shutdown) every service runs by implementing the `Service` trait."
+
+[dependencies]
+telemetry    = { workspace = true }
+infra-config = { workspace = true }
+transport    = { workspace = true }
+
+tokio       = { workspace = true }
+async-trait = { workspace = true }
+anyhow      = { workspace = true }
+tracing     = { workspace = true }
+
+tonic        = { workspace = true }
+tonic-health = { workspace = true }

--- a/crates/platform/service-runtime/README.md
+++ b/crates/platform/service-runtime/README.md
@@ -1,0 +1,145 @@
+# service-runtime
+
+The unified fleet bootstrap. Every service runs the **same** boot sequence by
+implementing one trait; the deployable binary is then a one-liner.
+
+`serve::<S>(addr)` owns the process-wide concerns so no service re-implements
+them:
+
+```text
+telemetry::init  (logs + OTLP traces + metrics; guard kept for the process)
+  └─ infra-config load  (infrastructure.toml → InfraRegistry, fail-closed at boot)
+      └─ spawn_watcher   (hot-reload: resilience / cache / traffic / telemetry)
+          └─ [telemetry] sink wired to the live TelemetryControl
+              └─ S::build(infra)              (the service's composition root)
+                  └─ gRPC server: InboundTraceLayer (outer) + TrafficLayer (inner)
+                      ├─ health service  (driven by S::health_probes)
+                      └─ S::register(routes)  (the service's own gRPC services)
+                          └─ readiness loop + traffic prune loop
+                              └─ serve_with_shutdown (SIGINT-drained)
+```
+
+## The contract
+
+A service implements `Service`. That is the entire surface:
+
+```rust
+use std::sync::Arc;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+
+pub struct ChatService { app: App }
+
+#[async_trait::async_trait]
+impl Service for ChatService {
+    const NAME: &'static str = "chat";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    // The health-reporting key: the concrete tonic server's NamedService::NAME.
+    const GRPC_SERVICE_NAME: &'static str =
+        <ChatServiceServer<ChatServiceHandler<InMemoryCommandBus, InMemoryQueryBus>>
+            as tonic::server::NamedService>::NAME;
+
+    /// Pure composition root. `infra` carries the hot-reloadable registries
+    /// (resilience / cache / traffic); services that don't consume externalized
+    /// policy may ignore it.
+    async fn build(infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let app = App::build(/* env-derived config + backends */).await?;
+        Ok(Self { app })
+    }
+
+    /// Backend liveness probes. The runtime polls these and only reports the
+    /// service `SERVING` once all pass — so K8s readiness reflects real
+    /// dependency reachability, not mere process liveness. Default: none.
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        vec![Arc::new(FnProbe::new("scylla", move || {
+            let scylla = Arc::clone(&scylla);
+            async move {
+                scylla_storage::health::health_check(&scylla.session)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+            }
+        }))]
+    }
+
+    /// Register the concrete gRPC service(s) (typically the service + reflection)
+    /// onto the type-erased `routes`. The runtime applies the shared layer stack
+    /// and serves, so the layer types never reach this signature.
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+        routes.add_service(reflection);
+        routes.add_service(ChatServiceServer::new(self.app.handler));
+        Ok(())
+    }
+}
+```
+
+The deployable binary (`crates/apps/<svc>-server/src/main.rs`) is just:
+
+```rust
+use std::net::SocketAddr;
+use chat::service::ChatService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("CHAT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50051".to_owned())
+        .parse()?;
+    service_runtime::serve::<ChatService>(addr).await
+}
+```
+
+Adding a service to the fleet = a `service.rs` implementing `Service` + an
+`apps/<svc>-server` crate this size. Nothing else.
+
+## What the runtime does — and does not — own
+
+| Concern | Owner |
+|---|---|
+| Telemetry init, OTLP, log/sampling dials | **runtime** (`serve`) |
+| Config load + hot-reload watcher | **runtime** |
+| Ingress trace + rate-limit layers, prune loop | **runtime** |
+| gRPC health, readiness loop | **runtime** |
+| Graceful shutdown (SIGINT drain) | **runtime** |
+| Domain wiring (repos, caches, buses, workers) | **service** (`build`) |
+| Concrete gRPC services + reflection | **service** (`register`) |
+| Backend probes | **service** (`health_probes`) |
+
+The split is enforced by the type-erased `RoutesBuilder` seam: `register` never
+sees the Tower layer stack the runtime wraps around it.
+
+## Health probes
+
+`HealthProbe` is an async `check()`; [`FnProbe`] adapts a closure so a service
+registers a backend check without a bespoke struct. With **no** probes a service
+is reported `SERVING` once built; with probes it starts `NOT_SERVING` and flips
+on the first successful poll (and back on any failure).
+
+## Environment
+
+| Variable | Default | Effect |
+|---|---|---|
+| `INFRA_CONFIG_PATH` | `infrastructure.toml` | Externalized-config document path |
+| `HEALTH_PROBE_INTERVAL_SECS` | `10` | Readiness poll cadence |
+| `TRAFFIC_PRUNE_INTERVAL_SECS` | `60` | Rate-limiter memory-bounding cadence |
+
+Per-service `*_GRPC_ADDR` and tuning variables are documented in each service's
+own README. Telemetry honours the standard `RUST_LOG` / `OTEL_*` variables at
+boot; the live dials are then driven by the `[telemetry]` section of
+`infrastructure.toml`.
+
+## Live retuning
+
+Because the runtime spawns the config watcher, an `infrastructure.toml` push
+retunes the fleet with no restart:
+
+```toml
+[telemetry]
+log_filter = "info,chat=debug"            # live EnvFilter reload
+sampling   = { kind = "trace_id_ratio", ratio = 0.05 }   # live, parent-based
+
+[traffic.profiles.standard]
+rps = 2000                                  # shadow → enforce, quotas, all live
+```

--- a/crates/platform/service-runtime/src/lib.rs
+++ b/crates/platform/service-runtime/src/lib.rs
@@ -1,0 +1,370 @@
+//! Unified fleet bootstrap.
+//!
+//! [`serve`] owns the *one* boot sequence every service in the fleet runs:
+//! telemetry init → externalized-config load + hot-reload watcher → service
+//! composition → gRPC serving (trace + traffic layers, health, and the service's
+//! own routes) → graceful shutdown. A service plugs in by implementing [`Service`];
+//! the deployable binary is then a one-liner —
+//! `service_runtime::serve::<MyService>(addr).await`.
+//!
+//! The split of responsibility is deliberate:
+//! * the **runtime** owns process-wide concerns (observability, config IO and its
+//!   hot-reload watcher, ingress rate-limiting, socket binding, shutdown, and the
+//!   **readiness loop** that drives gRPC health from backend liveness) — written
+//!   once, here;
+//! * the **service** owns only its domain wiring, its concrete tonic services
+//!   ([`Service::register`]), and the backend probes it wants polled
+//!   ([`Service::health_probes`]).
+//!
+//! Services register onto a type-erased [`RoutesBuilder`], so the (statically
+//! typed) Tower layer stack the runtime wraps every request in — inbound
+//! trace-context extraction on the outside, ingress rate-limiting nested within —
+//! never leaks into the [`Service`] contract.
+//!
+//! ## Ingress rate-limiting
+//!
+//! When the loaded config has a `[traffic]` section, [`serve`] installs
+//! transport's `TrafficLayer` (keyed per the bound profile, honouring its
+//! hot-reloadable shadow/enforce flag) and spawns a background loop calling
+//! [`TrafficRegistry::prune_all`] to bound limiter memory for unbounded
+//! keyspaces. With no `[traffic]` section the layer is a transparent pass-through
+//! and no prune loop runs.
+//!
+//! ## Dynamic health
+//!
+//! The gRPC `grpc.health.v1.Health` status is **not** pinned to `SERVING` at
+//! boot. A service reports `SERVING` only once every [`HealthProbe`] it returns
+//! has passed at least once, and is demoted to `NOT_SERVING` the moment any probe
+//! fails — so Kubernetes readiness reflects real backend reachability.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use infra_config::{
+    load_from_path, spawn_watcher, ConfigError, TelemetrySamplingSpec, TelemetrySettings,
+    TelemetrySink, TrafficRegistry,
+};
+// Re-exported so services name the build() parameter type without each taking a
+// direct `infra-config` dependency.
+pub use infra_config::InfraRegistry;
+use telemetry::{SamplingStrategy, TelemetryConfig, TelemetryControl};
+use tonic::service::RoutesBuilder;
+use tonic_health::server::{health_reporter, HealthReporter};
+use tonic_health::ServingStatus;
+use transport::grpc::server::{GrpcServerBuilder, GrpcServerConfig};
+
+/// Environment variable naming the externalized-config document.
+const INFRA_CONFIG_PATH_ENV: &str = "INFRA_CONFIG_PATH";
+/// Path used when [`INFRA_CONFIG_PATH_ENV`] is unset (relative to the working dir).
+const DEFAULT_INFRA_CONFIG_PATH: &str = "infrastructure.toml";
+/// Environment variable overriding how often [`HealthProbe`]s are polled.
+const HEALTH_INTERVAL_ENV: &str = "HEALTH_PROBE_INTERVAL_SECS";
+/// Default readiness poll cadence.
+const DEFAULT_HEALTH_INTERVAL_SECS: u64 = 10;
+/// Environment variable overriding how often the traffic registry is pruned.
+const TRAFFIC_PRUNE_INTERVAL_ENV: &str = "TRAFFIC_PRUNE_INTERVAL_SECS";
+/// Default traffic-registry prune cadence.
+const DEFAULT_TRAFFIC_PRUNE_INTERVAL_SECS: u64 = 60;
+
+/// A liveness probe the runtime polls to drive the service's gRPC health status.
+///
+/// Implemented by the *service* over its live backend clients (a storage crate
+/// can't depend on this platform crate), typically via [`FnProbe`]. Probes must
+/// be cheap — they run on every readiness tick.
+#[async_trait]
+pub trait HealthProbe: Send + Sync + 'static {
+    /// Short identifier for logs, e.g. `"scylla"` or `"redis"`.
+    fn name(&self) -> &str;
+
+    /// Returns `Ok(())` when the dependency is reachable. Any `Err` demotes the
+    /// whole service to `NOT_SERVING` until the next tick clears it.
+    async fn check(&self) -> anyhow::Result<()>;
+}
+
+/// A [`HealthProbe`] backed by an async closure, so a service registers a backend
+/// check without hand-rolling a trait impl per dependency. The closure is `Fn`
+/// (re-run every tick), typically capturing a cloned client handle:
+///
+/// ```ignore
+/// FnProbe::new("redis", move || {
+///     let client = client.clone();
+///     async move {
+///         redis_storage::health::health_check(&*client)
+///             .await
+///             .map_err(|e| anyhow::anyhow!("redis: {e}"))
+///     }
+/// })
+/// ```
+pub struct FnProbe<F> {
+    name: &'static str,
+    check: F,
+}
+
+impl<F> FnProbe<F> {
+    pub fn new(name: &'static str, check: F) -> Self {
+        Self { name, check }
+    }
+}
+
+#[async_trait]
+impl<F, Fut> HealthProbe for FnProbe<F>
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    async fn check(&self) -> anyhow::Result<()> {
+        (self.check)().await
+    }
+}
+
+/// A fleet service the [`serve`] runtime can host.
+///
+/// Implementors supply domain wiring ([`build`](Service::build)), registration of
+/// their concrete tonic services ([`register`](Service::register)), and —
+/// optionally — the backend [`HealthProbe`]s the readiness loop should poll.
+/// Everything else (telemetry, config, ingress layers, shutdown, health loop) is
+/// the runtime's job.
+#[async_trait]
+pub trait Service: Sized + Send + 'static {
+    /// Stable service name; the telemetry resource and a structured-log field.
+    const NAME: &'static str;
+    /// Service version, conventionally `env!("CARGO_PKG_VERSION")`.
+    const VERSION: &'static str;
+    /// Fully-qualified gRPC service name used as the health-reporting key,
+    /// i.e. `<ConcreteServer as tonic::server::NamedService>::NAME`.
+    const GRPC_SERVICE_NAME: &'static str;
+
+    /// Pure composition root: build the fully-wired service graph.
+    ///
+    /// `infra` carries the resolved, hot-reloadable infrastructure registries
+    /// (resilience / cache / traffic) for services that consume externalized
+    /// policy; services that don't may ignore it.
+    async fn build(infra: Arc<InfraRegistry>) -> anyhow::Result<Self>;
+
+    /// Backend liveness probes the readiness loop polls. Default: none — the
+    /// service is reported `SERVING` as soon as it is built.
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        Vec::new()
+    }
+
+    /// Register the service's concrete gRPC service(s) (typically the service plus
+    /// reflection) onto the type-erased `routes`. The runtime applies the shared
+    /// layer stack and serves, so the layer types never reach this signature.
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()>;
+}
+
+/// Boots and runs a [`Service`] until a shutdown signal, then drains.
+///
+/// This is the entire production entrypoint: a deployable binary is just
+/// `serve::<S>(addr)`.
+pub async fn serve<S: Service>(addr: SocketAddr) -> anyhow::Result<()> {
+    // ── Observability ──────────────────────────────────────────────────────────
+    // The guard must outlive the server: dropping it flushes in-flight spans/logs.
+    // Its control handle is wired into the config watcher below for live retuning.
+    let telemetry_guard = telemetry::init(TelemetryConfig::from_env(S::NAME, S::VERSION))
+        .context("telemetry init")?;
+
+    // ── Externalized config + hot-reload ───────────────────────────────────────
+    // Fail-closed at boot: a malformed document stops the pod from ever serving.
+    // `_watcher` must stay alive for the process lifetime — dropping it ends the
+    // watch and freezes config at its boot value.
+    let path = PathBuf::from(
+        std::env::var(INFRA_CONFIG_PATH_ENV)
+            .unwrap_or_else(|_| DEFAULT_INFRA_CONFIG_PATH.to_owned()),
+    );
+    let document = load_from_path(&path)
+        .with_context(|| format!("load infrastructure config from {}", path.display()))?;
+    let infra = Arc::new(
+        InfraRegistry::from_config(document).context("resolve infrastructure config")?,
+    );
+
+    // Bridge the `[telemetry]` section to the live pipeline: registering the sink
+    // applies the boot-time dials immediately, and the watcher pushes every
+    // subsequent change — so a config push retunes log filter + sampling with no
+    // restart, fleet-wide.
+    if let Some(registry) = infra.telemetry() {
+        registry
+            .set_sink(Arc::new(TelemetryControlSink { control: telemetry_guard.control() }))
+            .context("register telemetry control sink")?;
+    }
+
+    let _watcher = spawn_watcher(path, Arc::clone(&infra)).context("spawn config watcher")?;
+
+    // ── Compose the service graph ──────────────────────────────────────────────
+    let service = S::build(Arc::clone(&infra)).await.context("service build")?;
+    let probes = service.health_probes();
+
+    // ── Routes: health (runtime-owned) + the service's own services ────────────
+    let (health, health_service) = health_reporter();
+    let mut routes = RoutesBuilder::default();
+    routes.add_service(health_service);
+    service
+        .register(&mut routes)
+        .context("register grpc routes")?;
+
+    // ── gRPC server: inbound-trace (outer) + traffic (inner) layers ────────────
+    let traffic = infra.traffic();
+    let mut server_builder = GrpcServerBuilder::new(GrpcServerConfig::default());
+    if let Some(registry) = &traffic {
+        server_builder = server_builder.with_traffic(Arc::clone(registry));
+    }
+    let mut server = server_builder.build().context("build gRPC server")?;
+    let router = server.add_routes(routes.routes());
+
+    // ── Background loops: readiness health + traffic-memory bounding ────────────
+    spawn_readiness(S::GRPC_SERVICE_NAME, health, probes);
+    if let Some(registry) = traffic {
+        spawn_traffic_prune(registry);
+    }
+
+    tracing::info!(service = S::NAME, version = S::VERSION, %addr, "gRPC server listening");
+
+    router
+        .serve_with_shutdown(addr, shutdown_signal())
+        .await
+        .context("grpc server terminated")?;
+
+    tracing::info!(service = S::NAME, "shutdown complete");
+    Ok(())
+}
+
+/// Spawns the background loop that maps backend [`HealthProbe`] results onto the
+/// service's gRPC health status.
+///
+/// With no probes the service is marked `SERVING` once and the task exits. With
+/// probes, the loop polls on [`HEALTH_INTERVAL_ENV`] cadence (first tick fires
+/// immediately) and only writes the reporter on a *transition*, so watchers
+/// aren't churned every tick.
+fn spawn_readiness(
+    service_name: &'static str,
+    health: HealthReporter,
+    probes: Vec<Arc<dyn HealthProbe>>,
+) {
+    if probes.is_empty() {
+        tokio::spawn(async move {
+            health
+                .set_service_status(service_name, ServingStatus::Serving)
+                .await;
+        });
+        return;
+    }
+
+    let interval = interval_from_env(HEALTH_INTERVAL_ENV, DEFAULT_HEALTH_INTERVAL_SECS);
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // `None` until the first poll establishes a baseline, so the first result
+        // is always written.
+        let mut last_serving: Option<bool> = None;
+
+        loop {
+            ticker.tick().await;
+
+            let mut serving = true;
+            for probe in &probes {
+                if let Err(error) = probe.check().await {
+                    serving = false;
+                    tracing::warn!(
+                        service = service_name,
+                        probe = probe.name(),
+                        %error,
+                        "health probe failed; marking NOT_SERVING"
+                    );
+                    break; // one failed dependency is enough to fail readiness
+                }
+            }
+
+            if last_serving != Some(serving) {
+                let status = if serving {
+                    ServingStatus::Serving
+                } else {
+                    ServingStatus::NotServing
+                };
+                health.set_service_status(service_name, status).await;
+                tracing::info!(service = service_name, serving, "gRPC health status changed");
+                last_serving = Some(serving);
+            }
+        }
+    });
+}
+
+/// Spawns the background loop that bounds rate-limiter memory by dropping idle
+/// keys across every traffic profile on [`TRAFFIC_PRUNE_INTERVAL_ENV`] cadence.
+/// Cheap for bounded (`per_method`) profiles; essential for unbounded
+/// (`per_caller`) ones.
+fn spawn_traffic_prune(registry: Arc<TrafficRegistry>) {
+    let interval = interval_from_env(
+        TRAFFIC_PRUNE_INTERVAL_ENV,
+        DEFAULT_TRAFFIC_PRUNE_INTERVAL_SECS,
+    );
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // first tick is immediate; nothing to prune at t=0
+        loop {
+            ticker.tick().await;
+            registry.prune_all();
+            tracing::debug!(tracked_keys = registry.tracked_keys(), "traffic registry pruned");
+        }
+    });
+}
+
+/// Reads a seconds-valued interval from `env_var`, falling back to `default_secs`
+/// when unset or unparseable.
+fn interval_from_env(env_var: &str, default_secs: u64) -> Duration {
+    Duration::from_secs(
+        std::env::var(env_var)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default_secs),
+    )
+}
+
+/// Resolves when the process receives SIGINT (Ctrl-C). The tonic server drains
+/// in-flight requests before returning. If the handler cannot be installed we
+/// park forever rather than shutting down spuriously.
+async fn shutdown_signal() {
+    if tokio::signal::ctrl_c().await.is_err() {
+        tracing::error!("failed to install Ctrl-C handler; shutdown signalling disabled");
+        std::future::pending::<()>().await;
+    }
+    tracing::info!("shutdown signal received; draining in-flight requests");
+}
+
+/// Bridges the `infra-config` `[telemetry]` section to the live telemetry
+/// pipeline. Lives here (the platform tier) because it depends on both
+/// `infra-config` and `telemetry`, which must not depend on each other.
+struct TelemetryControlSink {
+    control: TelemetryControl,
+}
+
+impl TelemetrySink for TelemetryControlSink {
+    fn apply(&self, settings: &TelemetrySettings) -> Result<(), ConfigError> {
+        if let Some(directive) = &settings.log_filter {
+            self.control
+                .set_log_filter(directive)
+                .map_err(|e| ConfigError::validation(format!("telemetry log filter: {e}")))?;
+        }
+        if let Some(spec) = &settings.sampling {
+            let strategy = match spec {
+                TelemetrySamplingSpec::AlwaysOn => SamplingStrategy::AlwaysOn,
+                TelemetrySamplingSpec::AlwaysOff => SamplingStrategy::AlwaysOff,
+                TelemetrySamplingSpec::TraceIdRatio { ratio } => {
+                    SamplingStrategy::TraceIdRatio(*ratio)
+                }
+            };
+            self.control
+                .set_sampling(strategy)
+                .map_err(|e| ConfigError::validation(format!("telemetry sampling: {e}")))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/services/account/Cargo.toml
+++ b/crates/services/account/Cargo.toml
@@ -19,6 +19,8 @@ cqrs         = { workspace = true }
 auth-context = { workspace = true }
 telemetry    = { workspace = true }
 transport    = { workspace = true }
+service-runtime = { workspace = true }
+anyhow       = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/account/README.md
+++ b/crates/services/account/README.md
@@ -259,3 +259,26 @@ command — the gRPC handler applies these hard-coded defaults:
 | `tonic` / `prost` | gRPC server and protobuf codegen |
 | `uuid` (v7) | Time-sortable primary keys |
 | `chrono` | UTC timestamps |
+
+---
+
+## 🚀 Deployment
+
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `account::service::AccountService` (`build` constructs the PostgreSQL pool via
+`PgPoolBuilder` and wires the CQRS buses; `register` adds the gRPC + reflection
+services; `health_probes` checks Postgres — the pool is `Arc`-backed, so the probe
+shares it). The deployable binary is `crates/apps/account-server`:
+
+```rust
+use std::net::SocketAddr;
+use account::service::AccountService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("ACCOUNT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50059".to_owned())
+        .parse()?;
+    service_runtime::serve::<AccountService>(addr).await
+}
+```

--- a/crates/services/account/build.rs
+++ b/crates/services/account/build.rs
@@ -1,7 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("account_descriptor.bin");
+
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
+        .file_descriptor_set_path(&descriptor_path)
         .compile_protos(
             &[
                 "proto/account/v1/enums.proto",

--- a/crates/services/account/src/infrastructure/grpc/server.rs
+++ b/crates/services/account/src/infrastructure/grpc/server.rs
@@ -7,6 +7,10 @@ use super::handler::account_service_handler::{proto, AccountServiceHandler};
 // Import the tonic-generated trait from the bundled proto module.
 use proto::account_service_server::AccountService;
 
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `build.rs`. Registered by the service's runtime adapter ([`crate::service`]).
+pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("account_descriptor");
+
 #[tonic::async_trait]
 impl<CB, QB> AccountService for AccountServiceHandler<CB, QB>
 where

--- a/crates/services/account/src/lib.rs
+++ b/crates/services/account/src/lib.rs
@@ -3,5 +3,6 @@ pub mod application;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;
 
 pub use error::AccountError;

--- a/crates/services/account/src/service.rs
+++ b/crates/services/account/src/service.rs
@@ -1,0 +1,74 @@
+//! Adapts the account composition root to the fleet [`service_runtime::Service`]
+//! contract. Account is PostgreSQL-backed; the pool is built here, shared into
+//! [`App::build`], and reused (it is `Clone`/`Arc`-backed) for the readiness probe.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use postgres_storage::{PgPoolBuilder, PostgresConfig};
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use sqlx::PgPool;
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+
+use crate::app::App;
+use crate::infrastructure::grpc::handler::account_service_handler::AccountServiceServer;
+use crate::infrastructure::grpc::handler::AccountServiceHandler;
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+
+type AccountServer =
+    AccountServiceServer<AccountServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
+
+/// The account service as hosted by [`service_runtime`].
+pub struct AccountService {
+    app: App,
+    pool: PgPool,
+}
+
+#[async_trait]
+impl Service for AccountService {
+    const NAME: &'static str = "account";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <AccountServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let pool = PgPoolBuilder::build(PostgresConfig::from_env())
+            .await
+            .map_err(|e| anyhow::anyhow!("account postgres pool: {e}"))?;
+
+        // `PgPool` is `Arc`-backed: one clone serves the app graph, one the probe.
+        let app = App::build(pool.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("account app build: {e}"))?;
+
+        Ok(Self { app, pool })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let pool = self.pool.clone();
+        vec![Arc::new(FnProbe::new("postgres", move || {
+            let pool = pool.clone();
+            async move {
+                postgres_storage::health_check(&pool)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("postgres: {e}"))
+            }
+        }))]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = AccountServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+        );
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(AccountServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/chat/Cargo.toml
+++ b/crates/services/chat/Cargo.toml
@@ -16,6 +16,9 @@ redis-storage  = { workspace = true }
 cqrs           = { workspace = true }
 telemetry      = { workspace = true }
 transport      = { workspace = true }
+service-runtime = { workspace = true }
+infra-config   = { workspace = true }
+anyhow         = { workspace = true }
 
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }
@@ -67,6 +70,7 @@ uuid                   = { workspace = true }
 chrono                 = { workspace = true }
 tonic                  = { workspace = true }
 
+test-support   = { workspace = true }
 scylla-storage = { workspace = true }
 redis-storage  = { workspace = true }
 transport      = { workspace = true }

--- a/crates/services/chat/README.md
+++ b/crates/services/chat/README.md
@@ -130,27 +130,34 @@ service ChatService {
 chat = { path = "crates/services/chat" }
 ```
 
-The crate is **library‑only**; it exposes `serve(addr)` and is embedded by a thin binary or the platform's service launcher.
+The crate is **library‑only**. It plugs into the shared fleet runtime by
+implementing [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `chat::service::ChatService` — `build` wires every adapter (and spawns the
+per-pod plane subscriber, registry reapers, and VisibilityWorker), `register`
+adds the gRPC services, and `health_probes` exposes the Scylla/Redis liveness
+checks. Telemetry, config + hot-reload, ingress rate-limiting, health, and
+graceful shutdown are all owned by the runtime.
 
 ### Standard Bootstrap Pattern
+
+The deployable binary is `crates/apps/chat-server`, and it is the entire
+entrypoint:
 
 ```rust
 use std::net::SocketAddr;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Installs the global tracing/OTel subscriber (Scylla/Redis/Kafka clients hook into
-    // it). Keep `_guard` alive for the process lifetime to flush telemetry on shutdown.
-    let _guard = telemetry::init(telemetry::TelemetryConfig::from_env("chat", env!("CARGO_PKG_VERSION")))?;
+use chat::service::ChatService;
 
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = std::env::var("CHAT_GRPC_ADDR")
-        .unwrap_or_else(|_| "0.0.0.0:50061".into())
+        .unwrap_or_else(|_| "0.0.0.0:50051".to_owned())
         .parse()?;
 
-    // Reads ChatConfig + Scylla/Redis/Kafka config from the environment, wires every
-    // adapter, starts the per-pod plane subscriber, the registry reapers, and the
-    // VisibilityWorker, then blocks serving gRPC until shutdown.
-    chat::infrastructure::grpc::server::serve(addr).await
+    // Owns telemetry, infrastructure.toml load + hot-reload, the inbound-trace
+    // and traffic layers, dynamic gRPC health, and SIGINT-drained shutdown — then
+    // builds `ChatService` and serves until shutdown.
+    service_runtime::serve::<ChatService>(addr).await
 }
 ```
 

--- a/crates/services/chat/src/app.rs
+++ b/crates/services/chat/src/app.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig, RedisSubscriberBuilder};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig, RedisSubscriberBuilder};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 use transport::kafka::config::client::KafkaClientConfig;
 use transport::kafka::config::producer::ProducerConfig;
 use transport::kafka::producer::KafkaProducerBuilder;
@@ -88,6 +88,10 @@ pub struct AppConfig {
 /// here, so a scenario reads the live state the handler mutates.
 pub struct App {
     pub handler:           ChatServiceHandler<InMemoryCommandBus, InMemoryQueryBus>,
+    /// Live storage clients, retained so the runtime's readiness loop can probe
+    /// their liveness (see [`crate::service`]).
+    pub scylla:            Arc<ScyllaClient>,
+    pub redis:             RedisClient,
     pub presence:          Arc<dyn PresenceStore>,
     pub routing:           Arc<dyn RoutingRegistry>,
     pub hot_tail:          Arc<dyn HotTailCache>,
@@ -227,6 +231,8 @@ impl App {
 
         Ok(Self {
             handler,
+            scylla: scylla_client,
+            redis: redis_client,
             presence: presence as Arc<dyn PresenceStore>,
             routing: routing as Arc<dyn RoutingRegistry>,
             hot_tail: hot_tail as Arc<dyn HotTailCache>,

--- a/crates/services/chat/src/lib.rs
+++ b/crates/services/chat/src/lib.rs
@@ -22,3 +22,4 @@ pub mod config;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/chat/src/service.rs
+++ b/crates/services/chat/src/service.rs
@@ -1,0 +1,116 @@
+//! Adapts the chat composition root to the fleet [`service_runtime::Service`]
+//! contract so the shared runtime can host it.
+//!
+//! All domain wiring stays in [`crate::app`]; this module only maps env → config,
+//! defers to [`App::build`], registers the concrete tonic services, and reports
+//! backend liveness via [`FnProbe`] closures over the storage clients `App`
+//! retains. It is the seam that lets `chat-server` be a one-liner over the shared
+//! runtime while the integration harness keeps driving [`App::build`] directly.
+//!
+//! The probes are wired here (not in the storage crates) because the
+//! `HealthProbe`/`FnProbe` machinery is a platform concern a storage crate must
+//! not depend on; once the role-tiering lands, the storage crates can expose
+//! their own probe constructors, shared across services.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use infra_config::InfraRegistry;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::client::KafkaClientConfig;
+
+use crate::app::{App, AppConfig, Backends};
+use crate::config::ChatConfig;
+use crate::infrastructure::grpc::handler::{ChatServiceHandler, ChatServiceServer};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+
+/// The concrete tonic server type for chat, named once so both the health key
+/// and the reflection registration agree.
+type ChatServer = ChatServiceServer<ChatServiceHandler<InMemoryCommandBus, InMemoryQueryBus>>;
+
+/// The chat service as hosted by [`service_runtime`]. Owns the wired [`App`]
+/// until it is consumed into the gRPC router.
+pub struct ChatService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for ChatService {
+    const NAME: &'static str = "chat";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <ChatServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        // chat reads its tuning from the environment today; `_infra` is the seam
+        // for migrating these knobs onto hot-reloadable `[traffic]`/`[cache]`
+        // sections later without touching this signature.
+        let config = ChatConfig::from_env();
+
+        let app_config = AppConfig {
+            max_page_size:               config.max_page_size,
+            hot_tail_cache_size:         config.hot_tail_cache_size,
+            message_bucket_hours:        config.message_bucket_hours,
+            member_stream_buffer_size:   config.member_stream_buffer_size,
+            audience_stream_buffer_size: config.audience_stream_buffer_size,
+            audience_shard_count:        config.audience_shard_count,
+            presence_ttl_secs:           config.presence_ttl_secs,
+            typing_ttl_secs:             config.typing_ttl_secs,
+            // Production reuses the presence TTL for the Audience Plane.
+            audience_ttl_secs:           config.presence_ttl_secs,
+            visibility_consumer_group:   "chat-visibility-consumer".to_owned(),
+        };
+
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+            kafka:  Some(KafkaClientConfig::from_env()),
+        };
+
+        // `App::build` errors are `Box<dyn Error>` (not `Send + Sync`), so flatten
+        // to a message rather than propagating the box into `anyhow`.
+        let app = App::build(&app_config, backends)
+            .await
+            .map_err(|e| anyhow::anyhow!("chat app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        let redis = self.app.redis.clone();
+        vec![
+            Arc::new(FnProbe::new("scylla", move || {
+                let scylla = Arc::clone(&scylla);
+                async move {
+                    scylla_storage::health::health_check(&scylla.session)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+                }
+            })),
+            Arc::new(FnProbe::new("redis", move || {
+                let redis = redis.clone();
+                async move {
+                    redis_storage::health::health_check(&*redis)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
+                }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(ChatServiceServer::new(self.app.handler));
+        Ok(())
+    }
+}

--- a/crates/services/chat/tests/chat_it/harness/mod.rs
+++ b/crates/services/chat/tests/chat_it/harness/mod.rs
@@ -167,6 +167,9 @@ impl TestHarness {
             member_registry,
             audience_registry,
             params,
+            // Storage clients are retained on `App` for the runtime's readiness
+            // probes; the harness drives the graph directly and doesn't need them.
+            ..
         } = App::build(&config, backends).await.expect("integration: build chat app");
 
         Self {

--- a/crates/services/comment/Cargo.toml
+++ b/crates/services/comment/Cargo.toml
@@ -15,6 +15,8 @@ scylla-storage = { workspace = true }
 cqrs           = { workspace = true }
 telemetry      = { workspace = true }
 transport      = { workspace = true }
+service-runtime = { workspace = true }
+anyhow         = { workspace = true }
 
 tokio        = { workspace = true }
 async-trait  = { workspace = true }

--- a/crates/services/comment/README.md
+++ b/crates/services/comment/README.md
@@ -136,14 +136,25 @@ comment = { path = "crates/services/comment" }
 
 ### Bootstrap pattern
 
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `comment::service::CommentService` (`build` wires the ScyllaDB repository and
+the durable Kafka publisher; `register` adds the gRPC + reflection services;
+`health_probes` checks Scylla). The deployable binary is
+`crates/apps/comment-server`:
+
 ```rust
-use comment::infrastructure::grpc::server::serve;
+use std::net::SocketAddr;
+
+use comment::service::CommentService;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    telemetry::init();
-    let addr = "[::1]:50054".parse()?;
-    serve(addr).await
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("COMMENT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50057".to_owned())
+        .parse()?;
+
+    // Runtime owns telemetry, config + hot-reload, traffic, health, shutdown.
+    service_runtime::serve::<CommentService>(addr).await
 }
 ```
 

--- a/crates/services/comment/src/app.rs
+++ b/crates/services/comment/src/app.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 
 use crate::application::command::create_comment::{CreateCommentCommand, CreateCommentHandler};
 use crate::application::command::delete_comment::{DeleteCommentCommand, DeleteCommentHandler};
@@ -37,6 +37,9 @@ pub struct Backends {
 pub struct App {
     pub command_bus: Arc<InMemoryCommandBus>,
     pub query_bus:   Arc<InMemoryQueryBus>,
+    /// Live storage client, retained so the runtime's readiness loop can probe
+    /// its liveness (see [`crate::service`]).
+    pub scylla:      Arc<ScyllaClient>,
 }
 
 impl App {
@@ -47,7 +50,7 @@ impl App {
         publisher: Arc<P>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let scylla_client = Arc::new(ScyllaSessionBuilder::new(backends.scylla).build().await?);
-        let repository = Arc::new(ScyllaCommentRepository::new(scylla_client));
+        let repository = Arc::new(ScyllaCommentRepository::new(Arc::clone(&scylla_client)));
 
         let command_bus = Arc::new(
             CommandBusBuilder::new()
@@ -76,6 +79,6 @@ impl App {
                 .build(),
         );
 
-        Ok(Self { command_bus, query_bus })
+        Ok(Self { command_bus, query_bus, scylla: scylla_client })
     }
 }

--- a/crates/services/comment/src/lib.rs
+++ b/crates/services/comment/src/lib.rs
@@ -3,3 +3,4 @@ pub mod application;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/comment/src/service.rs
+++ b/crates/services/comment/src/service.rs
@@ -1,0 +1,79 @@
+//! Adapts the comment composition root to the fleet [`service_runtime::Service`]
+//! contract. Comment is ScyllaDB-only and publishes domain events through the
+//! durable Kafka publisher.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::app::{App, Backends};
+use crate::infrastructure::grpc::handler::comment_service_handler::{
+    CommentServiceHandler, CommentServiceServer,
+};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::publisher::KafkaCommentEventPublisher;
+
+type CommentServer =
+    CommentServiceServer<CommentServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
+
+/// The comment service as hosted by [`service_runtime`].
+pub struct CommentService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for CommentService {
+    const NAME: &'static str = "comment";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <CommentServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+        };
+
+        let producer = KafkaProducerBuilder::new(ProducerConfig::new(KafkaClientConfig::from_env()))
+            .build()?;
+        let publisher = Arc::new(KafkaCommentEventPublisher::new(producer));
+
+        let app = App::build(backends, publisher)
+            .await
+            .map_err(|e| anyhow::anyhow!("comment app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        vec![Arc::new(FnProbe::new("scylla", move || {
+            let scylla = Arc::clone(&scylla);
+            async move {
+                scylla_storage::health::health_check(&scylla.session)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+            }
+        }))]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = CommentServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+        );
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(CommentServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/engagement/Cargo.toml
+++ b/crates/services/engagement/Cargo.toml
@@ -16,6 +16,8 @@ redis-storage  = { workspace = true }
 cqrs           = { workspace = true }
 telemetry      = { workspace = true }
 transport      = { workspace = true }
+service-runtime = { workspace = true }
+anyhow         = { workspace = true }
 
 tokio        = { workspace = true }
 futures      = { workspace = true }

--- a/crates/services/engagement/README.md
+++ b/crates/services/engagement/README.md
@@ -162,14 +162,25 @@ engagement = { path = "crates/services/engagement" }
 
 ### Bootstrap pattern
 
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `engagement::service::EngagementService` (`build` wires the Redis score store,
+reaction-weights config, the Kafka publisher, and the write-behind workers;
+`register` adds the gRPC + reflection services; `health_probes` checks Redis —
+the always-on hot path). The deployable binary is `crates/apps/engagement-server`:
+
 ```rust
-use engagement::infrastructure::grpc::server::serve;
+use std::net::SocketAddr;
+
+use engagement::service::EngagementService;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Load ENGAGEMENT_* and SCYLLA_* and REDIS_* and KAFKA_* env vars
-    let addr = "0.0.0.0:50054".parse()?;
-    serve(addr).await
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("ENGAGEMENT_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50058".to_owned())
+        .parse()?;
+
+    // Runtime owns telemetry, config + hot-reload, traffic, health, shutdown.
+    service_runtime::serve::<EngagementService>(addr).await
 }
 ```
 

--- a/crates/services/engagement/src/app.rs
+++ b/crates/services/engagement/src/app.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
 use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
 use transport::kafka::config::client::KafkaClientConfig;
 
@@ -55,6 +55,10 @@ pub struct App {
     pub command_bus: Arc<InMemoryCommandBus>,
     pub query_bus:   Arc<InMemoryQueryBus>,
     pub score_store: Arc<dyn ScoreStore>,
+    /// Live Redis client (the always-on hot path), retained so the runtime's
+    /// readiness loop can probe it (see [`crate::service`]). ScyllaDB is only the
+    /// async write-behind ledger and is not part of the serving readiness gate.
+    pub redis:       RedisClient,
 }
 
 impl App {
@@ -70,7 +74,8 @@ impl App {
         // ── Redis hot path (always) ──────────────────────────────────────────
         let redis_client = RedisClientBuilder::new(redis).build().await?;
         let dirty_tracker = DirtyPostTracker::new();
-        let score_store = Arc::new(RedisScoreStore::new(redis_client, dirty_tracker.clone()));
+        let score_store =
+            Arc::new(RedisScoreStore::new(redis_client.clone(), dirty_tracker.clone()));
 
         // ── CQRS buses ───────────────────────────────────────────────────────
         let command_bus = Arc::new(
@@ -138,6 +143,7 @@ impl App {
             command_bus,
             query_bus,
             score_store: score_store as Arc<dyn ScoreStore>,
+            redis: redis_client,
         })
     }
 }

--- a/crates/services/engagement/src/lib.rs
+++ b/crates/services/engagement/src/lib.rs
@@ -4,3 +4,4 @@ pub mod config;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/engagement/src/service.rs
+++ b/crates/services/engagement/src/service.rs
@@ -1,0 +1,92 @@
+//! Adapts the engagement composition root to the fleet
+//! [`service_runtime::Service`] contract.
+//!
+//! Engagement is Redis-primary (the always-on hot path) with a ScyllaDB
+//! write-behind ledger driven by Kafka workers spawned inside [`App::build`].
+//! Readiness therefore gates on Redis only. Reaction weights are loaded from the
+//! externalized weights config.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::app::{App, Backends};
+use crate::config::ReactionWeightsConfig;
+use crate::infrastructure::grpc::handler::engagement_handler::EngagementServiceServer;
+use crate::infrastructure::grpc::handler::EngagementServiceHandler;
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::publisher::KafkaEngagementEventPublisher;
+
+type EngagementServer =
+    EngagementServiceServer<EngagementServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
+
+/// The engagement service as hosted by [`service_runtime`].
+pub struct EngagementService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for EngagementService {
+    const NAME: &'static str = "engagement";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str =
+        <EngagementServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+            kafka:  Some(KafkaClientConfig::from_env()),
+        };
+
+        let weights = Arc::new(
+            ReactionWeightsConfig::from_env()
+                .map_err(|e| anyhow::anyhow!("engagement reaction weights: {e}"))?,
+        );
+
+        let producer = KafkaProducerBuilder::new(ProducerConfig::new(KafkaClientConfig::from_env()))
+            .build()?;
+        let publisher = Arc::new(KafkaEngagementEventPublisher::new(producer));
+
+        let app = App::build(backends, weights, publisher)
+            .await
+            .map_err(|e| anyhow::anyhow!("engagement app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let redis = self.app.redis.clone();
+        vec![Arc::new(FnProbe::new("redis", move || {
+            let redis = redis.clone();
+            async move {
+                redis_storage::health::health_check(&*redis)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("redis: {e}"))
+            }
+        }))]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = EngagementServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+        );
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(EngagementServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/geo-discovery/Cargo.toml
+++ b/crates/services/geo-discovery/Cargo.toml
@@ -16,6 +16,8 @@ redis-storage  = { workspace = true }
 cqrs           = { workspace = true }
 telemetry      = { workspace = true }
 transport      = { workspace = true }
+service-runtime = { workspace = true }
+anyhow         = { workspace = true }
 
 tokio        = { workspace = true }
 futures      = { workspace = true }

--- a/crates/services/geo-discovery/README.md
+++ b/crates/services/geo-discovery/README.md
@@ -362,28 +362,28 @@ tokio         = { workspace = true }
 
 ### Standard Bootstrap Pattern
 
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `geo_discovery::service::GeoDiscoveryService`. `build` constructs the
+ScyllaDB/Redis clients, instantiates `RedisGeoSpatialIndex` / `RedisCardStore` /
+`ScyllaTileRepository`, registers `QueryTileHandler` (the gRPC surface is
+query-only — writes arrive via Kafka), and spawns `PostIndexerWorker` /
+`ScoreUpdaterWorker` / `TilePrunerWorker`; `register` adds the gRPC + reflection
+services; `health_probes` checks Scylla/Redis. The deployable binary is
+`crates/apps/geo-discovery-server`:
+
 ```rust
-// src/main.rs
 use std::net::SocketAddr;
-use geo_discovery::infrastructure::grpc::server;
+
+use geo_discovery::service::GeoDiscoveryService;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialise OTel tracing + metrics from env.
-    telemetry::init_from_env("geo-discovery")?;
-
+async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = std::env::var("GEO_GRPC_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:50054".to_owned())
         .parse()?;
 
-    // serve() is blocking: it:
-    //   1. Builds ScyllaDB CachingSession (ScyllaSessionBuilder).
-    //   2. Builds RedisClient (RedisClientBuilder).
-    //   3. Instantiates RedisGeoSpatialIndex, RedisCardStore, ScyllaTileRepository.
-    //   4. Registers QueryTileHandler in the CQRS QueryBus.
-    //   5. Spawns PostIndexerWorker, ScoreUpdaterWorker, TilePrunerWorker.
-    //   6. Starts Tonic gRPC server with health + reflection.
-    server::serve(addr).await
+    // Runtime owns telemetry, config + hot-reload, traffic, health, shutdown.
+    service_runtime::serve::<GeoDiscoveryService>(addr).await
 }
 ```
 

--- a/crates/services/geo-discovery/src/app.rs
+++ b/crates/services/geo-discovery/src/app.rs
@@ -15,8 +15,8 @@ use std::sync::Arc;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 use transport::kafka::config::client::KafkaClientConfig;
 
 use crate::application::command::{
@@ -49,6 +49,10 @@ pub struct Backends {
 pub struct App {
     pub command_bus: Arc<InMemoryCommandBus>,
     pub query_bus:   Arc<InMemoryQueryBus>,
+    /// Live storage clients, retained so the runtime's readiness loop can probe
+    /// their liveness (see [`crate::service`]).
+    pub scylla:      Arc<ScyllaClient>,
+    pub redis:       RedisClient,
 }
 
 impl App {
@@ -130,7 +134,7 @@ impl App {
             );
             tokio::spawn(
                 TilePrunerWorker::new(
-                    redis_client,
+                    redis_client.clone(),
                     cfg.tile_pruner_interval,
                     cfg.tile_cold_threshold,
                     500,
@@ -139,6 +143,6 @@ impl App {
             );
         }
 
-        Ok(Self { command_bus, query_bus })
+        Ok(Self { command_bus, query_bus, scylla: scylla_client, redis: redis_client })
     }
 }

--- a/crates/services/geo-discovery/src/lib.rs
+++ b/crates/services/geo-discovery/src/lib.rs
@@ -4,3 +4,4 @@ pub mod config;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/geo-discovery/src/service.rs
+++ b/crates/services/geo-discovery/src/service.rs
@@ -1,0 +1,85 @@
+//! Adapts the geo-discovery composition root to the fleet
+//! [`service_runtime::Service`] contract.
+//!
+//! Geo-discovery's gRPC surface is query-only (writes arrive via Kafka workers
+//! spawned inside [`App::build`]), so the handler is constructed from the query
+//! bus alone.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::query::InMemoryQueryBus;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::KafkaClientConfig;
+
+use crate::app::{App, Backends};
+use crate::config::GeoDiscoveryConfig;
+use crate::infrastructure::grpc::handler::{GeoDiscoveryHandler, GeoDiscoveryServiceServer};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+
+type GeoServer = GeoDiscoveryServiceServer<GeoDiscoveryHandler<Arc<InMemoryQueryBus>>>;
+
+/// The geo-discovery service as hosted by [`service_runtime`].
+pub struct GeoDiscoveryService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for GeoDiscoveryService {
+    const NAME: &'static str = "geo-discovery";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <GeoServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let cfg = GeoDiscoveryConfig::from_env();
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+            kafka:  Some(KafkaClientConfig::from_env()),
+        };
+
+        let app = App::build(cfg, backends)
+            .await
+            .map_err(|e| anyhow::anyhow!("geo-discovery app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        let redis = self.app.redis.clone();
+        vec![
+            Arc::new(FnProbe::new("scylla", move || {
+                let scylla = Arc::clone(&scylla);
+                async move {
+                    scylla_storage::health::health_check(&scylla.session)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+                }
+            })),
+            Arc::new(FnProbe::new("redis", move || {
+                let redis = redis.clone();
+                async move {
+                    redis_storage::health::health_check(&*redis)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
+                }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = GeoDiscoveryHandler::new(Arc::clone(&self.app.query_bus));
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(GeoDiscoveryServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/notification/Cargo.toml
+++ b/crates/services/notification/Cargo.toml
@@ -16,6 +16,8 @@ redis-storage  = { workspace = true }
 cqrs           = { workspace = true }
 telemetry      = { workspace = true }
 transport      = { workspace = true }
+service-runtime = { workspace = true }
+anyhow         = { workspace = true }
 
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/services/notification/README.md
+++ b/crates/services/notification/README.md
@@ -134,18 +134,25 @@ notification = { path = "crates/services/notification" }
 
 ### Bootstrap
 
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `notification::service::NotificationService` (`build` wires the repository,
+cache, broadcast registry, CQRS buses, and the Kafka workers; `register` adds the
+gRPC + reflection services; `health_probes` checks Scylla/Redis). The deployable
+binary is `crates/apps/notification-server`:
+
 ```rust
 use std::net::SocketAddr;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    telemetry::init_from_env()?;
+use notification::service::NotificationService;
 
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = std::env::var("NOTIFICATION_GRPC_ADDR")
-        .unwrap_or_else(|_| "0.0.0.0:50056".to_owned())
+        .unwrap_or_else(|_| "0.0.0.0:50055".to_owned())
         .parse()?;
 
-    notification::infrastructure::grpc::server::serve(addr).await
+    // Runtime owns telemetry, config + hot-reload, traffic, health, shutdown.
+    service_runtime::serve::<NotificationService>(addr).await
 }
 ```
 

--- a/crates/services/notification/src/app.rs
+++ b/crates/services/notification/src/app.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 use transport::kafka::config::client::KafkaClientConfig;
 
 use crate::application::command::create_notification::{
@@ -65,6 +65,10 @@ pub struct App {
     pub counter:         Arc<dyn UnreadCounter>,
     pub repository:      Arc<dyn NotificationRepository>,
     pub block_cache:     Arc<dyn BlockCache>,
+    /// Live storage clients, retained so the runtime's readiness loop can probe
+    /// their liveness (see [`crate::service`]).
+    pub scylla:          Arc<ScyllaClient>,
+    pub redis:           RedisClient,
 }
 
 impl App {
@@ -189,6 +193,8 @@ impl App {
             counter:     counter as Arc<dyn UnreadCounter>,
             repository:  repository as Arc<dyn NotificationRepository>,
             block_cache: block_cache as Arc<dyn BlockCache>,
+            scylla:      scylla_client,
+            redis:       redis_client,
         })
     }
 }

--- a/crates/services/notification/src/lib.rs
+++ b/crates/services/notification/src/lib.rs
@@ -4,3 +4,4 @@ pub mod config;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/notification/src/service.rs
+++ b/crates/services/notification/src/service.rs
@@ -1,0 +1,94 @@
+//! Adapts the notification composition root to the fleet
+//! [`service_runtime::Service`] contract.
+//!
+//! The handler is generic over its broadcast registry (for the streaming RPC) in
+//! addition to the command/query buses; all three are the live instances `App`
+//! exposes. Kafka workers are spawned inside [`App::build`].
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::KafkaClientConfig;
+
+use crate::app::{App, Backends};
+use crate::config::NotificationConfig;
+use crate::infrastructure::grpc::handler::{NotificationServiceHandler, NotificationServiceServer};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::streaming::BroadcastRegistry;
+
+type NotificationServer = NotificationServiceServer<
+    NotificationServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>, BroadcastRegistry>,
+>;
+
+/// The notification service as hosted by [`service_runtime`].
+pub struct NotificationService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for NotificationService {
+    const NAME: &'static str = "notification";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str =
+        <NotificationServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let config = Arc::new(NotificationConfig::from_env());
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+            kafka:  Some(KafkaClientConfig::from_env()),
+        };
+
+        let app = App::build(config, backends)
+            .await
+            .map_err(|e| anyhow::anyhow!("notification app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        let redis = self.app.redis.clone();
+        vec![
+            Arc::new(FnProbe::new("scylla", move || {
+                let scylla = Arc::clone(&scylla);
+                async move {
+                    scylla_storage::health::health_check(&scylla.session)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+                }
+            })),
+            Arc::new(FnProbe::new("redis", move || {
+                let redis = redis.clone();
+                async move {
+                    redis_storage::health::health_check(&*redis)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
+                }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = NotificationServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+            Arc::clone(&self.app.stream_registry),
+        );
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(NotificationServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/post/Cargo.toml
+++ b/crates/services/post/Cargo.toml
@@ -16,6 +16,8 @@ cqrs         = { workspace = true }
 auth-context = { workspace = true }
 telemetry    = { workspace = true }
 transport    = { workspace = true }
+service-runtime = { workspace = true }
+anyhow       = { workspace = true }
 tokio        = { workspace = true }
 futures      = { workspace = true }
 async-trait  = { workspace = true }

--- a/crates/services/post/README.md
+++ b/crates/services/post/README.md
@@ -122,3 +122,25 @@ cqlsh -f migrations/0003_create_posts_by_profile_table.cql
 ```
 
 Dependencies: ScyllaDB cluster (`datacenter1`), Kafka broker.
+
+---
+
+## 🚀 Deployment
+
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `post::service::PostService` (`build` wires the ScyllaDB repository and the
+durable Kafka event publisher; `register` adds the gRPC + reflection services;
+`health_probes` checks Scylla). The deployable binary is `crates/apps/post-server`:
+
+```rust
+use std::net::SocketAddr;
+use post::service::PostService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("POST_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50056".to_owned())
+        .parse()?;
+    service_runtime::serve::<PostService>(addr).await
+}
+```

--- a/crates/services/post/build.rs
+++ b/crates/services/post/build.rs
@@ -1,7 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("post_descriptor.bin");
+
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
+        .file_descriptor_set_path(&descriptor_path)
         .compile_protos(
             &[
                 "proto/post/v1/enums.proto",

--- a/crates/services/post/src/app.rs
+++ b/crates/services/post/src/app.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 
 use crate::application::command::create_post::{CreatePostCommand, CreatePostHandler};
 use crate::application::command::delete_post::{DeletePostCommand, DeletePostHandler};
@@ -40,6 +40,9 @@ pub struct Backends {
 pub struct App {
     pub command_bus: Arc<InMemoryCommandBus>,
     pub query_bus:   Arc<InMemoryQueryBus>,
+    /// Live storage client, retained so the runtime's readiness loop can probe
+    /// its liveness (see [`crate::service`]).
+    pub scylla:      Arc<ScyllaClient>,
 }
 
 impl App {
@@ -50,7 +53,7 @@ impl App {
         publisher: Arc<P>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let scylla_client = Arc::new(ScyllaSessionBuilder::new(backends.scylla).build().await?);
-        let repository = Arc::new(ScyllaPostRepository::new(scylla_client));
+        let repository = Arc::new(ScyllaPostRepository::new(Arc::clone(&scylla_client)));
 
         let command_bus = Arc::new(
             CommandBusBuilder::new()
@@ -84,6 +87,6 @@ impl App {
                 .build(),
         );
 
-        Ok(Self { command_bus, query_bus })
+        Ok(Self { command_bus, query_bus, scylla: scylla_client })
     }
 }

--- a/crates/services/post/src/infrastructure/grpc/server.rs
+++ b/crates/services/post/src/infrastructure/grpc/server.rs
@@ -5,6 +5,10 @@ use cqrs::{CommandBus, QueryBus};
 use super::handler::post_service_handler::{proto, PostServiceHandler};
 use proto::post_service_server::PostService;
 
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `build.rs`. Registered by the service's runtime adapter ([`crate::service`]).
+pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("post_descriptor");
+
 #[tonic::async_trait]
 impl<CB, QB> PostService for PostServiceHandler<CB, QB>
 where

--- a/crates/services/post/src/lib.rs
+++ b/crates/services/post/src/lib.rs
@@ -3,3 +3,4 @@ pub mod application;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/post/src/service.rs
+++ b/crates/services/post/src/service.rs
@@ -1,0 +1,78 @@
+//! Adapts the post composition root to the fleet [`service_runtime::Service`]
+//! contract. Post is ScyllaDB-only and always publishes domain events through the
+//! durable Kafka publisher.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::app::{App, Backends};
+use crate::infrastructure::grpc::handler::post_service_handler::PostServiceServer;
+use crate::infrastructure::grpc::handler::PostServiceHandler;
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::publisher::KafkaEventPublisher;
+
+type PostServer =
+    PostServiceServer<PostServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
+
+/// The post service as hosted by [`service_runtime`].
+pub struct PostService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for PostService {
+    const NAME: &'static str = "post";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <PostServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+        };
+
+        let producer = KafkaProducerBuilder::new(ProducerConfig::new(KafkaClientConfig::from_env()))
+            .build()?;
+        let publisher = Arc::new(KafkaEventPublisher::new(producer));
+
+        let app = App::build(backends, publisher)
+            .await
+            .map_err(|e| anyhow::anyhow!("post app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        vec![Arc::new(FnProbe::new("scylla", move || {
+            let scylla = Arc::clone(&scylla);
+            async move {
+                scylla_storage::health::health_check(&scylla.session)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+            }
+        }))]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = PostServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+        );
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(PostServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/profile/Cargo.toml
+++ b/crates/services/profile/Cargo.toml
@@ -21,6 +21,8 @@ auth-context      = { workspace = true }
 telemetry         = { workspace = true }
 transport         = { workspace = true }
 infra-config      = { workspace = true }
+service-runtime   = { workspace = true }
+anyhow            = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/profile/README.md
+++ b/crates/services/profile/README.md
@@ -176,83 +176,40 @@ profile = { path = "crates/services/profile" }
 
 ### Bootstrap Pattern
 
-```rust
-use std::sync::Arc;
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
-use transport::kafka::{KafkaConsumerConfig, KafkaConsumerBuilder};
-use cqrs::{InMemoryCommandBus, InMemoryQueryBus};
+Library-only: all of the wiring shown previously here now lives in
+`profile::app::App::build` and `profile::service::ProfileService`, which
+implements [`service_runtime::Service`](../../platform/service-runtime/README.md).
+Profile is the canonical *infra-consuming* service:
 
-use profile::application::command::*;
-use profile::application::query::*;
-use profile::application::port::{ProfileRepository, ProfileCache};
-use profile::infrastructure::persistence::ScyllaProfileRepository;
-use profile::infrastructure::cache::RedisProfileCache;
-use profile::infrastructure::consumer::run_account_event_consumer;
-use profile::infrastructure::grpc::handler::ProfileServiceHandler;
+- `build(infra)` reads its cache-TTL profiles from `infra.cache()` (the `[cache]`
+  section of `infrastructure.toml`), assembles the repository, cache, and CQRS
+  buses, and **self-spawns the supervised account-event Kafka consumer** (poison
+  records dead-lettered to `account.v1.events.dlq`).
+- `register` adds the gRPC + reflection services (the handler is built from the
+  `Arc<InMemoryCommandBus>` / `Arc<InMemoryQueryBus>` the buses expose).
+- `health_probes` checks Scylla/Redis.
+
+The deployable binary is `crates/apps/profile-server`:
+
+```rust
+use std::net::SocketAddr;
+
+use profile::service::ProfileService;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // ── Storage ───────────────────────────────────────────────────────────────
-    let scylla_client = Arc::new(
-        ScyllaSessionBuilder::new(ScyllaConfig::from_env())
-            .build()
-            .await?,
-    );
-    let redis_client = Arc::new(
-        RedisClientBuilder::new(RedisConfig::from_env())
-            .build()
-            .await?,
-    );
-
-    // ── Adapters ──────────────────────────────────────────────────────────────
-    let repo: Arc<dyn ProfileRepository> =
-        Arc::new(ScyllaProfileRepository::new(Arc::clone(&scylla_client)));
-    let cache: Arc<dyn ProfileCache> =
-        Arc::new(RedisProfileCache::new(Arc::clone(&redis_client)));
-
-    // ── CQRS buses ────────────────────────────────────────────────────────────
-    let mut cmd_bus = InMemoryCommandBus::new();
-    cmd_bus.register(CreateProfileHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(UpdateProfileHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(ChangeHandleHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(UpdateAvatarHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(UpdateBannerHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(SetVisibilityHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(VerifyProfileHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(HideProfileHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(RestoreProfileHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    cmd_bus.register(DeleteProfileHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-
-    let mut qry_bus = InMemoryQueryBus::new();
-    qry_bus.register(GetProfileByIdHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    qry_bus.register(GetProfileByHandleHandler::new(Arc::clone(&repo), Arc::clone(&cache)));
-    qry_bus.register(ListProfilesByAccountHandler::new(Arc::clone(&repo)));
-
-    // ── gRPC server ───────────────────────────────────────────────────────────
-    let handler = ProfileServiceHandler::new(cmd_bus.clone(), qry_bus);
-    let grpc_addr = std::env::var("PROFILE_GRPC_HOST")
-        .unwrap_or_else(|_| "0.0.0.0:50052".into())
+    let addr: SocketAddr = std::env::var("PROFILE_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50052".to_owned())
         .parse()?;
 
-    // ── Kafka account event consumer ──────────────────────────────────────────
-    let kafka_consumer = KafkaConsumerBuilder::new(KafkaConsumerConfig::from_env())
-        .subscribe(&["account.v1.events"])
-        .build()?;
-    // The consumer also needs a producer to forward poison / retry-exhausted
-    // records to the account.v1.events.dlq dead-letter topic.
-    let dlq_producer = KafkaProducerBuilder::new(KafkaProducerConfig::from_env()).build()?;
-    tokio::spawn(run_account_event_consumer(kafka_consumer, cmd_bus, dlq_producer));
-
-    // ── Start server ──────────────────────────────────────────────────────────
-    tonic::transport::Server::builder()
-        .add_service(profile::infrastructure::grpc::handler::ProfileServiceServer::new(handler))
-        .serve(grpc_addr)
-        .await?;
-
-    Ok(())
+    // Runtime owns telemetry, infrastructure.toml load + hot-reload (incl. the
+    // [cache] TTLs profile consumes), traffic, health, and shutdown.
+    service_runtime::serve::<ProfileService>(addr).await
 }
 ```
+
+The integration harness still drives `App::build` directly, so the wired graph
+under test is the one that ships.
 
 ---
 
@@ -275,7 +232,7 @@ async fn main() -> anyhow::Result<()> {
 | `KAFKA_BROKERS` | Yes | `127.0.0.1:9092` | Comma-separated Kafka broker addresses. |
 | `KAFKA_CONSUMER_GROUP` | No | `profile-service` | Kafka consumer group ID. |
 | `KAFKA_AUTO_OFFSET_RESET` | No | `earliest` | Offset reset policy for new consumer groups. |
-| `PROFILE_GRPC_HOST` | No | `0.0.0.0:50052` | Bind address for the gRPC server. |
+| `PROFILE_GRPC_ADDR` | No | `0.0.0.0:50052` | Bind address for the gRPC server (read by `profile-server`). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | _(none)_ | OpenTelemetry collector endpoint (traces + metrics). |
 | `OTEL_SERVICE_NAME` | No | `profile` | Service name reported in OTel spans and metrics. |
 | `RUST_LOG` | No | `info` | Tracing log filter (e.g. `profile=debug,scylla=warn`). |

--- a/crates/services/profile/build.rs
+++ b/crates/services/profile/build.rs
@@ -1,7 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("profile_descriptor.bin");
+
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
+        .file_descriptor_set_path(&descriptor_path)
         .compile_protos(
             &[
                 "proto/profile/v1/enums.proto",

--- a/crates/services/profile/src/app.rs
+++ b/crates/services/profile/src/app.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
 use infra_config::CacheRegistry;
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 
 use crate::application::command::{
     ChangeHandleCommand, ChangeHandleHandler, CreateProfileCommand, CreateProfileHandler,
@@ -48,6 +48,10 @@ pub struct App {
     pub query_bus:   Arc<InMemoryQueryBus>,
     pub repository:  Arc<dyn ProfileRepository>,
     pub cache:       Arc<dyn ProfileCache>,
+    /// Live storage clients, retained so the runtime's readiness loop can probe
+    /// their liveness (see [`crate::service`]).
+    pub scylla:      Arc<ScyllaClient>,
+    pub redis:       Arc<RedisClient>,
 }
 
 impl App {
@@ -68,10 +72,12 @@ impl App {
         let redis_client = Arc::new(RedisClientBuilder::new(redis).build().await?);
 
         // ── Adapters (exposed behind their ports) ────────────────────────────
+        // `Arc::clone` rather than move: the readiness loop probes the same live
+        // clients the repository and cache use.
         let repository: Arc<dyn ProfileRepository> =
-            Arc::new(ScyllaProfileRepository::new(scylla_client));
+            Arc::new(ScyllaProfileRepository::new(Arc::clone(&scylla_client)));
         let cache: Arc<dyn ProfileCache> = Arc::new(RedisProfileCache::new(
-            redis_client,
+            Arc::clone(&redis_client),
             cache_registry.profile_for(PROFILE_CACHE_NAMESPACE),
             cache_registry.profile_for(HANDLE_CACHE_NAMESPACE),
         ));
@@ -139,6 +145,13 @@ impl App {
                 .build(),
         );
 
-        Ok(Self { command_bus, query_bus, repository, cache })
+        Ok(Self {
+            command_bus,
+            query_bus,
+            repository,
+            cache,
+            scylla: scylla_client,
+            redis: redis_client,
+        })
     }
 }

--- a/crates/services/profile/src/infrastructure/grpc/server.rs
+++ b/crates/services/profile/src/infrastructure/grpc/server.rs
@@ -5,6 +5,10 @@ use cqrs::{CommandBus, QueryBus};
 use super::handler::profile_service_handler::{proto, ProfileServiceHandler};
 use proto::profile_service_server::ProfileService;
 
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `build.rs`. Registered by the service's runtime adapter ([`crate::service`]).
+pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("profile_descriptor");
+
 #[tonic::async_trait]
 impl<CB, QB> ProfileService for ProfileServiceHandler<CB, QB>
 where

--- a/crates/services/profile/src/lib.rs
+++ b/crates/services/profile/src/lib.rs
@@ -3,5 +3,6 @@ pub mod application;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;
 
 pub use error::ProfileError;

--- a/crates/services/profile/src/service.rs
+++ b/crates/services/profile/src/service.rs
@@ -1,0 +1,152 @@
+//! Adapts the profile composition root to the fleet [`service_runtime::Service`]
+//! contract so the shared runtime can host it.
+//!
+//! Unlike chat, profile *consumes* the externalized infra registry: its cache
+//! TTLs come from the `[cache]` section via [`InfraRegistry::cache`], so a TTL
+//! push hot-reloads the live cache. Profile also has an inbound integration —
+//! the account-event consumer — which is self-spawned in [`build`](ProfileService::build)
+//! (mirroring how chat spawns its workers in `App::build`), so the single runtime
+//! entrypoint needs no service-specific hooks.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use infra_config::InfraRegistry;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
+use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
+use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
+
+use crate::app::{App, Backends};
+use crate::infrastructure::consumer::run_account_event_consumer;
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::grpc::{ProfileServiceHandler, ProfileServiceServer};
+
+/// Kafka topic carrying the account lifecycle events profile reacts to.
+const ACCOUNT_EVENTS_TOPIC: &str = "account.v1.events";
+/// Consumer group for profile's account-event consumer.
+const ACCOUNT_EVENTS_GROUP: &str = "profile-account-events";
+/// Backoff before respawning the consumer after the runner returns.
+const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
+
+/// The concrete tonic server type for profile (the buses are shared as `Arc`,
+/// which implement the bus traits), named once so the health key and reflection
+/// registration agree.
+type ProfileServer =
+    ProfileServiceServer<ProfileServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
+
+/// The profile service as hosted by [`service_runtime`].
+pub struct ProfileService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for ProfileService {
+    const NAME: &'static str = "profile";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <ProfileServer as tonic::server::NamedService>::NAME;
+
+    async fn build(infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+        };
+
+        // Profile's cache TTLs are externalized: the `[cache]` section is required.
+        let cache_registry = infra
+            .cache()
+            .context("profile requires a [cache] section in infrastructure.toml")?;
+
+        let app = App::build(backends, cache_registry)
+            .await
+            .map_err(|e| anyhow::anyhow!("profile app build: {e}"))?;
+
+        // Inbound integration: account lifecycle → profile masking/restoration.
+        spawn_account_event_consumer(Arc::clone(&app.command_bus));
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        let redis = Arc::clone(&self.app.redis);
+        vec![
+            Arc::new(FnProbe::new("scylla", move || {
+                let scylla = Arc::clone(&scylla);
+                async move {
+                    scylla_storage::health::health_check(&scylla.session)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+                }
+            })),
+            Arc::new(FnProbe::new("redis", move || {
+                let redis = Arc::clone(&redis);
+                async move {
+                    redis_storage::health::health_check(&**redis)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
+                }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        // The buses are shared behind `Arc`, which implements the bus traits.
+        let handler = ProfileServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+        );
+
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(ProfileServiceServer::new(handler));
+        Ok(())
+    }
+}
+
+/// Spawns the supervised account-event consumer. It rebuilds its Kafka handles
+/// and restarts after [`CONSUMER_RESPAWN_BACKOFF`] whenever the runner returns
+/// (stream end or unrecoverable broker/DLQ error), per the runner's contract.
+fn spawn_account_event_consumer(command_bus: Arc<InMemoryCommandBus>) {
+    tokio::spawn(async move {
+        loop {
+            match build_account_event_consumer() {
+                Ok((consumer, producer)) => {
+                    run_account_event_consumer(consumer, Arc::clone(&command_bus), producer).await;
+                    tracing::warn!("account event consumer exited; respawning after backoff");
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build account event consumer; retrying");
+                }
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Builds the manual-commit consumer (subscribed to the account topic) and the
+/// dead-letter producer the runner needs.
+fn build_account_event_consumer(
+) -> anyhow::Result<(KafkaConsumerHandle, KafkaProducerHandle)> {
+    let kafka = KafkaClientConfig::from_env();
+    let consumer =
+        KafkaConsumerBuilder::new(ConsumerConfig::new(kafka.clone(), ACCOUNT_EVENTS_GROUP))
+            .subscribe(ACCOUNT_EVENTS_TOPIC)
+            .build()
+            .context("build account event consumer")?;
+    let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+        .build()
+        .context("build account event dead-letter producer")?;
+    Ok((consumer, producer))
+}

--- a/crates/services/social-graph/Cargo.toml
+++ b/crates/services/social-graph/Cargo.toml
@@ -16,10 +16,12 @@ scylla-storage   = { workspace = true }
 redis-storage    = { workspace = true }
 
 # ── Shared platform crates ────────────────────────────────────────────────────
-cqrs         = { workspace = true }
-auth-context = { workspace = true }
-telemetry    = { workspace = true }
-transport    = { workspace = true }
+cqrs            = { workspace = true }
+auth-context    = { workspace = true }
+telemetry       = { workspace = true }
+transport       = { workspace = true }
+service-runtime = { workspace = true }
+anyhow          = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/social-graph/README.md
+++ b/crates/services/social-graph/README.md
@@ -192,3 +192,26 @@ cqlsh -f migrations/0003_create_following_table.cql
 cqlsh -f migrations/0004_create_follow_status_table.cql
 cqlsh -f migrations/0005_create_blocks_table.cql
 ```
+
+---
+
+## 🚀 Deployment
+
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `social_graph::service::SocialGraphService` (`build` wires the ScyllaDB
+repository, Redis cache, and the durable Kafka event publisher; `register` adds
+the gRPC + reflection services; `health_probes` checks Scylla/Redis). The
+deployable binary is `crates/apps/social-graph-server`:
+
+```rust
+use std::net::SocketAddr;
+use social_graph::service::SocialGraphService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("SOCIAL_GRAPH_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50053".to_owned())
+        .parse()?;
+    service_runtime::serve::<SocialGraphService>(addr).await
+}
+```

--- a/crates/services/social-graph/build.rs
+++ b/crates/services/social-graph/build.rs
@@ -1,7 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("social_graph_descriptor.bin");
+
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
+        .file_descriptor_set_path(&descriptor_path)
         .compile_protos(
             &[
                 "proto/social_graph/v1/enums.proto",

--- a/crates/services/social-graph/src/app.rs
+++ b/crates/services/social-graph/src/app.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 
 use crate::application::command::{
     BlockProfileCommand, BlockProfileHandler, FollowProfileCommand, FollowProfileHandler,
@@ -42,6 +42,10 @@ pub struct Backends {
 pub struct App {
     pub command_bus: Arc<InMemoryCommandBus>,
     pub query_bus:   Arc<InMemoryQueryBus>,
+    /// Live storage clients, retained so the runtime's readiness loop can probe
+    /// their liveness (see [`crate::service`]).
+    pub scylla:      Arc<ScyllaClient>,
+    pub redis:       Arc<RedisClient>,
 }
 
 impl App {
@@ -58,9 +62,9 @@ impl App {
         let redis_client = Arc::new(RedisClientBuilder::new(redis).build().await?);
 
         let repo: Arc<dyn SocialGraphRepository> =
-            Arc::new(ScyllaSocialGraphRepository::new(scylla_client));
+            Arc::new(ScyllaSocialGraphRepository::new(Arc::clone(&scylla_client)));
         let cache: Arc<dyn SocialGraphCache> =
-            Arc::new(RedisSocialGraphCache::new(redis_client));
+            Arc::new(RedisSocialGraphCache::new(Arc::clone(&redis_client)));
 
         let command_bus = Arc::new(
             CommandBusBuilder::new()
@@ -99,6 +103,6 @@ impl App {
                 .build(),
         );
 
-        Ok(Self { command_bus, query_bus })
+        Ok(Self { command_bus, query_bus, scylla: scylla_client, redis: redis_client })
     }
 }

--- a/crates/services/social-graph/src/infrastructure/grpc/server.rs
+++ b/crates/services/social-graph/src/infrastructure/grpc/server.rs
@@ -5,6 +5,11 @@ use cqrs::{CommandBus, QueryBus};
 use super::handler::social_graph_service_handler::{proto, SocialGraphServiceHandler};
 use proto::social_graph_service_server::SocialGraphService;
 
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `build.rs`. Registered by the service's runtime adapter ([`crate::service`]).
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("social_graph_descriptor");
+
 #[tonic::async_trait]
 impl<CB, QB> SocialGraphService for SocialGraphServiceHandler<CB, QB>
 where

--- a/crates/services/social-graph/src/lib.rs
+++ b/crates/services/social-graph/src/lib.rs
@@ -3,3 +3,4 @@ pub mod application;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/social-graph/src/service.rs
+++ b/crates/services/social-graph/src/service.rs
@@ -1,0 +1,98 @@
+//! Adapts the social-graph composition root to the fleet
+//! [`service_runtime::Service`] contract so the shared runtime can host it.
+//!
+//! Domain wiring stays in [`crate::app`]; this module maps env → config, builds
+//! the concrete Kafka event publisher, defers to [`App::build`], registers the
+//! gRPC services, and exposes the backend health probes.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::command::InMemoryCommandBus;
+use cqrs::query::InMemoryQueryBus;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::app::{App, Backends};
+use crate::application::port::EventPublisher;
+use crate::infrastructure::grpc::handler::social_graph_service_handler::SocialGraphServiceServer;
+use crate::infrastructure::grpc::handler::SocialGraphServiceHandler;
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::publisher::KafkaEventPublisher;
+
+type SocialGraphServer =
+    SocialGraphServiceServer<SocialGraphServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
+
+/// The social-graph service as hosted by [`service_runtime`].
+pub struct SocialGraphService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for SocialGraphService {
+    const NAME: &'static str = "social-graph";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str =
+        <SocialGraphServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+        };
+
+        // Social-graph always publishes downstream events; build the durable
+        // Kafka publisher from env.
+        let producer = KafkaProducerBuilder::new(ProducerConfig::new(KafkaClientConfig::from_env()))
+            .build()?;
+        let publisher: Arc<dyn EventPublisher> = Arc::new(KafkaEventPublisher::new(producer));
+
+        let app = App::build(backends, publisher)
+            .await
+            .map_err(|e| anyhow::anyhow!("social-graph app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        let redis = Arc::clone(&self.app.redis);
+        vec![
+            Arc::new(FnProbe::new("scylla", move || {
+                let scylla = Arc::clone(&scylla);
+                async move {
+                    scylla_storage::health::health_check(&scylla.session)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+                }
+            })),
+            Arc::new(FnProbe::new("redis", move || {
+                let redis = Arc::clone(&redis);
+                async move {
+                    redis_storage::health::health_check(&**redis)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
+                }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = SocialGraphServiceHandler::new(
+            Arc::clone(&self.app.command_bus),
+            Arc::clone(&self.app.query_bus),
+        );
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(SocialGraphServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/services/timeline/Cargo.toml
+++ b/crates/services/timeline/Cargo.toml
@@ -17,6 +17,8 @@ redis-storage  = { workspace = true }
 cqrs           = { workspace = true }
 telemetry      = { workspace = true }
 transport      = { workspace = true }
+service-runtime = { workspace = true }
+anyhow         = { workspace = true }
 
 # ── Async runtime & utilities ─────────────────────────────────────────────────
 tokio        = { workspace = true }

--- a/crates/services/timeline/README.md
+++ b/crates/services/timeline/README.md
@@ -311,3 +311,29 @@ cargo check -p timeline
 # Build
 cargo build -p timeline
 ```
+
+---
+
+## 🚀 Deployment
+
+Library-only: implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `timeline::service::TimelineService`. `build` maps `TimelineConfig` →
+`AppConfig`, constructs the social-graph gRPC client (`SocialGraphGrpcClient` over
+a lazily-connected channel, so timeline boots even if social-graph isn't yet
+reachable), assembles the cache/persistence adapters and CQRS buses, and spawns
+the ingestion workers; `register` adds the gRPC + reflection services (the surface
+is query-only — writes arrive via Kafka); `health_probes` checks Scylla/Redis. The
+deployable binary is `crates/apps/timeline-server`:
+
+```rust
+use std::net::SocketAddr;
+use timeline::service::TimelineService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("TIMELINE_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50060".to_owned())
+        .parse()?;
+    service_runtime::serve::<TimelineService>(addr).await
+}
+```

--- a/crates/services/timeline/src/app.rs
+++ b/crates/services/timeline/src/app.rs
@@ -23,8 +23,8 @@ use std::sync::{Arc, Mutex};
 
 use cqrs::command::{CommandBusBuilder, InMemoryCommandBus};
 use cqrs::query::{InMemoryQueryBus, QueryBusBuilder};
-use redis_storage::{RedisClientBuilder, RedisConfig};
-use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
 use tokio::sync::Semaphore;
 use transport::kafka::config::client::KafkaClientConfig;
 
@@ -104,6 +104,10 @@ pub struct App {
     // dyn-compatible; exposed as their concrete adapters.
     pub audio_feed_store: Arc<RedisAudioFeedStore>,
     pub audio_feed_repo:  Arc<ScyllaAudioFeedRepository>,
+    /// Live storage clients, retained so the runtime's readiness loop can probe
+    /// their liveness (see [`crate::service`]).
+    pub scylla:           Arc<ScyllaClient>,
+    pub redis:            RedisClient,
 }
 
 impl App {
@@ -126,7 +130,7 @@ impl App {
         let vip_registry = Arc::new(RedisVipRegistry::new(redis_client.clone()));
         let tier_cache = Arc::new(RedisTierCache::new(redis_client.clone()));
         let following_store = Arc::new(RedisFollowingStore::new(redis_client.clone()));
-        let audio_feed_store = Arc::new(RedisAudioFeedStore::new(redis_client));
+        let audio_feed_store = Arc::new(RedisAudioFeedStore::new(redis_client.clone()));
 
         // ── Persistence adapters ─────────────────────────────────────────────
         let feed_repository = Arc::new(ScyllaFeedRepository::new(Arc::clone(&scylla_client)));
@@ -258,6 +262,8 @@ impl App {
             author_post_repo: author_post_repo as Arc<dyn AuthorPostRepository>,
             audio_feed_store,
             audio_feed_repo,
+            scylla: scylla_client,
+            redis: redis_client,
         })
     }
 }

--- a/crates/services/timeline/src/lib.rs
+++ b/crates/services/timeline/src/lib.rs
@@ -4,3 +4,4 @@ pub mod config;
 pub mod domain;
 pub mod error;
 pub mod infrastructure;
+pub mod service;

--- a/crates/services/timeline/src/service.rs
+++ b/crates/services/timeline/src/service.rs
@@ -1,0 +1,115 @@
+//! Adapts the timeline composition root to the fleet [`service_runtime::Service`]
+//! contract.
+//!
+//! Timeline depends on social-graph over gRPC: the concrete
+//! [`SocialGraphGrpcClient`] is built here from the configured endpoint (lazily
+//! connected, so boot doesn't block on the dependency) and injected into the
+//! otherwise client-generic [`App::build`]. The gRPC surface is query-only;
+//! ingestion runs via Kafka workers spawned inside `App::build`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cqrs::query::InMemoryQueryBus;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic::transport::Channel;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::KafkaClientConfig;
+
+use crate::app::{App, AppConfig, Backends};
+use crate::config::TimelineConfig;
+use crate::infrastructure::client::SocialGraphGrpcClient;
+use crate::infrastructure::grpc::handler::{TimelineServiceHandler, TimelineServiceServer};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+
+type TimelineServer = TimelineServiceServer<TimelineServiceHandler<Arc<InMemoryQueryBus>>>;
+
+/// The timeline service as hosted by [`service_runtime`].
+pub struct TimelineService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for TimelineService {
+    const NAME: &'static str = "timeline";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <TimelineServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let cfg = TimelineConfig::from_env();
+
+        let app_config = AppConfig {
+            feed_cap:               cfg.feed_cap,
+            audio_feed_cap:         cfg.audio_feed_cap,
+            vip_registry_cap:       cfg.vip_registry_cap,
+            backfill_limit:         cfg.backfill_limit,
+            warm_ttl_secs:          cfg.warm_ttl_secs,
+            tier_cache_ttl_secs:    cfg.tier_cache_ttl_secs,
+            vip_registry_ttl_secs:  cfg.vip_registry_ttl_secs,
+            max_page_size:          cfg.max_page_size,
+            max_vip_merge_sources:  cfg.max_vip_merge_sources,
+            warm_max_concurrency:   cfg.warm_max_concurrency,
+            social_graph_page_size: cfg.social_graph_page_size,
+            kafka_group_post_published: cfg.kafka_group_post_published.clone(),
+            kafka_group_post_deleted:   cfg.kafka_group_post_deleted.clone(),
+            kafka_group_sg_followed:    cfg.kafka_group_sg_followed.clone(),
+            kafka_group_sg_unfollowed:  cfg.kafka_group_sg_unfollowed.clone(),
+        };
+
+        let backends = Backends {
+            scylla: ScyllaConfig::from_env(),
+            redis:  RedisConfig::from_env(),
+            kafka:  Some(KafkaClientConfig::from_env()),
+        };
+
+        // Lazily-connected channel: timeline boots even if social-graph is not
+        // yet reachable; the worker/cold-rebuild call sites tolerate latency.
+        let channel = Channel::from_shared(cfg.social_graph_endpoint.clone())
+            .map_err(|e| anyhow::anyhow!("invalid social-graph endpoint: {e}"))?
+            .connect_lazy();
+        let social_graph = Arc::new(SocialGraphGrpcClient::new(channel));
+
+        let app = App::build(&app_config, backends, social_graph)
+            .await
+            .map_err(|e| anyhow::anyhow!("timeline app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let scylla = Arc::clone(&self.app.scylla);
+        let redis = self.app.redis.clone();
+        vec![
+            Arc::new(FnProbe::new("scylla", move || {
+                let scylla = Arc::clone(&scylla);
+                async move {
+                    scylla_storage::health::health_check(&scylla.session)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+                }
+            })),
+            Arc::new(FnProbe::new("redis", move || {
+                let redis = redis.clone();
+                async move {
+                    redis_storage::health::health_check(&*redis)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
+                }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let handler = TimelineServiceHandler::new(Arc::clone(&self.app.query_bus));
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(TimelineServiceServer::new(handler));
+        Ok(())
+    }
+}

--- a/crates/shared/infra-config/README.md
+++ b/crates/shared/infra-config/README.md
@@ -9,11 +9,11 @@
 - **Fleet bindings** — resolves a dependency/namespace name (`"post-command"`, `"profile-view"`) to a named class-of-service profile (`"critical"`, `"hot"`).
 - **Hot-reload** — a `notify`-based watcher that re-applies the file on change via lock-free `ArcSwap` swaps, with no restart and no torn in-flight futures.
 
-It is **multi-tenant**: each infrastructure category is a `[section]` sharing one catalog shape, one watcher, and one fail-closed reload path. Today it ships `[resilience]` (timeouts, circuit breakers, retries) and `[cache]` (TTL profiles); `[traffic]` (rate limiting) and `[telemetry]` (log level, sampling) are planned tenants.
+It is **multi-tenant**: each infrastructure category is a `[section]` sharing one watcher and one fail-closed reload path. It ships four sections: `[resilience]` (timeouts, circuit breakers, retries), `[cache]` (TTL profiles), `[traffic]` (ingress rate limiting), and `[telemetry]` (log filter + trace sampling). The first three are catalog-shaped (profiles + bindings); `[telemetry]` carries two global dials pushed to the live observability pipeline through a [`TelemetrySink`] the serving binary registers (so this crate stays free of any tracing dependency).
 
 Keeping this separate is deliberate: the middleware crates link no `notify`, no `toml`, no filesystem. Services depend on **both** — the middleware for the layers/adapters, `infra-config` for where the numbers come from.
 
-> **Status:** complete and tested — `[resilience]` + `[cache]` sections, the generic catalog, the aggregate `InfraRegistry`, fail-closed cross-section validation, and a real-filesystem end-to-end hot-reload test.
+> **Status:** complete and tested — `[resilience]` + `[cache]` + `[traffic]` + `[telemetry]` sections, the generic catalog, the aggregate `InfraRegistry`, fail-closed cross-section validation, and a real-filesystem end-to-end hot-reload test. The serving binary (`service-runtime`) loads the document, spawns the watcher, and registers the traffic layer and telemetry sink — see [`service-runtime`](../../platform/service-runtime/README.md).
 
 ---
 
@@ -22,8 +22,9 @@ Keeping this separate is deliberate: the middleware crates link no `notify`, no 
 ```text
 infrastructure.toml ──load──▶ InfrastructureConfig ──resolve──▶ InfraRegistry
                                      ▲                          ├─ ResilienceRegistry ─▶ Tower layers
-                                notify event                    └─ CacheRegistry ──────▶ cache adapters
-                              spawn_watcher ──reload──▶ InfraRegistry::apply()
+                                notify event                    ├─ CacheRegistry ──────▶ cache adapters
+                              spawn_watcher                     ├─ TrafficRegistry ────▶ ingress limiter
+                              ──reload──▶ InfraRegistry::apply() └─ TelemetryRegistry ──▶ TelemetrySink (live)
                               (single writer, fail-closed, all-sections-or-nothing)
 ```
 

--- a/crates/shared/infra-config/src/error.rs
+++ b/crates/shared/infra-config/src/error.rs
@@ -19,7 +19,10 @@ pub enum ConfigError {
 }
 
 impl ConfigError {
-    pub(crate) fn validation(msg: impl Into<String>) -> Self {
+    /// Constructs a [`ConfigError::Validation`]. Public so external
+    /// [`TelemetrySink`](crate::TelemetrySink) implementors (which live outside
+    /// this crate) can surface an apply failure as a config rejection.
+    pub fn validation(msg: impl Into<String>) -> Self {
         ConfigError::Validation(msg.into())
     }
 }

--- a/crates/shared/infra-config/src/infra.rs
+++ b/crates/shared/infra-config/src/infra.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 
 use crate::{
     cache::CacheRegistry, error::ConfigError, reload::Reloadable, registry::ResilienceRegistry,
-    schema::InfrastructureConfig, traffic::TrafficRegistry,
+    schema::InfrastructureConfig, telemetry::TelemetryRegistry, traffic::TrafficRegistry,
 };
 
 /// Owns one resolved registry per `infrastructure.toml` section and presents them as a
@@ -28,6 +28,7 @@ pub struct InfraRegistry {
     resilience: Arc<ResilienceRegistry>,
     cache: Option<Arc<CacheRegistry>>,
     traffic: Option<Arc<TrafficRegistry>>,
+    telemetry: Option<Arc<TelemetryRegistry>>,
 }
 
 impl InfraRegistry {
@@ -45,8 +46,12 @@ impl InfraRegistry {
             Some(section) => Some(Arc::new(TrafficRegistry::from_section(section)?)),
             None => None,
         };
+        let telemetry = match config.telemetry {
+            Some(section) => Some(Arc::new(TelemetryRegistry::from_section(section)?)),
+            None => None,
+        };
 
-        Ok(Self { resilience, cache, traffic })
+        Ok(Self { resilience, cache, traffic, telemetry })
     }
 
     /// Shared resilience registry (always present).
@@ -62,6 +67,13 @@ impl InfraRegistry {
     /// Shared traffic (rate-limit) registry, if the deployment configured a `[traffic]` section.
     pub fn traffic(&self) -> Option<Arc<TrafficRegistry>> {
         self.traffic.clone()
+    }
+
+    /// Shared telemetry registry, if the deployment configured a `[telemetry]` section.
+    /// The serving binary registers a sink on it (see [`TelemetryRegistry::set_sink`])
+    /// so a config push retunes the live log filter and trace sampling.
+    pub fn telemetry(&self) -> Option<Arc<TelemetryRegistry>> {
+        self.telemetry.clone()
     }
 
     /// Hot-applies a freshly-parsed document to every live section (the reload entry point).
@@ -90,6 +102,20 @@ impl InfraRegistry {
             ),
             (None, Some(_)) => warn!(
                 "[traffic] section added at runtime — ignored (adding a section requires a restart)"
+            ),
+            (None, None) => {}
+        }
+
+        // Applied last: a bad log-filter directive can only surface here (it can't
+        // be validated up front without a tracing dependency), and telemetry is
+        // the one section whose apply has an external side effect (the live pipeline).
+        match (&self.telemetry, config.telemetry) {
+            (Some(registry), Some(section)) => registry.apply(section)?,
+            (Some(_), None) => warn!(
+                "[telemetry] section removed from reloaded config — keeping previous values"
+            ),
+            (None, Some(_)) => warn!(
+                "[telemetry] section added at runtime — ignored (adding a section requires a restart)"
             ),
             (None, None) => {}
         }

--- a/crates/shared/infra-config/src/lib.rs
+++ b/crates/shared/infra-config/src/lib.rs
@@ -27,6 +27,7 @@ pub mod infra;
 pub mod registry;
 pub mod reload;
 pub mod schema;
+pub mod telemetry;
 pub mod traffic;
 pub mod watcher;
 
@@ -37,5 +38,8 @@ pub use infra::InfraRegistry;
 pub use registry::ResilienceRegistry;
 pub use reload::Reloadable;
 pub use schema::{InfrastructureConfig, ResilienceSection};
+pub use telemetry::{
+    TelemetryRegistry, TelemetrySamplingSpec, TelemetrySection, TelemetrySettings, TelemetrySink,
+};
 pub use traffic::{TrafficRegistry, TrafficSection};
 pub use watcher::{load_from_path, spawn_watcher};

--- a/crates/shared/infra-config/src/schema.rs
+++ b/crates/shared/infra-config/src/schema.rs
@@ -20,7 +20,8 @@ use resilience::{retry::backoff::spec::BackoffSpec, ResilienceProfileSpec};
 use serde::Deserialize;
 
 use crate::{
-    cache::CacheSection, catalog::validate_bindings, error::ConfigError, traffic::TrafficSection,
+    cache::CacheSection, catalog::validate_bindings, error::ConfigError,
+    telemetry::TelemetrySection, traffic::TrafficSection,
 };
 
 /// Top-level `infrastructure.toml` document.
@@ -39,6 +40,11 @@ pub struct InfrastructureConfig {
     /// Externalized ingress rate-limit profiles. Absent in deployments that don't use them.
     #[serde(default)]
     pub traffic: Option<TrafficSection>,
+
+    /// Externalized observability dials (log filter, trace sampling). Absent in
+    /// deployments that don't hot-tune telemetry.
+    #[serde(default)]
+    pub telemetry: Option<TelemetrySection>,
 }
 
 impl InfrastructureConfig {
@@ -51,6 +57,9 @@ impl InfrastructureConfig {
         }
         if let Some(traffic) = &self.traffic {
             traffic.validate()?;
+        }
+        if let Some(telemetry) = &self.telemetry {
+            telemetry.validate()?;
         }
         Ok(())
     }

--- a/crates/shared/infra-config/src/telemetry.rs
+++ b/crates/shared/infra-config/src/telemetry.rs
@@ -1,0 +1,170 @@
+//! The `[telemetry]` section: externalized, hot-reloadable observability dials.
+//!
+//! Unlike the catalog sections, telemetry carries two *global* dials — the
+//! log-filter directive and the trace sampling strategy — pushed to the live
+//! pipeline through a [`TelemetrySink`] the serving binary registers after
+//! `telemetry::init`. This crate stays free of any `telemetry`/tracing
+//! dependency: the sink is a trait, and the sampling strategy is its own serde
+//! enum the binary translates onto `telemetry::SamplingStrategy`.
+//!
+//! ```toml
+//! [telemetry]
+//! log_filter = "info,chat=debug"
+//! sampling = { kind = "trace_id_ratio", ratio = 0.05 }
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use arc_swap::ArcSwap;
+use serde::Deserialize;
+
+use crate::error::ConfigError;
+
+/// The `[telemetry]` section. Both dials are optional; an absent dial leaves the
+/// live value untouched on apply.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TelemetrySection {
+    /// `EnvFilter` directive for the live log filter (e.g. `"info,chat=debug"`).
+    #[serde(default)]
+    pub log_filter: Option<String>,
+    /// Trace sampling strategy.
+    #[serde(default)]
+    pub sampling: Option<TelemetrySamplingSpec>,
+}
+
+/// Trace sampling strategy — infra-config's own serde mirror of
+/// `telemetry::SamplingStrategy` (the binary maps between them).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TelemetrySamplingSpec {
+    /// Sample every trace.
+    AlwaysOn,
+    /// Drop every trace.
+    AlwaysOff,
+    /// Probabilistic head-based sampling; `ratio` must be in `[0.0, 1.0]`.
+    TraceIdRatio { ratio: f64 },
+}
+
+impl TelemetrySection {
+    /// Validates the sampling ratio range. The log-filter directive can't be
+    /// validated here without a tracing dependency; it is checked at apply time
+    /// by the sink (a bad directive is rejected, leaving the previous filter).
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if let Some(TelemetrySamplingSpec::TraceIdRatio { ratio }) = &self.sampling {
+            if !(0.0..=1.0).contains(ratio) {
+                return Err(ConfigError::validation(format!(
+                    "[telemetry] sampling ratio {ratio} must be in [0.0, 1.0]"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolved telemetry settings pushed to the live pipeline on every apply.
+#[derive(Debug, Clone, Default)]
+pub struct TelemetrySettings {
+    pub log_filter: Option<String>,
+    pub sampling: Option<TelemetrySamplingSpec>,
+}
+
+impl From<&TelemetrySection> for TelemetrySettings {
+    fn from(section: &TelemetrySection) -> Self {
+        Self { log_filter: section.log_filter.clone(), sampling: section.sampling.clone() }
+    }
+}
+
+/// Pushes resolved telemetry settings to the live observability pipeline.
+///
+/// Implemented by the serving binary over `telemetry::TelemetryControl`
+/// (infra-config must not depend on the telemetry crate). Registered via
+/// [`TelemetryRegistry::set_sink`] once telemetry is initialised.
+pub trait TelemetrySink: Send + Sync + 'static {
+    fn apply(&self, settings: &TelemetrySettings) -> Result<(), ConfigError>;
+}
+
+/// Boot-resolved telemetry settings plus the live sink, hot-reloaded together.
+pub struct TelemetryRegistry {
+    settings: ArcSwap<TelemetrySettings>,
+    // Written once (set_sink) and read on each reload — not a hot path, so a
+    // plain mutex avoids the unsized-`ArcSwapOption<dyn _>` dance.
+    sink: Mutex<Option<Arc<dyn TelemetrySink>>>,
+}
+
+impl TelemetryRegistry {
+    /// Validates and resolves a `[telemetry]` section into the live registry.
+    pub fn from_section(section: TelemetrySection) -> Result<Self, ConfigError> {
+        section.validate()?;
+        Ok(Self {
+            settings: ArcSwap::from_pointee(TelemetrySettings::from(&section)),
+            sink: Mutex::new(None),
+        })
+    }
+
+    /// The currently-resolved settings.
+    pub fn settings(&self) -> Arc<TelemetrySettings> {
+        self.settings.load_full()
+    }
+
+    /// Registers the live sink and immediately applies the current settings, so
+    /// the boot-time `[telemetry]` values take effect as soon as telemetry is up.
+    pub fn set_sink(&self, sink: Arc<dyn TelemetrySink>) -> Result<(), ConfigError> {
+        sink.apply(&self.settings.load())?;
+        *self.sink.lock().expect("telemetry sink mutex poisoned") = Some(sink);
+        Ok(())
+    }
+
+    /// Hot-applies a reloaded `[telemetry]` section: pushes to the live sink
+    /// first (fail-closed — a rejected push leaves the stored settings intact),
+    /// then swaps the stored settings.
+    pub fn apply(&self, section: TelemetrySection) -> Result<(), ConfigError> {
+        section.validate()?;
+        let settings = TelemetrySettings::from(&section);
+        if let Some(sink) = self.sink.lock().expect("telemetry sink mutex poisoned").as_ref() {
+            sink.apply(&settings)?;
+        }
+        self.settings.store(Arc::new(settings));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ratio_out_of_range_rejected() {
+        let section = TelemetrySection {
+            log_filter: None,
+            sampling: Some(TelemetrySamplingSpec::TraceIdRatio { ratio: 1.5 }),
+        };
+        assert!(section.validate().is_err());
+    }
+
+    #[test]
+    fn set_sink_applies_current_settings_immediately() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct Counting(Arc<AtomicUsize>);
+        impl TelemetrySink for Counting {
+            fn apply(&self, _: &TelemetrySettings) -> Result<(), ConfigError> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let reg = TelemetryRegistry::from_section(TelemetrySection {
+            log_filter: Some("info".into()),
+            sampling: None,
+        })
+        .unwrap();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        reg.set_sink(Arc::new(Counting(calls.clone()))).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "boot settings applied on registration");
+
+        reg.apply(TelemetrySection { log_filter: Some("debug".into()), sampling: None })
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "reload pushed to sink");
+    }
+}

--- a/crates/shared/telemetry/Cargo.toml
+++ b/crates/shared/telemetry/Cargo.toml
@@ -12,6 +12,7 @@ description.workspace = true
 tokio = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
+arc-swap = { workspace = true }
 
 # Logging — non-blocking stdout + structured formatting
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }

--- a/crates/shared/telemetry/README.md
+++ b/crates/shared/telemetry/README.md
@@ -282,6 +282,37 @@ let cfg = TelemetryConfig {
 let _guard = telemetry::init(cfg).expect("telemetry init failed");
 ```
 
+### Runtime control (live dials)
+
+`init` returns a guard whose `control()` yields a cloneable [`TelemetryControl`].
+It exposes the two operability dials that otherwise need a redeploy:
+
+```rust
+let control = _guard.control();
+
+// Turn up a noisy module mid-incident — reloads the global `EnvFilter` live.
+control.set_log_filter("info,chat=debug").unwrap();
+
+// Drop trace volume under load (parent-based, so distributed traces stay whole).
+control.set_sampling(telemetry::SamplingStrategy::TraceIdRatio(0.01)).unwrap();
+```
+
+Sampling is backed by a `DynamicSampler` (a `ShouldSample` over an `ArcSwap`),
+and the log filter by a `tracing_subscriber::reload` handle — both swap
+lock-free, with no restart.
+
+In the fleet you don't call these directly: `service-runtime` registers the
+control as the sink for the `[telemetry]` section of `infrastructure.toml`, so a
+config push retunes log level and sampling across every pod. See
+[`service-runtime`](../../platform/service-runtime/README.md) and
+[`infra-config`](../infra-config/README.md).
+
+```toml
+[telemetry]
+log_filter = "info,chat=debug"
+sampling   = { kind = "trace_id_ratio", ratio = 0.05 }
+```
+
 ---
 
 ## ⚙️ Configuration & Runtime Environment

--- a/crates/shared/telemetry/src/control.rs
+++ b/crates/shared/telemetry/src/control.rs
@@ -1,0 +1,58 @@
+//! Runtime control surface for the live telemetry pipeline.
+//!
+//! [`TelemetryControl`] exposes the two operability dials that otherwise require
+//! a redeploy: the live log-filter directive and the trace sampling rate. It is
+//! produced by [`crate::init`] (via [`TelemetryGuard::control`](crate::TelemetryGuard::control))
+//! and is cheaply cloneable — every clone drives the same underlying
+//! `EnvFilter` reload handle and [`DynamicSampler`]. The serving runtime hands a
+//! clone to the `infrastructure.toml` reload watcher so a `[telemetry]` push
+//! retunes the fleet with no restart.
+
+use std::sync::Arc;
+
+use crate::error::TelemetryError;
+use crate::trace::config::SamplingStrategy;
+use crate::trace::dynamic_sampler::{sampler_for, DynamicSampler};
+
+/// Live, cloneable handle to the telemetry dials. See the module docs.
+#[derive(Clone)]
+pub struct TelemetryControl {
+    inner: Arc<ControlInner>,
+}
+
+struct ControlInner {
+    /// Reloads the global `EnvFilter` from a directive string. Boxed so the
+    /// subscriber type parameter of the underlying reload handle stays erased.
+    set_filter: Box<dyn Fn(&str) -> Result<(), TelemetryError> + Send + Sync>,
+    sampler: DynamicSampler,
+}
+
+impl TelemetryControl {
+    pub(crate) fn new(
+        set_filter: Box<dyn Fn(&str) -> Result<(), TelemetryError> + Send + Sync>,
+        sampler: DynamicSampler,
+    ) -> Self {
+        Self { inner: Arc::new(ControlInner { set_filter, sampler }) }
+    }
+
+    /// Replaces the live log-filter directive (e.g. `"info,chat=debug"`).
+    ///
+    /// Fails (leaving the previous filter intact) if `directive` is not a valid
+    /// `EnvFilter` expression.
+    pub fn set_log_filter(&self, directive: &str) -> Result<(), TelemetryError> {
+        (self.inner.set_filter)(directive)
+    }
+
+    /// Retunes trace sampling live. Ratio strategies are applied parent-based, so
+    /// distributed traces stay whole.
+    pub fn set_sampling(&self, strategy: SamplingStrategy) -> Result<(), TelemetryError> {
+        self.inner.sampler.set(sampler_for(&strategy)?);
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for TelemetryControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TelemetryControl")
+    }
+}

--- a/crates/shared/telemetry/src/error.rs
+++ b/crates/shared/telemetry/src/error.rs
@@ -14,6 +14,12 @@ pub enum TelemetryError {
 
     #[error("invalid sampling ratio {0}: must be in [0.0, 1.0]")]
     InvalidSamplingRatio(f64),
+
+    #[error("invalid log filter directive: {0}")]
+    InvalidFilter(String),
+
+    #[error("failed to apply log filter reload: {0}")]
+    FilterReload(String),
 }
 
 #[cfg(test)]

--- a/crates/shared/telemetry/src/guard.rs
+++ b/crates/shared/telemetry/src/guard.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use opentelemetry_sdk::trace::TracerProvider;
 use tracing_appender::non_blocking::WorkerGuard;
 
+use crate::control::TelemetryControl;
 use crate::metrics::{exporter::PrometheusHandle, layer::MetricsPipeline};
 
 /// Lifetime anchor for the entire telemetry pipeline.
@@ -40,6 +41,8 @@ pub struct TelemetryGuard {
     tracer_provider: TracerProvider,
     /// Holds the metrics pipeline; shutdown flushes the meter provider.
     metrics_pipeline: MetricsPipeline,
+    /// Runtime dials (log filter, sampling) for the live pipeline.
+    control: TelemetryControl,
 }
 
 impl TelemetryGuard {
@@ -47,12 +50,21 @@ impl TelemetryGuard {
         log_guard: WorkerGuard,
         tracer_provider: TracerProvider,
         metrics_pipeline: MetricsPipeline,
+        control: TelemetryControl,
     ) -> Self {
         Self {
             _log_guard: log_guard,
             tracer_provider,
             metrics_pipeline,
+            control,
         }
+    }
+
+    /// Returns a cloneable [`TelemetryControl`] for retuning the log filter and
+    /// trace sampling at runtime (e.g. driven by the `infrastructure.toml`
+    /// reload watcher).
+    pub fn control(&self) -> TelemetryControl {
+        self.control.clone()
     }
 
     /// Returns a cheaply cloneable handle to the Prometheus registry.

--- a/crates/shared/telemetry/src/init.rs
+++ b/crates/shared/telemetry/src/init.rs
@@ -1,6 +1,8 @@
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter};
 
-use crate::{config::TelemetryConfig, error::TelemetryError, guard::TelemetryGuard};
+use crate::{
+    config::TelemetryConfig, control::TelemetryControl, error::TelemetryError, guard::TelemetryGuard,
+};
 
 /// Initialises the full observability pipeline and returns a [`TelemetryGuard`].
 ///
@@ -23,7 +25,7 @@ use crate::{config::TelemetryConfig, error::TelemetryError, guard::TelemetryGuar
 pub fn init(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
     let (log_layer, log_guard) = crate::log::layer::build_log_layer(&config.log)?;
 
-    let (trace_layer, tracer_provider) = crate::trace::layer::build_trace_layer(
+    let (trace_layer, tracer_provider, sampler) = crate::trace::layer::build_trace_layer(
         &config.trace,
         &config.service_name,
         &config.service_version,
@@ -31,15 +33,30 @@ pub fn init(config: TelemetryConfig) -> Result<TelemetryGuard, TelemetryError> {
 
     let metrics_pipeline = crate::metrics::layer::init_metrics_pipeline(&config.metrics)?;
 
-    let env_filter = EnvFilter::try_from_default_env()
+    // Reloadable `EnvFilter`: base from `RUST_LOG`, else the configured default.
+    // Wrapping it in `reload::Layer` yields a handle that swaps the directive live.
+    let base_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(&config.log.default_filter));
+    let (filter_layer, filter_handle) = reload::Layer::new(base_filter);
 
     tracing_subscriber::registry()
-        .with(env_filter)
+        .with(filter_layer)
         .with(log_layer)
         .with(trace_layer)
         .try_init()
         .map_err(|e| TelemetryError::SubscriberInit(e.to_string()))?;
 
-    Ok(TelemetryGuard::new(log_guard, tracer_provider, metrics_pipeline))
+    // Erase the subscriber type parameter behind a closure so the control handle
+    // is nameable and storable beyond this function.
+    let set_filter = Box::new(move |directive: &str| -> Result<(), TelemetryError> {
+        let filter = EnvFilter::try_new(directive)
+            .map_err(|e| TelemetryError::InvalidFilter(e.to_string()))?;
+        filter_handle
+            .reload(filter)
+            .map_err(|e| TelemetryError::FilterReload(e.to_string()))
+    });
+
+    let control = TelemetryControl::new(set_filter, sampler);
+
+    Ok(TelemetryGuard::new(log_guard, tracer_provider, metrics_pipeline, control))
 }

--- a/crates/shared/telemetry/src/lib.rs
+++ b/crates/shared/telemetry/src/lib.rs
@@ -6,6 +6,7 @@
 //! lifetime of the process; dropping it flushes all in-flight spans and logs.
 
 pub mod config;
+pub mod control;
 pub mod error;
 pub mod guard;
 pub mod init;
@@ -14,6 +15,8 @@ pub mod metrics;
 pub mod trace;
 
 pub use config::TelemetryConfig;
+pub use control::TelemetryControl;
 pub use error::TelemetryError;
 pub use guard::TelemetryGuard;
 pub use init::init;
+pub use trace::config::SamplingStrategy;

--- a/crates/shared/telemetry/src/trace/dynamic_sampler.rs
+++ b/crates/shared/telemetry/src/trace/dynamic_sampler.rs
@@ -1,0 +1,127 @@
+//! A trace sampler whose decision policy can be swapped at runtime.
+//!
+//! The OpenTelemetry SDK fixes the sampler when the `TracerProvider` is built, so
+//! changing sampling normally means a redeploy. [`DynamicSampler`] wraps an
+//! [`ArcSwap`] over the concrete [`Sampler`] and delegates each decision to the
+//! current one, so [`TelemetryControl::set_sampling`](crate::TelemetryControl::set_sampling)
+//! can retune sampling live (e.g. drop to 1% during an incident, or raise it for
+//! a debug window) with no restart.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use opentelemetry::trace::{Link, SamplingResult, SpanKind, TraceId};
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_sdk::trace::{Sampler, ShouldSample};
+
+use crate::error::TelemetryError;
+use crate::trace::config::SamplingStrategy;
+
+/// A [`ShouldSample`] that delegates to a hot-swappable inner [`Sampler`].
+///
+/// Cloning shares the same swap cell (it is `Arc`-backed), so the copy held by
+/// the `TracerProvider` and the copy held by [`TelemetryControl`](crate::TelemetryControl)
+/// see each other's updates.
+#[derive(Clone)]
+pub struct DynamicSampler {
+    inner: Arc<ArcSwap<Sampler>>,
+}
+
+impl DynamicSampler {
+    /// Creates a sampler initialised to `initial`.
+    pub fn new(initial: Sampler) -> Self {
+        Self { inner: Arc::new(ArcSwap::from_pointee(initial)) }
+    }
+
+    /// Atomically replaces the active sampler. Lock-free; in-flight decisions
+    /// finish against whichever sampler they loaded.
+    pub fn set(&self, sampler: Sampler) {
+        self.inner.store(Arc::new(sampler));
+    }
+}
+
+impl std::fmt::Debug for DynamicSampler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DynamicSampler")
+    }
+}
+
+impl ShouldSample for DynamicSampler {
+    fn should_sample(
+        &self,
+        parent_context: Option<&Context>,
+        trace_id: TraceId,
+        name: &str,
+        span_kind: &SpanKind,
+        attributes: &[KeyValue],
+        links: &[Link],
+    ) -> SamplingResult {
+        let current = self.inner.load();
+        current.should_sample(parent_context, trace_id, name, span_kind, attributes, links)
+    }
+}
+
+/// Resolves a [`SamplingStrategy`] into a concrete [`Sampler`].
+///
+/// Ratio sampling is wrapped in [`Sampler::ParentBased`] so a span inherits its
+/// parent's decision when there is one (keeping distributed traces whole) and
+/// only falls back to the probability for roots. `AlwaysOn`/`AlwaysOff` map
+/// directly — they are deterministic regardless of parent.
+pub fn sampler_for(strategy: &SamplingStrategy) -> Result<Sampler, TelemetryError> {
+    match strategy {
+        SamplingStrategy::AlwaysOn => Ok(Sampler::AlwaysOn),
+        SamplingStrategy::AlwaysOff => Ok(Sampler::AlwaysOff),
+        SamplingStrategy::TraceIdRatio(ratio) => {
+            if !(0.0..=1.0).contains(ratio) {
+                return Err(TelemetryError::InvalidSamplingRatio(*ratio));
+            }
+            Ok(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(*ratio))))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_on_off_resolve() {
+        assert!(matches!(sampler_for(&SamplingStrategy::AlwaysOn).unwrap(), Sampler::AlwaysOn));
+        assert!(matches!(sampler_for(&SamplingStrategy::AlwaysOff).unwrap(), Sampler::AlwaysOff));
+    }
+
+    #[test]
+    fn ratio_is_parent_based() {
+        assert!(matches!(
+            sampler_for(&SamplingStrategy::TraceIdRatio(0.25)).unwrap(),
+            Sampler::ParentBased(_)
+        ));
+    }
+
+    #[test]
+    fn ratio_boundaries_valid() {
+        sampler_for(&SamplingStrategy::TraceIdRatio(0.0)).unwrap();
+        sampler_for(&SamplingStrategy::TraceIdRatio(1.0)).unwrap();
+    }
+
+    #[test]
+    fn out_of_range_ratio_rejected() {
+        assert!(matches!(
+            sampler_for(&SamplingStrategy::TraceIdRatio(-0.1)).unwrap_err(),
+            TelemetryError::InvalidSamplingRatio(_)
+        ));
+        assert!(matches!(
+            sampler_for(&SamplingStrategy::TraceIdRatio(1.5)).unwrap_err(),
+            TelemetryError::InvalidSamplingRatio(_)
+        ));
+    }
+
+    #[test]
+    fn set_swaps_active_sampler() {
+        let s = DynamicSampler::new(Sampler::AlwaysOff);
+        s.set(Sampler::AlwaysOn);
+        // A clone observes the swap (shared cell).
+        let clone = s.clone();
+        clone.set(Sampler::AlwaysOff);
+    }
+}

--- a/crates/shared/telemetry/src/trace/layer.rs
+++ b/crates/shared/telemetry/src/trace/layer.rs
@@ -1,23 +1,24 @@
-use opentelemetry::{
-    trace::TracerProvider as TracerProviderTrait,
-    KeyValue,
-};
+use opentelemetry::{trace::TracerProvider as TracerProviderTrait, KeyValue};
 use opentelemetry_sdk::{
     runtime,
-    trace::{BatchSpanProcessor, Sampler, TracerProvider},
+    trace::{BatchSpanProcessor, TracerProvider},
     Resource,
 };
 use opentelemetry_semantic_conventions::resource as semcov;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::Layer;
 
-use super::config::{SamplingStrategy, TraceConfig};
+use super::config::TraceConfig;
+use super::dynamic_sampler::{sampler_for, DynamicSampler};
 use crate::error::TelemetryError;
 
-/// Builds the OpenTelemetry tracing layer and the owning [`TracerProvider`].
+/// Builds the OpenTelemetry tracing layer, the owning [`TracerProvider`], and the
+/// [`DynamicSampler`] driving its sampling decisions.
 ///
 /// The provider **must** be stored inside [`crate::TelemetryGuard`];
-/// `provider.shutdown()` on drop flushes all buffered spans to the collector.
+/// `provider.shutdown()` on drop flushes all buffered spans to the collector. The
+/// returned [`DynamicSampler`] is handed to [`crate::TelemetryControl`] so sampling
+/// can be retuned at runtime.
 ///
 /// Pipeline:
 /// ```text
@@ -25,13 +26,13 @@ use crate::error::TelemetryError;
 ///   └─ BatchSpanProcessor (Tokio async, non-blocking)
 ///       └─ TracerProvider
 ///           └─ Resource { service.name, service.version }
-///           └─ Sampler  { AlwaysOn | AlwaysOff | TraceIdRatio }
+///           └─ DynamicSampler  → swappable { AlwaysOn | AlwaysOff | ParentBased(ratio) }
 /// ```
 pub fn build_trace_layer<S>(
     config: &TraceConfig,
     service_name: &str,
     service_version: &str,
-) -> Result<(Box<dyn Layer<S> + Send + Sync>, TracerProvider), TelemetryError>
+) -> Result<(Box<dyn Layer<S> + Send + Sync>, TracerProvider, DynamicSampler), TelemetryError>
 where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span> + Send + Sync,
 {
@@ -42,13 +43,13 @@ where
         KeyValue::new(semcov::SERVICE_VERSION, service_version.to_string()),
     ]);
 
-    let sampler = sampler_from(&config.sampling)?;
+    let sampler = DynamicSampler::new(sampler_for(&config.sampling)?);
 
     let batch = BatchSpanProcessor::builder(exporter, runtime::Tokio).build();
 
     let provider = TracerProvider::builder()
         .with_span_processor(batch)
-        .with_sampler(sampler)
+        .with_sampler(sampler.clone())
         .with_resource(resource)
         .build();
 
@@ -57,61 +58,5 @@ where
     let tracer = provider.tracer(service_name.to_string());
     let layer: Box<dyn Layer<S> + Send + Sync> = Box::new(OpenTelemetryLayer::new(tracer));
 
-    Ok((layer, provider))
-}
-
-fn sampler_from(strategy: &SamplingStrategy) -> Result<Sampler, TelemetryError> {
-    match strategy {
-        SamplingStrategy::AlwaysOn => Ok(Sampler::AlwaysOn),
-        SamplingStrategy::AlwaysOff => Ok(Sampler::AlwaysOff),
-        SamplingStrategy::TraceIdRatio(ratio) => {
-            if !(0.0..=1.0).contains(ratio) {
-                return Err(TelemetryError::InvalidSamplingRatio(*ratio));
-            }
-            Ok(Sampler::TraceIdRatioBased(*ratio))
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::error::TelemetryError;
-
-    #[test]
-    fn always_on_sampler_succeeds() {
-        sampler_from(&SamplingStrategy::AlwaysOn).unwrap();
-    }
-
-    #[test]
-    fn always_off_sampler_succeeds() {
-        sampler_from(&SamplingStrategy::AlwaysOff).unwrap();
-    }
-
-    #[test]
-    fn mid_range_ratio_succeeds() {
-        sampler_from(&SamplingStrategy::TraceIdRatio(0.5)).unwrap();
-    }
-
-    #[test]
-    fn zero_ratio_is_valid_boundary() {
-        sampler_from(&SamplingStrategy::TraceIdRatio(0.0)).unwrap();
-    }
-
-    #[test]
-    fn one_ratio_is_valid_boundary() {
-        sampler_from(&SamplingStrategy::TraceIdRatio(1.0)).unwrap();
-    }
-
-    #[test]
-    fn negative_ratio_returns_invalid_sampling_error() {
-        let err = sampler_from(&SamplingStrategy::TraceIdRatio(-0.1)).unwrap_err();
-        assert!(matches!(err, TelemetryError::InvalidSamplingRatio(r) if (r - (-0.1)).abs() < f64::EPSILON));
-    }
-
-    #[test]
-    fn ratio_above_one_returns_invalid_sampling_error() {
-        let err = sampler_from(&SamplingStrategy::TraceIdRatio(1.5)).unwrap_err();
-        assert!(matches!(err, TelemetryError::InvalidSamplingRatio(r) if (r - 1.5).abs() < f64::EPSILON));
-    }
+    Ok((layer, provider, sampler))
 }

--- a/crates/shared/telemetry/src/trace/mod.rs
+++ b/crates/shared/telemetry/src/trace/mod.rs
@@ -1,6 +1,8 @@
 pub mod config;
+pub mod dynamic_sampler;
 pub mod exporter;
 pub mod layer;
 
 pub use config::*;
+pub use dynamic_sampler::{sampler_for, DynamicSampler};
 pub use layer::*;

--- a/crates/shared/transport/README.md
+++ b/crates/shared/transport/README.md
@@ -122,7 +122,10 @@ tonic::Server
 ### Activating ingress rate limiting (server)
 
 `TrafficLayer` is always present in the server type but is a no-op until a
-`TrafficRegistry` is supplied. The serving binary wires it once at boot:
+`TrafficRegistry` is supplied. In this workspace the fleet runtime
+([`service-runtime`](../../platform/service-runtime/README.md)) already performs
+the wiring below for every service — the example shows what it does and how to
+reproduce it standalone:
 
 ```rust,ignore
 // 1. Load + resolve the whole infrastructure.toml, validating every section.

--- a/crates/shared/transport/src/grpc/layer/inbound.rs
+++ b/crates/shared/transport/src/grpc/layer/inbound.rs
@@ -39,6 +39,10 @@ impl<S> Layer<S> for InboundTraceLayer {
 }
 
 /// The concrete service produced by [`InboundTraceLayer`].
+///
+/// `Clone` is required: tonic clones the composed server service per connection,
+/// so every layer in the stack must be cloneable for `Router::serve*` to apply it.
+#[derive(Clone)]
 pub struct InboundTraceService<S> {
     inner: S,
 }


### PR DESCRIPTION
## Summary

Introduces **`crates/platform/service-runtime`** — the single boot sequence every service runs — and rolls it out across the whole fleet. A service is now library-only and implements one trait; each deployable is a ~6-line `apps/<svc>-server` binary calling `service_runtime::serve::<S>(addr)`.

`serve::<S>(addr)` owns: telemetry init → `infrastructure.toml` load + hot-reload watcher → ingress trace + rate-limit layers → service composition → dynamic gRPC health → SIGINT-drained shutdown. Services implement `Service` (`build` / `health_probes` / `register`) over a type-erased `RoutesBuilder` seam, so the Tower layer stack never leaks into their signatures.

## What's in here

**Runtime (`platform/service-runtime`)**
- The `Service` trait + `serve()` + `FnProbe` closure-backed health probe.

**Ingress rate-limiting (wired, was inert)**
- Installs transport's `TrafficLayer` from `infra.traffic()` and spawns the `prune_all()` memory-bounding loop.
- Fixes a latent missing `#[derive(Clone)]` on `transport::InboundTraceService` — the trace+traffic layer stack had never actually been served, so this is what makes it work.

**Dynamic health**
- `HealthProbe`/`FnProbe`; a readiness loop drives `grpc.health.v1.Health` from real storage probes (a pod stays `NOT_SERVING` until backends pass, and is demoted on failure).

**TelemetryControl (new capability)**
- Runtime-swappable `EnvFilter` (reload handle) + a parent-based `DynamicSampler` (`ShouldSample` over `ArcSwap`).
- New `[telemetry]` `infra-config` section pushed to the live pipeline via a `TelemetrySink`, so a config push retunes log level + trace sampling **fleet-wide with no restart**.

**Fleet rollout**
- All 10 services (account, chat, profile, social-graph, post, engagement, comment, geo-discovery, notification, timeline) retrofitted with `service.rs` adapters + `apps/<svc>-server` binaries; gRPC reflection descriptors added where missing.

**Docs**
- New `service-runtime` README (the canonical contract); updated every service README + `infra-config`/`telemetry`/`transport` and the root README to the finalized bootstrap. Also restored chat's missing `test-support` dev-dep.

## Testing
- `cargo check --workspace` ✅
- `telemetry` (37) + `infra-config` + `transport` traffic-layer (11) suites pass; both integration suites compile.
- clippy clean on all new/changed crates.

## Out of scope (deliberate, follow-ups)
- Resilience Tower layers at `serve()`.
- Directory re-tiering (`foundation`/`platform`/`storage`/`contracts`) + `contracts/` extraction + `apps/migrator` — a coordinated, quiet-window effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
