### PR TITLE
feat(apps): schema-migration runner + local backend stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,6 +2272,19 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "migrator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "include_dir",
+ "postgres",
+ "scylla",
+ "scylla-storage",
+ "sqlx",
+ "tokio",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/apps/engagement-server",
     "crates/apps/account-server",
     "crates/apps/timeline-server",
+    "crates/apps/migrator",
 ]
 resolver = "2"
 
@@ -114,6 +115,7 @@ url = "2.5.7"
 dyn-clone = "1.0.17"
 dotenvy = "0.15.7"
 sha2 = "0.11.0"
+include_dir = "0.7"
 
 # Observabilité
 tracing = "0.1"

--- a/crates/apps/migrator/Cargo.toml
+++ b/crates/apps/migrator/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name                 = "migrator"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Schema-migration runner for the fleet — applies each service's embedded ScyllaDB/PostgreSQL migrations, tracked and idempotent."
+
+[dependencies]
+scylla-storage   = { workspace = true }
+postgres-storage = { workspace = true }
+
+scylla      = { workspace = true }
+sqlx        = { workspace = true }
+tokio       = { workspace = true }
+anyhow      = { workspace = true }
+include_dir = { workspace = true }

--- a/crates/apps/migrator/README.md
+++ b/crates/apps/migrator/README.md
@@ -1,0 +1,59 @@
+# migrator
+
+The fleet schema-migration runner. Applies each service's migrations against the
+right backend — **ScyllaDB** for the `.cql` services, **PostgreSQL** for
+`account`'s `.sql` — tracked and idempotent.
+
+- **Self-contained.** Migrations are embedded at compile time (`include_dir!`), so
+  the binary needs no source tree or mounted volume in the container.
+- **Tracked.** Each applied `(service, version)` is recorded — in
+  `migrations.applied` (Scylla) and `schema_migrations` (Postgres) — so re-running
+  skips what's already done. Files use `IF NOT EXISTS`, so a partial run is safe to
+  resume.
+- **Ordered.** Files apply in filename order (the numeric prefix). The Scylla
+  session connects with no keyspace; the keyspace is created by each service's
+  `0001` migration and every statement is keyspace-qualified.
+
+## Usage
+
+```bash
+migrator            # migrate every service
+migrator chat       # migrate one service
+```
+
+Connection settings come from the same env vars the services read — `SCYLLA_*`,
+`REDIS_*` (unused here), `KAFKA_*` (unused here), and `DATABASE_URL` / `PG_*` for
+Postgres.
+
+## End-to-end smoke test (local)
+
+Validates the whole runtime path — migrate → boot a `*-server` → gRPC health —
+against real backends.
+
+```bash
+# 1. Start the local backend stack (Scylla, Redis, Redpanda/Kafka, Postgres).
+docker compose -f local-dev/docker-compose.backends.yml up -d
+# wait until all are healthy:
+docker compose -f local-dev/docker-compose.backends.yml ps
+
+# 2. Provision schema (defaults match the compose stack).
+export SCYLLA_CONTACT_POINTS=127.0.0.1:9042
+export DATABASE_URL=postgres://core:core@127.0.0.1:5432/core_platform
+cargo run -p migrator
+
+# 3. Boot a service against the same backends + a real infrastructure.toml.
+export INFRA_CONFIG_PATH=crates/shared/infra-config/examples/infrastructure.toml
+export REDIS_HOSTS=127.0.0.1:6379
+export KAFKA_BROKERS=127.0.0.1:9092
+export SCYLLA_KEYSPACE=chat
+cargo run -p chat-server          # listens on 0.0.0.0:50051
+
+# 4. In another shell, confirm readiness flips to SERVING once probes pass.
+grpcurl -plaintext localhost:50051 grpc.health.v1.Health/Check
+# → { "status": "SERVING" }
+grpcurl -plaintext localhost:50051 list      # reflection lists chat.v1.ChatService
+```
+
+> Requires Docker and `grpcurl`. `account-server` uses Postgres (`DATABASE_URL`);
+> the Scylla/Redis services additionally need their `SCYLLA_KEYSPACE` set to the
+> service keyspace.

--- a/crates/apps/migrator/src/main.rs
+++ b/crates/apps/migrator/src/main.rs
@@ -1,0 +1,253 @@
+//! `migrator` — the fleet schema-migration runner.
+//!
+//! Applies each service's migrations against the right backend (ScyllaDB for the
+//! `.cql` services, PostgreSQL for `account`'s `.sql`). Migrations are **embedded
+//! at compile time** (`include_dir!`), so the binary is self-contained — no
+//! source tree or mounted volume needed in the container. Application is
+//! **tracked and idempotent**: each applied `(service, version)` is recorded, so
+//! re-running skips what's already done.
+//!
+//! Usage:
+//! ```text
+//! migrator              # migrate every service
+//! migrator chat         # migrate one service
+//! ```
+//!
+//! Connection settings come from the same env vars the services use
+//! (`SCYLLA_*`, `PG_*` / `DATABASE_URL`).
+//!
+//! NOTE: statement splitting strips `--` line comments and splits on `;`. Our
+//! migration files contain no `;` inside string literals, so this is safe; revisit
+//! if that ever changes.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Context, Result};
+use include_dir::{include_dir, Dir};
+use postgres_storage::{PgPoolBuilder, PostgresConfig};
+use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+
+/// Which backend a service's migrations target.
+enum Store {
+    Scylla,
+    Postgres,
+}
+
+struct ServiceMigrations {
+    name: &'static str,
+    store: Store,
+    dir: Dir<'static>,
+}
+
+/// Every service's embedded migration tree, in dependency-free order (each
+/// service's keyspace/schema is self-contained).
+fn services() -> Vec<ServiceMigrations> {
+    vec![
+        ServiceMigrations { name: "chat",          store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/chat/migrations") },
+        ServiceMigrations { name: "profile",       store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/profile/migrations") },
+        ServiceMigrations { name: "social-graph",  store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/social-graph/migrations") },
+        ServiceMigrations { name: "post",          store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/post/migrations") },
+        ServiceMigrations { name: "engagement",    store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/engagement/migrations") },
+        ServiceMigrations { name: "comment",       store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/comment/migrations") },
+        ServiceMigrations { name: "geo-discovery", store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/geo-discovery/migrations") },
+        ServiceMigrations { name: "notification",  store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/notification/migrations") },
+        ServiceMigrations { name: "timeline",      store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/timeline/migrations") },
+        ServiceMigrations { name: "account",       store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/account/migrations") },
+    ]
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let filter = std::env::args().nth(1);
+
+    let all = services();
+    let targets: Vec<&ServiceMigrations> = all
+        .iter()
+        .filter(|s| filter.as_deref().is_none_or(|f| f == s.name))
+        .collect();
+
+    if targets.is_empty() {
+        anyhow::bail!(
+            "unknown service '{}'; known: {}",
+            filter.unwrap_or_default(),
+            all.iter().map(|s| s.name).collect::<Vec<_>>().join(", ")
+        );
+    }
+
+    let scylla: Vec<&ServiceMigrations> =
+        targets.iter().copied().filter(|s| matches!(s.store, Store::Scylla)).collect();
+    let postgres: Vec<&ServiceMigrations> =
+        targets.iter().copied().filter(|s| matches!(s.store, Store::Postgres)).collect();
+
+    if !scylla.is_empty() {
+        migrate_scylla(&scylla).await.context("scylla migrations")?;
+    }
+    if !postgres.is_empty() {
+        migrate_postgres(&postgres).await.context("postgres migrations")?;
+    }
+
+    println!("migrations complete");
+    Ok(())
+}
+
+// ── ScyllaDB ─────────────────────────────────────────────────────────────────
+
+async fn migrate_scylla(targets: &[&ServiceMigrations]) -> Result<()> {
+    // No keyspace on the session: the service keyspaces are created by their own
+    // 0001 migration, and every statement is keyspace-qualified.
+    let mut cfg = ScyllaConfig::from_env();
+    cfg.keyspace = None;
+    let client = ScyllaSessionBuilder::new(cfg).build().await.context("connect")?;
+    let session = client.session.get_session();
+
+    // Tracker (SimpleStrategy RF1 — bookkeeping, not service data).
+    session
+        .query_unpaged(
+            "CREATE KEYSPACE IF NOT EXISTS migrations WITH replication = \
+             {'class': 'SimpleStrategy', 'replication_factor': 1}",
+            (),
+        )
+        .await
+        .context("create migrations keyspace")?;
+    session
+        .query_unpaged(
+            "CREATE TABLE IF NOT EXISTS migrations.applied \
+             (service text, version text, applied_at timestamp, PRIMARY KEY ((service), version))",
+            (),
+        )
+        .await
+        .context("create migrations.applied")?;
+
+    for svc in targets {
+        println!("[scylla] {}", svc.name);
+
+        let result = session
+            .query_unpaged("SELECT version FROM migrations.applied WHERE service = ?", (svc.name,))
+            .await
+            .context("read applied versions")?
+            .into_rows_result()
+            .context("applied: rows")?;
+        let mut applied = BTreeSet::new();
+        for row in result.rows::<(String,)>().context("applied: typed")? {
+            applied.insert(row.context("applied: deser")?.0);
+        }
+
+        for (version, content) in sorted_migrations(&svc.dir) {
+            if applied.contains(&version) {
+                println!("  [skip] {version}");
+                continue;
+            }
+            for stmt in split_statements(&content) {
+                session
+                    .query_unpaged(stmt.as_str(), ())
+                    .await
+                    .with_context(|| format!("{}/{version}: {}", svc.name, first_line(&stmt)))?;
+            }
+            session
+                .query_unpaged(
+                    "INSERT INTO migrations.applied (service, version, applied_at) \
+                     VALUES (?, ?, toTimestamp(now()))",
+                    (svc.name, version.as_str()),
+                )
+                .await
+                .with_context(|| format!("record {}/{version}", svc.name))?;
+            println!("  [done] {version}");
+        }
+    }
+
+    Ok(())
+}
+
+// ── PostgreSQL ───────────────────────────────────────────────────────────────
+
+async fn migrate_postgres(targets: &[&ServiceMigrations]) -> Result<()> {
+    let pool = PgPoolBuilder::build(PostgresConfig::from_env()).await.context("connect")?;
+
+    sqlx::raw_sql(
+        "CREATE TABLE IF NOT EXISTS schema_migrations \
+         (service text NOT NULL, version text NOT NULL, \
+          applied_at timestamptz NOT NULL DEFAULT now(), \
+          PRIMARY KEY (service, version))",
+    )
+    .execute(&pool)
+    .await
+    .context("create schema_migrations")?;
+
+    for svc in targets {
+        println!("[postgres] {}", svc.name);
+
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT version FROM schema_migrations WHERE service = $1")
+                .bind(svc.name)
+                .fetch_all(&pool)
+                .await
+                .context("read applied versions")?;
+        let applied: BTreeSet<String> = rows.into_iter().map(|r| r.0).collect();
+
+        for (version, content) in sorted_migrations(&svc.dir) {
+            if applied.contains(&version) {
+                println!("  [skip] {version}");
+                continue;
+            }
+            // `raw_sql` runs the whole file (multiple statements) in one round-trip.
+            sqlx::raw_sql(&content)
+                .execute(&pool)
+                .await
+                .with_context(|| format!("{}/{version}", svc.name))?;
+            sqlx::query("INSERT INTO schema_migrations (service, version) VALUES ($1, $2)")
+                .bind(svc.name)
+                .bind(&version)
+                .execute(&pool)
+                .await
+                .with_context(|| format!("record {}/{version}", svc.name))?;
+            println!("  [done] {version}");
+        }
+    }
+
+    Ok(())
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Returns `(version, contents)` for each `.cql`/`.sql` file, ordered by filename
+/// (which is the numeric migration prefix).
+fn sorted_migrations(dir: &Dir<'static>) -> Vec<(String, String)> {
+    let mut files: Vec<(String, String)> = dir
+        .files()
+        .filter(|f| {
+            matches!(f.path().extension().and_then(|e| e.to_str()), Some("cql") | Some("sql"))
+        })
+        .filter_map(|f| {
+            let name = f.path().file_name()?.to_string_lossy().into_owned();
+            let body = f.contents_utf8()?.to_owned();
+            Some((name, body))
+        })
+        .collect();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
+}
+
+/// Strips `--` line comments and splits a migration file into individual
+/// statements on `;`.
+fn split_statements(content: &str) -> Vec<String> {
+    let stripped: String = content
+        .lines()
+        .map(|line| match line.find("--") {
+            Some(idx) => &line[..idx],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    stripped
+        .split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// First non-empty line of a statement, for error context.
+fn first_line(stmt: &str) -> &str {
+    stmt.lines().map(str::trim).find(|l| !l.is_empty()).unwrap_or(stmt)
+}

--- a/crates/apps/migrator/src/main.rs
+++ b/crates/apps/migrator/src/main.rs
@@ -16,9 +16,9 @@
 //! Connection settings come from the same env vars the services use
 //! (`SCYLLA_*`, `PG_*` / `DATABASE_URL`).
 //!
-//! NOTE: statement splitting strips `--` line comments and splits on `;`. Our
-//! migration files contain no `;` inside string literals, so this is safe; revisit
-//! if that ever changes.
+//! Scylla files are split into statements with a quote-aware splitter (see
+//! [`split_statements`]) that ignores `;` inside string literals — several `comment
+//! = '...'` clauses contain semicolons. Postgres files run whole via `sqlx::raw_sql`.
 
 use std::collections::BTreeSet;
 
@@ -138,10 +138,22 @@ async fn migrate_scylla(targets: &[&ServiceMigrations]) -> Result<()> {
                 continue;
             }
             for stmt in split_statements(&content) {
-                session
-                    .query_unpaged(stmt.as_str(), ())
-                    .await
-                    .with_context(|| format!("{}/{version}: {}", svc.name, first_line(&stmt)))?;
+                match session.query_unpaged(stmt.as_str(), ()).await {
+                    Ok(_) => {}
+                    // Idempotency for statements that can't express `IF NOT EXISTS`
+                    // (Scylla has no `ALTER TABLE ADD IF NOT EXISTS`): re-adding an
+                    // existing column on a fresh cluster is a benign no-op. Versioning
+                    // already prevents intentional re-runs, so this only covers the
+                    // fresh-cluster case, not masking real drift.
+                    Err(e) if is_already_exists(&e.to_string()) => {
+                        println!("  [exists] {version}: {}", first_line(&stmt));
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!("{}/{version}: {}", svc.name, first_line(&stmt))
+                        });
+                    }
+                }
             }
             session
                 .query_unpaged(
@@ -227,24 +239,89 @@ fn sorted_migrations(dir: &Dir<'static>) -> Vec<(String, String)> {
     files
 }
 
-/// Strips `--` line comments and splits a migration file into individual
-/// statements on `;`.
+/// Splits a migration file into individual statements on `;`, ignoring `;` inside
+/// single-quoted string literals (e.g. a `comment = '... ; ...'` clause) and
+/// stripping `--` line comments. Single-pass and quote-aware; handles CQL's `''`
+/// escape for a literal quote inside a string.
 fn split_statements(content: &str) -> Vec<String> {
-    let stripped: String = content
-        .lines()
-        .map(|line| match line.find("--") {
-            Some(idx) => &line[..idx],
-            None => line,
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut in_string = false;
+    let mut chars = content.chars().peekable();
 
-    stripped
-        .split(';')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
-        .collect()
+    while let Some(c) = chars.next() {
+        if in_string {
+            current.push(c);
+            if c == '\'' {
+                // `''` is an escaped quote, not the end of the string.
+                if chars.peek() == Some(&'\'') {
+                    current.push(chars.next().unwrap());
+                } else {
+                    in_string = false;
+                }
+            }
+            continue;
+        }
+
+        match c {
+            '\'' => {
+                in_string = true;
+                current.push(c);
+            }
+            // `--` line comment: skip to end of line (the newline is handled next).
+            '-' if chars.peek() == Some(&'-') => {
+                chars.next();
+                while chars.peek().is_some_and(|&n| n != '\n') {
+                    chars.next();
+                }
+            }
+            ';' => {
+                let stmt = current.trim();
+                if !stmt.is_empty() {
+                    statements.push(stmt.to_owned());
+                }
+                current.clear();
+            }
+            _ => current.push(c),
+        }
+    }
+
+    let tail = current.trim();
+    if !tail.is_empty() {
+        statements.push(tail.to_owned());
+    }
+    statements
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_statements;
+
+    #[test]
+    fn ignores_semicolons_inside_string_literals() {
+        let cql = "CREATE TABLE t (id uuid PRIMARY KEY) \
+                   AND comment = 'scores; and more'; CREATE TABLE u (id uuid PRIMARY KEY);";
+        let stmts = split_statements(cql);
+        assert_eq!(stmts.len(), 2, "got: {stmts:?}");
+        assert!(stmts[0].contains("'scores; and more'"));
+        assert!(stmts[1].starts_with("CREATE TABLE u"));
+    }
+
+    #[test]
+    fn strips_line_comments_and_blank_statements() {
+        let cql = "-- header\nCREATE KEYSPACE ks; -- trailing\n\n;";
+        let stmts = split_statements(cql);
+        assert_eq!(stmts.len(), 1);
+        assert!(stmts[0].starts_with("CREATE KEYSPACE ks"));
+    }
+}
+
+/// Whether a Scylla error is a benign "this DDL target already exists" — used to
+/// keep non-`IF NOT EXISTS` statements (notably `ALTER TABLE ... ADD`) idempotent
+/// on a fresh cluster.
+fn is_already_exists(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("already exists") || m.contains("conflicts with an existing column")
 }
 
 /// First non-empty line of a statement, for error context.

--- a/crates/services/geo-discovery/migrations/0004_add_author_tier_column.cql
+++ b/crates/services/geo-discovery/migrations/0004_add_author_tier_column.cql
@@ -11,5 +11,9 @@
 -- After applying, TierSyncWorker will backfill rows as profile.tier_changed
 -- events arrive. There is no need for a bulk backfill job; Standard is the
 -- correct tier for any post whose author has never changed tier.
+-- Scylla has no `ALTER TABLE ADD IF NOT EXISTS`, so on a fresh deployment (where
+-- the updated 0003 already defines the column) this conflicts; the migration
+-- runner treats an "already exists" ALTER as a benign no-op, so the full set still
+-- applies idempotently to fresh and legacy clusters alike.
 ALTER TABLE geo_discovery.map_post_cards
     ADD author_tier tinyint;

--- a/local-dev/docker-compose.backends.yml
+++ b/local-dev/docker-compose.backends.yml
@@ -1,0 +1,60 @@
+# Local backend stack for running the fleet end-to-end (migrator + *-server smoke test).
+#
+#   docker compose -f local-dev/docker-compose.backends.yml up -d
+#
+# Brings up ScyllaDB, Redis (standalone), Redpanda (Kafka API), and PostgreSQL on
+# their default ports, matching the storage crates' `from_env` defaults. This is a
+# dev/smoke stack — single-node, developer-mode, no persistence guarantees.
+services:
+  scylla:
+    image: scylladb/scylla:6.0
+    command: --smp 1 --developer-mode 1 --overprovisioned 1
+    ports:
+      - "9042:9042"
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh -e 'SELECT now() FROM system.local' || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.2.7
+    command:
+      - redpanda
+      - start
+      - --smp=1
+      - --overprovisioned
+      - --node-id=0
+      - --kafka-addr=PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr=PLAINTEXT://127.0.0.1:9092
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.*true'"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: core
+      POSTGRES_PASSWORD: core
+      POSTGRES_DB: core_platform
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U core -d core_platform"]
+      interval: 5s
+      timeout: 3s
+      retries: 10

--- a/local-dev/docker-compose.backends.yml
+++ b/local-dev/docker-compose.backends.yml
@@ -7,7 +7,9 @@
 # dev/smoke stack — single-node, developer-mode, no persistence guarantees.
 services:
   scylla:
-    image: scylladb/scylla:6.0
+    # 5.4 (pre-tablets): vnode keyspaces tolerate the migrations' RF=3 on a
+    # single node (under-replicated — fine for a dev/smoke stack; prod has 3).
+    image: scylladb/scylla:5.4
     command: --smp 1 --developer-mode 1 --overprovisioned 1
     ports:
       - "9042:9042"


### PR DESCRIPTION
## Summary

Adds **`crates/apps/migrator`** — the fleet schema-migration runner — closing the last hard production gap from the original audit: migrations were inert `.cql`/`.sql` files with no way to apply them, so no service could boot against a fresh cluster.

## Migrator

- **Self-contained.** Every service's migrations are embedded at compile time (`include_dir!`), so the binary needs no source tree or mounted volume in the container.
- **Tracked + idempotent.** Records each `(service, version)` in `migrations.applied` (Scylla) / `schema_migrations` (Postgres); re-runs skip applied versions, and files already use `IF NOT EXISTS` so a partial run resumes safely.
- **Dual-store.** `.cql` services run on ScyllaDB (session opens with no keyspace — each `0001` creates the keyspace and statements are keyspace-qualified); `account`'s `.sql` runs on PostgreSQL via `sqlx::raw_sql`.
- CLI: `migrator` (all) or `migrator <service>`.

## Local backend stack + smoke-test runbook

The repo had **no backend compose** (only a Keycloak Postgres + a bazel dev container), so the fleet couldn't be run locally at all. Adds `local-dev/docker-compose.backends.yml` (ScyllaDB, Redis, Redpanda/Kafka, Postgres on the default ports the storage crates expect) and an end-to-end runbook in the migrator README:

```bash
docker compose -f local-dev/docker-compose.backends.yml up -d
SCYLLA_CONTACT_POINTS=127.0.0.1:9042 DATABASE_URL=postgres://core:core@127.0.0.1:5432/core_platform \
  cargo run -p migrator
INFRA_CONFIG_PATH=crates/shared/infra-config/examples/infrastructure.toml \
  REDIS_HOSTS=127.0.0.1:6379 KAFKA_BROKERS=127.0.0.1:9092 SCYLLA_KEYSPACE=chat \
  cargo run -p chat-server
grpcurl -plaintext localhost:50051 grpc.health.v1.Health/Check   # → SERVING
```

## Testing

- `cargo check --workspace` ✅ (on top of current `develop`); `migrator` clippy-clean.
- ⚠️ The live end-to-end smoke test has **not** been executed yet — no Docker in the build environment. The runbook above is ready for a developer/CI to run; it's the first real exercise of `serve()` (only `App::build` is integration-tested so far).

## Follow-ups (unchanged)

- Container/k8s deploy wiring for the `*-server` binaries (the root Dockerfile is bazel-based).
- Directory re-tiering + `contracts/` (coordinated quiet-window effort).
- Resilience Tower layers at `serve()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
