### PR TITLE
feat(deploy): templatize fleet deploy slice across all 10 services

### DIFF
--- a/k8s/base/services/account/server/deployment.yaml
+++ b/k8s/base/services/account/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/account/server/deployment.yaml
+#
+# account-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `account-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: account-server
+  labels:
+    app: account-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: account-server
+  template:
+    metadata:
+      labels:
+        app: account-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-account
+          image: core-platform-migrator
+          args: ["account"]
+          envFrom:
+            - configMapRef:
+                name: account-config
+      containers:
+        - name: server
+          image: core-platform-account-server
+          envFrom:
+            - configMapRef:
+                name: account-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50059
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50059
+              service: account.v1.AccountService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50059
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/account/server/kustomization.yaml
+++ b/k8s/base/services/account/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/account/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/account/server/service.yaml
+++ b/k8s/base/services/account/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/account/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: account-server
+  labels:
+    app: account-server
+spec:
+  selector:
+    app: account-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50059
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/comment/server/deployment.yaml
+++ b/k8s/base/services/comment/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/comment/server/deployment.yaml
+#
+# comment-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `comment-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: comment-server
+  labels:
+    app: comment-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: comment-server
+  template:
+    metadata:
+      labels:
+        app: comment-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-comment
+          image: core-platform-migrator
+          args: ["comment"]
+          envFrom:
+            - configMapRef:
+                name: comment-config
+      containers:
+        - name: server
+          image: core-platform-comment-server
+          envFrom:
+            - configMapRef:
+                name: comment-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50057
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50057
+              service: comment.v1.CommentService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50057
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/comment/server/kustomization.yaml
+++ b/k8s/base/services/comment/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/comment/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/comment/server/service.yaml
+++ b/k8s/base/services/comment/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/comment/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-server
+  labels:
+    app: comment-server
+spec:
+  selector:
+    app: comment-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50057
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/engagement/server/deployment.yaml
+++ b/k8s/base/services/engagement/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/engagement/server/deployment.yaml
+#
+# engagement-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `engagement-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engagement-server
+  labels:
+    app: engagement-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: engagement-server
+  template:
+    metadata:
+      labels:
+        app: engagement-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-engagement
+          image: core-platform-migrator
+          args: ["engagement"]
+          envFrom:
+            - configMapRef:
+                name: engagement-config
+      containers:
+        - name: server
+          image: core-platform-engagement-server
+          envFrom:
+            - configMapRef:
+                name: engagement-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50058
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50058
+              service: engagement.v1.EngagementService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50058
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/engagement/server/kustomization.yaml
+++ b/k8s/base/services/engagement/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/engagement/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/engagement/server/service.yaml
+++ b/k8s/base/services/engagement/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/engagement/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: engagement-server
+  labels:
+    app: engagement-server
+spec:
+  selector:
+    app: engagement-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50058
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/geo-discovery/server/deployment.yaml
+++ b/k8s/base/services/geo-discovery/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/geo-discovery/server/deployment.yaml
+#
+# geo-discovery-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `geo-discovery-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: geo-discovery-server
+  labels:
+    app: geo-discovery-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: geo-discovery-server
+  template:
+    metadata:
+      labels:
+        app: geo-discovery-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-geo-discovery
+          image: core-platform-migrator
+          args: ["geo-discovery"]
+          envFrom:
+            - configMapRef:
+                name: geo-discovery-config
+      containers:
+        - name: server
+          image: core-platform-geo-discovery-server
+          envFrom:
+            - configMapRef:
+                name: geo-discovery-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50054
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50054
+              service: geo_discovery.v1.GeoDiscoveryService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50054
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/geo-discovery/server/kustomization.yaml
+++ b/k8s/base/services/geo-discovery/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/geo-discovery/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/geo-discovery/server/service.yaml
+++ b/k8s/base/services/geo-discovery/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/geo-discovery/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: geo-discovery-server
+  labels:
+    app: geo-discovery-server
+spec:
+  selector:
+    app: geo-discovery-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50054
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/notification/server/deployment.yaml
+++ b/k8s/base/services/notification/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/notification/server/deployment.yaml
+#
+# notification-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `notification-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-server
+  labels:
+    app: notification-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: notification-server
+  template:
+    metadata:
+      labels:
+        app: notification-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-notification
+          image: core-platform-migrator
+          args: ["notification"]
+          envFrom:
+            - configMapRef:
+                name: notification-config
+      containers:
+        - name: server
+          image: core-platform-notification-server
+          envFrom:
+            - configMapRef:
+                name: notification-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50055
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50055
+              service: notification.v1.NotificationService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50055
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/notification/server/kustomization.yaml
+++ b/k8s/base/services/notification/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/notification/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/notification/server/service.yaml
+++ b/k8s/base/services/notification/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/notification/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-server
+  labels:
+    app: notification-server
+spec:
+  selector:
+    app: notification-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50055
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/post/server/deployment.yaml
+++ b/k8s/base/services/post/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/post/server/deployment.yaml
+#
+# post-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `post-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: post-server
+  labels:
+    app: post-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: post-server
+  template:
+    metadata:
+      labels:
+        app: post-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-post
+          image: core-platform-migrator
+          args: ["post"]
+          envFrom:
+            - configMapRef:
+                name: post-config
+      containers:
+        - name: server
+          image: core-platform-post-server
+          envFrom:
+            - configMapRef:
+                name: post-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50056
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50056
+              service: post.v1.PostService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50056
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/post/server/kustomization.yaml
+++ b/k8s/base/services/post/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/post/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/post/server/service.yaml
+++ b/k8s/base/services/post/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/post/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-server
+  labels:
+    app: post-server
+spec:
+  selector:
+    app: post-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50056
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/profile/server/deployment.yaml
+++ b/k8s/base/services/profile/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/profile/server/deployment.yaml
+#
+# profile-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `profile-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: profile-server
+  labels:
+    app: profile-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: profile-server
+  template:
+    metadata:
+      labels:
+        app: profile-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-profile
+          image: core-platform-migrator
+          args: ["profile"]
+          envFrom:
+            - configMapRef:
+                name: profile-config
+      containers:
+        - name: server
+          image: core-platform-profile-server
+          envFrom:
+            - configMapRef:
+                name: profile-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50052
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50052
+              service: profile.v1.ProfileService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50052
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/profile/server/kustomization.yaml
+++ b/k8s/base/services/profile/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/profile/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/profile/server/service.yaml
+++ b/k8s/base/services/profile/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/profile/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: profile-server
+  labels:
+    app: profile-server
+spec:
+  selector:
+    app: profile-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50052
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/social-graph/server/deployment.yaml
+++ b/k8s/base/services/social-graph/server/deployment.yaml
@@ -1,0 +1,77 @@
+# k8s/base/services/social-graph/server/deployment.yaml
+#
+# social-graph-server on the shared fleet runtime. Schema is provisioned by the
+# migrator (init container) before the server starts. Image tags + the
+# `infra-config` and `social-graph-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: social-graph-server
+  labels:
+    app: social-graph-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: social-graph-server
+  template:
+    metadata:
+      labels:
+        app: social-graph-server
+    spec:
+      # Apply this service's ScyllaDB migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      # NOTE: the migrator target is the service name `social-graph`; the keyspace
+      # it creates is `social_graph` (see SCYLLA_KEYSPACE in the env).
+      initContainers:
+        - name: migrate-social-graph
+          image: core-platform-migrator
+          args: ["social-graph"]
+          envFrom:
+            - configMapRef:
+                name: social-graph-config
+      containers:
+        - name: server
+          image: core-platform-social-graph-server
+          envFrom:
+            - configMapRef:
+                name: social-graph-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50053
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's Scylla+Redis probes (SERVING only once they
+          # pass), so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50053
+              service: social_graph.v1.SocialGraphService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50053
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/social-graph/server/kustomization.yaml
+++ b/k8s/base/services/social-graph/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/social-graph/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/social-graph/server/service.yaml
+++ b/k8s/base/services/social-graph/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/social-graph/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: social-graph-server
+  labels:
+    app: social-graph-server
+spec:
+  selector:
+    app: social-graph-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50053
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/base/services/timeline/server/deployment.yaml
+++ b/k8s/base/services/timeline/server/deployment.yaml
@@ -1,0 +1,75 @@
+# k8s/base/services/timeline/server/deployment.yaml
+#
+# timeline-server on the shared fleet runtime. Schema is provisioned by the migrator
+# (init container) before the server starts. Image tags + the `infra-config` and
+# `timeline-config` ConfigMaps are supplied by the overlay.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: timeline-server
+  labels:
+    app: timeline-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: timeline-server
+  template:
+    metadata:
+      labels:
+        app: timeline-server
+    spec:
+      # Apply this service's schema migrations before the server boots. The
+      # migrator is self-contained (migrations embedded) and idempotent, so it is
+      # safe to run on every rollout; it exits 0 once schema is up to date.
+      initContainers:
+        - name: migrate-timeline
+          image: core-platform-migrator
+          args: ["timeline"]
+          envFrom:
+            - configMapRef:
+                name: timeline-config
+      containers:
+        - name: server
+          image: core-platform-timeline-server
+          envFrom:
+            - configMapRef:
+                name: timeline-config
+          env:
+            # The runtime is fail-closed on this file; mounted from infra-config.
+            - name: INFRA_CONFIG_PATH
+              value: /etc/infra/infrastructure.toml
+          ports:
+            - name: grpc
+              containerPort: 50060
+          volumeMounts:
+            - name: infra-config
+              mountPath: /etc/infra
+              readOnly: true
+          # Readiness gates on backend reachability: the per-service health key is
+          # driven by the runtime's storage probes (SERVING only once they pass),
+          # so a pod leaves rotation when a dependency is unreachable.
+          readinessProbe:
+            grpc:
+              port: 50060
+              service: timeline.v1.TimelineService
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # Liveness checks the overall ("") key = process alive, so a transient
+          # backend blip drops readiness without triggering a restart loop.
+          livenessProbe:
+            grpc:
+              port: 50060
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+      volumes:
+        - name: infra-config
+          configMap:
+            name: infra-config

--- a/k8s/base/services/timeline/server/kustomization.yaml
+++ b/k8s/base/services/timeline/server/kustomization.yaml
@@ -1,0 +1,6 @@
+# k8s/base/services/timeline/server/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/services/timeline/server/service.yaml
+++ b/k8s/base/services/timeline/server/service.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/timeline/server/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: timeline-server
+  labels:
+    app: timeline-server
+spec:
+  selector:
+    app: timeline-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50060
+      targetPort: grpc
+      appProtocol: grpc
+  type: ClusterIP

--- a/k8s/overlays/dev/account.env
+++ b/k8s/overlays/dev/account.env
@@ -1,0 +1,11 @@
+# k8s/overlays/dev/account.env — account-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── PostgreSQL (single-topology; account is the Postgres-backed service) ───────
+# Both the migrator (Store::Postgres) and the server read DATABASE_URL.
+PG_TOPOLOGY=single
+DATABASE_URL=postgres://postgres:postgres@dev-account-postgres:5432/account
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/comment.env
+++ b/k8s/overlays/dev/comment.env
@@ -1,0 +1,18 @@
+# k8s/overlays/dev/comment.env — comment-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=comment
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/engagement.env
+++ b/k8s/overlays/dev/engagement.env
@@ -1,0 +1,22 @@
+# k8s/overlays/dev/engagement.env — engagement-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=engagement
+
+# ── Redis (ElastiCache or in-cluster) ─────────────────────────────────────────
+REDIS_HOSTS=dev-engagement-redis:6379
+REDIS_TOPOLOGY=standalone
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/geo-discovery.env
+++ b/k8s/overlays/dev/geo-discovery.env
@@ -1,0 +1,22 @@
+# k8s/overlays/dev/geo-discovery.env — geo-discovery-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=geo_discovery
+
+# ── Redis (ElastiCache or in-cluster) ─────────────────────────────────────────
+REDIS_HOSTS=dev-geo-discovery-redis:6379
+REDIS_TOPOLOGY=standalone
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -9,6 +9,14 @@ resources:
   - ../../base/services/profile/apps/command-server
   - ../../base/services/chat/server
   - ../../base/services/social-graph/server
+  - ../../base/services/profile/server
+  - ../../base/services/geo-discovery/server
+  - ../../base/services/notification/server
+  - ../../base/services/post/server
+  - ../../base/services/comment/server
+  - ../../base/services/engagement/server
+  - ../../base/services/account/server
+  - ../../base/services/timeline/server
   - ingress.yaml
   - karpenter-config.yaml
   - hpa.yaml
@@ -25,6 +33,30 @@ configMapGenerator:
   - name: social-graph-config
     envs:
       - social-graph.env
+  - name: profile-config
+    envs:
+      - profile.env
+  - name: geo-discovery-config
+    envs:
+      - geo-discovery.env
+  - name: notification-config
+    envs:
+      - notification.env
+  - name: post-config
+    envs:
+      - post.env
+  - name: comment-config
+    envs:
+      - comment.env
+  - name: engagement-config
+    envs:
+      - engagement.env
+  - name: account-config
+    envs:
+      - account.env
+  - name: timeline-config
+    envs:
+      - timeline.env
   # Mounted at /etc/infra; the runtime loads + hot-reloads it fleet-wide.
   - name: infra-config
     files:
@@ -37,6 +69,30 @@ images:
     newTag: latest
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
+    newTag: latest
+  - name: core-platform-profile-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
+    newTag: latest
+  - name: core-platform-geo-discovery-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
+    newTag: latest
+  - name: core-platform-notification-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
+    newTag: latest
+  - name: core-platform-post-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
+    newTag: latest
+  - name: core-platform-comment-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
+    newTag: latest
+  - name: core-platform-engagement-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
+    newTag: latest
+  - name: core-platform-account-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
+    newTag: latest
+  - name: core-platform-timeline-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
     newTag: latest
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../base/services/profile/scylla
   - ../../base/services/profile/apps/command-server
   - ../../base/services/chat/server
+  - ../../base/services/social-graph/server
   - ingress.yaml
   - karpenter-config.yaml
   - hpa.yaml
@@ -21,6 +22,9 @@ configMapGenerator:
   - name: chat-config
     envs:
       - chat.env
+  - name: social-graph-config
+    envs:
+      - social-graph.env
   # Mounted at /etc/infra; the runtime loads + hot-reloads it fleet-wide.
   - name: infra-config
     files:
@@ -30,6 +34,9 @@ images:
     newTag: latest
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
+    newTag: latest
+  - name: core-platform-social-graph-server
+    newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
     newTag: latest
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator

--- a/k8s/overlays/dev/notification.env
+++ b/k8s/overlays/dev/notification.env
@@ -1,0 +1,22 @@
+# k8s/overlays/dev/notification.env — notification-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=notification
+
+# ── Redis (ElastiCache or in-cluster) ─────────────────────────────────────────
+REDIS_HOSTS=dev-notification-redis:6379
+REDIS_TOPOLOGY=standalone
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/post.env
+++ b/k8s/overlays/dev/post.env
@@ -1,0 +1,18 @@
+# k8s/overlays/dev/post.env — post-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=post
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/profile.env
+++ b/k8s/overlays/dev/profile.env
@@ -1,0 +1,22 @@
+# k8s/overlays/dev/profile.env — profile-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=profile
+
+# ── Redis (ElastiCache or in-cluster) ─────────────────────────────────────────
+REDIS_HOSTS=dev-profile-redis:6379
+REDIS_TOPOLOGY=standalone
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/social-graph.env
+++ b/k8s/overlays/dev/social-graph.env
@@ -1,0 +1,23 @@
+# k8s/overlays/dev/social-graph.env — social-graph-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+# The migrator target is `social-graph`; the keyspace it creates is `social_graph`.
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=social_graph
+
+# ── Redis (ElastiCache or in-cluster) ─────────────────────────────────────────
+REDIS_HOSTS=dev-social-graph-redis:6379
+REDIS_TOPOLOGY=standalone
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317

--- a/k8s/overlays/dev/timeline.env
+++ b/k8s/overlays/dev/timeline.env
@@ -1,0 +1,25 @@
+# k8s/overlays/dev/timeline.env — timeline-server + migrator runtime env.
+# These are the variable names the storage crates' `from_env` actually read.
+
+# ── ScyllaDB (managed, 3-node) ────────────────────────────────────────────────
+# RF=3 in the migrations places cleanly on a 3-node cluster.
+# NOTE: the keyspace migrations hardcode the DC name `datacenter1` in their
+# replication map, so the managed cluster's datacenter MUST be named datacenter1
+# (and SCYLLA_LOCAL_DC must match it for token/DC-aware routing).
+SCYLLA_CONTACT_POINTS=scylla-client.scylla.svc.cluster.local:9042
+SCYLLA_LOCAL_DC=datacenter1
+SCYLLA_KEYSPACE=timeline
+
+# ── Redis (ElastiCache or in-cluster) ─────────────────────────────────────────
+REDIS_HOSTS=dev-timeline-redis:6379
+REDIS_TOPOLOGY=standalone
+
+# ── Kafka (MSK or in-cluster; PLAINTEXT for dev) ──────────────────────────────
+KAFKA_BROKERS=dev-kafka:9092
+
+# ── Downstream dependency ─────────────────────────────────────────────────────
+TIMELINE_SOCIAL_GRAPH_ENDPOINT=http://dev-social-graph-server:50053
+
+# ── Observability ─────────────────────────────────────────────────────────────
+RUST_LOG=info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317


### PR DESCRIPTION
## Summary

Generalize the chat K8s deploy slice (#439) across the **entire fleet** — all 10
gRPC services now deploy through one uniform per-service template. Two commits:
a `social-graph` **pilot** (timeline's primary outbound dependency), then the
remaining **8** services.

## The template

Per service: `base/services/<svc>/server/{deployment,service,kustomization}.yaml`
+ `overlays/dev/<svc>.env`, wired into the dev overlay (resource + `<svc>-config`
ConfigMap + image remap). The Deployment is uniform — migrator init container →
server on the shared `service_runtime`, `infra-config` mounted at `/etc/infra`,
gRPC readiness + liveness probes. Only five fields vary: name, image, port,
migrator arg, readiness FQN. **All backend differences live in the env file**, in
three classes:

| class | services | env |
|---|---|---|
| standard | chat, social-graph, profile, geo-discovery, notification, engagement, timeline | Scylla + Redis + Kafka |
| no-Redis | post, comment | Scylla + Kafka |
| Postgres | account | `DATABASE_URL` only |

## Per-service care

- **Keyspace name is read from each service's migrations, not assumed equal to the service name.** geo-discovery's keyspace is `geo_discovery` (underscore) while its migrator target stays `geo-discovery` (hyphen) — a silent connect failure if templated naively. social-graph is the same shape (`social_graph`).
- **timeline** carries `TIMELINE_SOCIAL_GRAPH_ENDPOINT=http://dev-social-graph-server:50053`, closing the resilience loop wired in #440 end-to-end.
- **account** routes to Postgres (`DATABASE_URL`), shared by both its migrator init (`Store::Postgres`) and the server.

## Port / FQN map

| service | port | readiness FQN |
|---|---|---|
| chat | 50051 | chat.v1.ChatService |
| profile | 50052 | profile.v1.ProfileService |
| social-graph | 50053 | social_graph.v1.SocialGraphService |
| geo-discovery | 50054 | geo_discovery.v1.GeoDiscoveryService |
| notification | 50055 | notification.v1.NotificationService |
| post | 50056 | post.v1.PostService |
| comment | 50057 | comment.v1.CommentService |
| engagement | 50058 | engagement.v1.EngagementService |
| account | 50059 | account.v1.AccountService |
| timeline | 50060 | timeline.v1.TimelineService |

## Test plan

- `kubectl kustomize k8s/overlays/dev` builds (10 services, 1386 lines).
- `kubeconform -strict -ignore-missing-schemas` → **40 valid / 0 invalid / 6 skipped** (skipped = Scylla / CNPG `Cluster` / Karpenter CRDs).
- Spot-checked every service: distinct port/FQN/image, correct keyspace, class-appropriate env (post/comment no Redis, account Postgres-only, timeline social-graph endpoint).

## Known follow-ups (out of scope here)

- **Legacy `base/services/profile/`** (`profile-command-server` + its own postgres/redis/scylla + load-tests) is left untouched per plan and now **coexists with the new `profile-server`** — build is clean (distinct names), but the two profile deployments need a separate reconciliation pass.
- **prod/staging overlays** are pre-existing stale stubs (reference a non-existent `base/postgres`) — not addressed here.
- Backend **provisioning** (Scylla cluster, per-service Redis, Kafka topics, account Postgres) is assumed shared infra we reference, not provisioned in this pass.
- The deferred **Grand Re-tiering** is untouched — this PR is `k8s/`-only, no `apps/` or migrator `include_dir!` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
