### PR TITLE
feat(resilience): wire timeout + circuit-breaker into timeline's outb…

### DIFF
--- a/crates/services/timeline/src/app.rs
+++ b/crates/services/timeline/src/app.rs
@@ -3,8 +3,8 @@
 //! [`App::build`] is *pure composition*: storage configs and a
 //! [`SocialGraphClient`] in, a fully-wired service graph out. It binds no socket
 //! and reads no environment, so the production entrypoint
-//! ([`crate::infrastructure::grpc::server::serve`]) and the live integration
-//! harness drive the exact same assembly.
+//! ([`crate::service::TimelineService`], hosted by the fleet runtime) and the live
+//! integration harness drive the exact same assembly.
 //!
 //! Two deliberate seams make the read-heavy timeline testable:
 //!

--- a/crates/services/timeline/src/infrastructure/client/social_graph_grpc_client.rs
+++ b/crates/services/timeline/src/infrastructure/client/social_graph_grpc_client.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use tonic::transport::Channel;
+use transport::grpc::client::ResilientChannel;
 
 use crate::application::port::SocialGraphClient;
 use crate::domain::value_object::{AuthorId, ProfileId};
@@ -20,6 +20,10 @@ use sg_proto::{
 
 /// tonic gRPC client adapter for services/social-graph.
 ///
+/// The channel is a [`ResilientChannel`]: trace injection + circuit breaker + timeout,
+/// configured from the `social-graph` resilience binding and hot-reloaded with it (see
+/// [`crate::service`]). The breaker/timeout therefore wrap every paginated call below.
+///
 /// Both `list_all_followers` and `list_all_following` paginate internally
 /// until `next_page_token` is empty, returning the complete flattened list.
 /// This is safe because:
@@ -27,15 +31,15 @@ use sg_proto::{
 ///   - Following list: called at most once per cold-start rebuild — amortized over
 ///     the `TIMELINE_WARM_TTL_SECS` (default 24h) window.
 pub struct SocialGraphGrpcClient {
-    channel: Channel,
+    channel: ResilientChannel,
 }
 
 impl SocialGraphGrpcClient {
-    pub fn new(channel: Channel) -> Self {
+    pub fn new(channel: ResilientChannel) -> Self {
         Self { channel }
     }
 
-    fn client(&self) -> SocialGraphServiceClient<Channel> {
+    fn client(&self) -> SocialGraphServiceClient<ResilientChannel> {
         SocialGraphServiceClient::new(self.channel.clone())
     }
 }

--- a/crates/services/timeline/src/infrastructure/grpc/server.rs
+++ b/crates/services/timeline/src/infrastructure/grpc/server.rs
@@ -1,90 +1,11 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
-
-use cqrs::query::InMemoryQueryBus;
-use tonic::transport::{Channel, Server};
-use tonic_health::server::health_reporter;
-use tonic_reflection::server::Builder as ReflectionBuilder;
-
-use redis_storage::RedisConfig;
-use scylla_storage::ScyllaConfig;
-use transport::kafka::config::client::KafkaClientConfig;
-
-use crate::app::{App, AppConfig, Backends};
-use crate::config::TimelineConfig;
-use crate::infrastructure::client::SocialGraphGrpcClient;
-use crate::infrastructure::grpc::handler::{TimelineServiceHandler, TimelineServiceServer};
+//! Server-side proto artifacts for the timeline gRPC surface.
+//!
+//! The deployable binary boots through the fleet runtime
+//! (`service_runtime::serve::<TimelineService>` → [`crate::service::TimelineService`]),
+//! which owns config loading, hot-reload, observability, and the layer stack. This
+//! module is therefore reduced to the one artifact that path still needs: the embedded
+//! file-descriptor set used to register server reflection.
 
 /// Proto file descriptor blob embedded at build time for server reflection.
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("timeline_descriptor");
-
-/// The gRPC handler type the server serves: the query bus is shared by `Arc`
-/// (the same instance the composition root retains).
-type ServingHandler = TimelineServiceHandler<Arc<InMemoryQueryBus>>;
-
-/// Bootstraps and runs the timeline gRPC server with all background workers.
-///
-/// Reads configuration from the environment, connects the social-graph gRPC
-/// client, builds the full service graph via the shared composition root
-/// ([`App::build`]) — which also spawns the four ingestion workers — then binds
-/// the socket and serves until shutdown.
-pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
-    let config = TimelineConfig::from_env();
-
-    // ── Social-graph gRPC client ────────────────────────────────────────────────
-    let sg_channel = Channel::from_shared(config.social_graph_endpoint.clone())?
-        .connect()
-        .await?;
-    let social_graph = Arc::new(SocialGraphGrpcClient::new(sg_channel));
-
-    let app_config = AppConfig {
-        feed_cap:                   config.feed_cap,
-        audio_feed_cap:             config.audio_feed_cap,
-        vip_registry_cap:           config.vip_registry_cap,
-        backfill_limit:             config.backfill_limit,
-        warm_ttl_secs:              config.warm_ttl_secs,
-        tier_cache_ttl_secs:        config.tier_cache_ttl_secs,
-        vip_registry_ttl_secs:      config.vip_registry_ttl_secs,
-        max_page_size:              config.max_page_size,
-        max_vip_merge_sources:      config.max_vip_merge_sources,
-        warm_max_concurrency:       config.warm_max_concurrency,
-        social_graph_page_size:     config.social_graph_page_size,
-        kafka_group_post_published: config.kafka_group_post_published.clone(),
-        kafka_group_post_deleted:   config.kafka_group_post_deleted.clone(),
-        kafka_group_sg_followed:    config.kafka_group_sg_followed.clone(),
-        kafka_group_sg_unfollowed:  config.kafka_group_sg_unfollowed.clone(),
-    };
-
-    let backends = Backends {
-        scylla: ScyllaConfig::from_env(),
-        redis:  RedisConfig::from_env(),
-        kafka:  Some(KafkaClientConfig::from_env()),
-    };
-
-    let app = App::build(&app_config, backends, social_graph).await?;
-
-    // ── gRPC server ───────────────────────────────────────────────────────────
-
-    let (health_reporter, health_service) = health_reporter();
-    health_reporter
-        .set_serving::<TimelineServiceServer<ServingHandler>>()
-        .await;
-
-    let reflection = ReflectionBuilder::configure()
-        .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-        .build_v1()?;
-
-    let svc = TimelineServiceServer::new(TimelineServiceHandler::new(Arc::clone(&app.query_bus)));
-
-    tracing::info!(addr = %addr, "timeline gRPC server listening");
-
-    Server::builder()
-        .add_service(health_service)
-        .add_service(reflection)
-        .add_service(svc)
-        .serve(addr)
-        .await?;
-
-    Ok(())
-}

--- a/crates/services/timeline/src/service.rs
+++ b/crates/services/timeline/src/service.rs
@@ -4,8 +4,11 @@
 //! Timeline depends on social-graph over gRPC: the concrete
 //! [`SocialGraphGrpcClient`] is built here from the configured endpoint (lazily
 //! connected, so boot doesn't block on the dependency) and injected into the
-//! otherwise client-generic [`App::build`]. The gRPC surface is query-only;
-//! ingestion runs via Kafka workers spawned inside `App::build`.
+//! otherwise client-generic [`App::build`]. The channel is wrapped in the shared
+//! resilience stack (timeout + circuit breaker) resolved from the `social-graph`
+//! binding in `infrastructure.toml` via [`InfraRegistry::resilience`], so it
+//! hot-reloads with the fleet config. The gRPC surface is query-only; ingestion
+//! runs via Kafka workers spawned inside `App::build`.
 
 use std::sync::Arc;
 
@@ -15,8 +18,8 @@ use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
 use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
-use tonic::transport::Channel;
 use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::grpc::client::{GrpcClientBuilder, GrpcClientConfig};
 use transport::kafka::config::KafkaClientConfig;
 
 use crate::app::{App, AppConfig, Backends};
@@ -26,6 +29,11 @@ use crate::infrastructure::grpc::handler::{TimelineServiceHandler, TimelineServi
 use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
 
 type TimelineServer = TimelineServiceServer<TimelineServiceHandler<Arc<InMemoryQueryBus>>>;
+
+/// Logical dependency name for the outbound social-graph channel — the key its
+/// resilience profile is bound to under `[resilience.bindings]` in `infrastructure.toml`
+/// (falls back to the default profile when unbound).
+const SOCIAL_GRAPH_DEPENDENCY: &str = "social-graph";
 
 /// The timeline service as hosted by [`service_runtime`].
 pub struct TimelineService {
@@ -38,7 +46,7 @@ impl Service for TimelineService {
     const VERSION: &'static str = env!("CARGO_PKG_VERSION");
     const GRPC_SERVICE_NAME: &'static str = <TimelineServer as tonic::server::NamedService>::NAME;
 
-    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+    async fn build(infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
         let cfg = TimelineConfig::from_env();
 
         let app_config = AppConfig {
@@ -65,11 +73,16 @@ impl Service for TimelineService {
             kafka:  Some(KafkaClientConfig::from_env()),
         };
 
-        // Lazily-connected channel: timeline boots even if social-graph is not
-        // yet reachable; the worker/cold-rebuild call sites tolerate latency.
-        let channel = Channel::from_shared(cfg.social_graph_endpoint.clone())
-            .map_err(|e| anyhow::anyhow!("invalid social-graph endpoint: {e}"))?
-            .connect_lazy();
+        // Lazily-connected, resilience-wrapped channel: timeline boots even if
+        // social-graph is not yet reachable (the connection opens on first RPC),
+        // and the timeout + circuit-breaker stack — resolved from the
+        // `social-graph` binding and shared across the fleet — wraps every call.
+        let channel = GrpcClientBuilder::new(
+            GrpcClientConfig::new(cfg.social_graph_endpoint.clone())
+                .with_dependency(SOCIAL_GRAPH_DEPENDENCY),
+        )
+        .build_from_registry_lazy(&infra.resilience())
+        .map_err(|e| anyhow::anyhow!("build social-graph client: {e}"))?;
         let social_graph = Arc::new(SocialGraphGrpcClient::new(channel));
 
         let app = App::build(&app_config, backends, social_graph)

--- a/crates/shared/infra-config/examples/infrastructure.toml
+++ b/crates/shared/infra-config/examples/infrastructure.toml
@@ -31,6 +31,10 @@ retry = { max_attempts = 6, backoff = { kind = "exponential", base_ms = 100, max
 "post-command"  = "critical"
 "timeline-read" = "standard"
 "notification"  = "aggressive"
+# timeline -> social-graph (fan-out + cold-rebuild reads): tolerant of latency,
+# so it rides the standard profile. An unbound dependency falls back to
+# `default_profile`, so this line is documentation as much as configuration.
+"social-graph"  = "standard"
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/shared/transport/src/grpc/client/builder.rs
+++ b/crates/shared/transport/src/grpc/client/builder.rs
@@ -1,12 +1,15 @@
 use resilience::{error::ResilienceError, ResilienceProfile};
 use infra_config::ResilienceRegistry;
 use tonic::transport::Channel;
-use tower::{util::BoxCloneService, Layer, ServiceBuilder};
+use tower::{Layer, ServiceBuilder};
 
 use crate::{
     error::TransportError,
     grpc::{
-        client::config::GrpcClientConfig,
+        client::{
+            config::GrpcClientConfig,
+            sync_box::BoxCloneSyncService,
+        },
         layer::outbound::{OutboundTraceLayer, OutboundTraceService},
     },
 };
@@ -18,7 +21,11 @@ use crate::{
 /// Because the circuit-breaker and timeout layers read their config from the originating
 /// [`ResilienceProfile`]'s shared handles, a control-plane hot-swap reconfigures this live
 /// stack with no rebuild.
-pub type ResilientChannel = BoxCloneService<
+///
+/// The erasure is [`Send`] **and** [`Sync`] (via [`BoxCloneSyncService`]): a client adapter
+/// typically stores it behind an `Arc` and shares it across worker tasks, and `Arc<T>: Sync`
+/// requires `T: Sync`.
+pub type ResilientChannel = BoxCloneSyncService<
     http::Request<tonic::body::Body>,
     http::Response<tonic::body::Body>,
     TransportError,
@@ -46,7 +53,7 @@ fn compose_resilient(channel: Channel, profile: &ResilienceProfile) -> Resilient
         .layer(profile.circuit_breaker_layer())
         .service(traced);
 
-    BoxCloneService::new(svc)
+    BoxCloneSyncService::new(svc)
 }
 
 /// Builds a Tonic gRPC client channel, with optional TLS and outbound trace injection.
@@ -59,6 +66,10 @@ fn compose_resilient(channel: Channel, profile: &ResilienceProfile) -> Resilient
 /// | `build_traced()` | `OutboundTraceService<Channel>` | ✅ | trace injection only |
 /// | `build_resilient(&profile)` | [`ResilientChannel`] | ✅ | trace + circuit breaker + timeout |
 /// | `build_from_registry(&registry)` | [`ResilientChannel`] | ✅ | resolves the profile from bindings, then as above |
+///
+/// `build_resilient` / `build_from_registry` connect eagerly; their `*_lazy` counterparts
+/// compose the identical stack over a lazily-connected channel for callers that must not
+/// block boot on the dependency.
 ///
 /// # Resilience
 ///
@@ -131,6 +142,22 @@ impl GrpcClientBuilder {
         Ok(compose_resilient(channel, profile))
     }
 
+    /// Lazy counterpart to [`build_resilient`](Self::build_resilient): composes the same
+    /// stack over a [`connect_lazy`](tonic::transport::Endpoint::connect_lazy) channel, so
+    /// the connection is established on the first RPC instead of up front.
+    ///
+    /// Prefer this when the caller must boot even if the dependency is unreachable — the
+    /// channel is built without a network round-trip, and connect failures surface on the
+    /// first call (where the circuit breaker and timeout already wrap them) rather than at
+    /// construction. It is therefore synchronous: only endpoint/TLS parsing can fail here.
+    pub fn build_resilient_lazy(
+        self,
+        profile: &ResilienceProfile,
+    ) -> Result<ResilientChannel, TransportError> {
+        let channel = build_channel_lazy(&self.config)?;
+        Ok(compose_resilient(channel, profile))
+    }
+
     /// Resolves this client's resilience profile from the registry — keyed by
     /// [`GrpcClientConfig::dependency`] (its `[resilience.bindings]` entry, falling back to
     /// the default profile) — and builds the resilient channel from it.
@@ -153,9 +180,30 @@ impl GrpcClientBuilder {
         let profile = registry.profile_for(&self.config.dependency);
         self.build_resilient(&profile).await
     }
+
+    /// Lazy counterpart to [`build_from_registry`](Self::build_from_registry): resolves the
+    /// profile binding exactly the same way, but composes the stack over a lazily-connected
+    /// channel (see [`build_resilient_lazy`](Self::build_resilient_lazy)).
+    ///
+    /// This is the entry point for a caller that must not block boot on the dependency —
+    /// e.g. a read-path service whose downstream is only needed on cold-rebuild.
+    ///
+    /// ```rust,ignore
+    /// let channel = GrpcClientBuilder::new(GrpcClientConfig::new(uri).with_dependency("social-graph"))
+    ///     .build_from_registry_lazy(&infra.resilience())?;
+    /// let client = SocialGraphServiceClient::new(channel);
+    /// ```
+    pub fn build_from_registry_lazy(
+        self,
+        registry: &ResilienceRegistry,
+    ) -> Result<ResilientChannel, TransportError> {
+        let profile = registry.profile_for(&self.config.dependency);
+        self.build_resilient_lazy(&profile)
+    }
 }
 
-async fn build_channel(cfg: &GrpcClientConfig) -> Result<tonic::transport::Channel, TransportError> {
+/// Builds a configured [`Endpoint`] (URI, connect timeout, optional TLS) without connecting.
+fn build_endpoint(cfg: &GrpcClientConfig) -> Result<tonic::transport::Endpoint, TransportError> {
     use tonic::transport::{Certificate, ClientTlsConfig, Endpoint, Identity};
 
     let mut endpoint = Endpoint::new(cfg.endpoint.clone())
@@ -179,7 +227,18 @@ async fn build_channel(cfg: &GrpcClientConfig) -> Result<tonic::transport::Chann
         })?;
     }
 
-    endpoint.connect().await.map_err(TransportError::from)
+    Ok(endpoint)
+}
+
+/// Connects eagerly: the returned channel is backed by an established connection.
+async fn build_channel(cfg: &GrpcClientConfig) -> Result<tonic::transport::Channel, TransportError> {
+    build_endpoint(cfg)?.connect().await.map_err(TransportError::from)
+}
+
+/// Builds a lazily-connected channel: no network round-trip here; the connection is opened
+/// on first use. Only endpoint/TLS parsing can fail.
+fn build_channel_lazy(cfg: &GrpcClientConfig) -> Result<tonic::transport::Channel, TransportError> {
+    Ok(build_endpoint(cfg)?.connect_lazy())
 }
 
 #[cfg(test)]
@@ -202,6 +261,15 @@ retry = { max_attempts = 1, backoff = { kind = "exponential", base_ms = 20, max_
 [resilience.bindings]
 "post-command" = "critical"
 "#;
+
+    // A `ResilientChannel` is stored behind an `Arc` in client adapters that are shared
+    // across worker tasks, so it must be `Send + Sync` (not just `Send`). This locks in the
+    // `BoxCloneSyncService` erasure — a plain `BoxCloneService` would fail to compile here.
+    #[test]
+    fn resilient_channel_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ResilientChannel>();
+    }
 
     #[tokio::test]
     async fn composes_resilient_channel_bound_to_registry_profile() {

--- a/crates/shared/transport/src/grpc/client/mod.rs
+++ b/crates/shared/transport/src/grpc/client/mod.rs
@@ -1,5 +1,6 @@
 pub mod builder;
 pub mod config;
+mod sync_box;
 
 pub use builder::{GrpcClientBuilder, ResilientChannel};
 pub use config::{GrpcClientConfig, GrpcResilienceConfig, GrpcTlsConfig};

--- a/crates/shared/transport/src/grpc/client/sync_box.rs
+++ b/crates/shared/transport/src/grpc/client/sync_box.rs
@@ -1,0 +1,95 @@
+//! A `Clone + Send + Sync` boxed [`Service`].
+//!
+//! [`tower::util::BoxCloneService`] (tower 0.4) erases to a `Send`-only trait object, so a
+//! service built on top of it is not `Sync`. The resilient gRPC channel, however, is stored
+//! behind an `Arc` in a client adapter that is shared across worker tasks (`Arc<T>: Sync`
+//! requires `T: Sync`), so the erased channel must itself be `Sync`.
+//!
+//! tower 0.5 ships `BoxCloneSyncService` for exactly this, but the workspace is pinned to
+//! tower 0.4. This is a minimal port of that type: identical to `BoxCloneService` except the
+//! erased trait object (and the inner-service bound) carries `+ Sync`.
+
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+
+use futures_util::future::BoxFuture;
+use tower::Service;
+use tower::ServiceExt;
+
+/// A [`Clone`] + [`Send`] + [`Sync`] boxed [`Service`].
+///
+/// See the [module docs](self) for why the `Sync` bound matters here.
+pub struct BoxCloneSyncService<T, U, E>(
+    Box<
+        dyn CloneService<T, Response = U, Error = E, Future = BoxFuture<'static, Result<U, E>>>
+            + Send
+            + Sync,
+    >,
+);
+
+impl<T, U, E> BoxCloneSyncService<T, U, E> {
+    /// Erases `inner` into a `Clone + Send + Sync` boxed service.
+    pub fn new<S>(inner: S) -> Self
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + Sync + 'static,
+        S::Future: Send + 'static,
+    {
+        let inner = inner.map_future(|f| Box::pin(f) as _);
+        BoxCloneSyncService(Box::new(inner))
+    }
+}
+
+impl<T, U, E> Service<T> for BoxCloneSyncService<T, U, E> {
+    type Response = U;
+    type Error = E;
+    type Future = BoxFuture<'static, Result<U, E>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
+        self.0.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, request: T) -> Self::Future {
+        self.0.call(request)
+    }
+}
+
+impl<T, U, E> Clone for BoxCloneSyncService<T, U, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+trait CloneService<R>: Service<R> {
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future>
+            + Send
+            + Sync,
+    >;
+}
+
+impl<R, T> CloneService<R> for T
+where
+    T: Service<R> + Clone + Send + Sync + 'static,
+{
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future>
+            + Send
+            + Sync,
+    > {
+        Box::new(self.clone())
+    }
+}
+
+impl<T, U, E> fmt::Debug for BoxCloneSyncService<T, U, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BoxCloneSyncService").finish()
+    }
+}

--- a/k8s/overlays/dev/infrastructure.toml
+++ b/k8s/overlays/dev/infrastructure.toml
@@ -10,6 +10,13 @@ timeout = { duration_ms = 10000 }
 circuit_breaker = { failure_threshold = 5, success_threshold = 2, open_duration_ms = 30000, half_open_max_calls = 1 }
 retry = { max_attempts = 3, backoff = { kind = "exponential", base_ms = 50, max_ms = 10000, jitter = "full" } }
 
+# Dependency -> profile bindings. Only the `standard` profile exists in this overlay,
+# so every binding resolves to it (same as the unbound fallback); the entry is here to
+# make the dependency name discoverable and ready to re-point once more profiles land.
+[resilience.bindings]
+# timeline -> social-graph (fan-out + cold-rebuild reads)
+"social-graph" = "standard"
+
 [traffic]
 default_profile = "standard"
 


### PR DESCRIPTION
…ound gRPC

Apply infra.resilience() to the one live outbound call site — timeline's SocialGraphGrpcClient. The channel is now built via GrpcClientBuilder keyed by the "social-graph" binding, so it carries the shared timeout + circuit-breaker stack and hot-reloads with infrastructure.toml.

transport (reusable mechanism for fleet adoption):
- Add lazy entry points build_resilient_lazy / build_from_registry_lazy that compose the same stack over a connect_lazy channel, preserving timeline's boot contract (it must come up even if social-graph is unreachable).
- Add BoxCloneSyncService (minimal port of tower 0.5's, the workspace is pinned to tower 0.4) so ResilientChannel erases to Send + Sync, not Send-only. Client adapters hold it behind an Arc shared across worker tasks, and Arc<T>: Sync requires T: Sync — a latent gap that had no production caller until now. Locked in with a Send+Sync regression test.

timeline:
- SocialGraphGrpcClient holds a ResilientChannel; service.rs consumes the previously-unused infra registry to build it.
- Remove the dead legacy grpc::server::serve() (the binary boots via service_runtime::serve::<TimelineService>); keep FILE_DESCRIPTOR_SET and fix the stale "production entrypoint" doc.

config:
- Document the "social-graph" binding in the example infrastructure.toml and the dev overlay (resolves to the standard profile / unbound fallback today).