### PR TITLE
refactor(health): foundation/health crate + storage-owned probe constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,6 +1672,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "health"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,8 +3014,11 @@ dependencies = [
 name = "postgres"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "error",
  "futures",
+ "health",
  "http",
  "log",
  "seahash",
@@ -3493,8 +3504,11 @@ dependencies = [
 name = "redis-storage"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "error",
  "fred",
+ "health",
  "http",
  "thiserror 2.0.18",
  "tokio",
@@ -3910,8 +3924,11 @@ dependencies = [
 name = "scylla-storage"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "dashmap 7.0.0-rc2",
  "error",
+ "health",
  "http",
  "scylla",
  "thiserror 2.0.18",
@@ -4092,6 +4109,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "health",
  "infra-config",
  "telemetry",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 [workspace]
 members = [
     "crates/foundation/error",
+    "crates/foundation/health",
     "crates/foundation/resilience",
     "crates/foundation/infra-config",
     "crates/foundation/traffic",
@@ -68,6 +69,7 @@ description = "core-platform repo"
 # `package`) to avoid colliding with the crates.io `postgres` crate and to keep
 # the naming symmetric with `scylla-storage` / `redis-storage`.
 error             = { path = "crates/foundation/error" }
+health            = { path = "crates/foundation/health" }
 resilience        = { path = "crates/foundation/resilience" }
 infra-config      = { path = "crates/foundation/infra-config" }
 traffic           = { path = "crates/foundation/traffic" }

--- a/crates/foundation/health/Cargo.toml
+++ b/crates/foundation/health/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "health"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Liveness/readiness probe abstraction (HealthProbe + FnProbe) — a graph-leaf so storage crates can expose probes without depending on the runtime."
+
+[dependencies]
+async-trait = { workspace = true }
+anyhow      = { workspace = true }

--- a/crates/foundation/health/src/lib.rs
+++ b/crates/foundation/health/src/lib.rs
@@ -1,0 +1,62 @@
+//! Backend health probes for readiness/liveness gating.
+//!
+//! [`HealthProbe`] is a graph-leaf abstraction so that **storage crates** can
+//! expose ready-made probes for their clients (they only depend on this
+//! foundation crate, never on the runtime), and the runtime can poll them to
+//! drive a service's gRPC health status — without either side depending on the
+//! other.
+
+use std::future::Future;
+
+use async_trait::async_trait;
+
+/// A liveness probe the runtime polls to drive the service's gRPC health status.
+///
+/// Implemented by storage crates over their live clients (see each storage
+/// crate's `health::probe`) or, for bespoke checks, via [`FnProbe`]. Probes must
+/// be cheap — they run on every readiness tick.
+#[async_trait]
+pub trait HealthProbe: Send + Sync + 'static {
+    /// Short identifier for logs, e.g. `"scylla"` or `"redis"`.
+    fn name(&self) -> &str;
+
+    /// Returns `Ok(())` when the dependency is reachable. Any `Err` demotes the
+    /// whole service to `NOT_SERVING` until the next tick clears it.
+    async fn check(&self) -> anyhow::Result<()>;
+}
+
+/// A [`HealthProbe`] backed by an async closure, for a check that isn't already
+/// provided by a storage crate. The closure is `Fn` (re-run every tick),
+/// typically capturing a cloned client handle:
+///
+/// ```ignore
+/// FnProbe::new("elasticsearch", move || {
+///     let client = client.clone();
+///     async move { client.ping().await.map_err(Into::into) }
+/// })
+/// ```
+pub struct FnProbe<F> {
+    name: &'static str,
+    check: F,
+}
+
+impl<F> FnProbe<F> {
+    pub fn new(name: &'static str, check: F) -> Self {
+        Self { name, check }
+    }
+}
+
+#[async_trait]
+impl<F, Fut> HealthProbe for FnProbe<F>
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    async fn check(&self) -> anyhow::Result<()> {
+        (self.check)().await
+    }
+}

--- a/crates/platform/service-runtime/Cargo.toml
+++ b/crates/platform/service-runtime/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "Unified fleet bootstrap: the one boot sequence (telemetry → infra-config + hot-reload → compose → gRPC serve → graceful shutdown) every service runs by implementing the `Service` trait."
 
 [dependencies]
+health       = { workspace = true }
 telemetry    = { workspace = true }
 infra-config = { workspace = true }
 transport    = { workspace = true }

--- a/crates/platform/service-runtime/src/lib.rs
+++ b/crates/platform/service-runtime/src/lib.rs
@@ -70,60 +70,11 @@ const TRAFFIC_PRUNE_INTERVAL_ENV: &str = "TRAFFIC_PRUNE_INTERVAL_SECS";
 /// Default traffic-registry prune cadence.
 const DEFAULT_TRAFFIC_PRUNE_INTERVAL_SECS: u64 = 60;
 
-/// A liveness probe the runtime polls to drive the service's gRPC health status.
-///
-/// Implemented by the *service* over its live backend clients (a storage crate
-/// can't depend on this platform crate), typically via [`FnProbe`]. Probes must
-/// be cheap — they run on every readiness tick.
-#[async_trait]
-pub trait HealthProbe: Send + Sync + 'static {
-    /// Short identifier for logs, e.g. `"scylla"` or `"redis"`.
-    fn name(&self) -> &str;
-
-    /// Returns `Ok(())` when the dependency is reachable. Any `Err` demotes the
-    /// whole service to `NOT_SERVING` until the next tick clears it.
-    async fn check(&self) -> anyhow::Result<()>;
-}
-
-/// A [`HealthProbe`] backed by an async closure, so a service registers a backend
-/// check without hand-rolling a trait impl per dependency. The closure is `Fn`
-/// (re-run every tick), typically capturing a cloned client handle:
-///
-/// ```ignore
-/// FnProbe::new("redis", move || {
-///     let client = client.clone();
-///     async move {
-///         redis_storage::health::health_check(&*client)
-///             .await
-///             .map_err(|e| anyhow::anyhow!("redis: {e}"))
-///     }
-/// })
-/// ```
-pub struct FnProbe<F> {
-    name: &'static str,
-    check: F,
-}
-
-impl<F> FnProbe<F> {
-    pub fn new(name: &'static str, check: F) -> Self {
-        Self { name, check }
-    }
-}
-
-#[async_trait]
-impl<F, Fut> HealthProbe for FnProbe<F>
-where
-    F: Fn() -> Fut + Send + Sync + 'static,
-    Fut: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
-{
-    fn name(&self) -> &str {
-        self.name
-    }
-
-    async fn check(&self) -> anyhow::Result<()> {
-        (self.check)().await
-    }
-}
+/// Backend health probes now live in the `health` foundation crate, so storage
+/// crates can expose ready-made probes (`<storage>::health::probe(...)`) without
+/// depending on this platform crate. Re-exported here for ergonomic use from
+/// service `health_probes()` impls and the readiness loop below.
+pub use health::{FnProbe, HealthProbe};
 
 /// A fleet service the [`serve`] runtime can host.
 ///

--- a/crates/services/account/src/service.rs
+++ b/crates/services/account/src/service.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use cqrs::command::InMemoryCommandBus;
 use cqrs::query::InMemoryQueryBus;
 use postgres_storage::{PgPoolBuilder, PostgresConfig};
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use sqlx::PgPool;
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
@@ -47,15 +47,7 @@ impl Service for AccountService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let pool = self.pool.clone();
-        vec![Arc::new(FnProbe::new("postgres", move || {
-            let pool = pool.clone();
-            async move {
-                postgres_storage::health_check(&pool)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("postgres: {e}"))
-            }
-        }))]
+        vec![postgres_storage::health::probe(self.pool.clone())]
     }
 
     fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {

--- a/crates/services/chat/src/service.rs
+++ b/crates/services/chat/src/service.rs
@@ -3,14 +3,15 @@
 //!
 //! All domain wiring stays in [`crate::app`]; this module only maps env → config,
 //! defers to [`App::build`], registers the concrete tonic services, and reports
-//! backend liveness via [`FnProbe`] closures over the storage clients `App`
-//! retains. It is the seam that lets `chat-server` be a one-liner over the shared
-//! runtime while the integration harness keeps driving [`App::build`] directly.
+//! backend liveness via the storage crates' own probe constructors
+//! ([`scylla_storage::health::probe`] / [`redis_storage::health::probe`]) over the
+//! clients `App` retains. It is the seam that lets `chat-server` be a one-liner
+//! over the shared runtime while the integration harness keeps driving
+//! [`App::build`] directly.
 //!
-//! The probes are wired here (not in the storage crates) because the
-//! `HealthProbe`/`FnProbe` machinery is a platform concern a storage crate must
-//! not depend on; once the role-tiering lands, the storage crates can expose
-//! their own probe constructors, shared across services.
+//! The probe abstraction ([`HealthProbe`]) lives in the `health` foundation crate,
+//! so each storage crate exposes a ready-made probe for its client — no per-service
+//! closures.
 
 use std::sync::Arc;
 
@@ -20,7 +21,7 @@ use cqrs::query::InMemoryQueryBus;
 use infra_config::InfraRegistry;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, Service};
+use service_runtime::{HealthProbe, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::client::KafkaClientConfig;
@@ -82,25 +83,9 @@ impl Service for ChatService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        let redis = self.app.redis.clone();
         vec![
-            Arc::new(FnProbe::new("scylla", move || {
-                let scylla = Arc::clone(&scylla);
-                async move {
-                    scylla_storage::health::health_check(&scylla.session)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-                }
-            })),
-            Arc::new(FnProbe::new("redis", move || {
-                let redis = redis.clone();
-                async move {
-                    redis_storage::health::health_check(&*redis)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
-                }
-            })),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe(self.app.redis.clone()),
         ]
     }
 

--- a/crates/services/comment/src/service.rs
+++ b/crates/services/comment/src/service.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use cqrs::command::InMemoryCommandBus;
 use cqrs::query::InMemoryQueryBus;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
@@ -52,15 +52,7 @@ impl Service for CommentService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        vec![Arc::new(FnProbe::new("scylla", move || {
-            let scylla = Arc::clone(&scylla);
-            async move {
-                scylla_storage::health::health_check(&scylla.session)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-            }
-        }))]
+        vec![scylla_storage::health::probe(Arc::clone(&self.app.scylla))]
     }
 
     fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {

--- a/crates/services/engagement/src/service.rs
+++ b/crates/services/engagement/src/service.rs
@@ -13,7 +13,7 @@ use cqrs::command::InMemoryCommandBus;
 use cqrs::query::InMemoryQueryBus;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
@@ -65,15 +65,7 @@ impl Service for EngagementService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let redis = self.app.redis.clone();
-        vec![Arc::new(FnProbe::new("redis", move || {
-            let redis = redis.clone();
-            async move {
-                redis_storage::health::health_check(&*redis)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("redis: {e}"))
-            }
-        }))]
+        vec![redis_storage::health::probe(self.app.redis.clone())]
     }
 
     fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {

--- a/crates/services/geo-discovery/src/service.rs
+++ b/crates/services/geo-discovery/src/service.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use cqrs::query::InMemoryQueryBus;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::KafkaClientConfig;
@@ -50,25 +50,9 @@ impl Service for GeoDiscoveryService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        let redis = self.app.redis.clone();
         vec![
-            Arc::new(FnProbe::new("scylla", move || {
-                let scylla = Arc::clone(&scylla);
-                async move {
-                    scylla_storage::health::health_check(&scylla.session)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-                }
-            })),
-            Arc::new(FnProbe::new("redis", move || {
-                let redis = redis.clone();
-                async move {
-                    redis_storage::health::health_check(&*redis)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
-                }
-            })),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe(self.app.redis.clone()),
         ]
     }
 

--- a/crates/services/notification/src/service.rs
+++ b/crates/services/notification/src/service.rs
@@ -12,7 +12,7 @@ use cqrs::command::InMemoryCommandBus;
 use cqrs::query::InMemoryQueryBus;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::KafkaClientConfig;
@@ -55,25 +55,9 @@ impl Service for NotificationService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        let redis = self.app.redis.clone();
         vec![
-            Arc::new(FnProbe::new("scylla", move || {
-                let scylla = Arc::clone(&scylla);
-                async move {
-                    scylla_storage::health::health_check(&scylla.session)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-                }
-            })),
-            Arc::new(FnProbe::new("redis", move || {
-                let redis = redis.clone();
-                async move {
-                    redis_storage::health::health_check(&*redis)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
-                }
-            })),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe(self.app.redis.clone()),
         ]
     }
 

--- a/crates/services/post/src/service.rs
+++ b/crates/services/post/src/service.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use cqrs::command::InMemoryCommandBus;
 use cqrs::query::InMemoryQueryBus;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
@@ -51,15 +51,7 @@ impl Service for PostService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        vec![Arc::new(FnProbe::new("scylla", move || {
-            let scylla = Arc::clone(&scylla);
-            async move {
-                scylla_storage::health::health_check(&scylla.session)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-            }
-        }))]
+        vec![scylla_storage::health::probe(Arc::clone(&self.app.scylla))]
     }
 
     fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {

--- a/crates/services/profile/src/service.rs
+++ b/crates/services/profile/src/service.rs
@@ -18,7 +18,7 @@ use cqrs::query::InMemoryQueryBus;
 use infra_config::InfraRegistry;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, Service};
+use service_runtime::{HealthProbe, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
@@ -76,25 +76,9 @@ impl Service for ProfileService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        let redis = Arc::clone(&self.app.redis);
         vec![
-            Arc::new(FnProbe::new("scylla", move || {
-                let scylla = Arc::clone(&scylla);
-                async move {
-                    scylla_storage::health::health_check(&scylla.session)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-                }
-            })),
-            Arc::new(FnProbe::new("redis", move || {
-                let redis = Arc::clone(&redis);
-                async move {
-                    redis_storage::health::health_check(&**redis)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
-                }
-            })),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe((*self.app.redis).clone()),
         ]
     }
 

--- a/crates/services/social-graph/src/service.rs
+++ b/crates/services/social-graph/src/service.rs
@@ -12,7 +12,7 @@ use cqrs::command::InMemoryCommandBus;
 use cqrs::query::InMemoryQueryBus;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
@@ -60,25 +60,9 @@ impl Service for SocialGraphService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        let redis = Arc::clone(&self.app.redis);
         vec![
-            Arc::new(FnProbe::new("scylla", move || {
-                let scylla = Arc::clone(&scylla);
-                async move {
-                    scylla_storage::health::health_check(&scylla.session)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-                }
-            })),
-            Arc::new(FnProbe::new("redis", move || {
-                let redis = Arc::clone(&redis);
-                async move {
-                    redis_storage::health::health_check(&**redis)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
-                }
-            })),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe((*self.app.redis).clone()),
         ]
     }
 

--- a/crates/services/timeline/src/service.rs
+++ b/crates/services/timeline/src/service.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use cqrs::query::InMemoryQueryBus;
 use redis_storage::RedisConfig;
 use scylla_storage::ScyllaConfig;
-use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::grpc::client::{GrpcClientBuilder, GrpcClientConfig};
@@ -93,25 +93,9 @@ impl Service for TimelineService {
     }
 
     fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
-        let scylla = Arc::clone(&self.app.scylla);
-        let redis = self.app.redis.clone();
         vec![
-            Arc::new(FnProbe::new("scylla", move || {
-                let scylla = Arc::clone(&scylla);
-                async move {
-                    scylla_storage::health::health_check(&scylla.session)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("scylla: {e}"))
-                }
-            })),
-            Arc::new(FnProbe::new("redis", move || {
-                let redis = redis.clone();
-                async move {
-                    redis_storage::health::health_check(&*redis)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("redis: {e}"))
-                }
-            })),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe(self.app.redis.clone()),
         ]
     }
 

--- a/crates/storage/postgres/Cargo.toml
+++ b/crates/storage/postgres/Cargo.toml
@@ -9,6 +9,9 @@ description = "Production-grade PostgreSQL connection pool, transaction manager,
 
 [dependencies]
 error     = { workspace = true }
+health      = { workspace = true }
+async-trait = { workspace = true }
+anyhow      = { workspace = true }
 sqlx      = { workspace = true }
 tracing   = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/storage/postgres/src/health/mod.rs
+++ b/crates/storage/postgres/src/health/mod.rs
@@ -1,4 +1,6 @@
 pub mod check;
+mod probe;
 
 pub use check::health_check;
 pub use check::health_check_cluster;
+pub use probe::probe;

--- a/crates/storage/postgres/src/health/probe.rs
+++ b/crates/storage/postgres/src/health/probe.rs
@@ -1,0 +1,30 @@
+//! Ready-made [`HealthProbe`] over a Postgres pool, so services don't hand-roll
+//! the readiness closure.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use health::HealthProbe;
+use sqlx::PgPool;
+
+struct PostgresHealthProbe {
+    pool: PgPool,
+}
+
+#[async_trait]
+impl HealthProbe for PostgresHealthProbe {
+    fn name(&self) -> &str {
+        "postgres"
+    }
+
+    async fn check(&self) -> anyhow::Result<()> {
+        super::check::health_check(&self.pool)
+            .await
+            .map_err(|e| anyhow::anyhow!("postgres: {e}"))
+    }
+}
+
+/// Builds a readiness probe (name `"postgres"`) over a live Postgres pool.
+pub fn probe(pool: PgPool) -> Arc<dyn HealthProbe> {
+    Arc::new(PostgresHealthProbe { pool })
+}

--- a/crates/storage/redis/Cargo.toml
+++ b/crates/storage/redis/Cargo.toml
@@ -9,6 +9,9 @@ description = "Production-grade Redis client management, topology configuration,
 
 [dependencies]
 error     = { workspace = true }
+health      = { workspace = true }
+async-trait = { workspace = true }
+anyhow      = { workspace = true }
 thiserror = { workspace = true }
 tracing   = { workspace = true }
 http      = { workspace = true }

--- a/crates/storage/redis/src/health/mod.rs
+++ b/crates/storage/redis/src/health/mod.rs
@@ -1,3 +1,5 @@
 pub mod check;
+mod probe;
 
 pub use check::*;
+pub use probe::probe;

--- a/crates/storage/redis/src/health/probe.rs
+++ b/crates/storage/redis/src/health/probe.rs
@@ -1,0 +1,32 @@
+//! Ready-made [`HealthProbe`] over a Redis client, so services don't hand-roll
+//! the readiness closure. Accepts a [`RedisClient`] by value (cheap `Arc`-backed
+//! clone); callers holding an `Arc<RedisClient>` pass `(*client).clone()`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use health::HealthProbe;
+
+use crate::RedisClient;
+
+struct RedisHealthProbe {
+    client: RedisClient,
+}
+
+#[async_trait]
+impl HealthProbe for RedisHealthProbe {
+    fn name(&self) -> &str {
+        "redis"
+    }
+
+    async fn check(&self) -> anyhow::Result<()> {
+        super::check::health_check(&*self.client)
+            .await
+            .map_err(|e| anyhow::anyhow!("redis: {e}"))
+    }
+}
+
+/// Builds a readiness probe (name `"redis"`) over a live Redis client.
+pub fn probe(client: RedisClient) -> Arc<dyn HealthProbe> {
+    Arc::new(RedisHealthProbe { client })
+}

--- a/crates/storage/scylla/Cargo.toml
+++ b/crates/storage/scylla/Cargo.toml
@@ -9,6 +9,9 @@ description = "Production-grade ScyllaDB session management, execution profiles,
 
 [dependencies]
 error     = { workspace = true }
+health      = { workspace = true }
+async-trait = { workspace = true }
+anyhow      = { workspace = true }
 thiserror = { workspace = true }
 tracing   = { workspace = true }
 http      = { workspace = true }

--- a/crates/storage/scylla/src/health/mod.rs
+++ b/crates/storage/scylla/src/health/mod.rs
@@ -1,3 +1,5 @@
 pub mod check;
+mod probe;
 
 pub use check::*;
+pub use probe::probe;

--- a/crates/storage/scylla/src/health/probe.rs
+++ b/crates/storage/scylla/src/health/probe.rs
@@ -1,0 +1,31 @@
+//! Ready-made [`HealthProbe`] over a ScyllaDB client, so services don't hand-roll
+//! the readiness closure.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use health::HealthProbe;
+
+use crate::ScyllaClient;
+
+struct ScyllaHealthProbe {
+    client: Arc<ScyllaClient>,
+}
+
+#[async_trait]
+impl HealthProbe for ScyllaHealthProbe {
+    fn name(&self) -> &str {
+        "scylla"
+    }
+
+    async fn check(&self) -> anyhow::Result<()> {
+        super::check::health_check(&self.client.session)
+            .await
+            .map_err(|e| anyhow::anyhow!("scylla: {e}"))
+    }
+}
+
+/// Builds a readiness probe (name `"scylla"`) over a live ScyllaDB client.
+pub fn probe(client: Arc<ScyllaClient>) -> Arc<dyn HealthProbe> {
+    Arc::new(ScyllaHealthProbe { client })
+}


### PR DESCRIPTION
## Summary

The re-tiering payoff: eliminate the per-service health-probe closures by moving
the probe abstraction to a graph-leaf and letting the **storage crates own their
own probes**. Independent of, and following on from, the workspace re-tiering (#445).

### Why
Every service hand-rolled identical `FnProbe::new("scylla"/"redis"/"postgres", move || { … health_check … })` closures in `health_probes()`. The probe trait lived in `service-runtime` (platform tier), so storage crates **couldn't** expose probes — a storage crate may not depend on the runtime. Now that `foundation/` exists, the trait drops to a leaf and the constraint disappears.

### Changes
- **New `crates/foundation/health`** — owns `HealthProbe` + `FnProbe` (a pure leaf: `async-trait` + `anyhow`).
- **service-runtime** — drops the local trait/struct, deps `health`, **re-exports** `HealthProbe`/`FnProbe`. The `Service` trait and all existing `service_runtime::HealthProbe` imports are unchanged.
- **storage crates** expose `<crate>::health::probe(...) -> Arc<dyn HealthProbe>`:
  - `scylla_storage::health::probe(Arc<ScyllaClient>)` → name `"scylla"`
  - `redis_storage::health::probe(RedisClient)` → name `"redis"`
  - `postgres_storage::health::probe(PgPool)` → name `"postgres"`
- **All 10 services** replaced their `FnProbe` closures with the storage constructor. The per-service redis deref variants (`&*redis` for value holders, `&**redis` for `Arc<RedisClient>` holders) collapse to value-holders passing `redis.clone()` / `(*redis).clone()`. **`FnProbe` is gone from every service.**

`FnProbe` remains in `health` as the escape hatch for non-storage checks (e.g. a future Elasticsearch probe).

Before / after (representative):
```rust
// before — in every service
Arc::new(FnProbe::new("scylla", move || {
    let scylla = Arc::clone(&scylla);
    async move {
        scylla_storage::health::health_check(&scylla.session)
            .await.map_err(|e| anyhow::anyhow!("scylla: {e}"))
    }
}))
// after
scylla_storage::health::probe(Arc::clone(&self.app.scylla))
```

## Test plan
- `cargo check --workspace` + `cargo test --workspace --no-run` green.
- clippy clean on touched crates (health, service-runtime, the 3 storage crates, services) — remaining warnings are pre-existing/unrelated.
- Verified: `FnProbe` no longer referenced in any service; probe call sites resolve per the matrix (scylla ×8, redis ×7, postgres ×1).

## Notes
- Branches off develop (post-#445), **not stacked** — a normal merge is fine.
- Remaining tracked follow-up: the **buf breaking-change CI** job (the `buf.yaml` lint config already landed with the contracts tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
