### PR TITLE
docs(infra): dev→Kustomize GitOps migration (Phase A, gated — DRAFT)

### DIFF
--- a/infrastructure/argocd/DEV-MIGRATION.md
+++ b/infrastructure/argocd/DEV-MIGRATION.md
@@ -1,0 +1,44 @@
+# dev → Kustomize GitOps migration
+
+Move dev's ArgoCD off the **legacy Helm `catalog/profile-service`** path (which
+deploys only the old `profile-command-server` + its own DBs) onto the **new
+`k8s/overlays/dev` Kustomize fleet** (all 10 `service-runtime` services + the
+in-cluster backends) — the same path staging now uses.
+
+## Why this is gated
+The Kustomize fleet **has never run on any cluster.** Migrating dev — a working
+environment — onto it first makes dev the guinea pig. So:
+
+> **Do not merge the migration PR (Phase A) until the staging Kustomize fleet has
+> been applied and validated live.** The PR is held as a DRAFT; merging it puts
+> `deployments/dev/fleet.yaml` on develop, and dev's ArgoCD deploys the fleet.
+
+## Decisions (locked)
+- **Sequencing:** after staging is applied + proven.
+- **Cutover:** parallel-deploy, then cut (reversible at each step).
+- **Profile data:** accept dev data loss (old Postgres/`profile_service` → new Scylla `profile` keyspace; no migration — it's dev).
+
+## Phases
+
+### A — Author (done, in the held PR; zero live effect while unmerged)
+- `deployments/dev/fleet.yaml` — ArgoCD Application → `k8s/overlays/dev`, `prune: false`.
+- Legacy left in place (`domain-appset.yaml`, `profile-*.values.yaml`, `catalog/profile-service/`).
+
+### B — Parallel deploy + validate (merge the PR; live, post-staging)
+1. Merge → dev ArgoCD creates `dev-fleet` and syncs `k8s/overlays/dev`.
+2. The 10 services + in-cluster backends come up under `dev-` names, **without**
+   disturbing the running legacy profile (distinct resources, `prune: false`).
+3. Verify: migrator init-containers connect; gRPC readiness SERVING on all 10;
+   backends (Scylla/Redis/Redpanda/Postgres) healthy.
+
+### C — Cut the ingress + retire legacy
+4. Repoint the public ingress (`api.dev.core-platform.click`) to `dev-profile-server`
+   (the overlay ingress already targets it — consolidate onto it).
+5. Delete the legacy: `domain-appset.yaml`, `profile-*.values.yaml`,
+   `catalog/profile-service/`, and the chart's per-service DBs.
+6. Flip `dev-fleet` `prune: false → true`.
+
+## Risk controls
+- Reversible at each step; legacy stays until Phase C; the ingress cut is a one-line revert.
+- Each phase gated on the prior's health.
+- ⚠️ Phases B/C are **live-cluster** actions that cannot be validated from the repo.

--- a/infrastructure/argocd/apps/deployments/dev/fleet.yaml
+++ b/infrastructure/argocd/apps/deployments/dev/fleet.yaml
@@ -1,0 +1,34 @@
+# infrastructure/argocd/apps/deployments/dev/fleet.yaml
+#
+# Phase A of the dev -> Kustomize GitOps migration (see infrastructure/argocd/DEV-MIGRATION.md).
+#
+# ⚠️ GATED: this file must NOT reach `develop` until the staging Kustomize fleet
+# has been applied + proven live. Once on develop, the dev root-workloads appset
+# (directory recurse) creates this Application and ArgoCD deploys the 10-service
+# fleet to the live dev cluster. The migration PR is held as a DRAFT for exactly
+# this reason.
+#
+# `prune: false` so this comes up ALONGSIDE the legacy profile (domain-appset +
+# catalog/profile-service) without pruning it — the parallel-deploy step. At
+# Phase C (cut the ingress, retire the legacy), flip prune to true.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-fleet
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arnaudmaillet/core-platform
+    targetRevision: develop
+    path: k8s/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## ⛔ DRAFT — DO NOT MERGE until the staging Kustomize fleet (#449) is applied + validated live.

Tees up the **dev → Kustomize GitOps migration**: move dev's ArgoCD off the legacy Helm `catalog/profile-service` (only the old `profile-command-server`) onto the new `k8s/overlays/dev` Kustomize fleet (all 10 services + in-cluster backends) — the path staging uses.

**Why draft/gated:** the Kustomize fleet has never run on any cluster. Merging this puts `deployments/dev/fleet.yaml` on develop, and dev's ArgoCD (root-workloads recurse) immediately deploys the fleet to the **live dev cluster**. So it waits until staging proves the path.

**Contents (Phase A only — zero live effect while unmerged):**
- `infrastructure/argocd/DEV-MIGRATION.md` — the plan: locked decisions (sequence after staging; parallel-deploy-then-cut; accept dev profile data loss) + A/B/C phases + risk controls.
- `deployments/dev/fleet.yaml` — ArgoCD Application → `k8s/overlays/dev`, `prune: false` (parallel coexist with legacy).

**Execution (post-staging):** merge → Phase B (parallel deploy + verify) → Phase C (cut ingress to `dev-profile-server`, retire legacy `domain-appset`/`profile-*.values`/`catalog/profile-service`, flip prune→true).

Validated: YAML parses; the target `k8s/overlays/dev` already builds (kubeconform-clean, merged). Phases B/C are live-cluster actions, not testable from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)