### PR TITLE
feat(auth): IdP-agnostic authentication / session / token service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auth"
+version = "0.1.0"
+dependencies = [
+ "account-api",
+ "anyhow",
+ "async-trait",
+ "auth-api",
+ "auth-context",
+ "base64 0.22.1",
+ "chrono",
+ "cqrs",
+ "error",
+ "fred",
+ "http",
+ "jsonwebtoken",
+ "p256",
+ "postgres",
+ "prost-types",
+ "rand 0.9.2",
+ "rand_core 0.6.4",
+ "redis-storage",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "service-runtime",
+ "sha2 0.11.0",
+ "sqlx",
+ "test-support",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-reflection",
+ "tracing",
+ "transport",
+ "uuid",
+ "validate-core",
+ "validation",
+]
+
+[[package]]
+name = "auth-api"
+version = "0.1.0"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
 name = "auth-context"
 version = "0.1.0"
 dependencies = [
@@ -191,6 +242,16 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "auth-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "auth",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -344,6 +405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -623,6 +693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +755,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -771,15 +856,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -901,7 +995,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -922,10 +1016,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -969,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -995,7 +1100,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1017,7 +1122,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1706,7 +1811,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1762,6 +1867,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2160,7 +2274,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -2322,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2783,7 +2897,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2795,7 +2909,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3691,8 +3805,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4126,8 +4240,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4143,8 +4257,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4178,7 +4303,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4363,7 +4488,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -4402,7 +4527,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -4425,7 +4550,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -4446,7 +4571,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4486,7 +4611,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/services/notification",
     "crates/services/timeline",
     "crates/services/chat",
+    "crates/services/auth",
     "crates/apps/chat-server",
     "crates/apps/profile-server",
     "crates/apps/social-graph-server",
@@ -39,6 +40,7 @@ members = [
     "crates/apps/engagement-server",
     "crates/apps/account-server",
     "crates/apps/timeline-server",
+    "crates/apps/auth-server",
     "crates/apps/migrator",
     "crates/contracts/social-graph-api",
     "crates/contracts/account-api",
@@ -50,6 +52,7 @@ members = [
     "crates/contracts/post-api",
     "crates/contracts/profile-api",
     "crates/contracts/timeline-api",
+    "crates/contracts/auth-api",
 ]
 resolver = "2"
 
@@ -97,6 +100,7 @@ notification-api = { path = "crates/contracts/notification-api" }
 post-api = { path = "crates/contracts/post-api" }
 profile-api = { path = "crates/contracts/profile-api" }
 timeline-api = { path = "crates/contracts/timeline-api" }
+auth-api = { path = "crates/contracts/auth-api" }
 account          = { path = "crates/services/account" }
 chat             = { path = "crates/services/chat" }
 profile          = { path = "crates/services/profile" }
@@ -107,6 +111,7 @@ comment          = { path = "crates/services/comment" }
 geo-discovery    = { path = "crates/services/geo-discovery" }
 notification     = { path = "crates/services/notification" }
 timeline         = { path = "crates/services/timeline" }
+auth             = { path = "crates/services/auth" }
 
 
 # Communs

--- a/crates/apps/auth-server/Cargo.toml
+++ b/crates/apps/auth-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "auth-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the auth service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+auth            = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/auth-server/src/main.rs
+++ b/crates/apps/auth-server/src/main.rs
@@ -1,0 +1,16 @@
+//! `auth-server` — the deployable auth binary. A one-liner over the shared fleet
+//! runtime: telemetry, externalized config + hot-reload, ingress layers, dynamic
+//! health, and graceful shutdown are all the runtime's job.
+
+use std::net::SocketAddr;
+
+use auth::service::AuthService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("AUTH_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50060".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<AuthService>(addr).await
+}

--- a/crates/contracts/auth-api/Cargo.toml
+++ b/crates/contracts/auth-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name        = "auth-api"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Generated gRPC contract for auth.v1 — server + client stubs and reflection descriptor."
+
+[dependencies]
+tonic       = { workspace = true }
+tonic-prost = { workspace = true }
+prost       = { workspace = true }
+prost-types = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = { workspace = true }

--- a/crates/contracts/auth-api/build.rs
+++ b/crates/contracts/auth-api/build.rs
@@ -1,0 +1,20 @@
+//! Compiles the auth.v1 contract into server + client stubs plus a reflection
+//! descriptor set, from the shared contracts/proto root (the single IDL source).
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("auth_descriptor.bin");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(
+            &[
+                "../proto/auth/v1/enums.proto",
+                "../proto/auth/v1/messages.proto",
+                "../proto/auth/v1/service.proto",
+            ],
+            &["../proto/"],
+        )?;
+    Ok(())
+}

--- a/crates/contracts/auth-api/src/lib.rs
+++ b/crates/contracts/auth-api/src/lib.rs
@@ -1,0 +1,12 @@
+//! Generated gRPC contract for `auth.v1` (server + client stubs + descriptor),
+//! compiled from the shared contracts/proto IDL. Consumers depend on this crate
+//! instead of recompiling the .proto files.
+//!
+//! Contract rule (the IdP-agnosticism guarantee): `auth.v1` exposes only
+//! normalized identity types (`account_id`, `session_id`, `generation`,
+//! `permissions`) — never Keycloak/IdP-specific fields. See
+//! `project_auth_service_blueprint`.
+tonic::include_proto!("auth.v1");
+
+/// Encoded protobuf descriptor set for gRPC server reflection.
+pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("auth_descriptor");

--- a/crates/contracts/proto/auth/v1/enums.proto
+++ b/crates/contracts/proto/auth/v1/enums.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package auth.v1;
+
+option java_package = "com.coreplatform.auth.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/auth/v1;authv1";
+
+// Lifecycle status of a Session aggregate.
+enum SessionStatus {
+    SESSION_STATUS_UNSPECIFIED = 0;
+    // Live; can mint edge access tokens until its sliding/absolute expiry.
+    ACTIVE                     = 1;
+    // Explicitly revoked (logout, reuse-detection, or admin). Terminal.
+    REVOKED                    = 2;
+    // Reached its absolute expiry. Terminal.
+    EXPIRED                    = 3;
+}
+
+// How the caller authenticates at OUR boundary. Deliberately IdP-agnostic: the
+// concrete IdP protocol (Keycloak/Cognito/Okta) is brokered behind the
+// infrastructure adapter and never named in this contract.
+enum GrantType {
+    GRANT_TYPE_UNSPECIFIED = 0;
+    // OIDC authorization-code flow with PKCE (primary, browser/native clients).
+    AUTHORIZATION_CODE     = 1;
+    // Resource-owner password grant — first-party trusted clients only. The
+    // password transits TLS to the IdP broker and is NEVER stored by this service
+    // (credentials are owned by the IdP under the federated model).
+    PASSWORD               = 2;
+}

--- a/crates/contracts/proto/auth/v1/messages.proto
+++ b/crates/contracts/proto/auth/v1/messages.proto
@@ -1,0 +1,164 @@
+syntax = "proto3";
+
+package auth.v1;
+
+import "auth/v1/enums.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.coreplatform.auth.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/auth/v1;authv1";
+
+// ── Shared value objects ──────────────────────────────────────────────────────
+
+// Client/device context captured for session tracking and anomaly detection.
+// All fields are best-effort metadata; none are security-bearing on their own.
+message DeviceContext {
+    string  user_agent  = 1;
+    string  ip_address  = 2;
+    // Client-provided stable device identifier (optional); enables "this device"
+    // labelling and targeted revocation in ListSessions.
+    string  device_id   = 3;
+}
+
+// The pair of tokens returned on a successful Login/Refresh.
+//
+// `access_token` is the short-lived, locally-verifiable EDGE token (ES256 JWT in
+// the current phase; PASETO v4.public is a forward-compatible swap). Downstream
+// services verify it in pure CPU via the `auth-context` library — they do NOT
+// call this service on the hot path.
+//
+// `refresh_token` is a long-lived, opaque, single-use server-side handle. It is
+// rotated on every use; presenting a rotated token triggers reuse-detection and
+// revokes the whole session generation.
+message TokenPair {
+    string  access_token   = 1;
+    string  refresh_token  = 2;
+    // Always "Bearer"; present for OAuth2 client familiarity.
+    string  token_type     = 3;
+    // Lifetime of `access_token` in seconds (always ⊆ remaining session TTL).
+    int64   expires_in     = 4;
+    // The session this pair belongs to (normalized identifier).
+    string  session_id     = 5;
+}
+
+// A single session as seen by the account owner (device-management view).
+message SessionView {
+    string                          session_id       = 1;
+    SessionStatus                   status           = 2;
+    // Monotonic revocation epoch; a mass-logout bumps it.
+    int64                           generation       = 3;
+    DeviceContext                   device           = 4;
+    google.protobuf.Timestamp       issued_at        = 5;
+    // Sliding expiry of the session.
+    google.protobuf.Timestamp       expires_at       = 6;
+    // Hard cap beyond which the session cannot be extended.
+    google.protobuf.Timestamp       absolute_expiry  = 7;
+    // True for the session that issued the calling principal's token.
+    bool                            current          = 8;
+}
+
+// ── Login ─────────────────────────────────────────────────────────────────────
+
+// OIDC authorization-code grant (with PKCE). The code is obtained by the client
+// from the IdP's authorize endpoint; this service exchanges it via the broker.
+message AuthorizationCodeGrant {
+    string  code           = 1;
+    string  redirect_uri   = 2;
+    // PKCE verifier matching the challenge sent to the authorize endpoint.
+    string  code_verifier  = 3;
+}
+
+// Resource-owner password grant (first-party trusted clients only).
+message PasswordGrant {
+    string  username  = 1;
+    // Transits TLS to the IdP broker; never persisted by this service.
+    string  password  = 2;
+}
+
+message LoginRequest {
+    DeviceContext   device  = 1;
+    GrantType       grant_type = 2;
+    // Exactly one credential variant must be set, matching `grant_type`.
+    oneof credential {
+        AuthorizationCodeGrant  authorization_code  = 3;
+        PasswordGrant           password            = 4;
+    }
+}
+
+message LoginResponse {
+    // Internal account identifier (NOT the IdP subject) the session is bound to.
+    string      account_id  = 1;
+    TokenPair   tokens      = 2;
+    // True when this login established the IdP-subject → account link for the
+    // first time (a SubjectLinked event was emitted).
+    bool        first_link  = 3;
+}
+
+// ── Refresh ───────────────────────────────────────────────────────────────────
+
+message RefreshRequest {
+    string          refresh_token  = 1;
+    // Optional; re-validated against the session's bound device when present.
+    DeviceContext   device         = 2;
+}
+
+message RefreshResponse {
+    TokenPair   tokens  = 1;
+}
+
+// ── Logout ────────────────────────────────────────────────────────────────────
+
+message LogoutRequest {
+    // Session to revoke. Empty ⇒ the calling principal's current session
+    // (resolved from the authenticated edge token).
+    string  session_id  = 1;
+}
+
+message LogoutResponse {
+    bool    success  = 1;
+}
+
+// ── Logout all sessions (global sign-out / generation bump) ───────────────────
+
+message LogoutAllSessionsRequest {
+    // Target account. Empty ⇒ the calling principal's account.
+    string  account_id  = 1;
+}
+
+message LogoutAllSessionsResponse {
+    bool    success           = 1;
+    // The new session generation after the bump; every token below it is dead.
+    int64   generation        = 2;
+    int32   sessions_revoked  = 3;
+}
+
+// ── Introspect (internal) ─────────────────────────────────────────────────────
+
+message IntrospectRequest {
+    string  access_token  = 1;
+}
+
+// Normalized principal — the same shape `auth-context` produces on the inbound
+// path, exposed here for callers that need server-side introspection rather than
+// local verification (e.g. opaque-token gateways or audit tooling).
+message IntrospectResponse {
+    bool                            active       = 1;
+    string                          account_id   = 2;
+    string                          session_id   = 3;
+    int64                           generation   = 4;
+    // Normalized permissions, e.g. "posts:write" / "ROLE_ADMIN".
+    repeated string                 permissions  = 5;
+    google.protobuf.Timestamp       expires_at   = 6;
+}
+
+// ── List sessions ─────────────────────────────────────────────────────────────
+
+message ListSessionsRequest {
+    // Target account. Empty ⇒ the calling principal's account.
+    string  account_id  = 1;
+}
+
+message ListSessionsResponse {
+    repeated SessionView  sessions  = 1;
+}

--- a/crates/contracts/proto/auth/v1/service.proto
+++ b/crates/contracts/proto/auth/v1/service.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package auth.v1;
+
+import "auth/v1/messages.proto";
+
+option java_package = "com.coreplatform.auth.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/auth/v1;authv1";
+
+// AuthService is the platform's issuance / session / IdP-broker boundary. It
+// brokers authentication to an external IdP, tracks the resulting session, mints
+// short-lived edge tokens, and revokes them.
+//
+// IdP-agnosticism is a hard contract: this surface exposes only NORMALIZED
+// identity types (account_id, session_id, generation, permissions). No
+// Keycloak/Cognito/Okta-specific field appears here — migrating IdP is an
+// infrastructure-adapter swap with zero change to this contract.
+//
+// Identity records (who a person is) are owned by AccountService; credentials
+// (passwords/MFA) are owned by the IdP. This service owns the authentication act
+// and its lifecycle only.
+//
+// Token model: `access_token` is verified LOCALLY by downstream services via the
+// `auth-context` library (pure CPU, no call to this service on the hot path);
+// `refresh_token` is opaque, single-use, and rotated on every Refresh.
+service AuthService {
+
+    // ── Session establishment ─────────────────────────────────────────────────
+
+    // Broker credentials/authorization-code to the IdP, establish a session, and
+    // return an edge access token + opaque refresh token. Resolves (or, on first
+    // login, creates) the IdP-subject → account link and gates issuance on the
+    // account being active.
+    rpc Login(LoginRequest) returns (LoginResponse);
+
+    // Rotate the refresh token (single-use) and mint a fresh edge token. Reusing
+    // an already-rotated refresh token is treated as compromise and revokes the
+    // entire session generation.
+    rpc Refresh(RefreshRequest) returns (RefreshResponse);
+
+    // ── Revocation ────────────────────────────────────────────────────────────
+
+    // Revoke a single session (the caller's current one by default). Idempotent.
+    rpc Logout(LogoutRequest) returns (LogoutResponse);
+
+    // Global sign-out: bump the account's session generation so every previously
+    // minted edge token is rejected at the edge within one cache read.
+    rpc LogoutAllSessions(LogoutAllSessionsRequest) returns (LogoutAllSessionsResponse);
+
+    // ── Introspection & device management ─────────────────────────────────────
+
+    // INTERNAL. Server-side token introspection returning the normalized
+    // principal, for callers that cannot verify edge tokens locally.
+    rpc Introspect(IntrospectRequest) returns (IntrospectResponse);
+
+    // List the account's active sessions for device-management UIs.
+    rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+}

--- a/crates/services/auth/Cargo.toml
+++ b/crates/services/auth/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name        = "auth"
+version.workspace   = true
+edition.workspace   = true
+license.workspace   = true
+authors.workspace   = true
+repository.workspace = true
+description = "Auth microservice — issuance, session lifecycle, and IdP brokering boundary (identity SoR lives in `account`)."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# Only the canonical error namespace (AUT-XXXX) lives here today. Subsequent
+# phases add: domain/ (Phase 2), application/ + ports (Phase 3), infrastructure/
+# adapters incl. Keycloak/Postgres/Redis (Phase 4), and the service composition
+# root + tonic wiring (Phase 5). Dependencies grow per phase — kept minimal here
+[dependencies]
+# ── Contracts & runtime ───────────────────────────────────────────────────────
+auth-api        = { workspace = true }
+service-runtime = { workspace = true }
+anyhow          = { workspace = true }
+
+# ── Shared platform infrastructure ────────────────────────────────────────────
+error            = { workspace = true }
+validate-core    = { workspace = true }
+validation       = { workspace = true }
+postgres-storage = { workspace = true }
+
+# ── Shared platform crates ────────────────────────────────────────────────────
+cqrs          = { workspace = true }
+transport     = { workspace = true }
+redis-storage = { workspace = true }
+account-api   = { workspace = true }
+async-trait   = { workspace = true }
+
+# ── Domain types ──────────────────────────────────────────────────────────────
+serde      = { workspace = true }
+serde_json = { workspace = true }
+uuid       = { workspace = true }
+chrono     = { workspace = true }
+
+# ── Persistence / cache / transport adapters (Phase 4) ────────────────────────
+sqlx             = { workspace = true }
+fred             = { workspace = true }
+tonic            = { workspace = true }
+tonic-reflection = { workspace = true }
+prost-types      = { workspace = true }
+
+# ── Token minter & IdP broker (Phase 4/7) ─────────────────────────────────────
+jsonwebtoken = { workspace = true }
+reqwest      = { workspace = true }
+rand         = { workspace = true }
+sha2         = { workspace = true }
+base64       = { workspace = true }
+# P-256 public-key parsing for JWKS publication (key-ring rotation, Phase 7).
+p256         = { version = "0.13", features = ["pem", "pkcs8"] }
+
+# ── Observability ─────────────────────────────────────────────────────────────
+tracing = { workspace = true }
+
+# ── Error handling ────────────────────────────────────────────────────────────
+thiserror = { workspace = true }
+http      = { workspace = true }
+
+[features]
+# Gates the live, container-backed integration suite (tests/integration.rs). Off
+# by default so `cargo test -p auth` stays a fast, infra-free unit run; the live
+# suite boots real Postgres + Redis containers and is opt-in via
+# `cargo test -p auth --features integration-auth`.
+integration-auth = []
+
+[dev-dependencies]
+# Async runtime for the application-layer handler tests (#[tokio::test]).
+tokio        = { workspace = true }
+# Ephemeral P-256 keypair generation for tests — no key material is ever
+# hardcoded. `rand_core` 0.6 supplies the OsRng that `p256`'s ECDSA keygen wants
+# (the workspace `rand` 0.9 uses an incompatible rand_core major).
+rand_core    = { version = "0.6", features = ["getrandom"] }
+# Cross-crate edge-token verification (tests/edge_token_verify.rs) drives the same
+# `auth-context` decoder every downstream service uses — no container needed.
+auth-context = { workspace = true }
+# Live integration suite (feature = "integration-auth"): shared container
+# orchestration + `.sql` migration runner + `await_until`.
+test-support = { workspace = true }
+async-trait  = { workspace = true }
+uuid         = { workspace = true }
+chrono       = { workspace = true }
+serde        = { workspace = true }

--- a/crates/services/auth/README.fr.md
+++ b/crates/services/auth/README.fr.md
@@ -1,0 +1,212 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: 9ade3cb67df657ddcdad703267c16980398f951857524c1776eb0dc5bba2ebb0
+  translated_at: 2026-06-25
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, variables
+> d'environnement, topics Kafka, identifiants) sont volontairement laissés en anglais.
+
+# `auth` — Frontière d'authentification : émettre, suivre et révoquer des sessions sans accès base à chaque requête
+
+> **Fiche service** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Équipe** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **Astreinte / escalade** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-0** — chaque requête authentifiée dépend des jetons émis par ce service |
+> | **Déployable** | `crates/apps/auth-server` (crate bibliothèque : `crates/services/auth`) |
+> | **Stockage** | PostgreSQL/CockroachDB (db `auth`) · Redis Cluster (sessions/blacklist) |
+> | **Asynchrone** | publie `auth.v1.events` (SessionIssued/SessionRevoked/SubjectLinked) · ne consomme rien |
+> | **Appelants amont** | gateway / edge, clients utilisateurs (login & refresh) |
+> | **Dépendances aval** | Keycloak (IdP), `account` (gRPC, SoR d'identité), PostgreSQL, Redis Cluster |
+> | **SLO** | `<TODO: 99.95%>` dispo · login p99 `<TODO>` · refresh p99 `<TODO>` |
+
+> **✅ Statut — toutes les phases (0–7) terminées.** Contrat, domaine, application, infrastructure,
+> câblage serveur, suite d'intégration live sur conteneurs, et durcissement ops (**rotation par
+> trousseau** de clés de signature ES256 + publication **JWKS**, docs SLO/modes de défaillance/runbook)
+> sont en place et verts. Les `<TODO>` restants sont des valeurs propres au déploiement (équipe,
+> astreinte, chiffres SLO concrets). Voir [`project_auth_service_blueprint`] pour la conception
+> complète et le plan par phases.
+
+---
+
+## 🎯 Vue d'ensemble & rôle du service
+
+`auth` est la frontière **émission / session / courtage IdP** de la plateforme. Il possède l'*acte
+d'authentification et son cycle de vie* — courtage de connexion, suivi de session, rotation des
+refresh tokens, révocation et émission des jetons d'edge — ainsi que l'unique donnée d'identité qui
+relève de l'authentification : le lien sujet-IdP ↔ `account_id`.
+
+Le problème difficile qu'il résout : **authentifier un trafic à l'échelle hyperscale sans lecture en
+base à chaque appel**. Une conception naïve consulte une table de sessions à chaque requête et
+s'effondre sous la charge. `auth` y répond par un **modèle à jeton scindé** : des **jetons d'edge**
+courts et vérifiables localement (vérifiés en pur CPU par la bibliothèque `auth-context` dans chaque
+service aval) plus des **refresh tokens** longs, côté serveur, à usage unique, avec rotation
+obligatoire et détection de réutilisation. La déconnexion globale instantanée s'appuie sur un
+compteur de **génération** par session dans Redis Cluster ; la révocation se compte donc en
+millisecondes — jamais une écriture amplifiée sur tous les lecteurs.
+
+**Objectifs fondamentaux :** (1) aucune lecture en base sur le chemin chaud ; (2) réutilisation d'un
+refresh token = compromission ⇒ révocation de toute la génération de session ; (3) **100 %
+indépendant de l'IdP** — les couches domaine et application ne nomment jamais Keycloak ; migrer vers
+Cognito/Okta/custom est un nouvel adaptateur d'infrastructure et zéro changement de domaine.
+
+### Ce que ce service ne possède **pas**
+| Préoccupation | Propriétaire |
+|---|---|
+| Qui est une personne (dossier d'identité, KYC, RGPD, rôles RBAC) | service `account` (SoR d'identité) |
+| Identifiants (mots de passe, MFA, récupération) | Keycloak (IdP) — modèle fédéré |
+| Vérification entrante des jetons sur le chemin chaud | bibliothèque plateforme `auth-context` |
+
+---
+
+## 📐 Architecture & concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), bus CQRS commande/requête, PostgreSQL
+pour le registre durable des sessions, Redis Cluster pour la carte de génération / blacklist du
+chemin chaud, Kafka pour les événements. L'IdP est masqué derrière un `IdentityProviderPort`
+(Port/Adapter), si bien qu'aucun type Keycloak ne fuite au-dessus de `infrastructure`.
+
+```
+            ┌──────────────────────── auth-service ───────────────────────┐
+ client ──► │ Login/Refresh/Logout ─► bus CQRS ─► ports :                 │
+            │   IdentityProviderPort ─┐   SessionRepo/RefreshRepo (PG)     │
+            │   AccountDirectoryPort ─┤   SessionCachePort (Redis gen/blk) │
+            │   TokenMinterPort ──────┘   SubjectLinkRepo (PG)             │
+            └───────┬───────────────────────────┬─────────────────────────┘
+       courtage login│                           │émet le jeton d'edge (ES256 ; PASETO en suivi)
+                    ▼                            ▼
+              Keycloak (IdP)            les services aval vérifient LOCALEMENT via auth-context
+                    │                            │  (vérif. signature pur CPU + contrôle O(1)
+              résout l'identité ──► account      │   facultatif de `gen` Redis pour logout instantané)
+```
+
+**Chemin chaud à jeton scindé.** 99 % des appels API = vérification de signature seule, aucune E/S.
+La révocation est un incrément de `generation` écrit dans `auth:sess:{account}:gen` sur Redis ; un
+jeton d'edge portant une `gen` périmée est rejeté. Seul `/refresh` (faible QPS) touche PostgreSQL.
+
+> **Invariants** (et où ils sont appliqués) : TTL du jeton d'edge ⊆ TTL de session ⊆ plafond absolu ;
+> la rotation du refresh est obligatoire et à usage unique, et toute réutilisation révoque la
+> génération entière (appliqué dans l'agrégat `Session`, Phase 2) ; `SubjectLink (iss,sub)→account_id`
+> est immuable (Phase 2) ; l'émission de session est conditionnée au statut `account` (couche
+> application, Phase 3).
+
+---
+
+## 📊 Objectifs de niveau de service (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objectif | Fenêtre | Mesuré par |
+|---|---|---|---|
+| Disponibilité (non-5xx / non-`UNAVAILABLE`) | `<TODO 99.95%>` | 30j glissants | `<grpc_server_handled_total par code>` |
+| Latence `Login` p99 | `< <TODO> ms` | 1h | `<latence rpc par méthode>` (dominée par l'aller-retour IdP) |
+| Latence `Refresh` p99 | `< <TODO> ms` | 1h | `<latence rpc>` (une rotation Postgres) |
+| Latence `Introspect` p99 | `< <TODO> ms` | 1h | `<latence rpc>` (vérif CPU + ≤1 lecture Redis) |
+| Durabilité | aucune écriture session/refresh acquittée perdue | — | Postgres `LocalQuorum`/fsync |
+
+**Budget d'erreur :** `<0,05% / 30j ≈ 21m>`. **En cas de consommation :** gel du rollout, page astreinte.
+
+> **Note — l'edge n'est pas sur le chemin critique d'auth.** Les services aval vérifient les jetons
+> d'edge *localement* via `auth-context` ; seuls `Login` / `Refresh` / `Logout` touchent ce service.
+> Une panne d'auth empêche les *nouvelles* connexions et refresh mais ne casse **pas** le trafic
+> authentifié en vol (les jetons d'edge existants restent vérifiables jusqu'à expiration).
+
+## 🔗 Dépendances & rayon d'impact &nbsp;·&nbsp; OPS
+
+**Aval — ce dont `auth` a besoin :**
+
+| Dépendance | Rôle | Si en panne → | Dégradation |
+|---|---|---|---|
+| Keycloak (IdP) | vérification des identifiants au `Login` | `Login` échoue (`UNAVAILABLE`) | **Dur** pour les nouvelles connexions ; refresh/introspect intacts |
+| `account` (gRPC) | résolution compte + gating actif au `Login` | `Login` échoue | **Dur** pour les nouvelles connexions |
+| PostgreSQL | registre sessions + refresh + liens | écritures `Refresh`/`Logout` échouent | **Dur** pour refresh/révocation |
+| Redis Cluster | carte de génération + blacklist (chemin chaud) | contrôles de révocation dégradés | **Souple** — la génération se reconstruit depuis Postgres ; une entrée blacklist manquée expire avec le jeton |
+| Kafka | émission `auth.v1.events` | événements non émis | **Souple** — best-effort ; repli sur le log publisher |
+
+**Amont — rayon d'impact si `auth` tombe :**
+
+| Appelant | Utilise | Impact si `auth` est en panne |
+|---|---|---|
+| gateway / edge | `Login` / `Refresh` / `Logout` | impossible de se connecter, refresh ou se déconnecter ; **les requêtes déjà authentifiées continuent** jusqu'à expiration |
+| UI ops / gestion d'appareils | `ListSessions` / `Introspect` | listing de sessions + introspection côté serveur indisponibles |
+
+## ⚙️ Configuration
+
+| Variable d'env | Rôle | Défaut |
+|---|---|---|
+| `AUTH_GRPC_ADDR` | Adresse d'écoute gRPC | `0.0.0.0:50060` |
+| `AUTH_SIGNING_PRIVATE_PEM` / `AUTH_SIGNING_PUBLIC_PEM` | **Requis.** Paire de clés ES256 du jeton d'edge (PEM) | — |
+| `AUTH_SIGNING_KID` · `AUTH_TOKEN_ISSUER` · `AUTH_TOKEN_AUDIENCE` | `kid` / `iss` / `aud` du jeton d'edge | `auth-es256-1` · `https://auth.core-platform` · `core-platform` |
+| `AUTH_ACCESS_TTL_SECS` · `AUTH_SESSION_TTL_SECS` · `AUTH_ABSOLUTE_TTL_SECS` · `AUTH_REFRESH_TTL_SECS` | Durées de vie jeton / session | `600` · `1800` · `28800` · `604800` |
+| `AUTH_KEYCLOAK_TOKEN_ENDPOINT` · `AUTH_KEYCLOAK_CLIENT_ID` · `AUTH_KEYCLOAK_CLIENT_SECRET` · `AUTH_KEYCLOAK_SCOPE` | Courtier IdP | — · — · — · `openid` |
+| `AUTH_ACCOUNT_GRPC_ENDPOINT` | Endpoint du service `account` | `http://localhost:50059` |
+| Postgres / Redis / Kafka | via les `from_env()` des crates de stockage partagées | — |
+
+## 🧪 Développement local
+
+```bash
+cargo test -p auth                              # rapide, hermétique : units + edge-verify inter-crate
+cargo test -p auth --features integration-auth  # live : démarre des conteneurs Postgres + Redis
+```
+
+Le run par défaut ne nécessite pas Docker. Il couvre les units domaine/application/handler, le
+round-trip mint↔verify ES256, et **`tests/edge_token_verify.rs`** — la preuve inter-crate qu'un
+jeton émis ici est accepté par le même décodeur `auth-context` que chaque service aval exécute.
+
+La suite `integration-auth` (`tests/auth_it/`) démarre **PostgreSQL** + **Redis** réels via le
+harnais partagé `test-support` et pilote la composition root de production via le handler gRPC. Les
+dépendances *externes* d'auth (l'IdP et le service `account`) sont stubbées au niveau de leurs ports.
+Scénarios : cycle de vie (login → introspect → logout), rotation refresh + détection de réutilisation
+→ révocation de génération, logout global, et allers-retours d'écriture durable. **Keycloak n'est pas
+conteneurisé** — l'adaptateur OIDC est testé unitairement, et la suite live se concentre sur la
+machinerie session/jeton au-dessus des stores propres à auth.
+
+## 🔥 Modes de défaillance &nbsp;·&nbsp; OPS
+
+| Symptôme | Cause racine probable | Mitigation |
+|---|---|---|
+| Tous les `Login` → `UNAVAILABLE` | Keycloak ou `account` injoignable | vérifier la santé IdP / `account` ; refresh + introspect fonctionnent toujours |
+| Pic de `Refresh` → `UNAUTHENTICATED` | **réutilisation** de refresh token (vol) ou logout global | attendu en cas de réutilisation — la génération de session est révoquée ; investiguer l'IP/appareil source |
+| Jetons d'edge acceptés après logout | miss blacklist/génération Redis | les jetons meurent quand même au TTL (≤ `AUTH_ACCESS_TTL_SECS`) ; vérifier Redis et la clé de génération |
+| `Introspect` renvoie `active:false` pour un jeton frais | dérive d'horloge, ou un bump de génération (logout global) | vérifier NTP ; confirmer la génération courante du compte dans Redis |
+| Les services aval rejettent nos jetons | JWKS non publié / `kid` sorti de rotation | s'assurer que les clés publiques active **et** sortante sont dans le JWKS publié (voir Déploiement) |
+| `ConcurrentModification` (AUT-8001) | contention de verrou optimiste sur une ligne session | retryable — l'appelant retente ; persistant ⇒ investiguer des opérations concurrentes dupliquées |
+
+## 🚀 Déploiement &nbsp;·&nbsp; OPS
+
+- **Le throttling / lockout n'est *pas* le rôle de ce service.** La protection brute-force des
+  identifiants vit dans Keycloak (modèle fédéré) ; la limitation de débit en ingress est la couche
+  `[traffic]` du runtime partagé. Auth n'ajoute aucun throttle redondant.
+- **Rotation des clés de signature (sans interruption).** Les jetons d'edge sont ES256, vérifiés par
+  un **trousseau de clés** :
+  1. Générer une nouvelle paire P-256 ; la définir comme `AUTH_SIGNING_PRIVATE_PEM` /
+     `AUTH_SIGNING_PUBLIC_PEM` avec un nouveau `AUTH_SIGNING_KID`.
+  2. Déplacer la clé publique *précédente* vers `AUTH_SIGNING_RETIRING_PUBLIC_PEM` /
+     `AUTH_SIGNING_RETIRING_KID` pour que les jetons émis sous elle restent vérifiables et dans le JWKS.
+  3. Déployer. Les nouveaux jetons sont signés avec le nouveau `kid` ; les anciens valident contre la clé sortante.
+  4. Après une fenêtre `AUTH_ABSOLUTE_TTL_SECS` complète, retirer la clé sortante.
+- **Publication JWKS.** `Es256TokenMinter::jwks_json()` produit le JWKS de chaque clé du trousseau ;
+  le publier à l'URL JWKS well-known du service pour qu'`auth-context` (dans chaque service aval) le
+  récupère et le cache. La clé privée ne quitte jamais ce service — seul le matériel public est publié.
+
+## 🛠️ Dépannage
+
+- **`required env var AUTH_SIGNING_PRIVATE_PEM is not set` au démarrage** — la paire de clés de
+  signature ES256 est obligatoire ; fournir les deux PEM (voir Configuration).
+- **Les jetons se vérifient localement mais `Introspect` dit inactif** — `Introspect` applique en plus
+  les contrôles live génération + blacklist ; un jeton peut être cryptographiquement valide mais révoqué.
+- **Lancer un scénario :** `cargo test -p auth --features integration-auth <name> -- --nocapture`.
+
+---
+
+## 📋 Codes d'erreur
+
+Espace de noms canonique `AUT-XXXX` — voir [`src/error.rs`](src/error.rs) pour le catalogue faisant
+foi (1xxx session · 2xxx refresh/rotation · 3xxx liaison de sujet · 4xxx émission de jeton · 5xxx
+courtage IdP · 6xxx annuaire de comptes · 9xxx domaine/parsing). Les codes de stockage (`DB-*`) et de
+validation (`VAL-*`) sont délégués de manière transparente.
+
+[`project_auth_service_blueprint`]: ../../../docs/ <!-- TODO : lier le document de conception une fois publié -->

--- a/crates/services/auth/README.md
+++ b/crates/services/auth/README.md
@@ -1,0 +1,197 @@
+# `auth` — Authentication boundary: issue, track, and revoke sessions without a DB hit per request
+
+> **Service Card** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Owner** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **On-call / escalation** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-0** — every authenticated request depends on tokens this service issues |
+> | **Deployable** | `crates/apps/auth-server` (library crate: `crates/services/auth`) |
+> | **Datastores** | PostgreSQL/CockroachDB (db `auth`) · Redis Cluster (sessions/blacklist) |
+> | **Async** | publishes `auth.v1.events` (SessionIssued/SessionRevoked/SubjectLinked) · consumes nothing |
+> | **Upstream callers** | gateway / edge, end-user clients (login & refresh) |
+> | **Downstream deps** | Keycloak (IdP), `account` (gRPC, identity SoR), PostgreSQL, Redis Cluster |
+> | **SLO** | `<TODO: 99.95%>` avail · login p99 `<TODO>` · refresh p99 `<TODO>` |
+
+> **✅ Status — all phases (0–7) complete.** Contract, domain, application, infrastructure,
+> server wiring, a live container-backed integration suite, and ops hardening (ES256 signing-key
+> **ring rotation** + **JWKS** publication, SLO/failure-mode/runbook docs) are all in place and
+> green. Remaining `<TODO>`s are deployment-specific values (team, on-call, concrete SLO numbers).
+> See [`project_auth_service_blueprint`] for the full design and phased plan.
+
+---
+
+## 🎯 Overview & Service Role
+
+`auth` is the platform's **issuance / session / IdP-broker** boundary. It owns the
+*authentication act and its lifecycle* — login brokering, session tracking, refresh-token
+rotation, revocation, and edge-token minting — plus the one piece of identity data that is an
+authentication concern: the IdP-subject ↔ `account_id` linkage.
+
+The hard problem it solves is **authenticating hyperscale traffic without a datastore read per
+call**. A naive design checks a session table on every request and melts under load. `auth`
+resolves this with a **split-token model**: short-lived, locally-verifiable **edge tokens**
+(verified in pure CPU by the `auth-context` library in every downstream service) plus long-lived,
+server-side, single-use **refresh tokens** with mandatory rotation and reuse-detection. Instant
+global logout rides a per-session **generation** counter in Redis Cluster, so revocation is
+milliseconds — never a write amplified across every reader.
+
+**Core objectives:** (1) no datastore read on the request hot path; (2) refresh-token reuse =
+compromise ⇒ revoke the whole session generation; (3) **100% IdP-agnostic** — the domain and
+application layers never name Keycloak; migrating to Cognito/Okta/custom is a new infrastructure
+adapter and zero domain change.
+
+### What this service does **not** own
+| Concern | Owner |
+|---|---|
+| Who a person *is* (identity record, KYC, GDPR, RBAC roles) | `account` service (identity SoR) |
+| Credentials (passwords, MFA, recovery) | Keycloak (IdP) — federated model |
+| Inbound token *verification* on the hot path | `auth-context` platform library |
+
+---
+
+## 📐 Architecture & Concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), CQRS command/query buses,
+PostgreSQL for the durable session ledger, Redis Cluster for the hot-path generation map /
+blacklist, Kafka for events. The IdP sits behind an `IdentityProviderPort` (Port/Adapter), so no
+Keycloak type leaks above `infrastructure`.
+
+```
+            ┌──────────────────────── auth-service ───────────────────────┐
+ client ──► │ Login/Refresh/Logout ─► CQRS bus ─► ports:                  │
+            │   IdentityProviderPort ─┐   SessionRepo/RefreshRepo (PG)     │
+            │   AccountDirectoryPort ─┤   SessionCachePort (Redis gen/blk) │
+            │   TokenMinterPort ──────┘   SubjectLinkRepo (PG)             │
+            └───────┬───────────────────────────┬─────────────────────────┘
+        broker login│                            │mints edge token (ES256; PASETO fast-follow)
+                    ▼                            ▼
+              Keycloak (IdP)            downstream services verify LOCALLY via auth-context
+                    │                            │  (pure-CPU sig check + optional O(1)
+              resolves identity ──► account      │   Redis `gen` check for instant logout)
+```
+
+**Split-token hot path.** 99% of API calls = signature verify only, no I/O. Revocation is a
+`generation` bump written through to `auth:sess:{account}:gen` in Redis; an edge token carrying a
+stale `gen` is rejected. Only `/refresh` (low QPS) touches PostgreSQL.
+
+> **Invariants** (and where enforced): edge-token TTL ⊆ session TTL ⊆ absolute cap; refresh
+> rotation is mandatory + single-use, and reuse revokes the whole generation (enforced in the
+> `Session` aggregate, Phase 2); `SubjectLink (iss,sub)→account_id` is immutable (Phase 2);
+> session issuance is gated on `account` status (application layer, Phase 3).
+
+---
+
+## 📊 Service Level Objectives (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objective | Window | Measured by |
+|---|---|---|---|
+| Availability (non-5xx / non-`UNAVAILABLE`) | `<TODO 99.95%>` | 30d rolling | `<grpc_server_handled_total by code>` |
+| `Login` latency p99 | `< <TODO> ms` | 1h | `<rpc latency by method>` (dominated by the IdP round-trip) |
+| `Refresh` latency p99 | `< <TODO> ms` | 1h | `<rpc latency>` (one Postgres rotation) |
+| `Introspect` latency p99 | `< <TODO> ms` | 1h | `<rpc latency>` (CPU verify + ≤1 Redis read) |
+| Durability | no acked session/refresh write lost | — | Postgres `LocalQuorum`/fsync |
+
+**Error budget:** `<0.05% / 30d ≈ 21m>`. **On burn:** freeze rollout, page on-call.
+
+> **Note — the edge is not on auth's critical path.** Downstream services verify edge tokens
+> *locally* via `auth-context`; only `Login` / `Refresh` / `Logout` hit this service. An auth
+> outage stops *new* logins and refreshes but does **not** break in-flight authenticated traffic
+> (existing edge tokens keep verifying until they expire).
+
+## 🔗 Dependencies & Blast Radius &nbsp;·&nbsp; OPS
+
+**Downstream — what `auth` needs to function:**
+
+| Dependency | Purpose | If down → | Degradation |
+|---|---|---|---|
+| Keycloak (IdP) | credential verification on `Login` | `Login` fails (`UNAVAILABLE`) | **Hard** for new logins; refresh/introspect unaffected |
+| `account` (gRPC) | resolve account + gate active on `Login` | `Login` fails | **Hard** for new logins |
+| PostgreSQL | session + refresh-token + link ledger | `Refresh`/`Logout` writes fail | **Hard** for refresh/revocation |
+| Redis Cluster | generation map + blacklist (hot path) | revocation checks degrade | **Soft** — generation rebuilds from Postgres; a missed blacklist entry expires with the token |
+| Kafka | `auth.v1.events` emission | events not emitted | **Soft** — best-effort; falls back to the log publisher |
+
+**Upstream — blast radius if `auth` fails:**
+
+| Caller | Uses | Impact if `auth` is down |
+|---|---|---|
+| gateway / edge | `Login` / `Refresh` / `Logout` | users cannot sign in, refresh, or sign out; **already-authenticated requests keep working** until tokens expire |
+| ops / device-management UI | `ListSessions` / `Introspect` | session listing + server-side introspection unavailable |
+
+## ⚙️ Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `AUTH_GRPC_ADDR` | gRPC listen address | `0.0.0.0:50060` |
+| `AUTH_SIGNING_PRIVATE_PEM` / `AUTH_SIGNING_PUBLIC_PEM` | **Required.** ES256 edge-token key pair (PEM) | — |
+| `AUTH_SIGNING_KID` · `AUTH_TOKEN_ISSUER` · `AUTH_TOKEN_AUDIENCE` | Edge-token `kid` / `iss` / `aud` | `auth-es256-1` · `https://auth.core-platform` · `core-platform` |
+| `AUTH_ACCESS_TTL_SECS` · `AUTH_SESSION_TTL_SECS` · `AUTH_ABSOLUTE_TTL_SECS` · `AUTH_REFRESH_TTL_SECS` | Token / session lifetimes | `600` · `1800` · `28800` · `604800` |
+| `AUTH_KEYCLOAK_TOKEN_ENDPOINT` · `AUTH_KEYCLOAK_CLIENT_ID` · `AUTH_KEYCLOAK_CLIENT_SECRET` · `AUTH_KEYCLOAK_SCOPE` | IdP broker | — · — · — · `openid` |
+| `AUTH_ACCOUNT_GRPC_ENDPOINT` | `account` service endpoint | `http://localhost:50059` |
+| Postgres / Redis / Kafka | via the shared storage crates' own `from_env()` | — |
+
+## 🧪 Local Development
+
+```bash
+cargo test -p auth                              # fast, hermetic: unit + cross-crate edge-verify
+cargo test -p auth --features integration-auth  # live: boots Postgres + Redis containers
+```
+
+The default run needs no Docker. It covers the domain/application/handler units, the ES256
+mint↔verify round-trip, and **`tests/edge_token_verify.rs`** — the cross-crate proof that a token
+minted here is accepted by the same `auth-context` decoder every downstream service runs.
+
+The `integration-auth` suite (`tests/auth_it/`) boots real **PostgreSQL** + **Redis** via the shared
+`test-support` harness and drives the production composition root through the gRPC handler. Auth's
+*external* deps (the IdP and the `account` service) are stubbed at their ports. Scenarios:
+lifecycle (login → introspect → logout), refresh rotation + reuse-detection → generation revoke,
+global logout, and durable-write round-trips. **Keycloak is not containerized** — the OIDC adapter
+is unit-tested directly, and the live suite focuses on the session/token machinery over auth's own
+stores.
+
+## 🔥 Failure Modes &nbsp;·&nbsp; OPS
+
+| Symptom | Likely root cause | Mitigation |
+|---|---|---|
+| All `Login` → `UNAVAILABLE` | Keycloak or `account` unreachable | check IdP / `account` health; refresh + introspect keep working |
+| `Refresh` → `UNAUTHENTICATED` spike | refresh-token **reuse** (token theft) or a global logout | expected on reuse — the session generation is revoked; investigate the source IP/device |
+| Edge tokens accepted after logout | Redis blacklist/generation miss | tokens still die at TTL (≤ `AUTH_ACCESS_TTL_SECS`); verify Redis health and the generation key |
+| `Introspect` returns `active:false` for a fresh token | clock skew, or a generation bump (global logout) | check NTP; confirm the account's current generation in Redis |
+| Downstream services reject our tokens | JWKS not published / `kid` rotated out | ensure the active **and** retiring public keys are in the published JWKS (see Deployment) |
+| `ConcurrentModification` (AUT-8001) | optimistic-lock contention on a session row | retryable — the caller (or gateway) retries; persistent ⇒ investigate duplicate inflight ops |
+
+## 🚀 Deployment &nbsp;·&nbsp; OPS
+
+- **Throttling / lockout is *not* this service's job.** Credential brute-force protection lives in
+  Keycloak (federated model); ingress rate-limiting is the shared runtime's `[traffic]` layer. Auth
+  adds no redundant throttle.
+- **Signing-key rotation (zero-downtime).** Edge tokens are ES256, verified by a **key ring**:
+  1. Generate a new P-256 keypair; set it as `AUTH_SIGNING_PRIVATE_PEM` / `AUTH_SIGNING_PUBLIC_PEM`
+     with a fresh `AUTH_SIGNING_KID`.
+  2. Move the *previous* public key to `AUTH_SIGNING_RETIRING_PUBLIC_PEM` / `AUTH_SIGNING_RETIRING_KID`
+     so tokens minted under it keep verifying and stay in the JWKS.
+  3. Roll out. New tokens are signed with the new `kid`; old tokens validate against the retiring key.
+  4. After one full `AUTH_ABSOLUTE_TTL_SECS` window (no token can predate it), drop the retiring key.
+- **JWKS publication.** `Es256TokenMinter::jwks_json()` produces the JWKS for every ring key; publish
+  it at the service's well-known JWKS URL so `auth-context` (in every downstream service) fetches and
+  caches it. The private key never leaves this service — only public material is published.
+
+## 🛠️ Troubleshooting
+
+- **`required env var AUTH_SIGNING_PRIVATE_PEM is not set` at boot** — the ES256 signing key pair is
+  mandatory; provide both PEMs (see Configuration).
+- **Tokens verify locally but `Introspect` says inactive** — `Introspect` additionally applies the
+  live generation + blacklist checks; a token can be cryptographically valid yet revoked.
+- **Run one scenario:** `cargo test -p auth --features integration-auth <name> -- --nocapture`.
+
+---
+
+## 📋 Error Codes
+
+Canonical `AUT-XXXX` namespace — see [`src/error.rs`](src/error.rs) for the authoritative catalogue
+(1xxx session · 2xxx refresh/rotation · 3xxx subject linkage · 4xxx token minting · 5xxx IdP broker ·
+6xxx account directory · 9xxx domain/parse). Storage (`DB-*`) and validation (`VAL-*`) codes are
+delegated transparently.
+
+[`project_auth_service_blueprint`]: ../../../docs/ <!-- TODO: link the design doc when published -->

--- a/crates/services/auth/migrations/0001_create_auth_tables.sql
+++ b/crates/services/auth/migrations/0001_create_auth_tables.sql
@@ -1,0 +1,83 @@
+-- Migration: 0001_create_auth_tables
+-- Description: Durable state for the auth bounded context — session ledger,
+--              refresh-token rotation lineage, the immutable IdP-subject ↔ account
+--              link, and the edge-token signing-key ring. Pure ANSI SQL, portable
+--              across PostgreSQL and CockroachDB. All tables carry an account_id so
+--              a person's auth state co-locates on one shard (ShardKey = account_id).
+
+-- ── Sessions ─────────────────────────────────────────────────────────────────
+-- One row per authentication act. `generation` is the epoch the session was
+-- minted under; a global sign-out bumps the account's generation in Redis and
+-- the durable counter, invalidating every session below it at the edge.
+CREATE TABLE IF NOT EXISTS sessions (
+    id                  UUID         NOT NULL,
+    account_id          UUID         NOT NULL,
+    issuer              TEXT         NOT NULL,
+    subject             TEXT         NOT NULL,
+    generation          BIGINT       NOT NULL,
+    status              TEXT         NOT NULL DEFAULT 'active',
+    device_user_agent   TEXT,
+    device_ip           TEXT,
+    device_id           TEXT,
+    issued_at           TIMESTAMPTZ  NOT NULL,
+    expires_at          TIMESTAMPTZ  NOT NULL,
+    absolute_expiry     TIMESTAMPTZ  NOT NULL,
+    revoked_at          TIMESTAMPTZ,
+    version             BIGINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+);
+
+-- Device-management view + the set a global sign-out iterates.
+CREATE INDEX IF NOT EXISTS idx_sessions_account_active
+    ON sessions (account_id, status);
+
+-- ── Refresh tokens ───────────────────────────────────────────────────────────
+-- Opaque, single-use, rotated on every exchange. Only the hash is stored;
+-- `replaced_by` chains the rotation lineage for reuse-detection.
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id            UUID         NOT NULL,
+    session_id    UUID         NOT NULL,
+    account_id    UUID         NOT NULL,
+    token_hash    TEXT         NOT NULL,
+    status        TEXT         NOT NULL DEFAULT 'active',
+    issued_at     TIMESTAMPTZ  NOT NULL,
+    expires_at    TIMESTAMPTZ  NOT NULL,
+    used_at       TIMESTAMPTZ,
+    replaced_by   UUID,
+    version       BIGINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_refresh_tokens_hash UNIQUE (token_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_session
+    ON refresh_tokens (session_id);
+
+-- ── Subject links ────────────────────────────────────────────────────────────
+-- The immutable (issuer, subject) → account_id binding. Keyed on the full pair so
+-- an IdP migration (new issuer) never collides with existing links.
+CREATE TABLE IF NOT EXISTS subject_links (
+    issuer       TEXT         NOT NULL,
+    subject      TEXT         NOT NULL,
+    account_id   UUID         NOT NULL,
+    linked_at    TIMESTAMPTZ  NOT NULL,
+    version      BIGINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (issuer, subject)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subject_links_account
+    ON subject_links (account_id);
+
+-- ── Signing keys ─────────────────────────────────────────────────────────────
+-- The edge-token signing-key ring. Phase 4's minter loads its key from config;
+-- this table is the home for in-DB rotation (publish public material via JWKS,
+-- keep the private key encrypted at rest / in KMS). No adapter writes it yet.
+CREATE TABLE IF NOT EXISTS signing_keys (
+    kid                 TEXT         NOT NULL,
+    algorithm           TEXT         NOT NULL DEFAULT 'ES256',
+    public_pem          TEXT         NOT NULL,
+    private_pem_enc     BYTEA,
+    status              TEXT         NOT NULL DEFAULT 'active',
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    not_after           TIMESTAMPTZ,
+    PRIMARY KEY (kid)
+);

--- a/crates/services/auth/src/app.rs
+++ b/crates/services/auth/src/app.rs
@@ -1,0 +1,223 @@
+//! The auth service's composition root.
+//!
+//! [`App::compose`] is *pure* wiring: eight port handles in, a fully-assembled
+//! gRPC handler out — it binds no socket and reads no environment, so the live
+//! integration harness and the binary entrypoint build the exact same graph.
+//! [`App::build`] is the I/O variant that constructs the concrete adapters from
+//! config + backend connections, then defers to `compose`.
+
+use std::sync::Arc;
+
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use sqlx::PgPool;
+use tonic::transport::Channel;
+use transport::kafka::config::client::KafkaClientConfig;
+use transport::kafka::config::producer::ProducerConfig;
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::application::command::{
+    LoginHandler, LogoutAllSessionsHandler, LogoutHandler, RefreshHandler,
+};
+use crate::application::port::{
+    AccountDirectory, EventPublisher, IdentityProvider, RefreshTokenRepository, SessionCache,
+    SessionRepository, SubjectLinkRepository, TokenMinter,
+};
+use crate::application::query::{IntrospectHandler, ListSessionsHandler};
+use crate::application::SessionPolicy;
+use crate::config::AuthConfig;
+use crate::infrastructure::cache::RedisSessionCache;
+use crate::infrastructure::directory::GrpcAccountDirectory;
+use crate::infrastructure::event::{KafkaEventPublisher, LogEventPublisher};
+use crate::infrastructure::grpc::handler::AuthServiceHandler;
+use crate::infrastructure::idp::KeycloakIdentityProvider;
+use crate::infrastructure::persistence::{
+    PgRefreshTokenRepository, PgSessionRepository, PgSubjectLinkRepository,
+};
+use crate::infrastructure::token::Es256TokenMinter;
+
+/// The eight ports the application layer depends on, plus the token policy.
+pub struct AppDeps {
+    pub idp: Arc<dyn IdentityProvider>,
+    pub directory: Arc<dyn AccountDirectory>,
+    pub links: Arc<dyn SubjectLinkRepository>,
+    pub sessions: Arc<dyn SessionRepository>,
+    pub refresh_tokens: Arc<dyn RefreshTokenRepository>,
+    pub cache: Arc<dyn SessionCache>,
+    pub minter: Arc<dyn TokenMinter>,
+    pub publisher: Arc<dyn EventPublisher>,
+    pub policy: SessionPolicy,
+}
+
+/// Backend connection configs. `kafka` is optional: absent ⇒ the log publisher.
+pub struct Backends {
+    pub postgres: PostgresConfig,
+    pub redis: RedisConfig,
+    pub kafka: Option<KafkaClientConfig>,
+}
+
+/// A fully-wired auth service. Retains the Postgres pool and Redis client so the
+/// runtime can build liveness probes over the same connections.
+pub struct App {
+    pub handler: AuthServiceHandler,
+    pub pool: PgPool,
+    pub redis: RedisClient,
+}
+
+impl App {
+    /// Pure composition: assemble the six application handlers from the ports and
+    /// wrap them in the gRPC handler. No I/O — drives the unit/integration graph.
+    pub fn compose(deps: AppDeps) -> AuthServiceHandler {
+        let login = Arc::new(LoginHandler::new(
+            Arc::clone(&deps.idp),
+            Arc::clone(&deps.directory),
+            Arc::clone(&deps.links),
+            Arc::clone(&deps.sessions),
+            Arc::clone(&deps.refresh_tokens),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.minter),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let refresh = Arc::new(RefreshHandler::new(
+            Arc::clone(&deps.directory),
+            Arc::clone(&deps.sessions),
+            Arc::clone(&deps.refresh_tokens),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.minter),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let logout = Arc::new(LogoutHandler::new(
+            Arc::clone(&deps.sessions),
+            Arc::clone(&deps.refresh_tokens),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let logout_all = Arc::new(LogoutAllSessionsHandler::new(
+            Arc::clone(&deps.sessions),
+            Arc::clone(&deps.refresh_tokens),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let introspect =
+            Arc::new(IntrospectHandler::new(Arc::clone(&deps.minter), Arc::clone(&deps.cache)));
+        let list_sessions = Arc::new(ListSessionsHandler::new(Arc::clone(&deps.sessions)));
+
+        AuthServiceHandler::new(login, refresh, logout, logout_all, introspect, list_sessions)
+    }
+
+    /// Builds the concrete adapter graph from config + backend connections.
+    pub async fn build(
+        config: AuthConfig,
+        backends: Backends,
+    ) -> Result<App, Box<dyn std::error::Error>> {
+        let pool = PgPoolBuilder::build(backends.postgres).await?;
+        let tx = TransactionManager::new(pool.clone());
+        let redis = RedisClientBuilder::new(backends.redis).build().await?;
+
+        let publisher: Arc<dyn EventPublisher> = match backends.kafka {
+            Some(cfg) => {
+                let producer = KafkaProducerBuilder::new(ProducerConfig::new(cfg)).build()?;
+                Arc::new(KafkaEventPublisher::new(producer))
+            }
+            None => Arc::new(LogEventPublisher),
+        };
+
+        // Lazy connect: the channel dials `account` on first use, so a cold start
+        // does not require the dependency to be up at boot.
+        let channel = Channel::from_shared(config.account_endpoint)?.connect_lazy();
+
+        let deps = AppDeps {
+            idp: Arc::new(KeycloakIdentityProvider::new(reqwest::Client::new(), config.keycloak)),
+            directory: Arc::new(GrpcAccountDirectory::new(channel)),
+            links: Arc::new(PgSubjectLinkRepository::new(tx.clone())),
+            sessions: Arc::new(PgSessionRepository::new(tx.clone())),
+            refresh_tokens: Arc::new(PgRefreshTokenRepository::new(tx.clone())),
+            cache: Arc::new(RedisSessionCache::new(redis.clone())),
+            minter: Arc::new(Es256TokenMinter::from_key_ring(config.signing, config.retiring_keys)?),
+            publisher,
+            policy: config.policy,
+        };
+
+        Ok(App { handler: App::compose(deps), pool, redis })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::infrastructure::grpc::handler::proto;
+    use tonic::{Code, Request};
+
+    /// Composes the gRPC handler over the in-memory fakes — the exact graph
+    /// `App::build` produces, minus the real backends.
+    fn handler_from_fakes(fx: &Fixture) -> AuthServiceHandler {
+        App::compose(AppDeps {
+            idp: fx.idp.clone(),
+            directory: fx.directory.clone(),
+            links: fx.links.clone(),
+            sessions: fx.sessions.clone(),
+            refresh_tokens: fx.refresh_tokens.clone(),
+            cache: fx.cache.clone(),
+            minter: fx.minter.clone(),
+            publisher: fx.publisher.clone(),
+            policy: fx.policy.clone(),
+        })
+    }
+
+    #[tokio::test]
+    async fn login_rpc_maps_request_and_response() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+
+        let request = Request::new(proto::LoginRequest {
+            device: Some(proto::DeviceContext {
+                user_agent: "agent".into(),
+                ip_address: String::new(),
+                device_id: "dev-1".into(),
+            }),
+            grant_type: proto::GrantType::Password as i32,
+            credential: Some(proto::login_request::Credential::Password(proto::PasswordGrant {
+                username: "user".into(),
+                password: "secret".into(),
+            })),
+        });
+
+        let response = handler.login(request).await.unwrap().into_inner();
+        assert!(!response.account_id.is_empty());
+        assert!(response.first_link);
+        let tokens = response.tokens.expect("token pair present");
+        assert_eq!(tokens.token_type, "Bearer");
+        assert!(!tokens.access_token.is_empty());
+        assert!(!tokens.refresh_token.is_empty());
+        assert_eq!(tokens.expires_in, 600);
+    }
+
+    #[tokio::test]
+    async fn login_without_credential_is_invalid_argument() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::LoginRequest {
+            device: None,
+            grant_type: proto::GrantType::Unspecified as i32,
+            credential: None,
+        });
+        let status = handler.login(request).await.unwrap_err();
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn logout_unknown_session_maps_to_not_found() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::LogoutRequest {
+            session_id: crate::domain::value_object::SessionId::new().as_str(),
+        });
+        let status = handler.logout(request).await.unwrap_err();
+        assert_eq!(status.code(), Code::NotFound);
+    }
+}

--- a/crates/services/auth/src/application/command/login.rs
+++ b/crates/services/auth/src/application/command/login.rs
@@ -1,0 +1,307 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::ensure_valid;
+use crate::application::policy::SessionPolicy;
+use crate::application::port::{
+    AccountDirectory, AuthnGrant, EventPublisher, IdentityProvider, RefreshTokenRepository,
+    SessionCache, SessionRepository, SubjectLinkRepository, TokenMinter,
+};
+use crate::domain::aggregate::{
+    RefreshToken, RefreshTokenIssueParams, Session, SessionIssueParams, SubjectLink,
+};
+use crate::domain::value_object::{AccountId, DeviceFingerprint, IdpSubject};
+use crate::error::AuthError;
+
+/// Establish a session by brokering a credential to the IdP.
+#[derive(Debug, Clone)]
+pub struct LoginCommand {
+    pub grant: AuthnGrant,
+    pub device: DeviceFingerprint,
+}
+
+impl Validate for LoginCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        let mut v = Vec::new();
+        match &self.grant {
+            AuthnGrant::AuthorizationCode { code, redirect_uri, .. } => {
+                if code.trim().is_empty() {
+                    v.push(FieldViolation::new("code", "AUT-VAL-001", "code must not be empty"));
+                }
+                if redirect_uri.trim().is_empty() {
+                    v.push(FieldViolation::new(
+                        "redirect_uri",
+                        "AUT-VAL-002",
+                        "redirect_uri must not be empty",
+                    ));
+                }
+            }
+            AuthnGrant::Password { username, password } => {
+                if username.trim().is_empty() {
+                    v.push(FieldViolation::new(
+                        "username",
+                        "AUT-VAL-003",
+                        "username must not be empty",
+                    ));
+                }
+                if password.is_empty() {
+                    v.push(FieldViolation::new(
+                        "password",
+                        "AUT-VAL-004",
+                        "password must not be empty",
+                    ));
+                }
+            }
+        }
+        if v.is_empty() { Ok(()) } else { Err(v) }
+    }
+}
+
+/// The result of a successful login (or refresh). The plaintext refresh token is
+/// present exactly once — only its hash is ever persisted.
+#[derive(Debug, Clone)]
+pub struct IssuedSession {
+    pub account_id: AccountId,
+    pub session_id: crate::domain::value_object::SessionId,
+    pub access_token: String,
+    pub refresh_token: String,
+    pub access_expires_in: i64,
+    /// True when this call established the IdP-subject → account link.
+    pub first_link: bool,
+}
+
+/// Orchestrates login: authenticate → resolve/link account → gate active → issue
+/// session + tokens. Persists durably, then publishes events.
+pub struct LoginHandler {
+    idp: Arc<dyn IdentityProvider>,
+    directory: Arc<dyn AccountDirectory>,
+    links: Arc<dyn SubjectLinkRepository>,
+    sessions: Arc<dyn SessionRepository>,
+    refresh_tokens: Arc<dyn RefreshTokenRepository>,
+    cache: Arc<dyn SessionCache>,
+    minter: Arc<dyn TokenMinter>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: SessionPolicy,
+}
+
+impl LoginHandler {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        idp: Arc<dyn IdentityProvider>,
+        directory: Arc<dyn AccountDirectory>,
+        links: Arc<dyn SubjectLinkRepository>,
+        sessions: Arc<dyn SessionRepository>,
+        refresh_tokens: Arc<dyn RefreshTokenRepository>,
+        cache: Arc<dyn SessionCache>,
+        minter: Arc<dyn TokenMinter>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: SessionPolicy,
+    ) -> Self {
+        Self {
+            idp,
+            directory,
+            links,
+            sessions,
+            refresh_tokens,
+            cache,
+            minter,
+            publisher,
+            policy,
+        }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<LoginCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<IssuedSession, AuthError> {
+        ensure_valid(&envelope.payload)?;
+        let cmd = envelope.payload;
+        let correlation_id = envelope.correlation_id;
+
+        // 1. Broker the credential to the IdP and normalize the identity.
+        let claims = self.idp.authenticate(cmd.grant).await?;
+        let subject = IdpSubject::new(claims.issuer, claims.subject)?;
+
+        // 2. Resolve the account for this subject (provision on first sight). The
+        //    link itself is only established *after* the active gate, so an
+        //    inactive account never produces a spurious SubjectLinked event.
+        let (account_id, needs_link) = match self.links.find_by_subject(&subject).await? {
+            Some(link) => (link.account_id(), false),
+            None => (self.directory.resolve_or_provision(&subject).await?, true),
+        };
+
+        // 3. Gate issuance on the account being active; read authoritative perms.
+        let snapshot = self.directory.lookup(&account_id).await?;
+        let permissions = match snapshot.activation {
+            crate::application::port::AccountActivation::Active => snapshot.permissions,
+            crate::application::port::AccountActivation::Inactive { reason } => {
+                return Err(AuthError::AccountNotActive { current: reason });
+            }
+        };
+
+        // 4. Establish the immutable subject → account link on first login.
+        let mut first_link = false;
+        if needs_link {
+            let mut link = SubjectLink::establish(subject.clone(), account_id, now, correlation_id);
+            self.links.save(&link).await?;
+            self.publish_all(link.drain_events()).await?;
+            first_link = true;
+        }
+
+        // 5. Issue the session under the account's current generation.
+        let generation = self.cache.current_generation(&account_id).await?;
+        let mut session = Session::issue(SessionIssueParams {
+            account_id,
+            subject,
+            generation,
+            device: cmd.device,
+            issued_at: now,
+            expires_at: now + self.policy.session_ttl,
+            absolute_expiry: now + self.policy.absolute_ttl,
+            correlation_id,
+        })?;
+        self.sessions.save(&session).await?;
+        self.publish_all(session.drain_events()).await?;
+
+        // 5. Mint the refresh token and the edge access token.
+        let generated = self.minter.generate_refresh()?;
+        let refresh = RefreshToken::issue(RefreshTokenIssueParams {
+            session_id: session.id(),
+            account_id,
+            token_hash: generated.hash,
+            issued_at: now,
+            expires_at: now + self.policy.refresh_ttl,
+        })?;
+        self.refresh_tokens.save(&refresh).await?;
+
+        let claims = session.mint_access_token(now, self.policy.access_ttl, permissions)?;
+        let access_token = self.minter.mint_access(&claims).await?;
+
+        Ok(IssuedSession {
+            account_id,
+            session_id: session.id(),
+            access_token,
+            refresh_token: generated.plaintext,
+            access_expires_in: claims.expires_in_secs(now),
+            first_link,
+        })
+    }
+
+    async fn publish_all(
+        &self,
+        events: Vec<crate::domain::event::DomainEvent>,
+    ) -> Result<(), AuthError> {
+        for event in &events {
+            self.publisher.publish(event).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::application::port::AccountActivation;
+    use crate::domain::value_object::Generation;
+    use uuid::Uuid;
+
+    fn password_login() -> Envelope<LoginCommand> {
+        Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::Password {
+                    username: "user".into(),
+                    password: "secret".into(),
+                },
+                device: DeviceFingerprint::default(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn first_login_links_account_and_issues_tokens() {
+        let fx = Fixture::new();
+        let issued = fx.login_handler().handle(password_login(), t0()).await.unwrap();
+
+        assert!(issued.first_link);
+        assert!(!issued.access_token.is_empty());
+        assert!(!issued.refresh_token.is_empty());
+        assert_eq!(issued.access_expires_in, 600); // 10-minute access TTL
+        assert_eq!(fx.sessions.count(), 1);
+        // SubjectLinked then SessionIssued, in that order.
+        assert_eq!(fx.publisher.event_types(), vec!["auth.subject_linked", "auth.session_issued"]);
+    }
+
+    #[tokio::test]
+    async fn second_login_same_subject_does_not_relink() {
+        let fx = Fixture::new();
+        let first = fx.login_handler().handle(password_login(), t0()).await.unwrap();
+        let second = fx.login_handler().handle(password_login(), t0()).await.unwrap();
+
+        assert!(first.first_link);
+        assert!(!second.first_link, "subject already linked");
+        assert_eq!(first.account_id, second.account_id);
+        assert_eq!(fx.sessions.count(), 2);
+        // Only one subject_linked across both logins.
+        let linked = fx.publisher.event_types().iter().filter(|t| **t == "auth.subject_linked").count();
+        assert_eq!(linked, 1);
+    }
+
+    #[tokio::test]
+    async fn login_rejected_for_inactive_account() {
+        let fx = Fixture::new();
+        let subject = IdpSubject::new("https://idp.test", "sub-123").unwrap();
+        let account = AccountId::from_uuid(Uuid::now_v7());
+        fx.directory.with_account(
+            &subject,
+            account,
+            AccountActivation::Inactive { reason: "suspended".into() },
+            vec![],
+        );
+
+        let err = fx.login_handler().handle(password_login(), t0()).await.unwrap_err();
+        assert!(matches!(err, AuthError::AccountNotActive { .. }));
+        // No session, and crucially no SubjectLinked event for an inactive account.
+        assert_eq!(fx.sessions.count(), 0);
+        assert_eq!(fx.publisher.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn login_propagates_idp_failure() {
+        let mut fx = Fixture::new();
+        fx.idp = std::sync::Arc::new(crate::application::fakes::StubIdentityProvider::failing());
+        let err = fx.login_handler().handle(password_login(), t0()).await.unwrap_err();
+        assert!(matches!(err, AuthError::IdpAuthenticationFailed));
+    }
+
+    #[tokio::test]
+    async fn login_validation_rejects_empty_credential() {
+        let fx = Fixture::new();
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::AuthorizationCode {
+                    code: "".into(),
+                    redirect_uri: "".into(),
+                    code_verifier: "v".into(),
+                },
+                device: DeviceFingerprint::default(),
+            },
+        );
+        let err = fx.login_handler().handle(env, t0()).await.unwrap_err();
+        assert!(matches!(err, AuthError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn session_is_issued_under_current_generation() {
+        let fx = Fixture::new();
+        let issued = fx.login_handler().handle(password_login(), t0()).await.unwrap();
+        let session = fx.sessions.find_by_id(&issued.session_id).await.unwrap().unwrap();
+        assert_eq!(session.generation(), Generation::INITIAL);
+    }
+}

--- a/crates/services/auth/src/application/command/logout.rs
+++ b/crates/services/auth/src/application/command/logout.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::ensure_valid;
+use crate::application::policy::SessionPolicy;
+use crate::application::port::{
+    EventPublisher, RefreshTokenRepository, SessionCache, SessionRepository,
+};
+use crate::domain::value_object::{RevocationReason, SessionId, SessionStatus};
+use crate::error::AuthError;
+
+/// Revoke a single session. The gRPC layer resolves "my current session" to a
+/// concrete `session_id` from the authenticated principal before dispatch.
+#[derive(Debug, Clone)]
+pub struct LogoutCommand {
+    pub session_id: String,
+}
+
+impl Validate for LogoutCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        if self.session_id.trim().is_empty() {
+            return Err(vec![FieldViolation::new(
+                "session_id",
+                "AUT-VAL-020",
+                "session_id must not be empty",
+            )]);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LogoutOutcome {
+    pub success: bool,
+}
+
+/// Revokes one session: marks it revoked, blacklists it for the access-token
+/// window, and invalidates its refresh tokens. Idempotent — revoking an already
+/// terminal session succeeds without re-emitting events.
+pub struct LogoutHandler {
+    sessions: Arc<dyn SessionRepository>,
+    refresh_tokens: Arc<dyn RefreshTokenRepository>,
+    cache: Arc<dyn SessionCache>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: SessionPolicy,
+}
+
+impl LogoutHandler {
+    pub fn new(
+        sessions: Arc<dyn SessionRepository>,
+        refresh_tokens: Arc<dyn RefreshTokenRepository>,
+        cache: Arc<dyn SessionCache>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: SessionPolicy,
+    ) -> Self {
+        Self { sessions, refresh_tokens, cache, publisher, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<LogoutCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<LogoutOutcome, AuthError> {
+        ensure_valid(&envelope.payload)?;
+        let session_id = SessionId::try_from(envelope.payload.session_id.as_str())?;
+
+        let mut session = self
+            .sessions
+            .find_by_id(&session_id)
+            .await?
+            .ok_or(AuthError::SessionNotFound { id: session_id.as_str() })?;
+
+        // Already terminal ⇒ idempotent success, nothing to do.
+        if session.status() != SessionStatus::Active {
+            return Ok(LogoutOutcome { success: true });
+        }
+
+        session.revoke(now, RevocationReason::Logout, envelope.correlation_id)?;
+        self.sessions.save(&session).await?;
+        self.cache.blacklist_session(&session_id, self.policy.access_ttl).await?;
+        self.refresh_tokens.revoke_all_for_session(&session_id).await?;
+        for event in &session.drain_events() {
+            self.publisher.publish(event).await?;
+        }
+
+        Ok(LogoutOutcome { success: true })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::{LoginCommand, LoginHandler};
+    use crate::application::fakes::{t0, Fixture};
+    use crate::application::port::AuthnGrant;
+    use crate::domain::value_object::DeviceFingerprint;
+    use uuid::Uuid;
+
+    async fn login(fx: &Fixture) -> crate::application::command::IssuedSession {
+        let h: LoginHandler = fx.login_handler();
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::Password { username: "u".into(), password: "p".into() },
+                device: DeviceFingerprint::default(),
+            },
+        );
+        h.handle(env, t0()).await.unwrap()
+    }
+
+    fn logout_env(session_id: &str) -> Envelope<LogoutCommand> {
+        Envelope::new(Uuid::now_v7(), LogoutCommand { session_id: session_id.to_owned() })
+    }
+
+    #[tokio::test]
+    async fn logout_revokes_blacklists_and_emits() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+        let sid = issued.session_id;
+
+        let out = fx.logout_handler().handle(logout_env(&sid.as_str()), t0()).await.unwrap();
+        assert!(out.success);
+
+        assert!(fx.sessions.list_active_by_account(&issued.account_id).await.unwrap().is_empty());
+        assert!(fx.cache.is_blacklisted(&sid).await.unwrap());
+        assert!(fx.publisher.event_types().contains(&"auth.session_revoked"));
+    }
+
+    #[tokio::test]
+    async fn logout_is_idempotent() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+        let sid = issued.session_id.as_str();
+
+        assert!(fx.logout_handler().handle(logout_env(&sid), t0()).await.unwrap().success);
+        // Second logout on the now-revoked session still succeeds, no new events.
+        let before = fx.publisher.count();
+        assert!(fx.logout_handler().handle(logout_env(&sid), t0()).await.unwrap().success);
+        assert_eq!(fx.publisher.count(), before, "no duplicate revocation event");
+    }
+
+    #[tokio::test]
+    async fn logout_unknown_session_is_not_found() {
+        let fx = Fixture::new();
+        let err = fx
+            .logout_handler()
+            .handle(logout_env(&crate::domain::value_object::SessionId::new().as_str()), t0())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::SessionNotFound { .. }));
+    }
+}

--- a/crates/services/auth/src/application/command/logout_all_sessions.rs
+++ b/crates/services/auth/src/application/command/logout_all_sessions.rs
@@ -1,0 +1,145 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::ensure_valid;
+use crate::application::policy::SessionPolicy;
+use crate::application::port::{
+    EventPublisher, RefreshTokenRepository, SessionCache, SessionRepository,
+};
+use crate::domain::value_object::{AccountId, RevocationReason, SessionStatus};
+use crate::error::AuthError;
+
+/// Global sign-out for an account.
+#[derive(Debug, Clone)]
+pub struct LogoutAllSessionsCommand {
+    pub account_id: String,
+}
+
+impl Validate for LogoutAllSessionsCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        if self.account_id.trim().is_empty() {
+            return Err(vec![FieldViolation::new(
+                "account_id",
+                "AUT-VAL-021",
+                "account_id must not be empty",
+            )]);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LogoutAllSessionsOutcome {
+    /// The new generation after the bump; every token below it is dead.
+    pub generation: i64,
+    pub sessions_revoked: i32,
+}
+
+/// Bumps the account's generation — the instant, edge-enforced kill switch — then
+/// durably revokes each active session and its refresh tokens.
+///
+/// The generation bump is what actually invalidates outstanding edge tokens on
+/// the next request; the per-session revocation keeps the durable record and the
+/// blacklist consistent.
+pub struct LogoutAllSessionsHandler {
+    sessions: Arc<dyn SessionRepository>,
+    refresh_tokens: Arc<dyn RefreshTokenRepository>,
+    cache: Arc<dyn SessionCache>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: SessionPolicy,
+}
+
+impl LogoutAllSessionsHandler {
+    pub fn new(
+        sessions: Arc<dyn SessionRepository>,
+        refresh_tokens: Arc<dyn RefreshTokenRepository>,
+        cache: Arc<dyn SessionCache>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: SessionPolicy,
+    ) -> Self {
+        Self { sessions, refresh_tokens, cache, publisher, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<LogoutAllSessionsCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<LogoutAllSessionsOutcome, AuthError> {
+        ensure_valid(&envelope.payload)?;
+        let account_id = AccountId::try_from(envelope.payload.account_id.as_str())?;
+
+        // Instant global kill: every existing edge token now carries a stale gen.
+        let generation = self.cache.bump_generation(&account_id).await?;
+
+        // Durably revoke each active session for record-keeping + blacklist.
+        let sessions = self.sessions.list_active_by_account(&account_id).await?;
+        let mut revoked = 0;
+        for mut session in sessions {
+            if session.status() != SessionStatus::Active {
+                continue;
+            }
+            let session_id = session.id();
+            session.revoke(now, RevocationReason::GlobalLogout, envelope.correlation_id)?;
+            self.sessions.save(&session).await?;
+            self.cache.blacklist_session(&session_id, self.policy.access_ttl).await?;
+            self.refresh_tokens.revoke_all_for_session(&session_id).await?;
+            for event in &session.drain_events() {
+                self.publisher.publish(event).await?;
+            }
+            revoked += 1;
+        }
+
+        Ok(LogoutAllSessionsOutcome { generation: generation.value(), sessions_revoked: revoked })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::LoginCommand;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::application::port::AuthnGrant;
+    use crate::domain::value_object::{DeviceFingerprint, Generation};
+    use uuid::Uuid;
+
+    async fn login(fx: &Fixture) -> crate::application::command::IssuedSession {
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::Password { username: "u".into(), password: "p".into() },
+                device: DeviceFingerprint::default(),
+            },
+        );
+        fx.login_handler().handle(env, t0()).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn logout_all_bumps_generation_and_revokes_every_session() {
+        let fx = Fixture::new();
+        // Two sessions for the same account (same subject ⇒ same account).
+        let a = login(&fx).await;
+        let _b = login(&fx).await;
+        assert_eq!(fx.sessions.list_active_by_account(&a.account_id).await.unwrap().len(), 2);
+
+        let out = fx
+            .logout_all_handler()
+            .handle(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    LogoutAllSessionsCommand { account_id: a.account_id.as_str() },
+                ),
+                t0(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(out.sessions_revoked, 2);
+        assert_eq!(out.generation, Generation::INITIAL.next().value());
+        assert!(fx.sessions.list_active_by_account(&a.account_id).await.unwrap().is_empty());
+        let revoked = fx.publisher.event_types().iter().filter(|t| **t == "auth.session_revoked").count();
+        assert_eq!(revoked, 2);
+    }
+}

--- a/crates/services/auth/src/application/command/mod.rs
+++ b/crates/services/auth/src/application/command/mod.rs
@@ -1,0 +1,11 @@
+pub mod login;
+pub mod logout;
+pub mod logout_all_sessions;
+pub mod refresh;
+
+pub use login::{IssuedSession, LoginCommand, LoginHandler};
+pub use logout::{LogoutCommand, LogoutHandler, LogoutOutcome};
+pub use logout_all_sessions::{
+    LogoutAllSessionsCommand, LogoutAllSessionsHandler, LogoutAllSessionsOutcome,
+};
+pub use refresh::{RefreshCommand, RefreshHandler};

--- a/crates/services/auth/src/application/command/refresh.rs
+++ b/crates/services/auth/src/application/command/refresh.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+use validate_core::{FieldViolation, Validate};
+
+use crate::application::command::IssuedSession;
+use crate::application::ensure_valid;
+use crate::application::policy::SessionPolicy;
+use crate::application::port::{
+    AccountActivation, AccountDirectory, EventPublisher, RefreshTokenRepository, SessionCache,
+    SessionRepository, TokenMinter,
+};
+use crate::domain::value_object::{AccountId, DeviceFingerprint, RevocationReason, SessionId, SessionStatus};
+use crate::error::AuthError;
+
+/// Rotate a refresh token and mint a fresh edge token.
+#[derive(Debug, Clone)]
+pub struct RefreshCommand {
+    pub refresh_token: String,
+    /// Optional device context, re-validated against the session's bound device.
+    pub device: DeviceFingerprint,
+}
+
+impl Validate for RefreshCommand {
+    fn validate(&self) -> Result<(), Vec<FieldViolation>> {
+        if self.refresh_token.trim().is_empty() {
+            return Err(vec![FieldViolation::new(
+                "refresh_token",
+                "AUT-VAL-010",
+                "refresh_token must not be empty",
+            )]);
+        }
+        Ok(())
+    }
+}
+
+/// Orchestrates refresh-token rotation with reuse-detection. A re-presented
+/// (already-rotated) token triggers a full session-generation revocation.
+pub struct RefreshHandler {
+    directory: Arc<dyn AccountDirectory>,
+    sessions: Arc<dyn SessionRepository>,
+    refresh_tokens: Arc<dyn RefreshTokenRepository>,
+    cache: Arc<dyn SessionCache>,
+    minter: Arc<dyn TokenMinter>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: SessionPolicy,
+}
+
+impl RefreshHandler {
+    pub fn new(
+        directory: Arc<dyn AccountDirectory>,
+        sessions: Arc<dyn SessionRepository>,
+        refresh_tokens: Arc<dyn RefreshTokenRepository>,
+        cache: Arc<dyn SessionCache>,
+        minter: Arc<dyn TokenMinter>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: SessionPolicy,
+    ) -> Self {
+        Self { directory, sessions, refresh_tokens, cache, minter, publisher, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<RefreshCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<IssuedSession, AuthError> {
+        ensure_valid(&envelope.payload)?;
+        let cmd = envelope.payload;
+
+        // 1. Resolve the presented token by its hash.
+        let hash = self.minter.hash_refresh(&cmd.refresh_token)?;
+        let mut token = self
+            .refresh_tokens
+            .find_by_hash(&hash)
+            .await?
+            .ok_or(AuthError::RefreshTokenNotFound)?;
+
+        let session_id = token.session_id();
+        let account_id = token.account_id();
+
+        // 2. Rotate. Keep the successor plaintext to return; only its hash is
+        //    persisted. A reuse signal escalates to revoking the whole generation.
+        let generated = self.minter.generate_refresh()?;
+        let new_plaintext = generated.plaintext;
+        let successor = match token.rotate(now, generated.hash, now + self.policy.refresh_ttl) {
+            Ok(successor) => successor,
+            Err(AuthError::RefreshTokenReuseDetected) => {
+                self.revoke_generation(now, account_id, session_id, envelope.correlation_id).await?;
+                return Err(AuthError::RefreshTokenReuseDetected);
+            }
+            Err(other) => return Err(other),
+        };
+
+        // 3. Load the session and confirm it is still valid under the account's
+        //    current generation (catches a global sign-out that bumped it).
+        let mut session = self
+            .sessions
+            .find_by_id(&session_id)
+            .await?
+            .ok_or(AuthError::SessionNotFound { id: session_id.as_str() })?;
+
+        let current_generation = self.cache.current_generation(&account_id).await?;
+        if !session.is_valid_under(current_generation, now) {
+            return Err(AuthError::SessionRevoked);
+        }
+
+        // 4. Best-effort device re-binding (fail-open when ids are absent).
+        if !session.device().same_device_as(&cmd.device) {
+            return Err(AuthError::DomainViolation {
+                field: "device".into(),
+                message: "refresh device does not match the session's bound device".into(),
+            });
+        }
+
+        // 5. Re-read authoritative permissions; a deactivated account cannot refresh.
+        let snapshot = self.directory.lookup(&account_id).await?;
+        let permissions = match snapshot.activation {
+            AccountActivation::Active => snapshot.permissions,
+            AccountActivation::Inactive { reason } => {
+                return Err(AuthError::AccountNotActive { current: reason });
+            }
+        };
+
+        // 6. Persist the rotation, slide the window, mint the new pair.
+        self.refresh_tokens.save(&token).await?; // original, now Rotated
+        self.refresh_tokens.save(&successor).await?; // successor, Active
+        session.extend(now, self.policy.session_ttl)?;
+        self.sessions.save(&session).await?;
+
+        let claims = session.mint_access_token(now, self.policy.access_ttl, permissions)?;
+        let access_token = self.minter.mint_access(&claims).await?;
+
+        Ok(IssuedSession {
+            account_id,
+            session_id,
+            access_token,
+            refresh_token: new_plaintext,
+            access_expires_in: claims.expires_in_secs(now),
+            first_link: false,
+        })
+    }
+
+    /// Reuse-detected: bump the account generation (instant global kill), revoke
+    /// the session and all its refresh tokens, and emit the revocation.
+    async fn revoke_generation(
+        &self,
+        now: DateTime<Utc>,
+        account_id: AccountId,
+        session_id: SessionId,
+        correlation_id: uuid::Uuid,
+    ) -> Result<(), AuthError> {
+        self.cache.bump_generation(&account_id).await?;
+        self.refresh_tokens.revoke_all_for_session(&session_id).await?;
+        if let Some(mut session) = self.sessions.find_by_id(&session_id).await? {
+            if session.status() == SessionStatus::Active {
+                session.revoke(now, RevocationReason::RefreshReuse, correlation_id)?;
+                self.sessions.save(&session).await?;
+                self.cache.blacklist_session(&session_id, self.policy.access_ttl).await?;
+                for event in &session.drain_events() {
+                    self.publisher.publish(event).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::{LoginCommand, LoginHandler};
+    use crate::application::fakes::{t0, Fixture};
+    use crate::application::port::AuthnGrant;
+    use crate::domain::value_object::Generation;
+    use chrono::Duration;
+    use uuid::Uuid;
+
+    async fn login(fx: &Fixture) -> crate::application::command::IssuedSession {
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::Password { username: "u".into(), password: "p".into() },
+                device: DeviceFingerprint::default(),
+            },
+        );
+        login_handler(fx).handle(env, t0()).await.unwrap()
+    }
+
+    fn login_handler(fx: &Fixture) -> LoginHandler {
+        fx.login_handler()
+    }
+
+    fn refresh_env(token: &str) -> Envelope<RefreshCommand> {
+        Envelope::new(
+            Uuid::now_v7(),
+            RefreshCommand { refresh_token: token.to_owned(), device: DeviceFingerprint::default() },
+        )
+    }
+
+    #[tokio::test]
+    async fn refresh_rotates_to_a_new_pair() {
+        let fx = Fixture::new();
+        let first = login(&fx).await;
+
+        let now = t0() + Duration::minutes(1);
+        let second = fx.refresh_handler().handle(refresh_env(&first.refresh_token), now).await.unwrap();
+
+        assert_eq!(second.account_id, first.account_id);
+        assert_eq!(second.session_id, first.session_id);
+        assert_ne!(second.refresh_token, first.refresh_token, "refresh token rotates");
+        assert!(!second.access_token.is_empty());
+        assert!(!second.first_link);
+    }
+
+    #[tokio::test]
+    async fn refresh_then_reuse_old_token_detects_and_revokes_generation() {
+        let fx = Fixture::new();
+        let first = login(&fx).await;
+        let account = first.account_id;
+
+        // Legitimate rotation.
+        let _second = fx
+            .refresh_handler()
+            .handle(refresh_env(&first.refresh_token), t0() + Duration::minutes(1))
+            .await
+            .unwrap();
+
+        // Re-presenting the original (now rotated) token = theft signal.
+        let err = fx
+            .refresh_handler()
+            .handle(refresh_env(&first.refresh_token), t0() + Duration::minutes(2))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::RefreshTokenReuseDetected));
+
+        // Generation bumped (global kill) and the session revoked.
+        assert_eq!(fx.cache.current_generation(&account).await.unwrap(), Generation::INITIAL.next());
+        assert!(fx.sessions.list_active_by_account(&account).await.unwrap().is_empty());
+        assert!(fx.publisher.event_types().contains(&"auth.session_revoked"));
+    }
+
+    #[tokio::test]
+    async fn refresh_unknown_token_is_not_found() {
+        let fx = Fixture::new();
+        let err = fx.refresh_handler().handle(refresh_env("nope"), t0()).await.unwrap_err();
+        assert!(matches!(err, AuthError::RefreshTokenNotFound));
+    }
+
+    #[tokio::test]
+    async fn refresh_after_global_logout_is_rejected() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+
+        fx.logout_all_handler()
+            .handle(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    crate::application::command::LogoutAllSessionsCommand {
+                        account_id: issued.account_id.as_str(),
+                    },
+                ),
+                t0() + Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+
+        let err = fx
+            .refresh_handler()
+            .handle(refresh_env(&issued.refresh_token), t0() + Duration::minutes(2))
+            .await
+            .unwrap_err();
+        // The global logout invalidated the session's refresh tokens, so the
+        // presented handle no longer resolves.
+        assert!(matches!(err, AuthError::RefreshTokenNotFound));
+    }
+}

--- a/crates/services/auth/src/application/fakes.rs
+++ b/crates/services/auth/src/application/fakes.rs
@@ -1,0 +1,428 @@
+//! In-memory fakes for every outbound port, plus a [`Fixture`] that wires them
+//! into the handlers. Test-only (`#[cfg(test)]`) — they prove the application
+//! layer works against the port contracts with no real backend, which is exactly
+//! what makes the abstraction credible before the Phase 4 adapters exist.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use uuid::Uuid;
+
+use super::policy::SessionPolicy;
+use super::port::{
+    AccountActivation, AccountDirectory, AccountSnapshot, AuthnGrant, EventPublisher,
+    GeneratedRefresh, IdentityProvider, NormalizedClaims, RefreshTokenRepository, SessionCache,
+    SessionRepository, SubjectLinkRepository, TokenMinter,
+};
+use crate::domain::aggregate::{RefreshToken, Session, SubjectLink};
+use crate::domain::event::DomainEvent;
+use crate::domain::value_object::{
+    AccessTokenClaims, AccountId, Generation, IdpSubject, Permission, RefreshTokenHash, SessionId,
+    SessionStatus,
+};
+use crate::error::AuthError;
+
+/// A fixed reference instant for deterministic tests.
+pub fn t0() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+}
+
+// ─── IdentityProvider ────────────────────────────────────────────────────────
+
+pub struct StubIdentityProvider {
+    claims: Mutex<Option<NormalizedClaims>>,
+}
+
+impl StubIdentityProvider {
+    pub fn returning(issuer: &str, subject: &str) -> Self {
+        Self {
+            claims: Mutex::new(Some(NormalizedClaims {
+                issuer: issuer.to_owned(),
+                subject: subject.to_owned(),
+            })),
+        }
+    }
+
+    pub fn failing() -> Self {
+        Self { claims: Mutex::new(None) }
+    }
+}
+
+#[async_trait]
+impl IdentityProvider for StubIdentityProvider {
+    async fn authenticate(&self, _grant: AuthnGrant) -> Result<NormalizedClaims, AuthError> {
+        self.claims
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or(AuthError::IdpAuthenticationFailed)
+    }
+}
+
+// ─── AccountDirectory ────────────────────────────────────────────────────────
+
+pub struct StubAccountDirectory {
+    subjects: Mutex<HashMap<IdpSubject, AccountId>>,
+    snapshots: Mutex<HashMap<AccountId, AccountSnapshot>>,
+}
+
+impl StubAccountDirectory {
+    pub fn new() -> Self {
+        Self { subjects: Mutex::new(HashMap::new()), snapshots: Mutex::new(HashMap::new()) }
+    }
+
+    /// Pre-binds a subject to a known account with the given activation + perms.
+    pub fn with_account(
+        &self,
+        subject: &IdpSubject,
+        account_id: AccountId,
+        activation: AccountActivation,
+        permissions: Vec<Permission>,
+    ) {
+        self.subjects.lock().unwrap().insert(subject.clone(), account_id);
+        self.snapshots
+            .lock()
+            .unwrap()
+            .insert(account_id, AccountSnapshot { activation, permissions });
+    }
+}
+
+#[async_trait]
+impl AccountDirectory for StubAccountDirectory {
+    async fn resolve_or_provision(&self, subject: &IdpSubject) -> Result<AccountId, AuthError> {
+        let mut subjects = self.subjects.lock().unwrap();
+        if let Some(id) = subjects.get(subject) {
+            return Ok(*id);
+        }
+        let id = AccountId::from_uuid(Uuid::now_v7());
+        subjects.insert(subject.clone(), id);
+        self.snapshots.lock().unwrap().insert(
+            id,
+            AccountSnapshot { activation: AccountActivation::Active, permissions: Vec::new() },
+        );
+        Ok(id)
+    }
+
+    async fn lookup(&self, account_id: &AccountId) -> Result<AccountSnapshot, AuthError> {
+        Ok(self.snapshots.lock().unwrap().get(account_id).cloned().unwrap_or(AccountSnapshot {
+            activation: AccountActivation::Active,
+            permissions: Vec::new(),
+        }))
+    }
+}
+
+// ─── SubjectLinkRepository ───────────────────────────────────────────────────
+
+pub struct InMemorySubjectLinkRepository {
+    links: Mutex<HashMap<IdpSubject, SubjectLink>>,
+}
+
+impl InMemorySubjectLinkRepository {
+    pub fn new() -> Self {
+        Self { links: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl SubjectLinkRepository for InMemorySubjectLinkRepository {
+    async fn find_by_subject(
+        &self,
+        subject: &IdpSubject,
+    ) -> Result<Option<SubjectLink>, AuthError> {
+        Ok(self.links.lock().unwrap().get(subject).cloned())
+    }
+
+    async fn save(&self, link: &SubjectLink) -> Result<(), AuthError> {
+        let mut links = self.links.lock().unwrap();
+        if links.contains_key(link.subject()) {
+            return Err(AuthError::SubjectAlreadyLinked {
+                iss: link.subject().issuer().to_owned(),
+                sub: link.subject().subject().to_owned(),
+            });
+        }
+        // Persistence does not round-trip pending events.
+        let mut stored = link.clone();
+        let _ = stored.drain_events();
+        links.insert(stored.subject().clone(), stored);
+        Ok(())
+    }
+}
+
+// ─── SessionRepository ───────────────────────────────────────────────────────
+
+pub struct InMemorySessionRepository {
+    sessions: Mutex<HashMap<SessionId, Session>>,
+}
+
+impl InMemorySessionRepository {
+    pub fn new() -> Self {
+        Self { sessions: Mutex::new(HashMap::new()) }
+    }
+
+    pub fn count(&self) -> usize {
+        self.sessions.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl SessionRepository for InMemorySessionRepository {
+    async fn save(&self, session: &Session) -> Result<(), AuthError> {
+        let mut stored = session.clone();
+        let _ = stored.drain_events(); // events do not survive persistence
+        self.sessions.lock().unwrap().insert(stored.id(), stored);
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &SessionId) -> Result<Option<Session>, AuthError> {
+        Ok(self.sessions.lock().unwrap().get(id).cloned())
+    }
+
+    async fn list_active_by_account(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Vec<Session>, AuthError> {
+        Ok(self
+            .sessions
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|s| s.account_id() == *account_id && s.status() == SessionStatus::Active)
+            .cloned()
+            .collect())
+    }
+}
+
+// ─── RefreshTokenRepository ──────────────────────────────────────────────────
+
+pub struct InMemoryRefreshTokenRepository {
+    tokens: Mutex<HashMap<RefreshTokenHash, RefreshToken>>,
+}
+
+impl InMemoryRefreshTokenRepository {
+    pub fn new() -> Self {
+        Self { tokens: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl RefreshTokenRepository for InMemoryRefreshTokenRepository {
+    async fn save(&self, token: &RefreshToken) -> Result<(), AuthError> {
+        self.tokens.lock().unwrap().insert(token.token_hash().clone(), token.clone());
+        Ok(())
+    }
+
+    async fn find_by_hash(
+        &self,
+        hash: &RefreshTokenHash,
+    ) -> Result<Option<RefreshToken>, AuthError> {
+        Ok(self.tokens.lock().unwrap().get(hash).cloned())
+    }
+
+    async fn revoke_all_for_session(&self, session_id: &SessionId) -> Result<(), AuthError> {
+        // Modelled as deletion: a subsequent lookup misses, i.e. is invalid.
+        self.tokens.lock().unwrap().retain(|_, t| t.session_id() != *session_id);
+        Ok(())
+    }
+}
+
+// ─── SessionCache ────────────────────────────────────────────────────────────
+
+pub struct InMemorySessionCache {
+    generations: Mutex<HashMap<AccountId, Generation>>,
+    blacklist: Mutex<HashSet<SessionId>>,
+}
+
+impl InMemorySessionCache {
+    pub fn new() -> Self {
+        Self { generations: Mutex::new(HashMap::new()), blacklist: Mutex::new(HashSet::new()) }
+    }
+}
+
+#[async_trait]
+impl SessionCache for InMemorySessionCache {
+    async fn current_generation(&self, account_id: &AccountId) -> Result<Generation, AuthError> {
+        Ok(self.generations.lock().unwrap().get(account_id).copied().unwrap_or(Generation::INITIAL))
+    }
+
+    async fn bump_generation(&self, account_id: &AccountId) -> Result<Generation, AuthError> {
+        let mut gens = self.generations.lock().unwrap();
+        let next = gens.get(account_id).copied().unwrap_or(Generation::INITIAL).next();
+        gens.insert(*account_id, next);
+        Ok(next)
+    }
+
+    async fn blacklist_session(
+        &self,
+        session_id: &SessionId,
+        _ttl: Duration,
+    ) -> Result<(), AuthError> {
+        self.blacklist.lock().unwrap().insert(*session_id);
+        Ok(())
+    }
+
+    async fn is_blacklisted(&self, session_id: &SessionId) -> Result<bool, AuthError> {
+        Ok(self.blacklist.lock().unwrap().contains(session_id))
+    }
+}
+
+// ─── TokenMinter ─────────────────────────────────────────────────────────────
+
+pub struct StubTokenMinter {
+    issued: Mutex<HashMap<String, AccessTokenClaims>>,
+}
+
+impl StubTokenMinter {
+    pub fn new() -> Self {
+        Self { issued: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl TokenMinter for StubTokenMinter {
+    async fn mint_access(&self, claims: &AccessTokenClaims) -> Result<String, AuthError> {
+        let token = format!("access-{}", Uuid::now_v7());
+        self.issued.lock().unwrap().insert(token.clone(), claims.clone());
+        Ok(token)
+    }
+
+    async fn verify_access(&self, token: &str) -> Result<AccessTokenClaims, AuthError> {
+        self.issued
+            .lock()
+            .unwrap()
+            .get(token)
+            .cloned()
+            .ok_or(AuthError::IdpTokenRejected)
+    }
+
+    fn generate_refresh(&self) -> Result<GeneratedRefresh, AuthError> {
+        let plaintext = Uuid::now_v7().to_string();
+        let hash = self.hash_refresh(&plaintext)?;
+        Ok(GeneratedRefresh { plaintext, hash })
+    }
+
+    fn hash_refresh(&self, plaintext: &str) -> Result<RefreshTokenHash, AuthError> {
+        // Deterministic so generate→store and present→lookup agree.
+        RefreshTokenHash::new(format!("h:{plaintext}"))
+    }
+}
+
+// ─── EventPublisher ──────────────────────────────────────────────────────────
+
+pub struct RecordingEventPublisher {
+    events: Mutex<Vec<DomainEvent>>,
+}
+
+impl RecordingEventPublisher {
+    pub fn new() -> Self {
+        Self { events: Mutex::new(Vec::new()) }
+    }
+
+    pub fn event_types(&self) -> Vec<&'static str> {
+        self.events.lock().unwrap().iter().map(|e| e.event_type()).collect()
+    }
+
+    pub fn count(&self) -> usize {
+        self.events.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl EventPublisher for RecordingEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), AuthError> {
+        self.events.lock().unwrap().push(event.clone());
+        Ok(())
+    }
+}
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+/// Bundles concrete fakes and builds handlers wired to them. Handlers receive
+/// the fakes as `Arc<dyn Port>`; tests keep the concrete `Arc`s to assert on
+/// recorded state (published events, generation, stored sessions).
+pub struct Fixture {
+    pub idp: Arc<StubIdentityProvider>,
+    pub directory: Arc<StubAccountDirectory>,
+    pub links: Arc<InMemorySubjectLinkRepository>,
+    pub sessions: Arc<InMemorySessionRepository>,
+    pub refresh_tokens: Arc<InMemoryRefreshTokenRepository>,
+    pub cache: Arc<InMemorySessionCache>,
+    pub minter: Arc<StubTokenMinter>,
+    pub publisher: Arc<RecordingEventPublisher>,
+    pub policy: SessionPolicy,
+}
+
+impl Fixture {
+    /// Default: IdP returns `(iss, sub)`, directory auto-provisions active accounts.
+    pub fn new() -> Self {
+        Self {
+            idp: Arc::new(StubIdentityProvider::returning("https://idp.test", "sub-123")),
+            directory: Arc::new(StubAccountDirectory::new()),
+            links: Arc::new(InMemorySubjectLinkRepository::new()),
+            sessions: Arc::new(InMemorySessionRepository::new()),
+            refresh_tokens: Arc::new(InMemoryRefreshTokenRepository::new()),
+            cache: Arc::new(InMemorySessionCache::new()),
+            minter: Arc::new(StubTokenMinter::new()),
+            publisher: Arc::new(RecordingEventPublisher::new()),
+            policy: SessionPolicy::test_default(),
+        }
+    }
+
+    pub fn login_handler(&self) -> super::command::LoginHandler {
+        super::command::LoginHandler::new(
+            Arc::clone(&self.idp) as _,
+            Arc::clone(&self.directory) as _,
+            Arc::clone(&self.links) as _,
+            Arc::clone(&self.sessions) as _,
+            Arc::clone(&self.refresh_tokens) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.minter) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn refresh_handler(&self) -> super::command::RefreshHandler {
+        super::command::RefreshHandler::new(
+            Arc::clone(&self.directory) as _,
+            Arc::clone(&self.sessions) as _,
+            Arc::clone(&self.refresh_tokens) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.minter) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn logout_handler(&self) -> super::command::LogoutHandler {
+        super::command::LogoutHandler::new(
+            Arc::clone(&self.sessions) as _,
+            Arc::clone(&self.refresh_tokens) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn logout_all_handler(&self) -> super::command::LogoutAllSessionsHandler {
+        super::command::LogoutAllSessionsHandler::new(
+            Arc::clone(&self.sessions) as _,
+            Arc::clone(&self.refresh_tokens) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn introspect_handler(&self) -> super::query::IntrospectHandler {
+        super::query::IntrospectHandler::new(
+            Arc::clone(&self.minter) as _,
+            Arc::clone(&self.cache) as _,
+        )
+    }
+
+    pub fn list_sessions_handler(&self) -> super::query::ListSessionsHandler {
+        super::query::ListSessionsHandler::new(Arc::clone(&self.sessions) as _)
+    }
+}

--- a/crates/services/auth/src/application/mod.rs
+++ b/crates/services/auth/src/application/mod.rs
@@ -1,0 +1,41 @@
+//! The auth application layer — use-case orchestration over the domain and ports.
+//!
+//! ## Why not every use-case is a `cqrs::CommandHandler`
+//! `cqrs::CommandHandler` returns `Result<(), Error>`: a command mutates and
+//! yields nothing. Auth's `Login`/`Refresh`/`Logout`/`LogoutAllSessions` must
+//! return data (tokens, a new generation), so they are modelled as explicit
+//! application-service handlers with rich return types. The genuinely read-only
+//! `Introspect`/`ListSessions` implement [`cqrs::QueryHandler`] and ride the
+//! query bus like the rest of the fleet. All handlers take a [`cqrs::Envelope`]
+//! so the `correlation_id` threads into the domain events they emit.
+//!
+//! ## Ports
+//! Every external dependency is an `async_trait` port in [`port`], injected as an
+//! `Arc<dyn …>` at the composition root. The handlers never name a concrete
+//! adapter — that is what keeps the layer (and the domain) IdP- and
+//! storage-agnostic. In-memory fakes of every port back the unit tests.
+
+pub mod command;
+pub mod policy;
+pub mod port;
+pub mod query;
+
+#[cfg(test)]
+pub mod fakes;
+
+pub use policy::SessionPolicy;
+
+use validate_core::Validate;
+
+use crate::error::AuthError;
+
+/// Runs a payload's self-validation, mapping field violations to [`AuthError`].
+///
+/// Handlers call this at the top of `handle`, since the auth use-cases bypass the
+/// command bus (and thus the bus's `ValidationLayer`).
+pub(crate) fn ensure_valid<T: Validate>(payload: &T) -> Result<(), AuthError> {
+    match payload.validate() {
+        Ok(()) => Ok(()),
+        Err(violations) => Err(validation::ValidationError::new(violations).into()),
+    }
+}

--- a/crates/services/auth/src/application/policy.rs
+++ b/crates/services/auth/src/application/policy.rs
@@ -1,0 +1,44 @@
+use chrono::Duration;
+
+/// Time policy for session and token lifetimes, resolved from configuration at
+/// the composition root (Phase 5) and injected into the handlers.
+///
+/// Relationships the handlers rely on: `access_ttl ≤ session_ttl ≤ absolute_ttl`
+/// (the domain clamps regardless), and the blacklist TTL equals `access_ttl` —
+/// long enough to outlive any access token a session could have minted.
+#[derive(Debug, Clone)]
+pub struct SessionPolicy {
+    /// Edge access-token lifetime (short — minutes).
+    pub access_ttl: Duration,
+    /// Sliding session window, extended on each refresh.
+    pub session_ttl: Duration,
+    /// Hard cap from issue time; a session can never live past this.
+    pub absolute_ttl: Duration,
+    /// Refresh-token lifetime (long — days).
+    pub refresh_ttl: Duration,
+}
+
+impl SessionPolicy {
+    pub fn new(
+        access_ttl: Duration,
+        session_ttl: Duration,
+        absolute_ttl: Duration,
+        refresh_ttl: Duration,
+    ) -> Self {
+        Self { access_ttl, session_ttl, absolute_ttl, refresh_ttl }
+    }
+}
+
+#[cfg(test)]
+impl SessionPolicy {
+    /// A representative production-shaped policy for tests:
+    /// 10-minute access, 30-minute sliding session, 8-hour cap, 7-day refresh.
+    pub fn test_default() -> Self {
+        Self::new(
+            Duration::minutes(10),
+            Duration::minutes(30),
+            Duration::hours(8),
+            Duration::days(7),
+        )
+    }
+}

--- a/crates/services/auth/src/application/port/account_directory.rs
+++ b/crates/services/auth/src/application/port/account_directory.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::{AccountId, IdpSubject, Permission};
+use crate::error::AuthError;
+
+/// Whether an account may currently establish or keep a session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccountActivation {
+    Active,
+    /// Suspended / deactivated / deleted — `reason` carries the SoR's status.
+    Inactive { reason: String },
+}
+
+impl AccountActivation {
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Active)
+    }
+}
+
+/// A point-in-time view of an account from the `account` service (the SoR).
+#[derive(Debug, Clone)]
+pub struct AccountSnapshot {
+    pub activation: AccountActivation,
+    /// Normalized RBAC grants — `account` is authoritative for these, so they are
+    /// re-read on every login and refresh (a role change takes effect at the next
+    /// token mint, not at the next full sign-in).
+    pub permissions: Vec<Permission>,
+}
+
+/// Outbound port to the `account` service (gRPC adapter in Phase 4).
+///
+/// Auth reads identity here; it never writes it. Provisioning of the account
+/// record on first federated login is the `account` service's idempotent
+/// responsibility — auth only asks for the resulting internal id.
+#[async_trait]
+pub trait AccountDirectory: Send + Sync + 'static {
+    /// Resolves the internal account id for an IdP subject, provisioning the
+    /// account record on first sight (idempotent in the `account` service).
+    async fn resolve_or_provision(&self, subject: &IdpSubject) -> Result<AccountId, AuthError>;
+
+    /// Fetches the account's activation state and current permissions. Fails with
+    /// [`AuthError::AccountDirectoryUnavailable`] if the SoR is unreachable.
+    async fn lookup(&self, account_id: &AccountId) -> Result<AccountSnapshot, AuthError>;
+}

--- a/crates/services/auth/src/application/port/event_publisher.rs
+++ b/crates/services/auth/src/application/port/event_publisher.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+use crate::domain::event::DomainEvent;
+use crate::error::AuthError;
+
+/// Outbound port for publishing domain events to the `auth.v1.events` Kafka topic
+/// (Phase 4 adapter).
+///
+/// Handlers persist durably first, then publish — the durable write is the source
+/// of truth, the event is the notification. A publish failure surfaces so the
+/// caller can decide (the adapter may itself back an outbox).
+#[async_trait]
+pub trait EventPublisher: Send + Sync + 'static {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), AuthError>;
+}

--- a/crates/services/auth/src/application/port/identity_provider.rs
+++ b/crates/services/auth/src/application/port/identity_provider.rs
@@ -1,0 +1,46 @@
+use async_trait::async_trait;
+
+use crate::error::AuthError;
+
+/// A credential the caller presents at our boundary, to be brokered to the IdP.
+///
+/// Deliberately small and IdP-neutral: the adapter translates it into whatever
+/// the concrete provider's protocol needs. Mirrors the `auth.v1` `oneof`.
+#[derive(Debug, Clone)]
+pub enum AuthnGrant {
+    /// OIDC authorization-code flow with PKCE.
+    AuthorizationCode {
+        code: String,
+        redirect_uri: String,
+        code_verifier: String,
+    },
+    /// Resource-owner password grant (first-party trusted clients only). The
+    /// password is forwarded to the IdP and never stored.
+    Password { username: String, password: String },
+}
+
+/// The normalized identity an IdP returns after authenticating a grant.
+///
+/// Only what auth needs to bind a session: the `(issuer, subject)` that keys the
+/// [`SubjectLink`](crate::domain::aggregate::SubjectLink). Authorization (roles /
+/// permissions) is intentionally absent here — that is the `account` service's
+/// concern, resolved via [`AccountDirectory`](super::AccountDirectory).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedClaims {
+    pub issuer: String,
+    pub subject: String,
+}
+
+/// Outbound port brokering authentication to the external IdP (Keycloak today).
+///
+/// The single seam behind which a provider swap (Cognito/Okta/custom) is a new
+/// adapter with no change above `infrastructure`. Phase 4's adapter adds the
+/// concrete OIDC calls; later phases may extend this with IdP-side refresh /
+/// revoke, which the federated model does not require on the hot path.
+#[async_trait]
+pub trait IdentityProvider: Send + Sync + 'static {
+    /// Exchanges a grant for a normalized identity, or fails with
+    /// [`AuthError::IdpAuthenticationFailed`] / [`AuthError::IdpUnavailable`] /
+    /// [`AuthError::ClaimsNormalizationFailed`].
+    async fn authenticate(&self, grant: AuthnGrant) -> Result<NormalizedClaims, AuthError>;
+}

--- a/crates/services/auth/src/application/port/mod.rs
+++ b/crates/services/auth/src/application/port/mod.rs
@@ -1,0 +1,23 @@
+//! Outbound ports — the only contracts the application layer holds against the
+//! outside world. Concrete adapters (Keycloak, Postgres, Redis, the `account`
+//! gRPC client, the token minter) live in `infrastructure` (Phase 4) and are
+//! injected at the composition root. Each is an `async_trait` so it can be held
+//! as `Arc<dyn …>`.
+
+pub mod account_directory;
+pub mod event_publisher;
+pub mod identity_provider;
+pub mod refresh_token_repository;
+pub mod session_cache;
+pub mod session_repository;
+pub mod subject_link_repository;
+pub mod token_minter;
+
+pub use account_directory::{AccountActivation, AccountDirectory, AccountSnapshot};
+pub use event_publisher::EventPublisher;
+pub use identity_provider::{AuthnGrant, IdentityProvider, NormalizedClaims};
+pub use refresh_token_repository::RefreshTokenRepository;
+pub use session_cache::SessionCache;
+pub use session_repository::SessionRepository;
+pub use subject_link_repository::SubjectLinkRepository;
+pub use token_minter::{GeneratedRefresh, TokenMinter};

--- a/crates/services/auth/src/application/port/refresh_token_repository.rs
+++ b/crates/services/auth/src/application/port/refresh_token_repository.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+
+use crate::domain::aggregate::RefreshToken;
+use crate::domain::value_object::{RefreshTokenHash, SessionId};
+use crate::error::AuthError;
+
+/// Durable persistence port for refresh tokens (Postgres adapter, sharded by
+/// `account_id`).
+///
+/// Lookup is by hash: the presented plaintext is hashed and matched against the
+/// stored value, so the plaintext never has to be retained.
+#[async_trait]
+pub trait RefreshTokenRepository: Send + Sync + 'static {
+    /// Upserts a token row (insert on issue, update on rotate/revoke).
+    async fn save(&self, token: &RefreshToken) -> Result<(), AuthError>;
+
+    /// Finds a token by its stored hash, or `None` if absent.
+    async fn find_by_hash(
+        &self,
+        hash: &RefreshTokenHash,
+    ) -> Result<Option<RefreshToken>, AuthError>;
+
+    /// Invalidates every outstanding token for a session (logout / reuse-defence).
+    async fn revoke_all_for_session(&self, session_id: &SessionId) -> Result<(), AuthError>;
+}

--- a/crates/services/auth/src/application/port/session_cache.rs
+++ b/crates/services/auth/src/application/port/session_cache.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+use chrono::Duration;
+
+use crate::domain::value_object::{AccountId, Generation, SessionId};
+use crate::error::AuthError;
+
+/// Hot-path cache port (Redis Cluster adapter, hash-tag slot-safe).
+///
+/// This is what keeps authentication off the durable store on the request path:
+/// the per-account generation and the per-session blacklist are O(1) reads. The
+/// durable Postgres row remains the source of truth; the cache is a write-through
+/// projection that a miss can rebuild.
+#[async_trait]
+pub trait SessionCache: Send + Sync + 'static {
+    /// The account's current revocation epoch. A miss resolves to
+    /// [`Generation::INITIAL`] and should be re-warmed from the durable store by
+    /// the adapter.
+    async fn current_generation(&self, account_id: &AccountId) -> Result<Generation, AuthError>;
+
+    /// Atomically bumps and returns the account's generation — the global
+    /// sign-out kill switch.
+    async fn bump_generation(&self, account_id: &AccountId) -> Result<Generation, AuthError>;
+
+    /// Marks a single session revoked for `ttl` (≥ the max access-token lifetime),
+    /// so an already-minted edge token is rejected before its natural expiry.
+    async fn blacklist_session(
+        &self,
+        session_id: &SessionId,
+        ttl: Duration,
+    ) -> Result<(), AuthError>;
+
+    async fn is_blacklisted(&self, session_id: &SessionId) -> Result<bool, AuthError>;
+}

--- a/crates/services/auth/src/application/port/session_repository.rs
+++ b/crates/services/auth/src/application/port/session_repository.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+
+use crate::domain::aggregate::Session;
+use crate::domain::value_object::{AccountId, SessionId};
+use crate::error::AuthError;
+
+/// Durable persistence port for the [`Session`] aggregate (Postgres adapter,
+/// sharded by `account_id`).
+///
+/// `save` upserts with optimistic-lock semantics on the aggregate `version`.
+#[async_trait]
+pub trait SessionRepository: Send + Sync + 'static {
+    async fn save(&self, session: &Session) -> Result<(), AuthError>;
+
+    async fn find_by_id(&self, id: &SessionId) -> Result<Option<Session>, AuthError>;
+
+    /// Active sessions for an account — the device-management view and the set a
+    /// global sign-out iterates over.
+    async fn list_active_by_account(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Vec<Session>, AuthError>;
+}

--- a/crates/services/auth/src/application/port/subject_link_repository.rs
+++ b/crates/services/auth/src/application/port/subject_link_repository.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+
+use crate::domain::aggregate::SubjectLink;
+use crate::domain::value_object::IdpSubject;
+use crate::error::AuthError;
+
+/// Durable persistence port for the immutable IdP-subject → account link.
+///
+/// `save` must enforce uniqueness on the `(issuer, subject)` pair, surfacing a
+/// concurrent first-login race as [`AuthError::SubjectAlreadyLinked`].
+#[async_trait]
+pub trait SubjectLinkRepository: Send + Sync + 'static {
+    async fn find_by_subject(
+        &self,
+        subject: &IdpSubject,
+    ) -> Result<Option<SubjectLink>, AuthError>;
+
+    async fn save(&self, link: &SubjectLink) -> Result<(), AuthError>;
+}

--- a/crates/services/auth/src/application/port/token_minter.rs
+++ b/crates/services/auth/src/application/port/token_minter.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::{AccessTokenClaims, RefreshTokenHash};
+use crate::error::AuthError;
+
+/// A freshly generated opaque refresh token: the one-time plaintext shown to the
+/// client and the hash to persist.
+#[derive(Debug, Clone)]
+pub struct GeneratedRefresh {
+    /// 256-bit random handle — returned to the client exactly once.
+    pub plaintext: String,
+    /// Irreversible hash of `plaintext` — the only form stored.
+    pub hash: RefreshTokenHash,
+}
+
+/// Token cryptography port (Phase 4 adapter: ES256 edge tokens + a CSPRNG for
+/// refresh handles; PASETO v4 is a later drop-in).
+///
+/// Kept behind a port so the edge-token format is swappable without touching the
+/// handlers, and so the signing key never reaches the application layer.
+#[async_trait]
+pub trait TokenMinter: Send + Sync + 'static {
+    /// Serializes domain claims into a signed edge token string.
+    async fn mint_access(&self, claims: &AccessTokenClaims) -> Result<String, AuthError>;
+
+    /// Verifies a presented edge token and reconstructs its claims. Used by
+    /// `Introspect`; returns [`AuthError::IdpTokenRejected`] on a bad signature /
+    /// malformed token.
+    async fn verify_access(&self, token: &str) -> Result<AccessTokenClaims, AuthError>;
+
+    /// Generates a new opaque refresh token + its hash (pure CPU).
+    fn generate_refresh(&self) -> Result<GeneratedRefresh, AuthError>;
+
+    /// Recomputes the stored hash of a presented refresh plaintext, for lookup.
+    fn hash_refresh(&self, plaintext: &str) -> Result<RefreshTokenHash, AuthError>;
+}

--- a/crates/services/auth/src/application/query/introspect.rs
+++ b/crates/services/auth/src/application/query/introspect.rs
@@ -1,0 +1,213 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::{SessionCache, TokenMinter};
+use crate::error::AuthError;
+
+/// Server-side token introspection.
+#[derive(Debug, Clone)]
+pub struct IntrospectQuery {
+    pub access_token: String,
+}
+
+impl Query for IntrospectQuery {
+    type Response = IntrospectionView;
+}
+
+/// The normalized principal an edge token resolves to — the same shape
+/// `auth-context` produces on the inbound path. `active` is `false` (with empty
+/// fields) for any token that fails a check, never an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntrospectionView {
+    pub active: bool,
+    pub account_id: Option<String>,
+    pub session_id: Option<String>,
+    pub generation: i64,
+    pub permissions: Vec<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl IntrospectionView {
+    fn inactive() -> Self {
+        Self {
+            active: false,
+            account_id: None,
+            session_id: None,
+            generation: 0,
+            permissions: Vec::new(),
+            expires_at: None,
+        }
+    }
+}
+
+/// Verifies an edge token's signature, then applies the live revocation checks
+/// (generation epoch + blacklist + expiry) the edge would apply.
+pub struct IntrospectHandler {
+    minter: Arc<dyn TokenMinter>,
+    cache: Arc<dyn SessionCache>,
+}
+
+impl IntrospectHandler {
+    pub fn new(minter: Arc<dyn TokenMinter>, cache: Arc<dyn SessionCache>) -> Self {
+        Self { minter, cache }
+    }
+
+    /// Clock-injected core, for deterministic tests.
+    pub async fn handle_at(
+        &self,
+        envelope: Envelope<IntrospectQuery>,
+        now: DateTime<Utc>,
+    ) -> Result<IntrospectionView, AuthError> {
+        let claims = match self.minter.verify_access(&envelope.payload.access_token).await {
+            Ok(claims) => claims,
+            Err(_) => return Ok(IntrospectionView::inactive()),
+        };
+
+        if claims.expires_at <= now {
+            return Ok(IntrospectionView::inactive());
+        }
+        let current_generation = self.cache.current_generation(&claims.account_id).await?;
+        if claims.generation != current_generation {
+            return Ok(IntrospectionView::inactive());
+        }
+        if self.cache.is_blacklisted(&claims.session_id).await? {
+            return Ok(IntrospectionView::inactive());
+        }
+
+        Ok(IntrospectionView {
+            active: true,
+            account_id: Some(claims.account_id.as_str()),
+            session_id: Some(claims.session_id.as_str()),
+            generation: claims.generation.value(),
+            permissions: claims.permissions.iter().map(|p| p.as_str().to_owned()).collect(),
+            expires_at: Some(claims.expires_at),
+        })
+    }
+}
+
+impl QueryHandler<IntrospectQuery> for IntrospectHandler {
+    type Error = AuthError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<IntrospectQuery>,
+    ) -> Result<IntrospectionView, Self::Error> {
+        self.handle_at(envelope, Utc::now()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::{LoginCommand, LogoutAllSessionsCommand, LogoutCommand};
+    use crate::application::fakes::{t0, Fixture};
+    use crate::application::port::AuthnGrant;
+    use crate::domain::value_object::DeviceFingerprint;
+    use chrono::Duration;
+    use uuid::Uuid;
+
+    async fn login(fx: &Fixture) -> crate::application::command::IssuedSession {
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::Password { username: "u".into(), password: "p".into() },
+                device: DeviceFingerprint::default(),
+            },
+        );
+        fx.login_handler().handle(env, t0()).await.unwrap()
+    }
+
+    fn introspect_env(token: &str) -> Envelope<IntrospectQuery> {
+        Envelope::new(Uuid::now_v7(), IntrospectQuery { access_token: token.to_owned() })
+    }
+
+    #[tokio::test]
+    async fn active_token_introspects_to_principal() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+
+        let view = fx
+            .introspect_handler()
+            .handle_at(introspect_env(&issued.access_token), t0() + Duration::minutes(1))
+            .await
+            .unwrap();
+
+        assert!(view.active);
+        assert_eq!(view.account_id, Some(issued.account_id.as_str()));
+        assert_eq!(view.session_id, Some(issued.session_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn garbage_token_is_inactive() {
+        let fx = Fixture::new();
+        let view = fx.introspect_handler().handle_at(introspect_env("bogus"), t0()).await.unwrap();
+        assert!(!view.active);
+        assert_eq!(view, IntrospectionView::inactive());
+    }
+
+    #[tokio::test]
+    async fn expired_token_is_inactive() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+        // Access TTL is 10 minutes; introspect 11 minutes later.
+        let view = fx
+            .introspect_handler()
+            .handle_at(introspect_env(&issued.access_token), t0() + Duration::minutes(11))
+            .await
+            .unwrap();
+        assert!(!view.active);
+    }
+
+    #[tokio::test]
+    async fn token_inactive_after_global_logout_bumps_generation() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+
+        fx.logout_all_handler()
+            .handle(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    LogoutAllSessionsCommand { account_id: issued.account_id.as_str() },
+                ),
+                t0(),
+            )
+            .await
+            .unwrap();
+
+        // The token's embedded generation (0) is now below the account's (1).
+        let view = fx
+            .introspect_handler()
+            .handle_at(introspect_env(&issued.access_token), t0() + Duration::minutes(1))
+            .await
+            .unwrap();
+        assert!(!view.active);
+    }
+
+    #[tokio::test]
+    async fn token_inactive_after_single_logout_blacklist() {
+        let fx = Fixture::new();
+        let issued = login(&fx).await;
+
+        fx.logout_handler()
+            .handle(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    LogoutCommand { session_id: issued.session_id.as_str() },
+                ),
+                t0(),
+            )
+            .await
+            .unwrap();
+
+        // Generation still matches (single logout doesn't bump it); the blacklist
+        // is what makes the token inactive.
+        let view = fx
+            .introspect_handler()
+            .handle_at(introspect_env(&issued.access_token), t0() + Duration::minutes(1))
+            .await
+            .unwrap();
+        assert!(!view.active);
+    }
+}

--- a/crates/services/auth/src/application/query/list_sessions.rs
+++ b/crates/services/auth/src/application/query/list_sessions.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::SessionRepository;
+use crate::domain::value_object::{AccountId, SessionStatus};
+use crate::error::AuthError;
+
+/// List an account's active sessions for a device-management view.
+#[derive(Debug, Clone)]
+pub struct ListSessionsQuery {
+    pub account_id: String,
+    /// The caller's own session, flagged `current` in the result when present.
+    pub current_session_id: Option<String>,
+}
+
+impl Query for ListSessionsQuery {
+    type Response = Vec<SessionSummary>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub status: SessionStatus,
+    pub generation: i64,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub absolute_expiry: DateTime<Utc>,
+    pub current: bool,
+}
+
+pub struct ListSessionsHandler {
+    sessions: Arc<dyn SessionRepository>,
+}
+
+impl ListSessionsHandler {
+    pub fn new(sessions: Arc<dyn SessionRepository>) -> Self {
+        Self { sessions }
+    }
+}
+
+impl QueryHandler<ListSessionsQuery> for ListSessionsHandler {
+    type Error = AuthError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<ListSessionsQuery>,
+    ) -> Result<Vec<SessionSummary>, Self::Error> {
+        let query = &envelope.payload;
+        let account_id = AccountId::try_from(query.account_id.as_str())?;
+        let current = query.current_session_id.as_deref();
+
+        let sessions = self.sessions.list_active_by_account(&account_id).await?;
+        Ok(sessions
+            .into_iter()
+            .map(|s| {
+                let session_id = s.id().as_str();
+                let current = current == Some(session_id.as_str());
+                SessionSummary {
+                    session_id,
+                    status: s.status(),
+                    generation: s.generation().value(),
+                    issued_at: s.issued_at(),
+                    expires_at: s.expires_at(),
+                    absolute_expiry: s.absolute_expiry(),
+                    current,
+                }
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::LoginCommand;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::application::port::AuthnGrant;
+    use crate::domain::value_object::DeviceFingerprint;
+    use uuid::Uuid;
+
+    async fn login(fx: &Fixture) -> crate::application::command::IssuedSession {
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            LoginCommand {
+                grant: AuthnGrant::Password { username: "u".into(), password: "p".into() },
+                device: DeviceFingerprint::default(),
+            },
+        );
+        fx.login_handler().handle(env, t0()).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn lists_active_sessions_and_flags_current() {
+        let fx = Fixture::new();
+        let a = login(&fx).await;
+        let _b = login(&fx).await;
+
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            ListSessionsQuery {
+                account_id: a.account_id.as_str(),
+                current_session_id: Some(a.session_id.as_str()),
+            },
+        );
+        let sessions = fx.list_sessions_handler().handle(env).await.unwrap();
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions.iter().filter(|s| s.current).count(), 1);
+        assert!(sessions.iter().all(|s| s.status == SessionStatus::Active));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_account_id() {
+        let fx = Fixture::new();
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            ListSessionsQuery { account_id: "not-a-uuid".into(), current_session_id: None },
+        );
+        let err = fx.list_sessions_handler().handle(env).await.unwrap_err();
+        assert!(matches!(err, AuthError::InvalidAccountId(_)));
+    }
+}

--- a/crates/services/auth/src/application/query/mod.rs
+++ b/crates/services/auth/src/application/query/mod.rs
@@ -1,0 +1,5 @@
+pub mod introspect;
+pub mod list_sessions;
+
+pub use introspect::{IntrospectHandler, IntrospectQuery, IntrospectionView};
+pub use list_sessions::{ListSessionsHandler, ListSessionsQuery, SessionSummary};

--- a/crates/services/auth/src/config.rs
+++ b/crates/services/auth/src/config.rs
@@ -1,0 +1,83 @@
+//! Environment-sourced configuration for the auth service. Resolved once at boot
+//! and threaded into the composition root ([`crate::app::App::build`]).
+
+use chrono::Duration;
+
+use crate::application::SessionPolicy;
+use crate::infrastructure::idp::KeycloakConfig;
+use crate::infrastructure::token::{EsKeyMaterial, EsVerifyingKey};
+
+/// Fully-resolved auth configuration (token policy, signing material, IdP broker,
+/// and the `account` service endpoint). Backend connection configs (Postgres /
+/// Redis / Kafka) are resolved separately via their own `from_env`.
+pub struct AuthConfig {
+    pub policy: SessionPolicy,
+    pub signing: EsKeyMaterial,
+    /// Retiring keys still accepted for verification + published in the JWKS
+    /// during a rotation window. Empty in steady state.
+    pub retiring_keys: Vec<EsVerifyingKey>,
+    pub keycloak: KeycloakConfig,
+    /// gRPC endpoint of the `account` service, e.g. `http://account:50059`.
+    pub account_endpoint: String,
+}
+
+impl AuthConfig {
+    /// Resolves configuration from the environment.
+    ///
+    /// Required: `AUTH_SIGNING_PRIVATE_PEM`, `AUTH_SIGNING_PUBLIC_PEM`. Everything
+    /// else has a production-shaped default.
+    pub fn from_env() -> anyhow::Result<Self> {
+        let policy = SessionPolicy::new(
+            Duration::seconds(env_secs("AUTH_ACCESS_TTL_SECS", 600)),
+            Duration::seconds(env_secs("AUTH_SESSION_TTL_SECS", 1_800)),
+            Duration::seconds(env_secs("AUTH_ABSOLUTE_TTL_SECS", 28_800)),
+            Duration::seconds(env_secs("AUTH_REFRESH_TTL_SECS", 604_800)),
+        );
+
+        let signing = EsKeyMaterial {
+            private_pem: env_required("AUTH_SIGNING_PRIVATE_PEM")?.into_bytes(),
+            public_pem: env_required("AUTH_SIGNING_PUBLIC_PEM")?.into_bytes(),
+            key_id: env_or("AUTH_SIGNING_KID", "auth-es256-1"),
+            issuer: env_or("AUTH_TOKEN_ISSUER", "https://auth.core-platform"),
+            audience: env_or("AUTH_TOKEN_AUDIENCE", "core-platform"),
+        };
+
+        let keycloak = KeycloakConfig {
+            token_endpoint: env_or("AUTH_KEYCLOAK_TOKEN_ENDPOINT", String::new()),
+            client_id: env_or("AUTH_KEYCLOAK_CLIENT_ID", String::new()),
+            client_secret: env_or("AUTH_KEYCLOAK_CLIENT_SECRET", String::new()),
+            scope: env_or("AUTH_KEYCLOAK_SCOPE", "openid".to_owned()),
+        };
+
+        // Optional single retiring key for a rotation window.
+        let retiring_keys = match (
+            std::env::var("AUTH_SIGNING_RETIRING_PUBLIC_PEM").ok(),
+            std::env::var("AUTH_SIGNING_RETIRING_KID").ok(),
+        ) {
+            (Some(pem), Some(kid)) if !pem.is_empty() && !kid.is_empty() => {
+                vec![EsVerifyingKey { key_id: kid, public_pem: pem.into_bytes() }]
+            }
+            _ => Vec::new(),
+        };
+
+        Ok(Self {
+            policy,
+            signing,
+            retiring_keys,
+            keycloak,
+            account_endpoint: env_or("AUTH_ACCOUNT_GRPC_ENDPOINT", "http://localhost:50059"),
+        })
+    }
+}
+
+fn env_or(key: &str, default: impl Into<String>) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.into())
+}
+
+fn env_secs(key: &str, default: i64) -> i64 {
+    std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
+fn env_required(key: &str) -> anyhow::Result<String> {
+    std::env::var(key).map_err(|_| anyhow::anyhow!("required env var {key} is not set"))
+}

--- a/crates/services/auth/src/domain/aggregate/mod.rs
+++ b/crates/services/auth/src/domain/aggregate/mod.rs
@@ -1,0 +1,7 @@
+pub mod refresh_token;
+pub mod session;
+pub mod subject_link;
+
+pub use refresh_token::{RefreshToken, RefreshTokenIssueParams};
+pub use session::{Session, SessionIssueParams};
+pub use subject_link::SubjectLink;

--- a/crates/services/auth/src/domain/aggregate/refresh_token.rs
+++ b/crates/services/auth/src/domain/aggregate/refresh_token.rs
@@ -1,0 +1,299 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{
+    AccountId, RefreshTokenHash, RefreshTokenId, RefreshTokenStatus, SessionId,
+};
+use crate::error::AuthError;
+
+/// Parameters to mint a fresh refresh token.
+#[derive(Debug, Clone)]
+pub struct RefreshTokenIssueParams {
+    pub session_id: SessionId,
+    pub account_id: AccountId,
+    pub token_hash: RefreshTokenHash,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// A single refresh token in a session's rotation lineage.
+///
+/// Modelled as its own aggregate (its own row, keyed by [`RefreshTokenId`]) so a
+/// rotation never has to load the whole chain. The plaintext is opaque to the
+/// client; only its [`RefreshTokenHash`] is held.
+///
+/// # Invariant 2 — single-use rotation with reuse-detection
+/// A token rotates exactly once (`Active → Rotated`). Presenting a token that is
+/// already `Rotated` is a theft signal: [`RefreshToken::rotate`] returns
+/// [`AuthError::RefreshTokenReuseDetected`], on which the application revokes the
+/// session's entire generation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RefreshToken {
+    id: RefreshTokenId,
+    session_id: SessionId,
+    account_id: AccountId,
+    token_hash: RefreshTokenHash,
+    status: RefreshTokenStatus,
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    used_at: Option<DateTime<Utc>>,
+    /// Successor minted when this token was rotated.
+    replaced_by: Option<RefreshTokenId>,
+    version: i64,
+}
+
+impl RefreshToken {
+    // ─── Construction ────────────────────────────────────────────────────────
+
+    /// Mints a new `Active` refresh token. Rejects a non-positive lifetime.
+    pub fn issue(params: RefreshTokenIssueParams) -> Result<Self, AuthError> {
+        if params.expires_at <= params.issued_at {
+            return Err(AuthError::DomainViolation {
+                field: "refresh_token.expires_at".into(),
+                message: "refresh-token expiry must be after its issue time".into(),
+            });
+        }
+        Ok(Self {
+            id: RefreshTokenId::new(),
+            session_id: params.session_id,
+            account_id: params.account_id,
+            token_hash: params.token_hash,
+            status: RefreshTokenStatus::Active,
+            issued_at: params.issued_at,
+            expires_at: params.expires_at,
+            used_at: None,
+            replaced_by: None,
+            version: 0,
+        })
+    }
+
+    /// Reconstructs from storage (no validation).
+    #[allow(clippy::too_many_arguments)]
+    pub fn reconstitute(
+        id: RefreshTokenId,
+        session_id: SessionId,
+        account_id: AccountId,
+        token_hash: RefreshTokenHash,
+        status: RefreshTokenStatus,
+        issued_at: DateTime<Utc>,
+        expires_at: DateTime<Utc>,
+        used_at: Option<DateTime<Utc>>,
+        replaced_by: Option<RefreshTokenId>,
+        version: i64,
+    ) -> Self {
+        Self {
+            id,
+            session_id,
+            account_id,
+            token_hash,
+            status,
+            issued_at,
+            expires_at,
+            used_at,
+            replaced_by,
+            version,
+        }
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    pub fn id(&self) -> RefreshTokenId {
+        self.id
+    }
+
+    pub fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    pub fn account_id(&self) -> AccountId {
+        self.account_id
+    }
+
+    pub fn token_hash(&self) -> &RefreshTokenHash {
+        &self.token_hash
+    }
+
+    pub fn status(&self) -> RefreshTokenStatus {
+        self.status
+    }
+
+    pub fn replaced_by(&self) -> Option<RefreshTokenId> {
+        self.replaced_by
+    }
+
+    pub fn issued_at(&self) -> DateTime<Utc> {
+        self.issued_at
+    }
+
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    pub fn used_at(&self) -> Option<DateTime<Utc>> {
+        self.used_at
+    }
+
+    pub fn version(&self) -> i64 {
+        self.version
+    }
+
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now >= self.expires_at
+    }
+
+    // ─── Commands ────────────────────────────────────────────────────────────
+
+    /// Rotates this token (single-use), returning its `Active` successor.
+    ///
+    /// - `Active` + unexpired ⇒ marks self `Rotated`, links `replaced_by`, mints
+    ///   the successor with `new_hash`.
+    /// - already `Rotated` ⇒ [`AuthError::RefreshTokenReuseDetected`] (invariant 2).
+    /// - `Revoked` ⇒ [`AuthError::RefreshTokenAlreadyRotated`] (session signed out).
+    /// - expired ⇒ [`AuthError::RefreshTokenExpired`].
+    pub fn rotate(
+        &mut self,
+        now: DateTime<Utc>,
+        new_hash: RefreshTokenHash,
+        new_expires_at: DateTime<Utc>,
+    ) -> Result<RefreshToken, AuthError> {
+        match self.status {
+            RefreshTokenStatus::Rotated => return Err(AuthError::RefreshTokenReuseDetected),
+            RefreshTokenStatus::Revoked => return Err(AuthError::RefreshTokenAlreadyRotated),
+            RefreshTokenStatus::Active => {}
+        }
+        if self.is_expired(now) {
+            return Err(AuthError::RefreshTokenExpired);
+        }
+
+        let successor = RefreshToken::issue(RefreshTokenIssueParams {
+            session_id: self.session_id,
+            account_id: self.account_id,
+            token_hash: new_hash,
+            issued_at: now,
+            expires_at: new_expires_at,
+        })?;
+
+        self.status = RefreshTokenStatus::Rotated;
+        self.used_at = Some(now);
+        self.replaced_by = Some(successor.id);
+        self.touch();
+        Ok(successor)
+    }
+
+    /// Revokes an `Active` token (its session was signed out). Idempotent-safe at
+    /// the application layer: already-terminal tokens return an error the caller
+    /// can treat as a no-op.
+    pub fn revoke(&mut self, now: DateTime<Utc>) -> Result<(), AuthError> {
+        match self.status {
+            RefreshTokenStatus::Active => {
+                self.status = RefreshTokenStatus::Revoked;
+                self.used_at = Some(now);
+                self.touch();
+                Ok(())
+            }
+            RefreshTokenStatus::Rotated => Err(AuthError::RefreshTokenAlreadyRotated),
+            RefreshTokenStatus::Revoked => Err(AuthError::InvalidSessionTransition {
+                from: "revoked".into(),
+                to: "revoked".into(),
+            }),
+        }
+    }
+
+    fn touch(&mut self) {
+        self.version += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use uuid::Uuid;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn hash(s: &str) -> RefreshTokenHash {
+        RefreshTokenHash::new(s).unwrap()
+    }
+
+    fn issue() -> RefreshToken {
+        RefreshToken::issue(RefreshTokenIssueParams {
+            session_id: SessionId::new(),
+            account_id: AccountId::from_uuid(Uuid::now_v7()),
+            token_hash: hash("h0"),
+            issued_at: t0(),
+            expires_at: t0() + Duration::days(7),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn issue_starts_active() {
+        let rt = issue();
+        assert_eq!(rt.status(), RefreshTokenStatus::Active);
+        assert!(rt.replaced_by().is_none());
+    }
+
+    #[test]
+    fn issue_rejects_non_positive_lifetime() {
+        let err = RefreshToken::issue(RefreshTokenIssueParams {
+            session_id: SessionId::new(),
+            account_id: AccountId::from_uuid(Uuid::now_v7()),
+            token_hash: hash("h"),
+            issued_at: t0(),
+            expires_at: t0(),
+        })
+        .unwrap_err();
+        assert!(matches!(err, AuthError::DomainViolation { .. }));
+    }
+
+    #[test]
+    fn rotate_links_lineage_and_marks_rotated() {
+        let mut rt = issue();
+        let successor = rt.rotate(t0() + Duration::hours(1), hash("h1"), t0() + Duration::days(7)).unwrap();
+        assert_eq!(rt.status(), RefreshTokenStatus::Rotated);
+        assert_eq!(rt.replaced_by(), Some(successor.id()));
+        assert_eq!(successor.status(), RefreshTokenStatus::Active);
+        assert_eq!(successor.session_id(), rt.session_id());
+        assert_eq!(successor.account_id(), rt.account_id());
+    }
+
+    #[test]
+    fn reuse_of_rotated_token_is_detected() {
+        let mut rt = issue();
+        let _succ = rt.rotate(t0() + Duration::hours(1), hash("h1"), t0() + Duration::days(7)).unwrap();
+        // Presenting the SAME (now-rotated) token again ⇒ reuse.
+        let err = rt.rotate(t0() + Duration::hours(2), hash("h2"), t0() + Duration::days(7)).unwrap_err();
+        assert!(matches!(err, AuthError::RefreshTokenReuseDetected));
+    }
+
+    #[test]
+    fn rotate_fails_when_expired() {
+        let mut rt = issue();
+        let err = rt.rotate(t0() + Duration::days(8), hash("h1"), t0() + Duration::days(15)).unwrap_err();
+        assert!(matches!(err, AuthError::RefreshTokenExpired));
+        // unchanged
+        assert_eq!(rt.status(), RefreshTokenStatus::Active);
+    }
+
+    #[test]
+    fn rotate_of_revoked_token_reports_already_rotated() {
+        let mut rt = issue();
+        rt.revoke(t0() + Duration::hours(1)).unwrap();
+        let err = rt.rotate(t0() + Duration::hours(2), hash("h1"), t0() + Duration::days(7)).unwrap_err();
+        assert!(matches!(err, AuthError::RefreshTokenAlreadyRotated));
+    }
+
+    #[test]
+    fn revoke_active_then_double_revoke_is_illegal() {
+        let mut rt = issue();
+        rt.revoke(t0() + Duration::hours(1)).unwrap();
+        assert_eq!(rt.status(), RefreshTokenStatus::Revoked);
+        assert!(matches!(
+            rt.revoke(t0() + Duration::hours(2)).unwrap_err(),
+            AuthError::InvalidSessionTransition { .. }
+        ));
+    }
+}

--- a/crates/services/auth/src/domain/aggregate/session.rs
+++ b/crates/services/auth/src/domain/aggregate/session.rs
@@ -1,0 +1,496 @@
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::event::{DomainEvent, SessionIssued, SessionRevoked};
+use crate::domain::value_object::{
+    AccessTokenClaims, AccountId, DeviceFingerprint, Generation, IdpSubject, Permission,
+    RevocationReason, SessionId, SessionStatus,
+};
+use crate::error::AuthError;
+
+/// Parameters to establish a new [`Session`].
+#[derive(Debug, Clone)]
+pub struct SessionIssueParams {
+    pub account_id: AccountId,
+    pub subject: IdpSubject,
+    /// The account's current generation at issue time.
+    pub generation: Generation,
+    pub device: DeviceFingerprint,
+    pub issued_at: DateTime<Utc>,
+    /// Sliding expiry; must be after `issued_at` and at/under `absolute_expiry`.
+    pub expires_at: DateTime<Utc>,
+    /// Hard cap the session can never be extended past.
+    pub absolute_expiry: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// The **Session** aggregate root — the authentication act and its lifecycle.
+///
+/// A session is the authority for minting edge access tokens. It is *not* the
+/// user (that's the `account` service) and *not* the credential (that's the IdP).
+///
+/// # Invariants (enforced here)
+/// 1. A token can be minted only while `status == Active` and the session has not
+///    passed its expiry (`ensure_mintable`).
+/// 2. A minted access token's lifetime is clamped to the session's horizon
+///    (`min(expires_at, absolute_expiry)`), so token TTL ⊆ session TTL ⊆ cap
+///    (`mint_access_token`).
+/// 3. A session can never be extended beyond its `absolute_expiry` (`extend`).
+/// 4. A session is valid for a request only if its `generation` still matches the
+///    account's current generation (`is_valid_under`) — a global sign-out bump
+///    invalidates it without touching this row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    id: SessionId,
+    account_id: AccountId,
+    subject: IdpSubject,
+    generation: Generation,
+    status: SessionStatus,
+    device: DeviceFingerprint,
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    absolute_expiry: DateTime<Utc>,
+    revoked_at: Option<DateTime<Utc>>,
+    version: i64,
+
+    #[serde(skip)]
+    pending_events: Vec<DomainEvent>,
+}
+
+impl Session {
+    // ─── Construction ────────────────────────────────────────────────────────
+
+    /// Establishes a new `Active` session. Emits [`SessionIssued`].
+    ///
+    /// Rejects a non-positive lifetime or an `expires_at` beyond the absolute cap.
+    pub fn issue(params: SessionIssueParams) -> Result<Self, AuthError> {
+        if params.expires_at <= params.issued_at {
+            return Err(AuthError::DomainViolation {
+                field: "session.expires_at".into(),
+                message: "session expiry must be after its issue time".into(),
+            });
+        }
+        if params.absolute_expiry < params.expires_at {
+            return Err(AuthError::DomainViolation {
+                field: "session.absolute_expiry".into(),
+                message: "absolute expiry must be at or after the sliding expiry".into(),
+            });
+        }
+
+        let id = SessionId::new();
+        let event = DomainEvent::SessionIssued(SessionIssued {
+            session_id: id,
+            account_id: params.account_id,
+            subject: params.subject.clone(),
+            generation: params.generation,
+            issued_at: params.issued_at,
+            expires_at: params.expires_at,
+            absolute_expiry: params.absolute_expiry,
+            occurred_at: params.issued_at,
+            correlation_id: params.correlation_id,
+        });
+
+        Ok(Self {
+            id,
+            account_id: params.account_id,
+            subject: params.subject,
+            generation: params.generation,
+            status: SessionStatus::Active,
+            device: params.device,
+            issued_at: params.issued_at,
+            expires_at: params.expires_at,
+            absolute_expiry: params.absolute_expiry,
+            revoked_at: None,
+            version: 0,
+            pending_events: vec![event],
+        })
+    }
+
+    /// Reconstructs a session from storage (no events emitted).
+    #[allow(clippy::too_many_arguments)]
+    pub fn reconstitute(
+        id: SessionId,
+        account_id: AccountId,
+        subject: IdpSubject,
+        generation: Generation,
+        status: SessionStatus,
+        device: DeviceFingerprint,
+        issued_at: DateTime<Utc>,
+        expires_at: DateTime<Utc>,
+        absolute_expiry: DateTime<Utc>,
+        revoked_at: Option<DateTime<Utc>>,
+        version: i64,
+    ) -> Self {
+        Self {
+            id,
+            account_id,
+            subject,
+            generation,
+            status,
+            device,
+            issued_at,
+            expires_at,
+            absolute_expiry,
+            revoked_at,
+            version,
+            pending_events: Vec::new(),
+        }
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    pub fn id(&self) -> SessionId {
+        self.id
+    }
+
+    pub fn account_id(&self) -> AccountId {
+        self.account_id
+    }
+
+    pub fn subject(&self) -> &IdpSubject {
+        &self.subject
+    }
+
+    pub fn generation(&self) -> Generation {
+        self.generation
+    }
+
+    pub fn status(&self) -> SessionStatus {
+        self.status
+    }
+
+    pub fn device(&self) -> &DeviceFingerprint {
+        &self.device
+    }
+
+    pub fn issued_at(&self) -> DateTime<Utc> {
+        self.issued_at
+    }
+
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    pub fn absolute_expiry(&self) -> DateTime<Utc> {
+        self.absolute_expiry
+    }
+
+    pub fn revoked_at(&self) -> Option<DateTime<Utc>> {
+        self.revoked_at
+    }
+
+    pub fn version(&self) -> i64 {
+        self.version
+    }
+
+    /// Whether the session has passed its sliding or absolute expiry at `now`.
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now >= self.expires_at || now >= self.absolute_expiry
+    }
+
+    /// Invariant 4: a session backs a request only if it is `Active`, unexpired,
+    /// and still on the account's current generation.
+    pub fn is_valid_under(&self, current_generation: Generation, now: DateTime<Utc>) -> bool {
+        self.status == SessionStatus::Active
+            && !self.is_expired(now)
+            && self.generation == current_generation
+    }
+
+    // ─── Commands ────────────────────────────────────────────────────────────
+
+    /// Invariants 1 + 2: mints an access token clamped to the session horizon.
+    ///
+    /// `requested_ttl` is the desired edge-token lifetime; the returned claims'
+    /// `expires_at` is `min(now + requested_ttl, expires_at, absolute_expiry)`.
+    /// Fails if the session cannot currently mint (revoked / expired).
+    pub fn mint_access_token(
+        &self,
+        now: DateTime<Utc>,
+        requested_ttl: Duration,
+        permissions: Vec<Permission>,
+    ) -> Result<AccessTokenClaims, AuthError> {
+        self.ensure_mintable(now)?;
+
+        let horizon = self.expires_at.min(self.absolute_expiry);
+        let expires_at = (now + requested_ttl).min(horizon);
+        if expires_at <= now {
+            // Horizon already reached within this instant — treat as expired.
+            return Err(AuthError::SessionExpired);
+        }
+
+        Ok(AccessTokenClaims::new(
+            self.account_id,
+            self.id,
+            self.generation,
+            permissions,
+            now,
+            expires_at,
+        ))
+    }
+
+    /// Invariant 3: slides the sliding expiry forward by `ttl`, never past the
+    /// absolute cap. Requires a mintable (active, unexpired) session.
+    pub fn extend(&mut self, now: DateTime<Utc>, ttl: Duration) -> Result<(), AuthError> {
+        self.ensure_mintable(now)?;
+        let proposed = (now + ttl).min(self.absolute_expiry);
+        if proposed > self.expires_at {
+            self.expires_at = proposed;
+            self.touch();
+        }
+        Ok(())
+    }
+
+    /// Revokes the session (single-session logout, reuse-detection, or admin).
+    /// Emits [`SessionRevoked`]. Illegal from a terminal state.
+    pub fn revoke(
+        &mut self,
+        now: DateTime<Utc>,
+        reason: RevocationReason,
+        correlation_id: Uuid,
+    ) -> Result<(), AuthError> {
+        self.transition_to(SessionStatus::Revoked)?;
+        self.revoked_at = Some(now);
+        self.touch();
+        self.pending_events.push(DomainEvent::SessionRevoked(SessionRevoked {
+            session_id: self.id,
+            account_id: self.account_id,
+            generation: self.generation,
+            reason,
+            occurred_at: now,
+            correlation_id,
+        }));
+        Ok(())
+    }
+
+    /// Marks an `Active` session that has passed its expiry as `Expired`
+    /// (housekeeping). No event — expiry is the absence of validity, not a fact
+    /// the rest of the platform must react to.
+    pub fn mark_expired(&mut self, now: DateTime<Utc>) -> Result<(), AuthError> {
+        if !self.is_expired(now) {
+            return Err(AuthError::DomainViolation {
+                field: "session".into(),
+                message: "session has not yet reached its expiry".into(),
+            });
+        }
+        self.transition_to(SessionStatus::Expired)?;
+        self.touch();
+        Ok(())
+    }
+
+    /// Drains accumulated events for the unit-of-work to publish.
+    pub fn drain_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    // ─── Internals ───────────────────────────────────────────────────────────
+
+    fn ensure_mintable(&self, now: DateTime<Utc>) -> Result<(), AuthError> {
+        match self.status {
+            SessionStatus::Revoked => Err(AuthError::SessionRevoked),
+            SessionStatus::Expired => Err(AuthError::SessionExpired),
+            SessionStatus::Active if self.is_expired(now) => Err(AuthError::SessionExpired),
+            SessionStatus::Active => Ok(()),
+        }
+    }
+
+    fn transition_to(&mut self, next: SessionStatus) -> Result<(), AuthError> {
+        if !self.status.can_transition_to(next) {
+            return Err(AuthError::InvalidSessionTransition {
+                from: self.status.to_string(),
+                to: next.to_string(),
+            });
+        }
+        self.status = next;
+        Ok(())
+    }
+
+    fn touch(&mut self) {
+        self.version += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn params() -> SessionIssueParams {
+        let now = t0();
+        SessionIssueParams {
+            account_id: AccountId::from_uuid(Uuid::now_v7()),
+            subject: IdpSubject::new("iss", "sub").unwrap(),
+            generation: Generation::INITIAL,
+            device: DeviceFingerprint::default(),
+            issued_at: now,
+            expires_at: now + Duration::minutes(30),
+            absolute_expiry: now + Duration::hours(8),
+            correlation_id: Uuid::now_v7(),
+        }
+    }
+
+    fn active_session() -> Session {
+        Session::issue(params()).unwrap()
+    }
+
+    #[test]
+    fn issue_emits_event_and_starts_active() {
+        let mut s = active_session();
+        assert_eq!(s.status(), SessionStatus::Active);
+        assert_eq!(s.version(), 0);
+        let events = s.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "auth.session_issued");
+        assert!(s.drain_events().is_empty(), "events drain once");
+    }
+
+    #[test]
+    fn issue_rejects_non_positive_lifetime() {
+        let mut p = params();
+        p.expires_at = p.issued_at;
+        assert!(matches!(Session::issue(p).unwrap_err(), AuthError::DomainViolation { .. }));
+    }
+
+    #[test]
+    fn issue_rejects_expiry_beyond_absolute_cap() {
+        let mut p = params();
+        p.absolute_expiry = p.expires_at - Duration::seconds(1);
+        assert!(matches!(Session::issue(p).unwrap_err(), AuthError::DomainViolation { .. }));
+    }
+
+    #[test]
+    fn mint_clamps_to_sliding_expiry() {
+        let s = active_session();
+        let now = t0();
+        // Ask for 2h, but sliding expiry is 30m away ⇒ clamp to 30m.
+        let claims = s.mint_access_token(now, Duration::hours(2), vec![]).unwrap();
+        assert_eq!(claims.expires_at, now + Duration::minutes(30));
+        assert_eq!(claims.generation, s.generation());
+        assert_eq!(claims.session_id, s.id());
+    }
+
+    #[test]
+    fn mint_shorter_ttl_is_not_extended() {
+        let s = active_session();
+        let now = t0();
+        let claims = s.mint_access_token(now, Duration::minutes(5), vec![]).unwrap();
+        assert_eq!(claims.expires_at, now + Duration::minutes(5));
+        assert_eq!(claims.expires_in_secs(now), 300);
+    }
+
+    #[test]
+    fn mint_carries_permissions() {
+        let s = active_session();
+        let perms = vec![Permission::new("posts:write"), Permission::new("ROLE_ADMIN")];
+        let claims = s.mint_access_token(t0(), Duration::minutes(5), perms.clone()).unwrap();
+        assert_eq!(claims.permissions, perms);
+    }
+
+    #[test]
+    fn mint_fails_when_expired() {
+        let s = active_session();
+        let later = t0() + Duration::minutes(31);
+        assert!(matches!(
+            s.mint_access_token(later, Duration::minutes(5), vec![]).unwrap_err(),
+            AuthError::SessionExpired
+        ));
+    }
+
+    #[test]
+    fn mint_fails_when_revoked() {
+        let mut s = active_session();
+        s.revoke(t0(), RevocationReason::Logout, Uuid::now_v7()).unwrap();
+        assert!(matches!(
+            s.mint_access_token(t0(), Duration::minutes(5), vec![]).unwrap_err(),
+            AuthError::SessionRevoked
+        ));
+    }
+
+    #[test]
+    fn extend_never_exceeds_absolute_cap() {
+        let mut s = active_session();
+        let now = t0() + Duration::minutes(10);
+        // Slide by 20h, but cap is 8h from issue ⇒ clamp to absolute_expiry.
+        s.extend(now, Duration::hours(20)).unwrap();
+        assert_eq!(s.expires_at(), s.absolute_expiry());
+    }
+
+    #[test]
+    fn extend_slides_forward_within_cap() {
+        let mut s = active_session();
+        let before = s.expires_at();
+        let now = t0() + Duration::minutes(10);
+        s.extend(now, Duration::minutes(30)).unwrap();
+        assert_eq!(s.expires_at(), now + Duration::minutes(30));
+        assert!(s.expires_at() > before);
+        assert_eq!(s.version(), 1, "extension bumps version");
+    }
+
+    #[test]
+    fn extend_fails_on_revoked() {
+        let mut s = active_session();
+        s.revoke(t0(), RevocationReason::Logout, Uuid::now_v7()).unwrap();
+        assert!(matches!(
+            s.extend(t0(), Duration::minutes(30)).unwrap_err(),
+            AuthError::SessionRevoked
+        ));
+    }
+
+    #[test]
+    fn revoke_emits_event_and_is_terminal() {
+        let mut s = active_session();
+        s.drain_events();
+        s.revoke(t0(), RevocationReason::RefreshReuse, Uuid::now_v7()).unwrap();
+        assert_eq!(s.status(), SessionStatus::Revoked);
+        let events = s.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "auth.session_revoked");
+    }
+
+    #[test]
+    fn double_revoke_is_illegal_transition() {
+        let mut s = active_session();
+        s.revoke(t0(), RevocationReason::Logout, Uuid::now_v7()).unwrap();
+        assert!(matches!(
+            s.revoke(t0(), RevocationReason::Logout, Uuid::now_v7()).unwrap_err(),
+            AuthError::InvalidSessionTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn mark_expired_requires_passing_expiry() {
+        let mut s = active_session();
+        // Not yet expired.
+        assert!(matches!(
+            s.mark_expired(t0()).unwrap_err(),
+            AuthError::DomainViolation { .. }
+        ));
+        // After expiry it succeeds.
+        s.mark_expired(t0() + Duration::hours(9)).unwrap();
+        assert_eq!(s.status(), SessionStatus::Expired);
+    }
+
+    #[test]
+    fn is_valid_under_checks_generation_status_and_time() {
+        let s = active_session();
+        let now = t0();
+        let g = s.generation();
+        // happy path
+        assert!(s.is_valid_under(g, now));
+        // stale generation ⇒ invalid (global logout happened)
+        assert!(!s.is_valid_under(g.next(), now));
+        // expired ⇒ invalid
+        assert!(!s.is_valid_under(g, now + Duration::hours(9)));
+    }
+
+    #[test]
+    fn is_valid_under_false_when_revoked() {
+        let mut s = active_session();
+        let g = s.generation();
+        s.revoke(t0(), RevocationReason::Logout, Uuid::now_v7()).unwrap();
+        assert!(!s.is_valid_under(g, t0()));
+    }
+}

--- a/crates/services/auth/src/domain/aggregate/subject_link.rs
+++ b/crates/services/auth/src/domain/aggregate/subject_link.rs
@@ -1,0 +1,124 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::event::{DomainEvent, SubjectLinked};
+use crate::domain::value_object::{AccountId, IdpSubject};
+
+/// The immutable binding of an IdP subject to an internal account.
+///
+/// This is the one piece of identity data the auth context legitimately owns —
+/// it is an authentication concern, not an identity-record concern (the record
+/// lives in `account`). Keying on the full [`IdpSubject`] `(issuer, subject)` is
+/// what makes IdP migration safe.
+///
+/// # Invariant 5 — immutable once established
+/// A link has no mutating methods: there is no setter for `account_id` or
+/// `subject`. Re-pointing a subject to a different account is modelled elsewhere
+/// as a *new* link plus an audit trail, never as a mutation of this aggregate.
+/// Uniqueness (one link per subject) is enforced at the repository boundary,
+/// surfacing as [`AuthError::SubjectAlreadyLinked`](crate::error::AuthError::SubjectAlreadyLinked).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubjectLink {
+    subject: IdpSubject,
+    account_id: AccountId,
+    linked_at: DateTime<Utc>,
+    version: i64,
+
+    #[serde(skip)]
+    pending_events: Vec<DomainEvent>,
+}
+
+impl SubjectLink {
+    /// Establishes a new link on first login. Emits [`SubjectLinked`].
+    pub fn establish(
+        subject: IdpSubject,
+        account_id: AccountId,
+        now: DateTime<Utc>,
+        correlation_id: Uuid,
+    ) -> Self {
+        let event = DomainEvent::SubjectLinked(SubjectLinked {
+            account_id,
+            subject: subject.clone(),
+            occurred_at: now,
+            correlation_id,
+        });
+        Self {
+            subject,
+            account_id,
+            linked_at: now,
+            version: 0,
+            pending_events: vec![event],
+        }
+    }
+
+    /// Reconstructs from storage (no events emitted).
+    pub fn reconstitute(
+        subject: IdpSubject,
+        account_id: AccountId,
+        linked_at: DateTime<Utc>,
+        version: i64,
+    ) -> Self {
+        Self {
+            subject,
+            account_id,
+            linked_at,
+            version,
+            pending_events: Vec::new(),
+        }
+    }
+
+    pub fn subject(&self) -> &IdpSubject {
+        &self.subject
+    }
+
+    pub fn account_id(&self) -> AccountId {
+        self.account_id
+    }
+
+    pub fn linked_at(&self) -> DateTime<Utc> {
+        self.linked_at
+    }
+
+    pub fn version(&self) -> i64 {
+        self.version
+    }
+
+    pub fn drain_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn establish_emits_subject_linked() {
+        let subject = IdpSubject::new("iss", "sub").unwrap();
+        let account = AccountId::from_uuid(Uuid::now_v7());
+        let mut link = SubjectLink::establish(subject.clone(), account, t0(), Uuid::now_v7());
+
+        assert_eq!(link.subject(), &subject);
+        assert_eq!(link.account_id(), account);
+        let events = link.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "auth.subject_linked");
+    }
+
+    #[test]
+    fn reconstituted_link_emits_nothing() {
+        let mut link = SubjectLink::reconstitute(
+            IdpSubject::new("iss", "sub").unwrap(),
+            AccountId::from_uuid(Uuid::now_v7()),
+            t0(),
+            3,
+        );
+        assert!(link.drain_events().is_empty());
+        assert_eq!(link.version(), 3);
+    }
+}

--- a/crates/services/auth/src/domain/event/mod.rs
+++ b/crates/services/auth/src/domain/event/mod.rs
@@ -1,0 +1,36 @@
+pub mod session_issued;
+pub mod session_revoked;
+pub mod subject_linked;
+
+pub use session_issued::SessionIssued;
+pub use session_revoked::SessionRevoked;
+pub use subject_linked::SubjectLinked;
+
+use serde::{Deserialize, Serialize};
+
+/// Sealed sum type of every domain event the auth context publishes to the
+/// `auth.v1.events` Kafka topic.
+///
+/// Events are serde structs (JSON on the wire), matching the fleet convention —
+/// they are deliberately **not** proto messages. The infrastructure event
+/// adapter (Phase 4) pattern-matches on this enum for routing keys and payload
+/// serialization. Refresh-token rotation is intentionally absent: it is an
+/// internal mechanic, not a published fact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DomainEvent {
+    SessionIssued(SessionIssued),
+    SessionRevoked(SessionRevoked),
+    SubjectLinked(SubjectLinked),
+}
+
+impl DomainEvent {
+    /// Dotted routing key used as the Kafka message type.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::SessionIssued(_) => "auth.session_issued",
+            Self::SessionRevoked(_) => "auth.session_revoked",
+            Self::SubjectLinked(_) => "auth.subject_linked",
+        }
+    }
+}

--- a/crates/services/auth/src/domain/event/session_issued.rs
+++ b/crates/services/auth/src/domain/event/session_issued.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::value_object::{AccountId, Generation, IdpSubject, SessionId};
+
+/// A new session was established for an account (successful login).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionIssued {
+    pub session_id: SessionId,
+    pub account_id: AccountId,
+    pub subject: IdpSubject,
+    pub generation: Generation,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub absolute_expiry: DateTime<Utc>,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}

--- a/crates/services/auth/src/domain/event/session_revoked.rs
+++ b/crates/services/auth/src/domain/event/session_revoked.rs
@@ -1,0 +1,18 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::value_object::{AccountId, Generation, RevocationReason, SessionId};
+
+/// A session was revoked. For a global sign-out, one event is emitted per
+/// affected session and `reason` is `GlobalLogout`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRevoked {
+    pub session_id: SessionId,
+    pub account_id: AccountId,
+    /// The generation the session was minted under.
+    pub generation: Generation,
+    pub reason: RevocationReason,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}

--- a/crates/services/auth/src/domain/event/subject_linked.rs
+++ b/crates/services/auth/src/domain/event/subject_linked.rs
@@ -1,0 +1,15 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::value_object::{AccountId, IdpSubject};
+
+/// An IdP subject was linked to an internal account for the first time. Emitted
+/// once, on first login; the link is immutable thereafter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubjectLinked {
+    pub account_id: AccountId,
+    pub subject: IdpSubject,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}

--- a/crates/services/auth/src/domain/mod.rs
+++ b/crates/services/auth/src/domain/mod.rs
@@ -1,0 +1,21 @@
+//! The auth bounded context's domain layer — pure, free of I/O.
+//!
+//! It owns the **authentication act and its lifecycle**: the [`Session`] aggregate
+//! (issue / mint / extend / revoke / expire), the [`RefreshToken`] rotation
+//! lineage with reuse-detection, and the immutable [`SubjectLink`] that ties an
+//! IdP subject to an internal account. Identity records live in the `account`
+//! service; credentials live in the IdP — neither is modelled here.
+//!
+//! ## Clock injection
+//! Several invariants are time-based (token/session expiry, refresh-token TTL).
+//! To keep the state machine deterministically unit-testable, time-dependent
+//! methods take `now: DateTime<Utc>` as a parameter rather than reading the wall
+//! clock internally. The application layer supplies the clock.
+//!
+//! [`Session`]: aggregate::Session
+//! [`RefreshToken`]: aggregate::RefreshToken
+//! [`SubjectLink`]: aggregate::SubjectLink
+
+pub mod aggregate;
+pub mod event;
+pub mod value_object;

--- a/crates/services/auth/src/domain/value_object/access_token_claims.rs
+++ b/crates/services/auth/src/domain/value_object/access_token_claims.rs
@@ -1,0 +1,45 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{AccountId, Generation, Permission, SessionId};
+
+/// The normalized claim set for an edge access token, produced by
+/// [`Session::mint_access_token`](crate::domain::aggregate::Session::mint_access_token).
+///
+/// This is the **domain** view of a token — not its wire form. The infrastructure
+/// `TokenMinterPort` (Phase 4) serializes it into an ES256 JWT (PASETO later);
+/// the `auth-context` library reconstructs the same shape on verification. By
+/// construction `expires_at` is clamped to the session's horizon, so the token's
+/// lifetime is always a subset of its session's lifetime.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccessTokenClaims {
+    /// `sub` — the internal account id (never the IdP subject).
+    pub account_id: AccountId,
+    /// `sid` — the session this token belongs to.
+    pub session_id: SessionId,
+    /// `gen` — the revocation epoch checked at the edge for instant logout.
+    pub generation: Generation,
+    /// Normalized authorization grants.
+    pub permissions: Vec<Permission>,
+    pub issued_at: DateTime<Utc>,
+    /// Always ≤ the session's sliding and absolute expiry.
+    pub expires_at: DateTime<Utc>,
+}
+
+impl AccessTokenClaims {
+    pub(crate) fn new(
+        account_id: AccountId,
+        session_id: SessionId,
+        generation: Generation,
+        permissions: Vec<Permission>,
+        issued_at: DateTime<Utc>,
+        expires_at: DateTime<Utc>,
+    ) -> Self {
+        Self { account_id, session_id, generation, permissions, issued_at, expires_at }
+    }
+
+    /// Remaining lifetime in whole seconds at `now` (saturating at zero).
+    pub fn expires_in_secs(&self, now: DateTime<Utc>) -> i64 {
+        (self.expires_at - now).num_seconds().max(0)
+    }
+}

--- a/crates/services/auth/src/domain/value_object/account_id.rs
+++ b/crates/services/auth/src/domain/value_object/account_id.rs
@@ -1,0 +1,106 @@
+use std::fmt;
+use std::hash::Hasher;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::AuthError;
+
+/// Internal account identifier the session is bound to.
+///
+/// This is the platform-canonical account id owned by the `account` service
+/// (a UUIDv7) — **not** the IdP subject. The auth context only ever references
+/// it; it never mints it. Wrapping it keeps the IdP `sub` (an opaque string
+/// living in [`IdpSubject`](super::IdpSubject)) from being confused with the
+/// internal id at any call site.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AccountId(Uuid);
+
+impl AccountId {
+    /// Wraps an existing UUID without validation. Use when reconstructing from a
+    /// trusted source (a DB row, a verified token claim, an upstream response).
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    /// Returns the inner UUID value.
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    /// Returns the hyphenated string representation.
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl fmt::Debug for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AccountId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for AccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+impl From<Uuid> for AccountId {
+    fn from(id: Uuid) -> Self {
+        Self(id)
+    }
+}
+
+impl TryFrom<&str> for AccountId {
+    type Error = AuthError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| AuthError::InvalidAccountId(s.to_owned()))
+    }
+}
+
+impl TryFrom<String> for AccountId {
+    type Error = AuthError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::try_from(s.as_str())
+    }
+}
+
+/// `AccountId` is the shard key for every durable auth table (`sessions`,
+/// `refresh_tokens`, `subject_links`): all of a person's auth state co-locates,
+/// so logout-all and session listing route to a single shard. The 16-byte UUID
+/// is fed directly into the hasher — zero allocation.
+impl postgres_storage::ShardKey for AccountId {
+    #[inline]
+    fn hash_shard_key<H: Hasher>(&self, state: &mut H) {
+        state.write(self.0.as_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_uuid() {
+        let id = AccountId::try_from("018f4c2a-9b7e-7a3d-b2c1-000000000001").unwrap();
+        assert_eq!(id.as_str(), "018f4c2a-9b7e-7a3d-b2c1-000000000001");
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        let err = AccountId::try_from("not-a-uuid").unwrap_err();
+        assert!(matches!(err, AuthError::InvalidAccountId(_)));
+    }
+
+    #[test]
+    fn round_trips_through_uuid() {
+        let raw = Uuid::now_v7();
+        assert_eq!(AccountId::from_uuid(raw).as_uuid(), raw);
+    }
+}

--- a/crates/services/auth/src/domain/value_object/device_fingerprint.rs
+++ b/crates/services/auth/src/domain/value_object/device_fingerprint.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Serialize};
+
+/// Best-effort client/device metadata captured at login for session tracking
+/// and anomaly signalling.
+///
+/// None of these fields are security-bearing on their own — they label sessions
+/// in the device-management view and let a refresh optionally re-check that the
+/// presenting device matches the one the session was bound to. All components
+/// are optional.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceFingerprint {
+    user_agent: Option<String>,
+    ip_address: Option<String>,
+    device_id: Option<String>,
+}
+
+impl DeviceFingerprint {
+    pub fn new(
+        user_agent: Option<String>,
+        ip_address: Option<String>,
+        device_id: Option<String>,
+    ) -> Self {
+        Self { user_agent, ip_address, device_id }
+    }
+
+    pub fn user_agent(&self) -> Option<&str> {
+        self.user_agent.as_deref()
+    }
+
+    pub fn ip_address(&self) -> Option<&str> {
+        self.ip_address.as_deref()
+    }
+
+    pub fn device_id(&self) -> Option<&str> {
+        self.device_id.as_deref()
+    }
+
+    /// Whether `other` plausibly originates from the same device.
+    ///
+    /// Compares the stable `device_id` when both sides provide one; if either is
+    /// absent the check is inconclusive and returns `true` (fail-open — device
+    /// binding is a signal, not an authentication factor).
+    pub fn same_device_as(&self, other: &DeviceFingerprint) -> bool {
+        match (self.device_id(), other.device_id()) {
+            (Some(a), Some(b)) => a == b,
+            _ => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_device(id: &str) -> DeviceFingerprint {
+        DeviceFingerprint::new(None, None, Some(id.to_owned()))
+    }
+
+    #[test]
+    fn same_device_when_ids_match() {
+        assert!(with_device("d1").same_device_as(&with_device("d1")));
+    }
+
+    #[test]
+    fn different_device_when_ids_differ() {
+        assert!(!with_device("d1").same_device_as(&with_device("d2")));
+    }
+
+    #[test]
+    fn inconclusive_when_id_missing_is_fail_open() {
+        let none = DeviceFingerprint::default();
+        assert!(with_device("d1").same_device_as(&none));
+        assert!(none.same_device_as(&with_device("d1")));
+    }
+}

--- a/crates/services/auth/src/domain/value_object/generation.rs
+++ b/crates/services/auth/src/domain/value_object/generation.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Monotonic per-account revocation epoch.
+///
+/// An edge token carries the `Generation` it was minted under. A global sign-out
+/// bumps the account's current generation (see [`Generation::next`]); any token
+/// whose embedded generation is below the account's current value is logically
+/// dead and rejected at the edge with a single cache read — no per-request DB
+/// lookup. Backed by `i64` to match the Postgres `bigint` column and the proto
+/// `int64` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Generation(i64);
+
+impl Generation {
+    /// The generation a brand-new account session registry starts at.
+    pub const INITIAL: Generation = Generation(0);
+
+    /// Wraps a raw value from a trusted source (DB row / verified claim).
+    pub fn from_i64(value: i64) -> Self {
+        Self(value)
+    }
+
+    pub fn value(&self) -> i64 {
+        self.0
+    }
+
+    /// The next epoch after a global sign-out. Saturating, so a (practically
+    /// impossible) overflow degrades safely instead of wrapping to a live value.
+    #[must_use]
+    pub fn next(&self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+impl Default for Generation {
+    fn default() -> Self {
+        Self::INITIAL
+    }
+}
+
+impl fmt::Display for Generation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_is_strictly_increasing() {
+        let g0 = Generation::INITIAL;
+        let g1 = g0.next();
+        assert!(g1 > g0);
+        assert_eq!(g1.value(), 1);
+        assert_eq!(g1.next().value(), 2);
+    }
+
+    #[test]
+    fn next_saturates_instead_of_wrapping() {
+        let max = Generation::from_i64(i64::MAX);
+        assert_eq!(max.next(), max);
+    }
+}

--- a/crates/services/auth/src/domain/value_object/idp_subject.rs
+++ b/crates/services/auth/src/domain/value_object/idp_subject.rs
@@ -1,0 +1,90 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuthError;
+
+/// A normalized identity-provider subject: the `(issuer, subject)` pair that
+/// uniquely identifies a principal at the IdP, independent of which IdP it is.
+///
+/// `issuer` is the OIDC `iss` (e.g. a Keycloak realm URL); `subject` is the `sub`
+/// claim. Keying the [`SubjectLink`](crate::domain::aggregate::SubjectLink) on the
+/// pair — not on `sub` alone — is what makes IdP migration safe: links minted
+/// under the old issuer stay valid and unambiguous after a new issuer is added.
+/// No IdP-specific structure is assumed; both fields are opaque strings.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct IdpSubject {
+    issuer: String,
+    subject: String,
+}
+
+impl IdpSubject {
+    /// Builds a subject, rejecting empty components.
+    pub fn new(
+        issuer: impl Into<String>,
+        subject: impl Into<String>,
+    ) -> Result<Self, AuthError> {
+        let issuer = issuer.into();
+        let subject = subject.into();
+        if issuer.trim().is_empty() {
+            return Err(AuthError::DomainViolation {
+                field: "idp_subject.issuer".into(),
+                message: "issuer must not be empty".into(),
+            });
+        }
+        if subject.trim().is_empty() {
+            return Err(AuthError::DomainViolation {
+                field: "idp_subject.subject".into(),
+                message: "subject must not be empty".into(),
+            });
+        }
+        Ok(Self { issuer, subject })
+    }
+
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+}
+
+impl fmt::Display for IdpSubject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Stable, log-safe rendering; the issuer disambiguates the subject.
+        write!(f, "{}#{}", self.issuer, self.subject)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_with_both_components() {
+        let s = IdpSubject::new("https://idp.example/realms/app", "abc-123").unwrap();
+        assert_eq!(s.issuer(), "https://idp.example/realms/app");
+        assert_eq!(s.subject(), "abc-123");
+    }
+
+    #[test]
+    fn rejects_empty_components() {
+        assert!(matches!(
+            IdpSubject::new("", "sub").unwrap_err(),
+            AuthError::DomainViolation { .. }
+        ));
+        assert!(matches!(
+            IdpSubject::new("iss", "   ").unwrap_err(),
+            AuthError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn equality_is_pairwise() {
+        let a = IdpSubject::new("iss-1", "sub").unwrap();
+        let b = IdpSubject::new("iss-2", "sub").unwrap();
+        // same subject, different issuer ⇒ distinct principals
+        assert_ne!(a, b);
+    }
+}

--- a/crates/services/auth/src/domain/value_object/mod.rs
+++ b/crates/services/auth/src/domain/value_object/mod.rs
@@ -1,0 +1,25 @@
+pub mod access_token_claims;
+pub mod account_id;
+pub mod device_fingerprint;
+pub mod generation;
+pub mod idp_subject;
+pub mod permission;
+pub mod refresh_token_hash;
+pub mod refresh_token_id;
+pub mod refresh_token_status;
+pub mod revocation_reason;
+pub mod session_id;
+pub mod session_status;
+
+pub use access_token_claims::AccessTokenClaims;
+pub use account_id::AccountId;
+pub use device_fingerprint::DeviceFingerprint;
+pub use generation::Generation;
+pub use idp_subject::IdpSubject;
+pub use permission::Permission;
+pub use refresh_token_hash::RefreshTokenHash;
+pub use refresh_token_id::RefreshTokenId;
+pub use refresh_token_status::RefreshTokenStatus;
+pub use revocation_reason::RevocationReason;
+pub use session_id::SessionId;
+pub use session_status::SessionStatus;

--- a/crates/services/auth/src/domain/value_object/permission.rs
+++ b/crates/services/auth/src/domain/value_object/permission.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// A normalized permission string, e.g. `"posts:write"` or `"ROLE_ADMIN"`.
+///
+/// This mirrors the `Permission` shape the `auth-context` library produces on the
+/// inbound path, so the claims this service mints and the claims downstream
+/// services read are the same vocabulary. Normalization from IdP-specific shapes
+/// (Keycloak `realm_access.roles`, Okta `groups`, …) happens in the
+/// infrastructure adapter; the domain only ever sees the normalized form.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Permission(String);
+
+impl Permission {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wraps_value() {
+        assert_eq!(Permission::new("posts:write").as_str(), "posts:write");
+    }
+}

--- a/crates/services/auth/src/domain/value_object/refresh_token_hash.rs
+++ b/crates/services/auth/src/domain/value_object/refresh_token_hash.rs
@@ -1,0 +1,58 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuthError;
+
+/// The stored, irreversible hash of an opaque refresh token.
+///
+/// The plaintext refresh token is a 256-bit random handle shown to the client
+/// exactly once; only this hash is persisted, so a database disclosure never
+/// yields usable tokens. The domain treats the value opaquely — the choice of
+/// digest (SHA-256, Argon2id, …) is an infrastructure concern. A lookup matches
+/// by recomputing the presented token's hash and comparing.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RefreshTokenHash(String);
+
+impl RefreshTokenHash {
+    /// Wraps a precomputed hash string, rejecting an empty value.
+    pub fn new(hash: impl Into<String>) -> Result<Self, AuthError> {
+        let hash = hash.into();
+        if hash.trim().is_empty() {
+            return Err(AuthError::DomainViolation {
+                field: "refresh_token_hash".into(),
+                message: "hash must not be empty".into(),
+            });
+        }
+        Ok(Self(hash))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Never print the hash itself, even at debug — keep it out of logs entirely.
+impl fmt::Debug for RefreshTokenHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RefreshTokenHash(***)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty() {
+        assert!(RefreshTokenHash::new("  ").is_err());
+    }
+
+    #[test]
+    fn debug_is_redacted() {
+        let h = RefreshTokenHash::new("deadbeef").unwrap();
+        assert_eq!(format!("{h:?}"), "RefreshTokenHash(***)");
+        assert_eq!(h.as_str(), "deadbeef");
+    }
+}

--- a/crates/services/auth/src/domain/value_object/refresh_token_id.rs
+++ b/crates/services/auth/src/domain/value_object/refresh_token_id.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::AuthError;
+
+/// Identifier of a single refresh-token row (UUIDv7).
+///
+/// Each rotation mints a new `RefreshTokenId`; the chain of `replaced_by` links
+/// forms the rotation lineage used for reuse-detection.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RefreshTokenId(Uuid);
+
+impl RefreshTokenId {
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl Default for RefreshTokenId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for RefreshTokenId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RefreshTokenId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for RefreshTokenId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+impl TryFrom<&str> for RefreshTokenId {
+    type Error = AuthError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| AuthError::DomainViolation {
+                field: "refresh_token_id".into(),
+                message: format!("invalid UUID: '{s}'"),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_unique() {
+        assert_ne!(RefreshTokenId::new(), RefreshTokenId::new());
+    }
+}

--- a/crates/services/auth/src/domain/value_object/refresh_token_status.rs
+++ b/crates/services/auth/src/domain/value_object/refresh_token_status.rs
@@ -1,0 +1,75 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuthError;
+
+/// Lifecycle state of a single refresh-token row.
+///
+/// `Active` is non-terminal. A successful rotation moves `Active → Rotated`
+/// (single-use); an explicit revoke moves `Active → Revoked`. Presenting a token
+/// already in `Rotated` is the reuse-detection signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefreshTokenStatus {
+    /// Valid and unused; may be rotated exactly once.
+    Active,
+    /// Already exchanged for a successor. Terminal. Re-presentation ⇒ reuse.
+    Rotated,
+    /// Invalidated (its session was revoked / signed out). Terminal.
+    Revoked,
+}
+
+impl RefreshTokenStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Rotated => "rotated",
+            Self::Revoked => "revoked",
+        }
+    }
+
+    pub fn can_transition_to(&self, next: RefreshTokenStatus) -> bool {
+        use RefreshTokenStatus::*;
+        matches!((self, next), (Active, Rotated) | (Active, Revoked))
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Rotated | Self::Revoked)
+    }
+}
+
+impl fmt::Display for RefreshTokenStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for RefreshTokenStatus {
+    type Error = AuthError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "active" => Ok(Self::Active),
+            "rotated" => Ok(Self::Rotated),
+            "revoked" => Ok(Self::Revoked),
+            other => Err(AuthError::DomainViolation {
+                field: "refresh_token_status".into(),
+                message: format!("unknown refresh-token status: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitions() {
+        assert!(RefreshTokenStatus::Active.can_transition_to(RefreshTokenStatus::Rotated));
+        assert!(RefreshTokenStatus::Active.can_transition_to(RefreshTokenStatus::Revoked));
+        assert!(!RefreshTokenStatus::Rotated.can_transition_to(RefreshTokenStatus::Revoked));
+        assert!(!RefreshTokenStatus::Revoked.can_transition_to(RefreshTokenStatus::Rotated));
+    }
+}

--- a/crates/services/auth/src/domain/value_object/revocation_reason.rs
+++ b/crates/services/auth/src/domain/value_object/revocation_reason.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuthError;
+
+/// Why a session was revoked — carried on the `SessionRevoked` event for audit
+/// and anomaly analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RevocationReason {
+    /// User-initiated single-session sign-out.
+    Logout,
+    /// Account-wide sign-out (generation bump).
+    GlobalLogout,
+    /// A rotated refresh token was re-presented — treated as compromise.
+    RefreshReuse,
+    /// Operator / security action.
+    Administrative,
+}
+
+impl RevocationReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Logout => "logout",
+            Self::GlobalLogout => "global_logout",
+            Self::RefreshReuse => "refresh_reuse",
+            Self::Administrative => "administrative",
+        }
+    }
+}
+
+impl fmt::Display for RevocationReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for RevocationReason {
+    type Error = AuthError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "logout" => Ok(Self::Logout),
+            "global_logout" => Ok(Self::GlobalLogout),
+            "refresh_reuse" => Ok(Self::RefreshReuse),
+            "administrative" => Ok(Self::Administrative),
+            other => Err(AuthError::DomainViolation {
+                field: "revocation_reason".into(),
+                message: format!("unknown revocation reason: '{other}'"),
+            }),
+        }
+    }
+}

--- a/crates/services/auth/src/domain/value_object/session_id.rs
+++ b/crates/services/auth/src/domain/value_object/session_id.rs
@@ -1,0 +1,91 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::AuthError;
+
+/// Opaque session identifier (UUIDv7).
+///
+/// Travels in the edge token's `sid` claim so a downstream service — or this
+/// service's `Introspect` — can name the exact session a request belongs to.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionId(Uuid);
+
+impl SessionId {
+    /// Generates a fresh UUIDv7 session identifier.
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    /// Wraps an existing UUID without validation (reconstruction from storage).
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl Default for SessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SessionId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+impl TryFrom<&str> for SessionId {
+    type Error = AuthError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| AuthError::InvalidSessionId(s.to_owned()))
+    }
+}
+
+impl TryFrom<String> for SessionId {
+    type Error = AuthError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::try_from(s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_unique_and_v7() {
+        let a = SessionId::new();
+        let b = SessionId::new();
+        assert_ne!(a, b);
+        assert_eq!(a.as_uuid().get_version_num(), 7);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(matches!(
+            SessionId::try_from("nope").unwrap_err(),
+            AuthError::InvalidSessionId(_)
+        ));
+    }
+}

--- a/crates/services/auth/src/domain/value_object/session_status.rs
+++ b/crates/services/auth/src/domain/value_object/session_status.rs
@@ -1,0 +1,93 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuthError;
+
+/// Lifecycle state of a [`Session`](crate::domain::aggregate::Session).
+///
+/// `Active` is the only non-terminal state. Transitions are gated by
+/// [`SessionStatus::can_transition_to`]; the aggregate rejects any illegal
+/// transition before mutating state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    /// Live; may mint edge tokens and be extended until its expiry.
+    Active,
+    /// Explicitly revoked (logout / reuse-detection / admin). Terminal.
+    Revoked,
+    /// Reached its absolute expiry. Terminal.
+    Expired,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Revoked => "revoked",
+            Self::Expired => "expired",
+        }
+    }
+
+    /// Returns `true` if `self → next` is a permitted transition.
+    pub fn can_transition_to(&self, next: SessionStatus) -> bool {
+        use SessionStatus::*;
+        matches!(
+            (self, next),
+            (Active, Revoked) | (Active, Expired)
+        )
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Revoked | Self::Expired)
+    }
+}
+
+impl fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for SessionStatus {
+    type Error = AuthError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "active" => Ok(Self::Active),
+            "revoked" => Ok(Self::Revoked),
+            "expired" => Ok(Self::Expired),
+            other => Err(AuthError::DomainViolation {
+                field: "session_status".into(),
+                message: format!("unknown session status: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_active_can_transition() {
+        assert!(SessionStatus::Active.can_transition_to(SessionStatus::Revoked));
+        assert!(SessionStatus::Active.can_transition_to(SessionStatus::Expired));
+        // terminal states never transition
+        for from in [SessionStatus::Revoked, SessionStatus::Expired] {
+            for to in [SessionStatus::Active, SessionStatus::Revoked, SessionStatus::Expired] {
+                assert!(!from.can_transition_to(to), "{from} -> {to} must be illegal");
+            }
+        }
+        // Active cannot go back to Active
+        assert!(!SessionStatus::Active.can_transition_to(SessionStatus::Active));
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for s in [SessionStatus::Active, SessionStatus::Revoked, SessionStatus::Expired] {
+            assert_eq!(SessionStatus::try_from(s.as_str()).unwrap(), s);
+        }
+        assert!(SessionStatus::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/auth/src/error.rs
+++ b/crates/services/auth/src/error.rs
@@ -1,0 +1,294 @@
+use error::{AppError, Severity};
+use http::StatusCode;
+use thiserror::Error;
+
+/// Canonical domain and application error type for the auth microservice.
+///
+/// The `AUT-XXXX` namespace is grouped by concern so a code alone localizes the
+/// fault: 1xxx session lifecycle, 2xxx refresh/rotation, 3xxx subject linkage,
+/// 4xxx token minting, 5xxx IdP broker, 6xxx account directory, 9xxx domain/parse.
+///
+/// ## Code catalogue
+///
+/// | Code     | Variant                      | HTTP | Severity | Retryable |
+/// |----------|------------------------------|------|----------|-----------|
+/// | AUT-1001 | SessionNotFound              | 404  | Low      | No        |
+/// | AUT-1002 | SessionRevoked               | 401  | Low      | No        |
+/// | AUT-1003 | SessionExpired               | 401  | Low      | No        |
+/// | AUT-1004 | InvalidSessionTransition     | 422  | Medium   | No        |
+/// | AUT-2001 | RefreshTokenNotFound         | 401  | Low      | No        |
+/// | AUT-2002 | RefreshTokenExpired          | 401  | Low      | No        |
+/// | AUT-2003 | RefreshTokenReuseDetected    | 401  | **High** | No        |
+/// | AUT-2004 | RefreshTokenAlreadyRotated   | 401  | Medium   | No        |
+/// | AUT-3001 | SubjectLinkNotFound          | 404  | Low      | No        |
+/// | AUT-3002 | SubjectAlreadyLinked         | 409  | Low      | No        |
+/// | AUT-4001 | TokenSigningFailed           | 500  | **High** | No        |
+/// | AUT-4002 | SigningKeyUnavailable        | 503  | **High** | **Yes**   |
+/// | AUT-4003 | InvalidTokenGeneration       | 401  | Low      | No        |
+/// | AUT-5001 | IdpUnavailable               | 503  | High     | **Yes**   |
+/// | AUT-5002 | IdpAuthenticationFailed      | 401  | Low      | No        |
+/// | AUT-5003 | IdpTokenRejected             | 401  | Low      | No        |
+/// | AUT-5004 | ClaimsNormalizationFailed    | 502  | Medium   | No        |
+/// | AUT-6001 | AccountNotActive             | 403  | Medium   | No        |
+/// | AUT-6002 | AccountDirectoryUnavailable  | 503  | High     | **Yes**   |
+/// | AUT-9001 | DomainViolation              | 422  | Medium   | No        |
+/// | AUT-9002 | InvalidSessionId             | 422  | Low      | No        |
+/// | AUT-9003 | InvalidAccountId             | 422  | Low      | No        |
+/// | DB-*     | Storage (delegated)          | var  | var      | var       |
+/// | VAL-*    | Validation (delegated)       | 422  | Low      | No        |
+///
+/// > Migration to a different IdP (Cognito/Okta/custom) reuses this exact
+/// > namespace: the broker faults (AUT-5xxx) are normalized, never IdP-specific.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AuthError {
+    // ── Infrastructure delegates ──────────────────────────────────────────────
+    #[error(transparent)]
+    Storage(#[from] postgres_storage::StorageError),
+
+    #[error(transparent)]
+    Cache(#[from] redis_storage::RedisStorageError),
+
+    #[error(transparent)]
+    Validation(#[from] validation::ValidationError),
+
+    // ── Event publication (AUT-7xxx) ──────────────────────────────────────────
+    #[error("failed to publish auth event: {0}")]
+    EventPublishFailed(String),
+
+    // ── Optimistic concurrency (AUT-8xxx) ─────────────────────────────────────
+    #[error("concurrent modification detected; reload and retry")]
+    ConcurrentModification,
+
+    // ── Session lifecycle (AUT-1xxx) ──────────────────────────────────────────
+    #[error("session not found: {id}")]
+    SessionNotFound { id: String },
+
+    #[error("session has been revoked")]
+    SessionRevoked,
+
+    #[error("session has expired")]
+    SessionExpired,
+
+    #[error("session transition from '{from}' to '{to}' is not permitted")]
+    InvalidSessionTransition { from: String, to: String },
+
+    // ── Refresh / rotation (AUT-2xxx) ─────────────────────────────────────────
+    #[error("refresh token not found")]
+    RefreshTokenNotFound,
+
+    #[error("refresh token has expired")]
+    RefreshTokenExpired,
+
+    /// Presenting an already-rotated refresh token signals theft; the handler
+    /// revokes the entire session generation in response (OAuth2 BCP).
+    #[error("refresh token reuse detected; the session generation has been revoked")]
+    RefreshTokenReuseDetected,
+
+    #[error("refresh token has already been rotated")]
+    RefreshTokenAlreadyRotated,
+
+    // ── Subject linkage (AUT-3xxx) ────────────────────────────────────────────
+    #[error("no account is linked to IdP subject ({iss}, {sub})")]
+    SubjectLinkNotFound { iss: String, sub: String },
+
+    #[error("IdP subject ({iss}, {sub}) is already linked to an account")]
+    SubjectAlreadyLinked { iss: String, sub: String },
+
+    // ── Token minting (AUT-4xxx) ──────────────────────────────────────────────
+    #[error("failed to sign edge token")]
+    TokenSigningFailed,
+
+    #[error("no signing key is currently available")]
+    SigningKeyUnavailable,
+
+    #[error("edge token generation is stale for this session")]
+    InvalidTokenGeneration,
+
+    // ── IdP broker (AUT-5xxx) — normalized, never IdP-specific ────────────────
+    #[error("identity provider is unavailable")]
+    IdpUnavailable,
+
+    #[error("identity provider rejected the credentials")]
+    IdpAuthenticationFailed,
+
+    #[error("identity provider rejected the presented token")]
+    IdpTokenRejected,
+
+    #[error("failed to normalize identity-provider claims: {0}")]
+    ClaimsNormalizationFailed(String),
+
+    // ── Account directory (AUT-6xxx) ──────────────────────────────────────────
+    #[error("account is not active; current status: '{current}'")]
+    AccountNotActive { current: String },
+
+    #[error("account directory service is unavailable")]
+    AccountDirectoryUnavailable,
+
+    // ── Domain invariants & parse errors (AUT-9xxx) ───────────────────────────
+    #[error("domain invariant violated on '{field}': {message}")]
+    DomainViolation { field: String, message: String },
+
+    #[error("invalid session ID: '{0}'")]
+    InvalidSessionId(String),
+
+    #[error("invalid account ID: '{0}'")]
+    InvalidAccountId(String),
+}
+
+impl AppError for AuthError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            AuthError::Storage(e) => e.error_code(),
+            AuthError::Cache(e) => e.error_code(),
+            AuthError::Validation(e) => e.error_code(),
+
+            AuthError::EventPublishFailed(_) => "AUT-7001",
+            AuthError::ConcurrentModification => "AUT-8001",
+
+            AuthError::SessionNotFound { .. } => "AUT-1001",
+            AuthError::SessionRevoked => "AUT-1002",
+            AuthError::SessionExpired => "AUT-1003",
+            AuthError::InvalidSessionTransition { .. } => "AUT-1004",
+
+            AuthError::RefreshTokenNotFound => "AUT-2001",
+            AuthError::RefreshTokenExpired => "AUT-2002",
+            AuthError::RefreshTokenReuseDetected => "AUT-2003",
+            AuthError::RefreshTokenAlreadyRotated => "AUT-2004",
+
+            AuthError::SubjectLinkNotFound { .. } => "AUT-3001",
+            AuthError::SubjectAlreadyLinked { .. } => "AUT-3002",
+
+            AuthError::TokenSigningFailed => "AUT-4001",
+            AuthError::SigningKeyUnavailable => "AUT-4002",
+            AuthError::InvalidTokenGeneration => "AUT-4003",
+
+            AuthError::IdpUnavailable => "AUT-5001",
+            AuthError::IdpAuthenticationFailed => "AUT-5002",
+            AuthError::IdpTokenRejected => "AUT-5003",
+            AuthError::ClaimsNormalizationFailed(_) => "AUT-5004",
+
+            AuthError::AccountNotActive { .. } => "AUT-6001",
+            AuthError::AccountDirectoryUnavailable => "AUT-6002",
+
+            AuthError::DomainViolation { .. } => "AUT-9001",
+            AuthError::InvalidSessionId(_) => "AUT-9002",
+            AuthError::InvalidAccountId(_) => "AUT-9003",
+        }
+    }
+
+    fn http_status(&self) -> StatusCode {
+        match self {
+            AuthError::Storage(e) => e.http_status(),
+            AuthError::Cache(e) => e.http_status(),
+            AuthError::Validation(e) => e.http_status(),
+
+            AuthError::EventPublishFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            AuthError::ConcurrentModification => StatusCode::CONFLICT,
+
+            AuthError::SessionNotFound { .. } | AuthError::SubjectLinkNotFound { .. } => {
+                StatusCode::NOT_FOUND
+            }
+
+            AuthError::SessionRevoked
+            | AuthError::SessionExpired
+            | AuthError::RefreshTokenNotFound
+            | AuthError::RefreshTokenExpired
+            | AuthError::RefreshTokenReuseDetected
+            | AuthError::RefreshTokenAlreadyRotated
+            | AuthError::InvalidTokenGeneration
+            | AuthError::IdpAuthenticationFailed
+            | AuthError::IdpTokenRejected => StatusCode::UNAUTHORIZED,
+
+            AuthError::SubjectAlreadyLinked { .. } => StatusCode::CONFLICT,
+
+            AuthError::AccountNotActive { .. } => StatusCode::FORBIDDEN,
+
+            AuthError::TokenSigningFailed => StatusCode::INTERNAL_SERVER_ERROR,
+
+            AuthError::ClaimsNormalizationFailed(_) => StatusCode::BAD_GATEWAY,
+
+            AuthError::SigningKeyUnavailable
+            | AuthError::IdpUnavailable
+            | AuthError::AccountDirectoryUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+
+            _ => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            AuthError::Storage(e) => e.severity(),
+            AuthError::Cache(e) => e.severity(),
+            AuthError::Validation(e) => e.severity(),
+
+            AuthError::EventPublishFailed(_) => Severity::Medium,
+            AuthError::ConcurrentModification => Severity::High,
+
+            AuthError::RefreshTokenReuseDetected
+            | AuthError::TokenSigningFailed
+            | AuthError::SigningKeyUnavailable
+            | AuthError::IdpUnavailable
+            | AuthError::AccountDirectoryUnavailable => Severity::High,
+
+            AuthError::InvalidSessionTransition { .. }
+            | AuthError::RefreshTokenAlreadyRotated
+            | AuthError::ClaimsNormalizationFailed(_)
+            | AuthError::AccountNotActive { .. }
+            | AuthError::DomainViolation { .. } => Severity::Medium,
+
+            _ => Severity::Low,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            AuthError::Storage(e) => e.is_retryable(),
+            AuthError::Cache(e) => e.is_retryable(),
+            AuthError::ConcurrentModification
+            | AuthError::SigningKeyUnavailable
+            | AuthError::IdpUnavailable
+            | AuthError::AccountDirectoryUnavailable => true,
+            _ => false,
+        }
+    }
+
+    fn category(&self) -> &'static str {
+        match self {
+            AuthError::Storage(e) => e.category(),
+            AuthError::Cache(e) => e.category(),
+            AuthError::Validation(e) => e.category(),
+            _ => "AUT",
+        }
+    }
+
+    fn user_facing_message(&self) -> &'static str {
+        match self {
+            AuthError::Storage(e) => e.user_facing_message(),
+            AuthError::Cache(e) => e.user_facing_message(),
+            AuthError::Validation(e) => e.user_facing_message(),
+
+            AuthError::EventPublishFailed(_) => "We could not complete that action. Please try again.",
+
+            AuthError::SessionNotFound { .. } => "The session does not exist.",
+            AuthError::SessionRevoked => "This session has been signed out.",
+            AuthError::SessionExpired => "This session has expired; please sign in again.",
+            AuthError::InvalidSessionTransition { .. } => "This session operation is not permitted.",
+            AuthError::RefreshTokenNotFound
+            | AuthError::RefreshTokenExpired
+            | AuthError::RefreshTokenAlreadyRotated => "Your session could not be refreshed; please sign in again.",
+            AuthError::RefreshTokenReuseDetected => "A security issue was detected; please sign in again.",
+            AuthError::SubjectLinkNotFound { .. } => "No account is linked to this identity.",
+            AuthError::SubjectAlreadyLinked { .. } => "This identity is already linked to an account.",
+            AuthError::TokenSigningFailed | AuthError::SigningKeyUnavailable => "We could not issue a session right now. Please try again.",
+            AuthError::InvalidTokenGeneration => "Your session is no longer valid; please sign in again.",
+            AuthError::IdpUnavailable => "The sign-in service is temporarily unavailable.",
+            AuthError::IdpAuthenticationFailed => "The credentials provided are incorrect.",
+            AuthError::IdpTokenRejected => "Your sign-in could not be verified; please sign in again.",
+            AuthError::ClaimsNormalizationFailed(_) => "We could not complete sign-in. Please try again.",
+            AuthError::AccountNotActive { .. } => "This account cannot sign in at this time.",
+            AuthError::AccountDirectoryUnavailable => "The account service is temporarily unavailable.",
+            _ => "A domain constraint was violated.",
+        }
+    }
+}

--- a/crates/services/auth/src/infrastructure/cache/keys.rs
+++ b/crates/services/auth/src/infrastructure/cache/keys.rs
@@ -1,0 +1,29 @@
+use crate::domain::value_object::{AccountId, SessionId};
+
+/// The account's revocation-generation counter. Hash-tagged on the account so the
+/// `GET`/`INCR` stays slot-local in a Redis Cluster.
+pub fn generation_key(account_id: &AccountId) -> String {
+    format!("auth:{{acct:{account_id}}}:gen")
+}
+
+/// Per-session blacklist marker. Set with a TTL equal to the access-token window
+/// so it self-evicts once no live edge token could reference the session.
+pub fn blacklist_key(session_id: &SessionId) -> String {
+    format!("auth:{{sess:{session_id}}}:revoked")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn keys_carry_hash_tags() {
+        let acct = AccountId::from_uuid(Uuid::nil());
+        let sess = SessionId::from_uuid(Uuid::nil());
+        assert!(generation_key(&acct).contains("{acct:"));
+        assert!(blacklist_key(&sess).contains("{sess:"));
+        assert!(generation_key(&acct).ends_with(":gen"));
+        assert!(blacklist_key(&sess).ends_with(":revoked"));
+    }
+}

--- a/crates/services/auth/src/infrastructure/cache/mod.rs
+++ b/crates/services/auth/src/infrastructure/cache/mod.rs
@@ -1,0 +1,11 @@
+//! Redis Cluster adapter for the hot-path [`SessionCache`](crate::application::port::SessionCache).
+//!
+//! Keys are hash-tagged so each is slot-pinned and every operation is a
+//! single-key, single-round-trip command (no `CROSSSLOT`):
+//! * `auth:{acct:<id>}:gen`     — the account's revocation generation (`INCR`/`GET`).
+//! * `auth:{sess:<id>}:revoked` — per-session blacklist marker with TTL.
+
+pub mod keys;
+pub mod redis_session_cache;
+
+pub use redis_session_cache::RedisSessionCache;

--- a/crates/services/auth/src/infrastructure/cache/redis_session_cache.rs
+++ b/crates/services/auth/src/infrastructure/cache/redis_session_cache.rs
@@ -1,0 +1,68 @@
+use async_trait::async_trait;
+use chrono::Duration;
+use fred::interfaces::KeysInterface;
+use fred::types::Expiration;
+use redis_storage::{RedisClient, RedisStorageError};
+use tracing::instrument;
+
+use crate::application::port::SessionCache;
+use crate::domain::value_object::{AccountId, Generation, SessionId};
+use crate::error::AuthError;
+
+use super::keys::{blacklist_key, generation_key};
+
+/// Redis Cluster implementation of [`SessionCache`].
+#[derive(Clone)]
+pub struct RedisSessionCache {
+    client: RedisClient,
+}
+
+impl RedisSessionCache {
+    pub fn new(client: RedisClient) -> Self {
+        Self { client }
+    }
+}
+
+fn cache_err(e: fred::error::Error) -> AuthError {
+    AuthError::Cache(RedisStorageError::from(e))
+}
+
+#[async_trait]
+impl SessionCache for RedisSessionCache {
+    #[instrument(name = "auth.cache.current_generation", skip(self), fields(account.id = %account_id))]
+    async fn current_generation(&self, account_id: &AccountId) -> Result<Generation, AuthError> {
+        // A missing counter means "never bumped" ⇒ the initial generation.
+        let value: Option<i64> =
+            self.client.get(generation_key(account_id)).await.map_err(cache_err)?;
+        Ok(value.map(Generation::from_i64).unwrap_or(Generation::INITIAL))
+    }
+
+    #[instrument(name = "auth.cache.bump_generation", skip(self), fields(account.id = %account_id))]
+    async fn bump_generation(&self, account_id: &AccountId) -> Result<Generation, AuthError> {
+        // INCR is atomic and creates the key at 1 on first use, which matches
+        // `Generation::INITIAL.next()`.
+        let next: i64 = self.client.incr(generation_key(account_id)).await.map_err(cache_err)?;
+        Ok(Generation::from_i64(next))
+    }
+
+    #[instrument(name = "auth.cache.blacklist", skip(self), fields(session.id = %session_id))]
+    async fn blacklist_session(
+        &self,
+        session_id: &SessionId,
+        ttl: Duration,
+    ) -> Result<(), AuthError> {
+        let secs = ttl.num_seconds().max(1);
+        let _: () = self
+            .client
+            .set(blacklist_key(session_id), "1", Some(Expiration::EX(secs)), None, false)
+            .await
+            .map_err(cache_err)?;
+        Ok(())
+    }
+
+    #[instrument(name = "auth.cache.is_blacklisted", skip(self), fields(session.id = %session_id))]
+    async fn is_blacklisted(&self, session_id: &SessionId) -> Result<bool, AuthError> {
+        let count: i64 = self.client.exists(blacklist_key(session_id)).await.map_err(cache_err)?;
+        Ok(count > 0)
+    }
+}

--- a/crates/services/auth/src/infrastructure/directory/grpc_account_directory.rs
+++ b/crates/services/auth/src/infrastructure/directory/grpc_account_directory.rs
@@ -1,0 +1,89 @@
+use account_api::account_service_client::AccountServiceClient;
+use account_api::{AccountStatus, GetAccountByIdRequest, GetAccountByIdentityIdRequest};
+use async_trait::async_trait;
+use tonic::transport::Channel;
+use tonic::Code;
+use tracing::instrument;
+
+use crate::application::port::{AccountActivation, AccountDirectory, AccountSnapshot};
+use crate::domain::value_object::{AccountId, IdpSubject, Permission};
+use crate::error::AuthError;
+
+/// gRPC implementation of [`AccountDirectory`], backed by the `account` service.
+///
+/// The tonic client is cheaply cloneable (the `Channel` is `Arc`-backed), so each
+/// call clones it to satisfy the `&self` port signature.
+#[derive(Clone)]
+pub struct GrpcAccountDirectory {
+    client: AccountServiceClient<Channel>,
+}
+
+impl GrpcAccountDirectory {
+    pub fn new(channel: Channel) -> Self {
+        Self { client: AccountServiceClient::new(channel) }
+    }
+}
+
+/// Maps an `account.v1` identity to the IdP subject string the `account` service
+/// stores as `identity_id`. The composite `issuer#subject` keeps subjects from
+/// distinct issuers unambiguous after an IdP migration.
+fn identity_id(subject: &IdpSubject) -> String {
+    subject.to_string()
+}
+
+#[async_trait]
+impl AccountDirectory for GrpcAccountDirectory {
+    #[instrument(name = "auth.directory.resolve", skip(self), fields(subject = %subject))]
+    async fn resolve_or_provision(&self, subject: &IdpSubject) -> Result<AccountId, AuthError> {
+        let mut client = self.client.clone();
+        let response = client
+            .get_account_by_identity_id(GetAccountByIdentityIdRequest {
+                identity_id: identity_id(subject),
+            })
+            .await;
+
+        match response {
+            Ok(view) => AccountId::try_from(view.into_inner().id.as_str()),
+            // Auto-provisioning from IdP claims (which requires the email/profile,
+            // i.e. extending NormalizedClaims) is a product decision deferred to a
+            // follow-up; for now an unknown subject cannot establish a session.
+            Err(status) if status.code() == Code::NotFound => {
+                Err(AuthError::AccountNotActive { current: "account_not_provisioned".into() })
+            }
+            Err(_) => Err(AuthError::AccountDirectoryUnavailable),
+        }
+    }
+
+    #[instrument(name = "auth.directory.lookup", skip(self), fields(account.id = %account_id))]
+    async fn lookup(&self, account_id: &AccountId) -> Result<AccountSnapshot, AuthError> {
+        let mut client = self.client.clone();
+        let view = client
+            .get_account_by_id(GetAccountByIdRequest { account_id: account_id.as_str() })
+            .await
+            .map_err(|status| match status.code() {
+                Code::NotFound => AuthError::AccountNotActive { current: "not_found".into() },
+                _ => AuthError::AccountDirectoryUnavailable,
+            })?
+            .into_inner();
+
+        let activation = match AccountStatus::try_from(view.status).unwrap_or(AccountStatus::Unspecified) {
+            AccountStatus::Active => AccountActivation::Active,
+            other => AccountActivation::Inactive { reason: status_name(other) },
+        };
+        let permissions = view.roles.into_iter().map(Permission::new).collect();
+
+        Ok(AccountSnapshot { activation, permissions })
+    }
+}
+
+fn status_name(status: AccountStatus) -> String {
+    match status {
+        AccountStatus::Unspecified => "unspecified",
+        AccountStatus::PendingVerification => "pending_verification",
+        AccountStatus::Active => "active",
+        AccountStatus::Suspended => "suspended",
+        AccountStatus::Deactivated => "deactivated",
+        AccountStatus::Deleted => "deleted",
+    }
+    .to_owned()
+}

--- a/crates/services/auth/src/infrastructure/directory/mod.rs
+++ b/crates/services/auth/src/infrastructure/directory/mod.rs
@@ -1,0 +1,7 @@
+//! `account` service adapter for the [`AccountDirectory`](crate::application::port::AccountDirectory)
+//! port — a gRPC client over the `account.v1` contract. Auth reads identity here;
+//! it never writes it.
+
+pub mod grpc_account_directory;
+
+pub use grpc_account_directory::GrpcAccountDirectory;

--- a/crates/services/auth/src/infrastructure/event/kafka_event_publisher.rs
+++ b/crates/services/auth/src/infrastructure/event/kafka_event_publisher.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+use transport::error::TransportError;
+use transport::kafka::envelope::EventEnvelope;
+use transport::kafka::producer::handle::KafkaProducerHandle;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::AuthError;
+
+use super::{event_key, TOPIC_AUTH_EVENTS};
+
+/// Kafka-backed [`EventPublisher`]. Handlers persist durably first, then publish;
+/// a publish failure surfaces as [`AuthError::EventPublishFailed`] (the adapter
+/// may itself back an outbox in a later iteration).
+pub struct KafkaEventPublisher {
+    producer: KafkaProducerHandle,
+}
+
+impl KafkaEventPublisher {
+    pub fn new(producer: KafkaProducerHandle) -> Self {
+        Self { producer }
+    }
+}
+
+fn publish_err(e: TransportError) -> AuthError {
+    AuthError::EventPublishFailed(e.to_string())
+}
+
+#[async_trait]
+impl EventPublisher for KafkaEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), AuthError> {
+        let key = event_key(event).as_str();
+        let envelope = EventEnvelope::new(TOPIC_AUTH_EVENTS, key.clone(), event.clone())
+            .with_header("event_type", event.event_type().to_owned())
+            .with_header("account_id", key);
+        self.producer.publish(envelope).await.map_err(publish_err)
+    }
+}

--- a/crates/services/auth/src/infrastructure/event/log_event_publisher.rs
+++ b/crates/services/auth/src/infrastructure/event/log_event_publisher.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+use tracing::info;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::AuthError;
+
+use super::event_key;
+
+/// A no-Kafka [`EventPublisher`] that traces events instead of emitting them.
+/// Used for local development and tests where a broker is not wired.
+#[derive(Default)]
+pub struct LogEventPublisher;
+
+#[async_trait]
+impl EventPublisher for LogEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), AuthError> {
+        info!(
+            event_type = event.event_type(),
+            account_id = %event_key(event),
+            "auth domain event (log publisher)"
+        );
+        Ok(())
+    }
+}

--- a/crates/services/auth/src/infrastructure/event/mod.rs
+++ b/crates/services/auth/src/infrastructure/event/mod.rs
@@ -1,0 +1,26 @@
+//! Event-publication adapters for the `auth.v1.events` topic.
+//!
+//! All three domain events share one topic, keyed by `account_id` so a person's
+//! auth events keep per-account order on one partition; the `event_type` header
+//! carries the dotted routing key.
+
+pub mod kafka_event_publisher;
+pub mod log_event_publisher;
+
+pub use kafka_event_publisher::KafkaEventPublisher;
+pub use log_event_publisher::LogEventPublisher;
+
+/// The single Kafka topic every auth domain event is published to.
+pub const TOPIC_AUTH_EVENTS: &str = "auth.v1.events";
+
+use crate::domain::event::DomainEvent;
+use crate::domain::value_object::AccountId;
+
+/// The partition key (account id) for an event — keeps per-account ordering.
+pub(crate) fn event_key(event: &DomainEvent) -> AccountId {
+    match event {
+        DomainEvent::SessionIssued(e) => e.account_id,
+        DomainEvent::SessionRevoked(e) => e.account_id,
+        DomainEvent::SubjectLinked(e) => e.account_id,
+    }
+}

--- a/crates/services/auth/src/infrastructure/grpc/handler/auth_service_handler.rs
+++ b/crates/services/auth/src/infrastructure/grpc/handler/auth_service_handler.rs
@@ -1,0 +1,247 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+use error::AppError;
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+use crate::application::command::{
+    IssuedSession, LoginCommand, LoginHandler, LogoutAllSessionsCommand, LogoutAllSessionsHandler,
+    LogoutCommand, LogoutHandler, RefreshCommand, RefreshHandler,
+};
+use crate::application::port::AuthnGrant;
+use crate::application::query::{
+    IntrospectHandler, IntrospectQuery, ListSessionsHandler, ListSessionsQuery, SessionSummary,
+};
+use crate::domain::value_object::{DeviceFingerprint, SessionStatus};
+use crate::error::AuthError;
+
+// ── Proto inclusion ───────────────────────────────────────────────────────────
+pub use auth_api as proto;
+
+/// gRPC request handler for the `auth.v1` service.
+///
+/// Each method translates an inbound Protobuf request into an application
+/// command/query, invokes the corresponding handler with a fresh correlation id
+/// and the wall clock, and maps the result (or [`AuthError`]) back to Protobuf /
+/// [`Status`]. The application handlers — not a CQRS bus — are held directly,
+/// because the token-returning use-cases do not fit the command bus's `()` return.
+#[derive(Clone)]
+pub struct AuthServiceHandler {
+    login: Arc<LoginHandler>,
+    refresh: Arc<RefreshHandler>,
+    logout: Arc<LogoutHandler>,
+    logout_all: Arc<LogoutAllSessionsHandler>,
+    introspect: Arc<IntrospectHandler>,
+    list_sessions: Arc<ListSessionsHandler>,
+}
+
+impl AuthServiceHandler {
+    pub fn new(
+        login: Arc<LoginHandler>,
+        refresh: Arc<RefreshHandler>,
+        logout: Arc<LogoutHandler>,
+        logout_all: Arc<LogoutAllSessionsHandler>,
+        introspect: Arc<IntrospectHandler>,
+        list_sessions: Arc<ListSessionsHandler>,
+    ) -> Self {
+        Self { login, refresh, logout, logout_all, introspect, list_sessions }
+    }
+
+    pub async fn login(
+        &self,
+        request: Request<proto::LoginRequest>,
+    ) -> Result<Response<proto::LoginResponse>, Status> {
+        let req = request.into_inner();
+        let grant = grant_from_proto(req.credential)?;
+        let cmd = LoginCommand { grant, device: device_from_proto(req.device) };
+
+        let issued = self
+            .login
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(auth_error_to_status)?;
+
+        Ok(Response::new(proto::LoginResponse {
+            account_id: issued.account_id.as_str(),
+            tokens: Some(token_pair(&issued)),
+            first_link: issued.first_link,
+        }))
+    }
+
+    pub async fn refresh(
+        &self,
+        request: Request<proto::RefreshRequest>,
+    ) -> Result<Response<proto::RefreshResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = RefreshCommand {
+            refresh_token: req.refresh_token,
+            device: device_from_proto(req.device),
+        };
+
+        let issued = self
+            .refresh
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(auth_error_to_status)?;
+
+        Ok(Response::new(proto::RefreshResponse { tokens: Some(token_pair(&issued)) }))
+    }
+
+    pub async fn logout(
+        &self,
+        request: Request<proto::LogoutRequest>,
+    ) -> Result<Response<proto::LogoutResponse>, Status> {
+        let cmd = LogoutCommand { session_id: request.into_inner().session_id };
+        let out = self
+            .logout
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(auth_error_to_status)?;
+        Ok(Response::new(proto::LogoutResponse { success: out.success }))
+    }
+
+    pub async fn logout_all_sessions(
+        &self,
+        request: Request<proto::LogoutAllSessionsRequest>,
+    ) -> Result<Response<proto::LogoutAllSessionsResponse>, Status> {
+        let cmd = LogoutAllSessionsCommand { account_id: request.into_inner().account_id };
+        let out = self
+            .logout_all
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(auth_error_to_status)?;
+        Ok(Response::new(proto::LogoutAllSessionsResponse {
+            success: true,
+            generation: out.generation,
+            sessions_revoked: out.sessions_revoked,
+        }))
+    }
+
+    pub async fn introspect(
+        &self,
+        request: Request<proto::IntrospectRequest>,
+    ) -> Result<Response<proto::IntrospectResponse>, Status> {
+        let query = IntrospectQuery { access_token: request.into_inner().access_token };
+        let view = self
+            .introspect
+            .handle_at(Envelope::new(Uuid::now_v7(), query), Utc::now())
+            .await
+            .map_err(auth_error_to_status)?;
+
+        Ok(Response::new(proto::IntrospectResponse {
+            active: view.active,
+            account_id: view.account_id.unwrap_or_default(),
+            session_id: view.session_id.unwrap_or_default(),
+            generation: view.generation,
+            permissions: view.permissions,
+            expires_at: view.expires_at.map(to_timestamp),
+        }))
+    }
+
+    pub async fn list_sessions(
+        &self,
+        request: Request<proto::ListSessionsRequest>,
+    ) -> Result<Response<proto::ListSessionsResponse>, Status> {
+        use cqrs::QueryHandler;
+        let query = ListSessionsQuery {
+            account_id: request.into_inner().account_id,
+            current_session_id: None,
+        };
+        let sessions = self
+            .list_sessions
+            .handle(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(auth_error_to_status)?;
+
+        Ok(Response::new(proto::ListSessionsResponse {
+            sessions: sessions.into_iter().map(session_view).collect(),
+        }))
+    }
+}
+
+// ── Mapping helpers ───────────────────────────────────────────────────────────
+
+fn grant_from_proto(
+    credential: Option<proto::login_request::Credential>,
+) -> Result<AuthnGrant, Status> {
+    match credential {
+        Some(proto::login_request::Credential::AuthorizationCode(g)) => {
+            Ok(AuthnGrant::AuthorizationCode {
+                code: g.code,
+                redirect_uri: g.redirect_uri,
+                code_verifier: g.code_verifier,
+            })
+        }
+        Some(proto::login_request::Credential::Password(g)) => {
+            Ok(AuthnGrant::Password { username: g.username, password: g.password })
+        }
+        None => Err(Status::invalid_argument("login requires a credential")),
+    }
+}
+
+fn device_from_proto(device: Option<proto::DeviceContext>) -> DeviceFingerprint {
+    let non_empty = |s: String| if s.is_empty() { None } else { Some(s) };
+    match device {
+        Some(d) => DeviceFingerprint::new(
+            non_empty(d.user_agent),
+            non_empty(d.ip_address),
+            non_empty(d.device_id),
+        ),
+        None => DeviceFingerprint::default(),
+    }
+}
+
+fn token_pair(issued: &IssuedSession) -> proto::TokenPair {
+    proto::TokenPair {
+        access_token: issued.access_token.clone(),
+        refresh_token: issued.refresh_token.clone(),
+        token_type: "Bearer".to_owned(),
+        expires_in: issued.access_expires_in,
+        session_id: issued.session_id.as_str(),
+    }
+}
+
+fn session_view(summary: SessionSummary) -> proto::SessionView {
+    proto::SessionView {
+        session_id: summary.session_id,
+        status: session_status_to_proto(summary.status),
+        generation: summary.generation,
+        device: None,
+        issued_at: Some(to_timestamp(summary.issued_at)),
+        expires_at: Some(to_timestamp(summary.expires_at)),
+        absolute_expiry: Some(to_timestamp(summary.absolute_expiry)),
+        current: summary.current,
+    }
+}
+
+fn session_status_to_proto(status: SessionStatus) -> i32 {
+    let s = match status {
+        SessionStatus::Active => proto::SessionStatus::Active,
+        SessionStatus::Revoked => proto::SessionStatus::Revoked,
+        SessionStatus::Expired => proto::SessionStatus::Expired,
+    };
+    s as i32
+}
+
+fn to_timestamp(dt: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp { seconds: dt.timestamp(), nanos: dt.timestamp_subsec_nanos() as i32 }
+}
+
+/// Maps an [`AuthError`] to a gRPC [`Status`] using its [`AppError`] metadata, so
+/// the HTTP semantics defined once in `error.rs` drive the gRPC code too.
+pub fn auth_error_to_status(err: AuthError) -> Status {
+    let msg = err.to_string();
+    let retryable = err.is_retryable();
+    match err.http_status().as_u16() {
+        401 => Status::unauthenticated(msg),
+        403 => Status::permission_denied(msg),
+        404 => Status::not_found(msg),
+        409 if retryable => Status::aborted(msg),
+        409 => Status::already_exists(msg),
+        400 | 422 => Status::failed_precondition(msg),
+        502 | 503 => Status::unavailable(msg),
+        _ => Status::internal(msg),
+    }
+}

--- a/crates/services/auth/src/infrastructure/grpc/handler/mod.rs
+++ b/crates/services/auth/src/infrastructure/grpc/handler/mod.rs
@@ -1,0 +1,4 @@
+pub mod auth_service_handler;
+
+pub use auth_service_handler::{proto, AuthServiceHandler};
+pub use proto::auth_service_server::AuthServiceServer;

--- a/crates/services/auth/src/infrastructure/grpc/mod.rs
+++ b/crates/services/auth/src/infrastructure/grpc/mod.rs
@@ -1,0 +1,6 @@
+//! gRPC inbound adapter: maps the `auth.v1` contract onto the application
+//! handlers. The generated server trait is implemented in [`server`]; the
+//! per-RPC translation lives in [`handler`].
+
+pub mod handler;
+pub mod server;

--- a/crates/services/auth/src/infrastructure/grpc/server.rs
+++ b/crates/services/auth/src/infrastructure/grpc/server.rs
@@ -1,0 +1,55 @@
+use tonic::{Request, Response, Status};
+
+use super::handler::auth_service_handler::{proto, AuthServiceHandler};
+
+// The tonic-generated trait from the bundled proto module.
+use proto::auth_service_server::AuthService;
+
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `auth-api`'s `build.rs`. Registered by the service's runtime adapter.
+pub const FILE_DESCRIPTOR_SET: &[u8] = auth_api::FILE_DESCRIPTOR_SET;
+
+#[tonic::async_trait]
+impl AuthService for AuthServiceHandler {
+    async fn login(
+        &self,
+        request: Request<proto::LoginRequest>,
+    ) -> Result<Response<proto::LoginResponse>, Status> {
+        self.login(request).await
+    }
+
+    async fn refresh(
+        &self,
+        request: Request<proto::RefreshRequest>,
+    ) -> Result<Response<proto::RefreshResponse>, Status> {
+        self.refresh(request).await
+    }
+
+    async fn logout(
+        &self,
+        request: Request<proto::LogoutRequest>,
+    ) -> Result<Response<proto::LogoutResponse>, Status> {
+        self.logout(request).await
+    }
+
+    async fn logout_all_sessions(
+        &self,
+        request: Request<proto::LogoutAllSessionsRequest>,
+    ) -> Result<Response<proto::LogoutAllSessionsResponse>, Status> {
+        self.logout_all_sessions(request).await
+    }
+
+    async fn introspect(
+        &self,
+        request: Request<proto::IntrospectRequest>,
+    ) -> Result<Response<proto::IntrospectResponse>, Status> {
+        self.introspect(request).await
+    }
+
+    async fn list_sessions(
+        &self,
+        request: Request<proto::ListSessionsRequest>,
+    ) -> Result<Response<proto::ListSessionsResponse>, Status> {
+        self.list_sessions(request).await
+    }
+}

--- a/crates/services/auth/src/infrastructure/idp/keycloak_identity_provider.rs
+++ b/crates/services/auth/src/infrastructure/idp/keycloak_identity_provider.rs
@@ -1,0 +1,157 @@
+use async_trait::async_trait;
+use base64::Engine;
+use serde::Deserialize;
+
+use crate::application::port::{AuthnGrant, IdentityProvider, NormalizedClaims};
+use crate::error::AuthError;
+
+/// Connection + client-credential config for the Keycloak OIDC token endpoint.
+#[derive(Debug, Clone)]
+pub struct KeycloakConfig {
+    /// Full token endpoint, e.g. `https://idp/realms/app/protocol/openid-connect/token`.
+    pub token_endpoint: String,
+    pub client_id: String,
+    pub client_secret: String,
+    /// OIDC scope requested; must include `openid` so the response carries `sub`.
+    pub scope: String,
+}
+
+impl Default for KeycloakConfig {
+    fn default() -> Self {
+        Self {
+            token_endpoint: String::new(),
+            client_id: String::new(),
+            client_secret: String::new(),
+            scope: "openid".to_owned(),
+        }
+    }
+}
+
+/// Keycloak implementation of [`IdentityProvider`].
+///
+/// Brokers the grant to the OIDC token endpoint over TLS and normalizes the
+/// returned identity. The access token is trusted as transport-authenticated (it
+/// came directly from the IdP over TLS); its `iss`/`sub` are read from the
+/// payload without a second signature check. Edge tokens this service *mints* are,
+/// of course, signature-verified by downstream services.
+pub struct KeycloakIdentityProvider {
+    http: reqwest::Client,
+    config: KeycloakConfig,
+}
+
+impl KeycloakIdentityProvider {
+    pub fn new(http: reqwest::Client, config: KeycloakConfig) -> Self {
+        Self { http, config }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+}
+
+/// The two claims auth needs from the IdP token.
+#[derive(Debug, Deserialize)]
+struct IdentityClaims {
+    iss: String,
+    sub: String,
+}
+
+/// Reads `iss`/`sub` from a JWT payload without verifying the signature.
+fn extract_identity(token: &str) -> Result<IdentityClaims, AuthError> {
+    let payload = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| AuthError::ClaimsNormalizationFailed("token is not a JWT".into()))?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| AuthError::ClaimsNormalizationFailed(format!("base64: {e}")))?;
+    serde_json::from_slice::<IdentityClaims>(&bytes)
+        .map_err(|e| AuthError::ClaimsNormalizationFailed(format!("claims: {e}")))
+}
+
+#[async_trait]
+impl IdentityProvider for KeycloakIdentityProvider {
+    async fn authenticate(&self, grant: AuthnGrant) -> Result<NormalizedClaims, AuthError> {
+        // Common confidential-client + scope params.
+        let mut form: Vec<(&str, String)> = vec![
+            ("client_id", self.config.client_id.clone()),
+            ("client_secret", self.config.client_secret.clone()),
+            ("scope", self.config.scope.clone()),
+        ];
+        match grant {
+            AuthnGrant::AuthorizationCode { code, redirect_uri, code_verifier } => {
+                form.push(("grant_type", "authorization_code".to_owned()));
+                form.push(("code", code));
+                form.push(("redirect_uri", redirect_uri));
+                form.push(("code_verifier", code_verifier));
+            }
+            AuthnGrant::Password { username, password } => {
+                form.push(("grant_type", "password".to_owned()));
+                form.push(("username", username));
+                form.push(("password", password));
+            }
+        }
+
+        let response = self
+            .http
+            .post(&self.config.token_endpoint)
+            .form(&form)
+            .send()
+            .await
+            .map_err(|_| AuthError::IdpUnavailable)?;
+
+        if !response.status().is_success() {
+            // 4xx ⇒ bad credentials / invalid grant; 5xx ⇒ IdP trouble.
+            return Err(if response.status().is_server_error() {
+                AuthError::IdpUnavailable
+            } else {
+                AuthError::IdpAuthenticationFailed
+            });
+        }
+
+        let body: TokenResponse = response
+            .json()
+            .await
+            .map_err(|e| AuthError::ClaimsNormalizationFailed(format!("token response: {e}")))?;
+
+        let claims = extract_identity(&body.access_token)?;
+        Ok(NormalizedClaims { issuer: claims.iss, subject: claims.sub })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    fn jwt_with(payload: &str) -> String {
+        let b64 = |s: &str| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(s.as_bytes());
+        format!("{}.{}.{}", b64("{\"alg\":\"RS256\"}"), b64(payload), "sig")
+    }
+
+    #[test]
+    fn extracts_iss_and_sub() {
+        let token = jwt_with("{\"iss\":\"https://idp/realms/app\",\"sub\":\"user-1\"}");
+        let claims = extract_identity(&token).unwrap();
+        assert_eq!(claims.iss, "https://idp/realms/app");
+        assert_eq!(claims.sub, "user-1");
+    }
+
+    #[test]
+    fn rejects_non_jwt() {
+        assert!(matches!(
+            extract_identity("not-a-jwt").unwrap_err(),
+            AuthError::ClaimsNormalizationFailed(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_payload_without_claims() {
+        let token = jwt_with("{\"foo\":\"bar\"}");
+        assert!(matches!(
+            extract_identity(&token).unwrap_err(),
+            AuthError::ClaimsNormalizationFailed(_)
+        ));
+    }
+}

--- a/crates/services/auth/src/infrastructure/idp/mod.rs
+++ b/crates/services/auth/src/infrastructure/idp/mod.rs
@@ -1,0 +1,8 @@
+//! Identity-provider adapter. Keycloak today; the OIDC/OAuth2 specifics live
+//! entirely here, behind the [`IdentityProvider`](crate::application::port::IdentityProvider)
+//! port. Swapping to Cognito/Okta/custom is a sibling module — no change above
+//! `infrastructure`.
+
+pub mod keycloak_identity_provider;
+
+pub use keycloak_identity_provider::{KeycloakConfig, KeycloakIdentityProvider};

--- a/crates/services/auth/src/infrastructure/mod.rs
+++ b/crates/services/auth/src/infrastructure/mod.rs
@@ -1,0 +1,12 @@
+//! Infrastructure adapters — the concrete implementations of the application
+//! ports. This is the only layer that names a real backend (Keycloak, Postgres,
+//! Redis Cluster, Kafka, the `account` gRPC service) or a token format (ES256).
+//! The composition root (Phase 5) selects and injects them.
+
+pub mod cache;
+pub mod directory;
+pub mod event;
+pub mod grpc;
+pub mod idp;
+pub mod persistence;
+pub mod token;

--- a/crates/services/auth/src/infrastructure/persistence/mod.rs
+++ b/crates/services/auth/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,22 @@
+//! PostgreSQL/CockroachDB adapters for the durable auth ports.
+//!
+//! Writes that carry an `account_id` route through
+//! [`TransactionManager::run_on_shard`] keyed on it, so a person's auth state
+//! co-locates on one shard. Lookups by `session_id` / `token_hash` / subject use
+//! the single pool — correct for SingleNode and CockroachDB; true app-sharding of
+//! those would need a secondary index (deferred, as in `account`).
+//!
+//! ## Optimistic locking
+//! The in-memory aggregate `version` mirrors the persisted value. A new aggregate
+//! (`version == 0`) is `INSERT`ed at version 0; a mutation bumps the in-memory
+//! version, and the adapter writes `SET version = $new WHERE version = $new - 1`,
+//! mapping a zero-row update to [`AuthError::ConcurrentModification`].
+
+pub mod model;
+pub mod pg_refresh_token_repository;
+pub mod pg_session_repository;
+pub mod pg_subject_link_repository;
+
+pub use pg_refresh_token_repository::PgRefreshTokenRepository;
+pub use pg_session_repository::PgSessionRepository;
+pub use pg_subject_link_repository::PgSubjectLinkRepository;

--- a/crates/services/auth/src/infrastructure/persistence/model/mod.rs
+++ b/crates/services/auth/src/infrastructure/persistence/model/mod.rs
@@ -1,0 +1,7 @@
+pub mod refresh_token_row;
+pub mod session_row;
+pub mod subject_link_row;
+
+pub use refresh_token_row::RefreshTokenRow;
+pub use session_row::SessionRow;
+pub use subject_link_row::SubjectLinkRow;

--- a/crates/services/auth/src/infrastructure/persistence/model/refresh_token_row.rs
+++ b/crates/services/auth/src/infrastructure/persistence/model/refresh_token_row.rs
@@ -1,0 +1,45 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::aggregate::RefreshToken;
+use crate::domain::value_object::{
+    AccountId, RefreshTokenHash, RefreshTokenId, RefreshTokenStatus, SessionId,
+};
+use crate::error::AuthError;
+
+/// Flat projection of the `refresh_tokens` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct RefreshTokenRow {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub account_id: Uuid,
+    pub token_hash: String,
+    pub status: String,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub used_at: Option<DateTime<Utc>>,
+    pub replaced_by: Option<Uuid>,
+    pub version: i64,
+}
+
+impl TryFrom<RefreshTokenRow> for RefreshToken {
+    type Error = AuthError;
+
+    fn try_from(row: RefreshTokenRow) -> Result<Self, Self::Error> {
+        let status = RefreshTokenStatus::try_from(row.status.as_str())?;
+        let token_hash = RefreshTokenHash::new(row.token_hash)?;
+
+        Ok(RefreshToken::reconstitute(
+            RefreshTokenId::from_uuid(row.id),
+            SessionId::from_uuid(row.session_id),
+            AccountId::from_uuid(row.account_id),
+            token_hash,
+            status,
+            row.issued_at,
+            row.expires_at,
+            row.used_at,
+            row.replaced_by.map(RefreshTokenId::from_uuid),
+            row.version,
+        ))
+    }
+}

--- a/crates/services/auth/src/infrastructure/persistence/model/session_row.rs
+++ b/crates/services/auth/src/infrastructure/persistence/model/session_row.rs
@@ -1,0 +1,53 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::aggregate::Session;
+use crate::domain::value_object::{
+    AccountId, DeviceFingerprint, Generation, IdpSubject, SessionId, SessionStatus,
+};
+use crate::error::AuthError;
+
+/// Flat projection of the `sessions` table. Domain reconstruction (validation,
+/// value-object construction) happens in [`TryFrom`], keeping persistence free of
+/// domain logic.
+#[derive(Debug, sqlx::FromRow)]
+pub struct SessionRow {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub issuer: String,
+    pub subject: String,
+    pub generation: i64,
+    pub status: String,
+    pub device_user_agent: Option<String>,
+    pub device_ip: Option<String>,
+    pub device_id: Option<String>,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub absolute_expiry: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub version: i64,
+}
+
+impl TryFrom<SessionRow> for Session {
+    type Error = AuthError;
+
+    fn try_from(row: SessionRow) -> Result<Self, Self::Error> {
+        let subject = IdpSubject::new(row.issuer, row.subject)?;
+        let device = DeviceFingerprint::new(row.device_user_agent, row.device_ip, row.device_id);
+        let status = SessionStatus::try_from(row.status.as_str())?;
+
+        Ok(Session::reconstitute(
+            SessionId::from_uuid(row.id),
+            AccountId::from_uuid(row.account_id),
+            subject,
+            Generation::from_i64(row.generation),
+            status,
+            device,
+            row.issued_at,
+            row.expires_at,
+            row.absolute_expiry,
+            row.revoked_at,
+            row.version,
+        ))
+    }
+}

--- a/crates/services/auth/src/infrastructure/persistence/model/subject_link_row.rs
+++ b/crates/services/auth/src/infrastructure/persistence/model/subject_link_row.rs
@@ -1,0 +1,30 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::aggregate::SubjectLink;
+use crate::domain::value_object::{AccountId, IdpSubject};
+use crate::error::AuthError;
+
+/// Flat projection of the `subject_links` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct SubjectLinkRow {
+    pub issuer: String,
+    pub subject: String,
+    pub account_id: Uuid,
+    pub linked_at: DateTime<Utc>,
+    pub version: i64,
+}
+
+impl TryFrom<SubjectLinkRow> for SubjectLink {
+    type Error = AuthError;
+
+    fn try_from(row: SubjectLinkRow) -> Result<Self, Self::Error> {
+        let subject = IdpSubject::new(row.issuer, row.subject)?;
+        Ok(SubjectLink::reconstitute(
+            subject,
+            AccountId::from_uuid(row.account_id),
+            row.linked_at,
+            row.version,
+        ))
+    }
+}

--- a/crates/services/auth/src/infrastructure/persistence/pg_refresh_token_repository.rs
+++ b/crates/services/auth/src/infrastructure/persistence/pg_refresh_token_repository.rs
@@ -1,0 +1,139 @@
+use async_trait::async_trait;
+use postgres_storage::{StorageError, TransactionManager};
+use tracing::instrument;
+
+use crate::application::port::RefreshTokenRepository;
+use crate::domain::aggregate::RefreshToken;
+use crate::domain::value_object::{RefreshTokenHash, SessionId};
+use crate::error::AuthError;
+
+use super::model::RefreshTokenRow;
+
+/// PostgreSQL adapter for [`RefreshTokenRepository`]. Writes route on `account_id`.
+#[derive(Clone)]
+pub struct PgRefreshTokenRepository {
+    tx: TransactionManager,
+}
+
+impl PgRefreshTokenRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+fn storage(e: sqlx::Error) -> AuthError {
+    AuthError::Storage(StorageError::from(e))
+}
+
+#[async_trait]
+impl RefreshTokenRepository for PgRefreshTokenRepository {
+    #[instrument(name = "auth.refresh.save", skip(self, token), fields(
+        refresh.id = %token.id(), refresh.version = token.version()
+    ))]
+    async fn save(&self, token: &RefreshToken) -> Result<(), AuthError> {
+        let account_id = token.account_id();
+        let id = token.id().as_uuid();
+        let session_id = token.session_id().as_uuid();
+        let account_uuid = account_id.as_uuid();
+        let hash = token.token_hash().as_str().to_owned();
+        let status = token.status().as_str().to_owned();
+        let replaced_by = token.replaced_by().map(|r| r.as_uuid());
+        let token_issued_at = token.issued_at();
+        let token_expires_at = token.expires_at();
+        let token_used_at = token.used_at();
+        let new_version = token.version();
+
+        if new_version == 0 {
+            self.tx
+                .run_on_shard(&account_id, move |tx| {
+                    Box::pin(async move {
+                        sqlx::query(
+                            r#"
+                            INSERT INTO refresh_tokens (
+                                id, session_id, account_id, token_hash, status,
+                                issued_at, expires_at, used_at, replaced_by, version
+                            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+                            "#,
+                        )
+                        .bind(id)
+                        .bind(session_id)
+                        .bind(account_uuid)
+                        .bind(hash)
+                        .bind(status)
+                        .bind(token_issued_at)
+                        .bind(token_expires_at)
+                        .bind(token_used_at)
+                        .bind(replaced_by)
+                        .bind(0i64)
+                        .execute(&mut **tx)
+                        .await
+                        .map(|_| ())
+                        .map_err(storage)
+                    })
+                })
+                .await
+        } else {
+            self.tx
+                .run_on_shard(&account_id, move |tx| {
+                    Box::pin(async move {
+                        let affected = sqlx::query(
+                            r#"
+                            UPDATE refresh_tokens SET
+                                status = $2,
+                                used_at = $3,
+                                replaced_by = $4,
+                                version = $5
+                            WHERE id = $1 AND version = $6
+                            "#,
+                        )
+                        .bind(id)
+                        .bind(status)
+                        .bind(token_used_at)
+                        .bind(replaced_by)
+                        .bind(new_version)
+                        .bind(new_version - 1)
+                        .execute(&mut **tx)
+                        .await
+                        .map_err(storage)?
+                        .rows_affected();
+
+                        if affected == 0 {
+                            Err(AuthError::ConcurrentModification)
+                        } else {
+                            Ok(())
+                        }
+                    })
+                })
+                .await
+        }
+    }
+
+    #[instrument(name = "auth.refresh.find_by_hash", skip(self, hash))]
+    async fn find_by_hash(
+        &self,
+        hash: &RefreshTokenHash,
+    ) -> Result<Option<RefreshToken>, AuthError> {
+        let row = sqlx::query_as::<_, RefreshTokenRow>(
+            "SELECT * FROM refresh_tokens WHERE token_hash = $1",
+        )
+        .bind(hash.as_str())
+        .fetch_optional(self.tx.pool())
+        .await
+        .map_err(storage)?;
+        row.map(RefreshToken::try_from).transpose()
+    }
+
+    #[instrument(name = "auth.refresh.revoke_all_for_session", skip(self), fields(session.id = %session_id))]
+    async fn revoke_all_for_session(&self, session_id: &SessionId) -> Result<(), AuthError> {
+        // Bulk infra operation keyed by session_id (not the shard key); single pool.
+        sqlx::query(
+            "UPDATE refresh_tokens SET status = 'revoked', used_at = NOW() \
+             WHERE session_id = $1 AND status = 'active'",
+        )
+        .bind(session_id.as_uuid())
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage)?;
+        Ok(())
+    }
+}

--- a/crates/services/auth/src/infrastructure/persistence/pg_session_repository.rs
+++ b/crates/services/auth/src/infrastructure/persistence/pg_session_repository.rs
@@ -1,0 +1,149 @@
+use async_trait::async_trait;
+use postgres_storage::{StorageError, TransactionManager};
+use tracing::instrument;
+
+use crate::application::port::SessionRepository;
+use crate::domain::aggregate::Session;
+use crate::domain::value_object::{AccountId, SessionId};
+use crate::error::AuthError;
+
+use super::model::SessionRow;
+
+/// PostgreSQL adapter for [`SessionRepository`]. Writes route on `account_id`.
+#[derive(Clone)]
+pub struct PgSessionRepository {
+    tx: TransactionManager,
+}
+
+impl PgSessionRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+fn storage(e: sqlx::Error) -> AuthError {
+    AuthError::Storage(StorageError::from(e))
+}
+
+#[async_trait]
+impl SessionRepository for PgSessionRepository {
+    #[instrument(name = "auth.session.save", skip(self, session), fields(
+        session.id = %session.id(), session.version = session.version()
+    ))]
+    async fn save(&self, session: &Session) -> Result<(), AuthError> {
+        let id = session.id();
+        let account_id = session.account_id();
+
+        // Pre-materialize owned values so the 'static closure does not borrow.
+        let p_account = account_id.as_uuid();
+        let p_issuer = session.subject().issuer().to_owned();
+        let p_subject = session.subject().subject().to_owned();
+        let p_generation = session.generation().value();
+        let p_status = session.status().as_str().to_owned();
+        let p_ua = session.device().user_agent().map(str::to_owned);
+        let p_ip = session.device().ip_address().map(str::to_owned);
+        let p_did = session.device().device_id().map(str::to_owned);
+        let p_issued = session.issued_at();
+        let p_expires = session.expires_at();
+        let p_absolute = session.absolute_expiry();
+        let p_revoked_at = session.revoked_at();
+        let new_version = session.version();
+        let id_uuid = id.as_uuid();
+
+        if new_version == 0 {
+            self.tx
+                .run_on_shard(&account_id, move |tx| {
+                    Box::pin(async move {
+                        sqlx::query(
+                            r#"
+                            INSERT INTO sessions (
+                                id, account_id, issuer, subject, generation, status,
+                                device_user_agent, device_ip, device_id,
+                                issued_at, expires_at, absolute_expiry, revoked_at, version
+                            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+                            "#,
+                        )
+                        .bind(id_uuid)
+                        .bind(p_account)
+                        .bind(p_issuer)
+                        .bind(p_subject)
+                        .bind(p_generation)
+                        .bind(p_status)
+                        .bind(p_ua)
+                        .bind(p_ip)
+                        .bind(p_did)
+                        .bind(p_issued)
+                        .bind(p_expires)
+                        .bind(p_absolute)
+                        .bind(p_revoked_at)
+                        .bind(0i64)
+                        .execute(&mut **tx)
+                        .await
+                        .map(|_| ())
+                        .map_err(storage)
+                    })
+                })
+                .await
+        } else {
+            self.tx
+                .run_on_shard(&account_id, move |tx| {
+                    Box::pin(async move {
+                        let affected = sqlx::query(
+                            r#"
+                            UPDATE sessions SET
+                                status = $2,
+                                expires_at = $3,
+                                revoked_at = $4,
+                                version = $5
+                            WHERE id = $1 AND version = $6
+                            "#,
+                        )
+                        .bind(id_uuid)
+                        .bind(p_status)
+                        .bind(p_expires)
+                        .bind(p_revoked_at)
+                        .bind(new_version)
+                        .bind(new_version - 1)
+                        .execute(&mut **tx)
+                        .await
+                        .map_err(storage)?
+                        .rows_affected();
+
+                        if affected == 0 {
+                            Err(AuthError::ConcurrentModification)
+                        } else {
+                            Ok(())
+                        }
+                    })
+                })
+                .await
+        }
+    }
+
+    #[instrument(name = "auth.session.find_by_id", skip(self), fields(session.id = %id))]
+    async fn find_by_id(&self, id: &SessionId) -> Result<Option<Session>, AuthError> {
+        // session_id is not the shard key; single-pool lookup (SingleNode/Cockroach).
+        let row = sqlx::query_as::<_, SessionRow>("SELECT * FROM sessions WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(storage)?;
+        row.map(Session::try_from).transpose()
+    }
+
+    #[instrument(name = "auth.session.list_active_by_account", skip(self), fields(account.id = %account_id))]
+    async fn list_active_by_account(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Vec<Session>, AuthError> {
+        let pool = self.tx.pool_for(account_id).map_err(AuthError::Storage)?;
+        let rows = sqlx::query_as::<_, SessionRow>(
+            "SELECT * FROM sessions WHERE account_id = $1 AND status = 'active' ORDER BY issued_at DESC",
+        )
+        .bind(account_id.as_uuid())
+        .fetch_all(pool)
+        .await
+        .map_err(storage)?;
+        rows.into_iter().map(Session::try_from).collect()
+    }
+}

--- a/crates/services/auth/src/infrastructure/persistence/pg_subject_link_repository.rs
+++ b/crates/services/auth/src/infrastructure/persistence/pg_subject_link_repository.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use postgres_storage::{StorageError, TransactionManager};
+use tracing::instrument;
+
+use crate::application::port::SubjectLinkRepository;
+use crate::domain::aggregate::SubjectLink;
+use crate::domain::value_object::IdpSubject;
+use crate::error::AuthError;
+
+use super::model::SubjectLinkRow;
+
+/// PostgreSQL adapter for [`SubjectLinkRepository`]. The link is immutable, so
+/// `save` is always an insert; uniqueness on `(issuer, subject)` is enforced by
+/// the primary key and surfaced as [`AuthError::SubjectAlreadyLinked`].
+#[derive(Clone)]
+pub struct PgSubjectLinkRepository {
+    tx: TransactionManager,
+}
+
+impl PgSubjectLinkRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+fn storage(e: sqlx::Error) -> AuthError {
+    AuthError::Storage(StorageError::from(e))
+}
+
+#[async_trait]
+impl SubjectLinkRepository for PgSubjectLinkRepository {
+    #[instrument(name = "auth.subject_link.find_by_subject", skip(self), fields(subject = %subject))]
+    async fn find_by_subject(
+        &self,
+        subject: &IdpSubject,
+    ) -> Result<Option<SubjectLink>, AuthError> {
+        let row = sqlx::query_as::<_, SubjectLinkRow>(
+            "SELECT * FROM subject_links WHERE issuer = $1 AND subject = $2",
+        )
+        .bind(subject.issuer())
+        .bind(subject.subject())
+        .fetch_optional(self.tx.pool())
+        .await
+        .map_err(storage)?;
+        row.map(SubjectLink::try_from).transpose()
+    }
+
+    #[instrument(name = "auth.subject_link.save", skip(self, link), fields(subject = %link.subject()))]
+    async fn save(&self, link: &SubjectLink) -> Result<(), AuthError> {
+        let account_id = link.account_id();
+        let issuer = link.subject().issuer().to_owned();
+        let subject = link.subject().subject().to_owned();
+        let account_uuid = account_id.as_uuid();
+        let linked_at = link.linked_at();
+
+        let affected = self
+            .tx
+            .run_on_shard(&account_id, move |tx| {
+                Box::pin(async move {
+                    sqlx::query(
+                        r#"
+                        INSERT INTO subject_links (issuer, subject, account_id, linked_at, version)
+                        VALUES ($1, $2, $3, $4, 0)
+                        ON CONFLICT (issuer, subject) DO NOTHING
+                        "#,
+                    )
+                    .bind(issuer)
+                    .bind(subject)
+                    .bind(account_uuid)
+                    .bind(linked_at)
+                    .execute(&mut **tx)
+                    .await
+                    .map(|r| r.rows_affected())
+                    .map_err(storage)
+                })
+            })
+            .await?;
+
+        if affected == 0 {
+            return Err(AuthError::SubjectAlreadyLinked {
+                iss: link.subject().issuer().to_owned(),
+                sub: link.subject().subject().to_owned(),
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/services/auth/src/infrastructure/token/es256_token_minter.rs
+++ b/crates/services/auth/src/infrastructure/token/es256_token_minter.rs
@@ -1,0 +1,388 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use base64::Engine;
+use chrono::{DateTime, TimeZone, Utc};
+use jsonwebtoken::{decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::pkcs8::DecodePublicKey;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::application::port::{GeneratedRefresh, TokenMinter};
+use crate::domain::value_object::{
+    AccessTokenClaims, AccountId, Generation, Permission, RefreshTokenHash, SessionId,
+};
+use crate::error::AuthError;
+
+/// PEM key material + token addressing for the ES256 minter's **active** key.
+pub struct EsKeyMaterial {
+    /// PKCS#8 (or SEC1) PEM of the P-256 signing key.
+    pub private_pem: Vec<u8>,
+    /// SPKI PEM of the corresponding public key (also published via JWKS).
+    pub public_pem: Vec<u8>,
+    /// `kid` stamped into the header so verifiers select the right JWKS key.
+    pub key_id: String,
+    pub issuer: String,
+    pub audience: String,
+}
+
+/// A public key still **accepted for verification** during a rotation, after it
+/// has stopped being the active signing key. Tokens minted under it stay valid
+/// until they expire; it is also published in the JWKS so downstream verifiers
+/// keep accepting them.
+pub struct EsVerifyingKey {
+    pub key_id: String,
+    pub public_pem: Vec<u8>,
+}
+
+/// The wire claim set. Field names follow JWT conventions so `auth-context` (and
+/// any standard verifier) reads them without bespoke handling.
+#[derive(Debug, Serialize, Deserialize)]
+struct EdgeClaims {
+    /// Internal account id (never the IdP subject).
+    sub: String,
+    /// Session id.
+    sid: String,
+    /// Revocation generation (`gen` is a reserved keyword in edition 2024).
+    #[serde(rename = "gen")]
+    generation: i64,
+    iss: String,
+    aud: String,
+    iat: i64,
+    exp: i64,
+    /// Normalized permissions.
+    perms: Vec<String>,
+}
+
+/// A verifying key plus the SPKI PEM it was built from (retained so the JWKS can
+/// be regenerated without a second source of truth).
+struct VerifyEntry {
+    decoding_key: DecodingKey,
+    public_pem: Vec<u8>,
+}
+
+/// ES256 implementation of [`TokenMinter`] with a verifying **key ring** for
+/// zero-downtime rotation: one active key signs; any key in the ring (selected by
+/// the token's `kid`) verifies.
+pub struct Es256TokenMinter {
+    encoding_key: EncodingKey,
+    /// Header for newly minted tokens — carries the active `kid`.
+    header: Header,
+    /// kid → verifying key. Includes the active key plus any retiring keys.
+    verifying: HashMap<String, VerifyEntry>,
+    validation: Validation,
+    issuer: String,
+    audience: String,
+}
+
+impl Es256TokenMinter {
+    /// Builds a minter whose ring contains only the active key.
+    pub fn from_pem(material: EsKeyMaterial) -> Result<Self, AuthError> {
+        Self::from_key_ring(material, Vec::new())
+    }
+
+    /// Builds a minter that signs with `active` and additionally **verifies**
+    /// tokens minted under any `retiring` key — the rotation window.
+    pub fn from_key_ring(
+        active: EsKeyMaterial,
+        retiring: Vec<EsVerifyingKey>,
+    ) -> Result<Self, AuthError> {
+        let encoding_key = EncodingKey::from_ec_pem(&active.private_pem)
+            .map_err(|_| AuthError::SigningKeyUnavailable)?;
+
+        let mut verifying = HashMap::new();
+        verifying.insert(active.key_id.clone(), verify_entry(&active.public_pem)?);
+        for key in retiring {
+            verifying.insert(key.key_id, verify_entry(&key.public_pem)?);
+        }
+
+        let mut validation = Validation::new(Algorithm::ES256);
+        validation.set_issuer(&[active.issuer.clone()]);
+        validation.set_audience(&[active.audience.clone()]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub"]);
+
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(active.key_id);
+
+        Ok(Self {
+            encoding_key,
+            header,
+            verifying,
+            validation,
+            issuer: active.issuer,
+            audience: active.audience,
+        })
+    }
+
+    /// The JWKS for every verifying key in the ring — what downstream services
+    /// (via `auth-context`) fetch to validate edge tokens. Publish it at the
+    /// service's well-known JWKS URL.
+    pub fn jwks(&self) -> Result<Jwks, AuthError> {
+        let mut keys: Vec<Jwk> = self
+            .verifying
+            .iter()
+            .map(|(kid, entry)| jwk_from_pem(kid, &entry.public_pem))
+            .collect::<Result<_, _>>()?;
+        keys.sort_by(|a, b| a.kid.cmp(&b.kid)); // deterministic ordering
+        Ok(Jwks { keys })
+    }
+
+    /// The JWKS as a JSON string.
+    pub fn jwks_json(&self) -> Result<String, AuthError> {
+        serde_json::to_string(&self.jwks()?)
+            .map_err(|e| AuthError::DomainViolation { field: "jwks".into(), message: e.to_string() })
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    }
+}
+
+fn verify_entry(public_pem: &[u8]) -> Result<VerifyEntry, AuthError> {
+    let decoding_key =
+        DecodingKey::from_ec_pem(public_pem).map_err(|_| AuthError::SigningKeyUnavailable)?;
+    Ok(VerifyEntry { decoding_key, public_pem: public_pem.to_vec() })
+}
+
+/// A single JSON Web Key (P-256 / ES256).
+#[derive(Debug, Serialize)]
+pub struct Jwk {
+    pub kty: &'static str,
+    pub crv: &'static str,
+    #[serde(rename = "use")]
+    pub use_: &'static str,
+    pub alg: &'static str,
+    pub kid: String,
+    pub x: String,
+    pub y: String,
+}
+
+/// A JSON Web Key Set.
+#[derive(Debug, Serialize)]
+pub struct Jwks {
+    pub keys: Vec<Jwk>,
+}
+
+fn jwk_from_pem(kid: &str, public_pem: &[u8]) -> Result<Jwk, AuthError> {
+    let pem = std::str::from_utf8(public_pem)
+        .map_err(|_| AuthError::SigningKeyUnavailable)?;
+    let public_key = p256::PublicKey::from_public_key_pem(pem)
+        .map_err(|_| AuthError::SigningKeyUnavailable)?;
+    let point = public_key.to_encoded_point(false);
+    let x = point.x().ok_or(AuthError::SigningKeyUnavailable)?;
+    let y = point.y().ok_or(AuthError::SigningKeyUnavailable)?;
+
+    Ok(Jwk {
+        kty: "EC",
+        crv: "P-256",
+        use_: "sig",
+        alg: "ES256",
+        kid: kid.to_owned(),
+        x: Es256TokenMinter::b64(x),
+        y: Es256TokenMinter::b64(y),
+    })
+}
+
+#[async_trait]
+impl TokenMinter for Es256TokenMinter {
+    async fn mint_access(&self, claims: &AccessTokenClaims) -> Result<String, AuthError> {
+        let edge = EdgeClaims {
+            sub: claims.account_id.as_str(),
+            sid: claims.session_id.as_str(),
+            generation: claims.generation.value(),
+            iss: self.issuer.clone(),
+            aud: self.audience.clone(),
+            iat: claims.issued_at.timestamp(),
+            exp: claims.expires_at.timestamp(),
+            perms: claims.permissions.iter().map(|p| p.as_str().to_owned()).collect(),
+        };
+        encode(&self.header, &edge, &self.encoding_key).map_err(|_| AuthError::TokenSigningFailed)
+    }
+
+    async fn verify_access(&self, token: &str) -> Result<AccessTokenClaims, AuthError> {
+        // Select the verifying key by the token's `kid` (key-ring rotation).
+        let header = decode_header(token).map_err(|_| AuthError::IdpTokenRejected)?;
+        let kid = header.kid.ok_or(AuthError::IdpTokenRejected)?;
+        let entry = self.verifying.get(&kid).ok_or(AuthError::IdpTokenRejected)?;
+
+        let data = decode::<EdgeClaims>(token, &entry.decoding_key, &self.validation)
+            .map_err(|_| AuthError::IdpTokenRejected)?;
+        let c = data.claims;
+
+        let account_id = AccountId::try_from(c.sub.as_str())?;
+        let session_id = SessionId::try_from(c.sid.as_str())?;
+        let to_utc = |secs: i64| {
+            Utc.timestamp_opt(secs, 0).single().ok_or_else(|| AuthError::DomainViolation {
+                field: "token.timestamp".into(),
+                message: "out-of-range timestamp claim".into(),
+            })
+        };
+        let issued_at: DateTime<Utc> = to_utc(c.iat)?;
+        let expires_at: DateTime<Utc> = to_utc(c.exp)?;
+        let permissions = c.perms.into_iter().map(Permission::new).collect();
+
+        Ok(AccessTokenClaims {
+            account_id,
+            session_id,
+            generation: Generation::from_i64(c.generation),
+            permissions,
+            issued_at,
+            expires_at,
+        })
+    }
+
+    fn generate_refresh(&self) -> Result<GeneratedRefresh, AuthError> {
+        let mut bytes = [0u8; 32];
+        rand::rng().fill_bytes(&mut bytes);
+        let plaintext = Self::b64(&bytes);
+        let hash = self.hash_refresh(&plaintext)?;
+        Ok(GeneratedRefresh { plaintext, hash })
+    }
+
+    fn hash_refresh(&self, plaintext: &str) -> Result<RefreshTokenHash, AuthError> {
+        let digest = Sha256::digest(plaintext.as_bytes());
+        RefreshTokenHash::new(Self::b64(&digest))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use uuid::Uuid;
+
+    /// Generates an ephemeral P-256 keypair as (PKCS#8 private PEM, SPKI public
+    /// PEM). No key material is ever hardcoded — keys live only for the test.
+    fn keypair() -> (Vec<u8>, Vec<u8>) {
+        use p256::ecdsa::SigningKey;
+        use p256::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+        let signing = SigningKey::random(&mut rand_core::OsRng);
+        let private_pem = signing.to_pkcs8_pem(LineEnding::LF).unwrap().as_bytes().to_vec();
+        let public_pem =
+            signing.verifying_key().to_public_key_pem(LineEnding::LF).unwrap().into_bytes();
+        (private_pem, public_pem)
+    }
+
+    fn material(private: Vec<u8>, public: Vec<u8>, kid: &str) -> EsKeyMaterial {
+        EsKeyMaterial {
+            private_pem: private,
+            public_pem: public,
+            key_id: kid.to_owned(),
+            issuer: "https://auth.test".into(),
+            audience: "core-platform".into(),
+        }
+    }
+
+    fn single_key_minter() -> Es256TokenMinter {
+        let (private_pem, public_pem) = keypair();
+        Es256TokenMinter::from_pem(material(private_pem, public_pem, "k1")).unwrap()
+    }
+
+    fn claims_at(now: DateTime<Utc>, ttl: Duration) -> AccessTokenClaims {
+        AccessTokenClaims {
+            account_id: AccountId::from_uuid(Uuid::now_v7()),
+            session_id: SessionId::new(),
+            generation: Generation::from_i64(3),
+            permissions: vec![Permission::new("posts:write")],
+            issued_at: now,
+            expires_at: now + ttl,
+        }
+    }
+
+    #[tokio::test]
+    async fn mint_then_verify_round_trips_claims() {
+        let minter = single_key_minter();
+        let now = Utc::now();
+        let claims = claims_at(now, Duration::minutes(10));
+        let token = minter.mint_access(&claims).await.unwrap();
+        let back = minter.verify_access(&token).await.unwrap();
+        assert_eq!(back.account_id, claims.account_id);
+        assert_eq!(back.session_id, claims.session_id);
+        assert_eq!(back.generation, claims.generation);
+        assert_eq!(back.permissions, claims.permissions);
+    }
+
+    #[tokio::test]
+    async fn expired_token_is_rejected() {
+        let minter = single_key_minter();
+        let past = Utc::now() - Duration::hours(1);
+        let token = minter.mint_access(&claims_at(past, Duration::minutes(10))).await.unwrap();
+        assert!(matches!(minter.verify_access(&token).await.unwrap_err(), AuthError::IdpTokenRejected));
+    }
+
+    #[tokio::test]
+    async fn tampered_token_is_rejected() {
+        let minter = single_key_minter();
+        let mut token = minter.mint_access(&claims_at(Utc::now(), Duration::minutes(10))).await.unwrap();
+        token.push('x');
+        assert!(matches!(minter.verify_access(&token).await.unwrap_err(), AuthError::IdpTokenRejected));
+    }
+
+    #[tokio::test]
+    async fn rotated_key_still_verifies_old_tokens() {
+        let (k1_private, k1_public) = keypair();
+        let (k2_private, k2_public) = keypair();
+
+        // A token minted under k1 (the retiring key)…
+        let old_minter =
+            Es256TokenMinter::from_pem(material(k1_private, k1_public.clone(), "k1")).unwrap();
+        let token = old_minter.mint_access(&claims_at(Utc::now(), Duration::minutes(10))).await.unwrap();
+
+        // …is still accepted by a minter whose ACTIVE key is k2 but whose ring
+        // retains k1 — the rotation window.
+        let rotated = Es256TokenMinter::from_key_ring(
+            material(k2_private, k2_public, "k2"),
+            vec![EsVerifyingKey { key_id: "k1".into(), public_pem: k1_public }],
+        )
+        .unwrap();
+        let back = rotated.verify_access(&token).await.unwrap();
+        assert_eq!(back.generation, Generation::from_i64(3));
+
+        // New tokens are minted under k2.
+        let fresh = rotated.mint_access(&claims_at(Utc::now(), Duration::minutes(10))).await.unwrap();
+        assert_eq!(decode_header(&fresh).unwrap().kid.as_deref(), Some("k2"));
+    }
+
+    #[tokio::test]
+    async fn token_with_unknown_kid_is_rejected() {
+        // k2-signed token presented to a minter that only knows k1.
+        let (k2_private, k2_public) = keypair();
+        let k2 = Es256TokenMinter::from_pem(material(k2_private, k2_public, "k2")).unwrap();
+        let token = k2.mint_access(&claims_at(Utc::now(), Duration::minutes(10))).await.unwrap();
+        let k1_only = single_key_minter();
+        assert!(matches!(k1_only.verify_access(&token).await.unwrap_err(), AuthError::IdpTokenRejected));
+    }
+
+    #[test]
+    fn jwks_publishes_every_ring_key() {
+        let (_k1_private, k1_public) = keypair();
+        let (k2_private, k2_public) = keypair();
+        let minter = Es256TokenMinter::from_key_ring(
+            material(k2_private, k2_public, "k2"),
+            vec![EsVerifyingKey { key_id: "k1".into(), public_pem: k1_public }],
+        )
+        .unwrap();
+        let jwks = minter.jwks().unwrap();
+        assert_eq!(jwks.keys.len(), 2);
+        let kids: Vec<&str> = jwks.keys.iter().map(|k| k.kid.as_str()).collect();
+        assert_eq!(kids, vec!["k1", "k2"]); // sorted
+        let k = &jwks.keys[0];
+        assert_eq!(k.kty, "EC");
+        assert_eq!(k.crv, "P-256");
+        assert_eq!(k.alg, "ES256");
+        assert!(!k.x.is_empty() && !k.y.is_empty());
+    }
+
+    #[test]
+    fn refresh_hash_is_deterministic_and_redacted() {
+        let minter = single_key_minter();
+        let generated = minter.generate_refresh().unwrap();
+        assert_eq!(
+            minter.hash_refresh(&generated.plaintext).unwrap().as_str(),
+            generated.hash.as_str()
+        );
+        assert_ne!(minter.hash_refresh("other").unwrap().as_str(), generated.hash.as_str());
+    }
+}

--- a/crates/services/auth/src/infrastructure/token/mod.rs
+++ b/crates/services/auth/src/infrastructure/token/mod.rs
@@ -1,0 +1,10 @@
+//! Token cryptography adapter: ES256 edge tokens + opaque refresh handles.
+//!
+//! ES256 (rather than RS256) keeps tokens compact and verification cheap on the
+//! edge hot path; the format is swappable for PASETO v4 behind the same
+//! [`TokenMinter`](crate::application::port::TokenMinter) port without touching
+//! the handlers.
+
+pub mod es256_token_minter;
+
+pub use es256_token_minter::{Es256TokenMinter, EsKeyMaterial, EsVerifyingKey, Jwk, Jwks};

--- a/crates/services/auth/src/lib.rs
+++ b/crates/services/auth/src/lib.rs
@@ -1,0 +1,31 @@
+//! `auth` — the platform's issuance / session / IdP-broker boundary.
+//!
+//! This service owns the **authentication act and its lifecycle** (sessions,
+//! refresh-token rotation, revocation, edge-token minting, and the IdP-subject ↔
+//! `account_id` linkage). It is deliberately distinct from its two neighbours:
+//!
+//! * [`account`](../account) — the identity **System of Record** (who a person
+//!   *is*). `auth` *reads* it to gate session issuance; it never stores a second
+//!   copy of the user.
+//! * [`auth-context`](../../platform/auth-context) — the inbound **verification**
+//!   library every service uses to validate an edge token on the hot path. `auth`
+//!   *mints* the tokens `auth-context` verifies.
+//!
+//! Credentials (passwords / MFA) live in the IdP (Keycloak) under the federated
+//! model — so no credential type appears in this crate. See
+//! `project_auth_service_blueprint` for the full design.
+//!
+//! ## Module roadmap (built phase by phase)
+//! Phase 0 (now): [`error`] — the canonical `AUT-XXXX` namespace.
+//! Phase 2: `domain` · Phase 3: `application` + ports · Phase 4: `infrastructure`
+//! · Phase 5: `app` (composition root) + `service` (runtime wiring).
+
+pub mod app;
+pub mod application;
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod infrastructure;
+pub mod service;
+
+pub use error::AuthError;

--- a/crates/services/auth/src/service.rs
+++ b/crates/services/auth/src/service.rs
@@ -1,0 +1,69 @@
+//! Adapts the auth composition root to the fleet [`service_runtime::Service`]
+//! contract. Maps env → config, defers to [`App::build`], registers the concrete
+//! tonic service, and reports Postgres + Redis liveness via the storage crates'
+//! ready-made probes over the connections `App` retains.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use postgres_storage::PostgresConfig;
+use redis_storage::RedisConfig;
+use service_runtime::{HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::client::KafkaClientConfig;
+
+use crate::app::{App, Backends};
+use crate::config::AuthConfig;
+use crate::infrastructure::grpc::handler::{AuthServiceHandler, AuthServiceServer};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+
+/// The concrete tonic server type, named once so the health key and the
+/// reflection registration agree.
+type AuthServer = AuthServiceServer<AuthServiceHandler>;
+
+/// The auth service as hosted by [`service_runtime`].
+pub struct AuthService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for AuthService {
+    const NAME: &'static str = "auth";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <AuthServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let config = AuthConfig::from_env()?;
+        let backends = Backends {
+            postgres: PostgresConfig::from_env(),
+            redis: RedisConfig::from_env(),
+            kafka: Some(KafkaClientConfig::from_env()),
+        };
+
+        // `App::build` errors are `Box<dyn Error>` (not `Send + Sync`); flatten to
+        // a message rather than propagating the box into `anyhow`.
+        let app = App::build(config, backends)
+            .await
+            .map_err(|e| anyhow::anyhow!("auth app build: {e}"))?;
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        vec![
+            postgres_storage::health::probe(self.app.pool.clone()),
+            redis_storage::health::probe(self.app.redis.clone()),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(AuthServiceServer::new(self.app.handler));
+        Ok(())
+    }
+}

--- a/crates/services/auth/tests/auth_it/harness/mod.rs
+++ b/crates/services/auth/tests/auth_it/harness/mod.rs
@@ -1,0 +1,229 @@
+//! Integration harness: boots ephemeral Postgres + Redis containers, applies the
+//! `.sql` migrations, and wires a real auth graph against them through the
+//! production composition root ([`auth::app::App::compose`]).
+//!
+//! Auth's own stores (Postgres + Redis) are real; its *external* dependencies —
+//! the IdP and the `account` service — are stubbed, exactly as they would be
+//! mocked at a service boundary. The token minter is the real ES256 one.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Duration as ChronoDuration;
+use sqlx::PgPool;
+use tonic::{Request, Status};
+use uuid::Uuid;
+
+use auth::app::{App, AppDeps};
+use auth::application::port::{
+    AccountActivation, AccountDirectory, AccountSnapshot, AuthnGrant, EventPublisher,
+    IdentityProvider, NormalizedClaims,
+};
+use auth::application::SessionPolicy;
+use auth::domain::value_object::{AccountId, IdpSubject, Permission};
+use auth::error::AuthError;
+use auth::infrastructure::cache::RedisSessionCache;
+use auth::infrastructure::event::LogEventPublisher;
+use auth::infrastructure::grpc::handler::{proto, AuthServiceHandler};
+use auth::infrastructure::persistence::{
+    PgRefreshTokenRepository, PgSessionRepository, PgSubjectLinkRepository,
+};
+use auth::infrastructure::token::{Es256TokenMinter, EsKeyMaterial};
+
+use postgres_storage::config::StatementLogLevel;
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClientBuilder, RedisConfig};
+
+const MIGRATIONS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations");
+
+/// Generates an ephemeral P-256 keypair (PKCS#8 private PEM, SPKI public PEM) for
+/// the test minter. No key material is hardcoded.
+fn ephemeral_es256_pem() -> (Vec<u8>, Vec<u8>) {
+    use p256::ecdsa::SigningKey;
+    use p256::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+    let signing = SigningKey::random(&mut rand_core::OsRng);
+    let private_pem = signing.to_pkcs8_pem(LineEnding::LF).unwrap().as_bytes().to_vec();
+    let public_pem = signing.verifying_key().to_public_key_pem(LineEnding::LF).unwrap().into_bytes();
+    (private_pem, public_pem)
+}
+
+// ── Stub external services ───────────────────────────────────────────────────
+
+/// IdP stub: echoes the password-grant username back as the subject (fixed
+/// issuer), so "log in as alice" deterministically maps to one subject/account.
+struct StubIdp;
+
+#[async_trait]
+impl IdentityProvider for StubIdp {
+    async fn authenticate(&self, grant: AuthnGrant) -> Result<NormalizedClaims, AuthError> {
+        let subject = match grant {
+            AuthnGrant::Password { username, .. } => username,
+            AuthnGrant::AuthorizationCode { code, .. } => code,
+        };
+        Ok(NormalizedClaims { issuer: "https://idp.test".to_owned(), subject })
+    }
+}
+
+/// `account` stub: provisions a stable account id per subject and reports every
+/// account active with a fixed permission set.
+struct StubDirectory {
+    accounts: Mutex<HashMap<IdpSubject, AccountId>>,
+}
+
+#[async_trait]
+impl AccountDirectory for StubDirectory {
+    async fn resolve_or_provision(&self, subject: &IdpSubject) -> Result<AccountId, AuthError> {
+        let mut accounts = self.accounts.lock().unwrap();
+        Ok(*accounts
+            .entry(subject.clone())
+            .or_insert_with(|| AccountId::from_uuid(Uuid::now_v7())))
+    }
+
+    async fn lookup(&self, _account_id: &AccountId) -> Result<AccountSnapshot, AuthError> {
+        Ok(AccountSnapshot {
+            activation: AccountActivation::Active,
+            permissions: vec![Permission::new("posts:write")],
+        })
+    }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+pub struct Harness {
+    pub handler: AuthServiceHandler,
+    pub pool: PgPool,
+}
+
+impl Harness {
+    pub async fn start() -> Self {
+        let pg_url = test_support::containers::postgres_ready(MIGRATIONS_DIR).await;
+        let redis_endpoint = test_support::containers::redis_endpoint().await;
+
+        let pg_config = PostgresConfig {
+            database_url: pg_url,
+            max_connections: 8,
+            min_connections: 1,
+            acquire_timeout: Duration::from_secs(5),
+            idle_timeout: None,
+            max_lifetime: None,
+            statement_log_level: StatementLogLevel::Debug,
+            slow_statement_threshold: Duration::from_millis(500),
+        };
+        let pool = PgPoolBuilder::build(pg_config).await.expect("it: postgres pool");
+        let tx = TransactionManager::new(pool.clone());
+
+        let redis = RedisClientBuilder::new(RedisConfig {
+            hosts: vec![redis_endpoint],
+            ..RedisConfig::default()
+        })
+        .build()
+        .await
+        .expect("it: redis client");
+
+        let (private_pem, public_pem) = ephemeral_es256_pem();
+        let minter = Es256TokenMinter::from_pem(EsKeyMaterial {
+            private_pem,
+            public_pem,
+            key_id: "auth-es256-1".to_owned(),
+            issuer: "https://auth.core-platform".to_owned(),
+            audience: "core-platform".to_owned(),
+        })
+        .expect("it: minter");
+
+        let deps = AppDeps {
+            idp: Arc::new(StubIdp),
+            directory: Arc::new(StubDirectory { accounts: Mutex::new(HashMap::new()) }),
+            links: Arc::new(PgSubjectLinkRepository::new(tx.clone())),
+            sessions: Arc::new(PgSessionRepository::new(tx.clone())),
+            refresh_tokens: Arc::new(PgRefreshTokenRepository::new(tx.clone())),
+            cache: Arc::new(RedisSessionCache::new(redis.clone())),
+            minter: Arc::new(minter),
+            publisher: Arc::new(LogEventPublisher) as Arc<dyn EventPublisher>,
+            policy: SessionPolicy::new(
+                ChronoDuration::minutes(10),
+                ChronoDuration::minutes(30),
+                ChronoDuration::hours(8),
+                ChronoDuration::days(7),
+            ),
+        };
+
+        Self { handler: App::compose(deps), pool }
+    }
+
+    // ── RPC helpers ──────────────────────────────────────────────────────────
+
+    pub async fn login(&self, username: &str) -> Result<proto::LoginResponse, Status> {
+        let request = Request::new(proto::LoginRequest {
+            device: None,
+            grant_type: proto::GrantType::Password as i32,
+            credential: Some(proto::login_request::Credential::Password(proto::PasswordGrant {
+                username: username.to_owned(),
+                password: "pw".to_owned(),
+            })),
+        });
+        self.handler.login(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn refresh(&self, refresh_token: &str) -> Result<proto::RefreshResponse, Status> {
+        let request = Request::new(proto::RefreshRequest {
+            refresh_token: refresh_token.to_owned(),
+            device: None,
+        });
+        self.handler.refresh(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn logout(&self, session_id: &str) -> Result<proto::LogoutResponse, Status> {
+        let request = Request::new(proto::LogoutRequest { session_id: session_id.to_owned() });
+        self.handler.logout(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn logout_all(
+        &self,
+        account_id: &str,
+    ) -> Result<proto::LogoutAllSessionsResponse, Status> {
+        let request =
+            Request::new(proto::LogoutAllSessionsRequest { account_id: account_id.to_owned() });
+        self.handler.logout_all_sessions(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn introspect(&self, access_token: &str) -> Result<proto::IntrospectResponse, Status> {
+        let request = Request::new(proto::IntrospectRequest { access_token: access_token.to_owned() });
+        self.handler.introspect(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn list_sessions(
+        &self,
+        account_id: &str,
+    ) -> Result<proto::ListSessionsResponse, Status> {
+        let request = Request::new(proto::ListSessionsRequest { account_id: account_id.to_owned() });
+        self.handler.list_sessions(request).await.map(|r| r.into_inner())
+    }
+
+    // ── Direct DB assertions ─────────────────────────────────────────────────
+
+    pub async fn count_active_sessions(&self, account_id: &str) -> i64 {
+        let id = Uuid::parse_str(account_id).unwrap();
+        sqlx::query_scalar("SELECT COUNT(*) FROM sessions WHERE account_id = $1 AND status = 'active'")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count active sessions")
+    }
+
+    pub async fn count_subject_links(&self, account_id: &str) -> i64 {
+        let id = Uuid::parse_str(account_id).unwrap();
+        sqlx::query_scalar("SELECT COUNT(*) FROM subject_links WHERE account_id = $1")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count subject links")
+    }
+}
+
+/// A fresh random username (⇒ a fresh subject ⇒ a fresh account).
+pub fn random_user() -> String {
+    format!("user-{}", Uuid::now_v7())
+}

--- a/crates/services/auth/tests/auth_it/mod.rs
+++ b/crates/services/auth/tests/auth_it/mod.rs
@@ -1,0 +1,4 @@
+//! Auth live integration suite: harness and scenarios.
+
+pub mod harness;
+pub mod scenarios;

--- a/crates/services/auth/tests/auth_it/scenarios/global_logout.rs
+++ b/crates/services/auth/tests/auth_it/scenarios/global_logout.rs
@@ -1,0 +1,34 @@
+//! Global sign-out bumps the account generation and invalidates every session's
+//! edge token at once — the instant, edge-enforced kill switch.
+
+use crate::auth_it::harness::{random_user, Harness};
+
+#[tokio::test]
+async fn logout_all_revokes_every_session_and_invalidates_tokens() {
+    let h = Harness::start().await;
+    let user = random_user();
+
+    // Two devices for one account.
+    let a = h.login(&user).await.expect("login a");
+    let b = h.login(&user).await.expect("login b");
+    let account_id = a.account_id.clone();
+    let token_a = a.tokens.unwrap().access_token;
+    let token_b = b.tokens.unwrap().access_token;
+    assert_eq!(h.count_active_sessions(&account_id).await, 2);
+
+    // Both tokens are active before the global logout.
+    assert!(h.introspect(&token_a).await.unwrap().active);
+    assert!(h.introspect(&token_b).await.unwrap().active);
+
+    let out = h.logout_all(&account_id).await.expect("logout all");
+    assert!(out.success);
+    assert_eq!(out.sessions_revoked, 2);
+    assert!(out.generation >= 1, "generation was bumped");
+
+    // Every previously-minted edge token is now inactive (stale generation), and
+    // no active sessions remain.
+    assert!(!h.introspect(&token_a).await.unwrap().active);
+    assert!(!h.introspect(&token_b).await.unwrap().active);
+    assert_eq!(h.count_active_sessions(&account_id).await, 0);
+    assert!(h.list_sessions(&account_id).await.unwrap().sessions.is_empty());
+}

--- a/crates/services/auth/tests/auth_it/scenarios/lifecycle.rs
+++ b/crates/services/auth/tests/auth_it/scenarios/lifecycle.rs
@@ -1,0 +1,67 @@
+//! Happy-path session lifecycle: login issues a verifiable, introspectable
+//! session; a single logout blacklists it so its edge token goes inactive.
+
+use tonic::Code;
+
+use crate::auth_it::harness::{random_user, Harness};
+
+#[tokio::test]
+async fn login_introspect_then_logout_invalidates_the_token() {
+    let h = Harness::start().await;
+    let user = random_user();
+
+    let login = h.login(&user).await.expect("login");
+    assert!(login.first_link, "first login establishes the subject link");
+    let tokens = login.tokens.expect("token pair");
+    assert_eq!(tokens.token_type, "Bearer");
+    assert!(!tokens.access_token.is_empty());
+    assert!(!tokens.refresh_token.is_empty());
+
+    // The just-issued access token introspects as active.
+    let view = h.introspect(&tokens.access_token).await.expect("introspect");
+    assert!(view.active);
+    assert_eq!(view.account_id, login.account_id);
+    assert_eq!(view.session_id, tokens.session_id);
+
+    // It is durably persisted.
+    assert_eq!(h.count_active_sessions(&login.account_id).await, 1);
+    assert_eq!(h.count_subject_links(&login.account_id).await, 1);
+
+    // Logging out blacklists the session ⇒ the edge token is now inactive.
+    let out = h.logout(&tokens.session_id).await.expect("logout");
+    assert!(out.success);
+    assert!(!h.introspect(&tokens.access_token).await.expect("introspect").active);
+    assert_eq!(h.count_active_sessions(&login.account_id).await, 0);
+
+    // Logout is idempotent.
+    assert!(h.logout(&tokens.session_id).await.expect("idempotent logout").success);
+}
+
+#[tokio::test]
+async fn second_login_same_user_reuses_the_account_link() {
+    let h = Harness::start().await;
+    let user = random_user();
+
+    let first = h.login(&user).await.expect("first login");
+    let second = h.login(&user).await.expect("second login");
+
+    assert!(first.first_link);
+    assert!(!second.first_link, "subject already linked");
+    assert_eq!(first.account_id, second.account_id);
+    assert_eq!(h.count_subject_links(&first.account_id).await, 1, "exactly one link");
+    assert_eq!(h.count_active_sessions(&first.account_id).await, 2, "two sessions");
+}
+
+#[tokio::test]
+async fn introspecting_garbage_is_inactive_not_an_error() {
+    let h = Harness::start().await;
+    let view = h.introspect("not-a-token").await.expect("introspect never errors on bad tokens");
+    assert!(!view.active);
+}
+
+#[tokio::test]
+async fn logout_unknown_session_is_not_found() {
+    let h = Harness::start().await;
+    let status = h.logout(&uuid::Uuid::now_v7().to_string()).await.unwrap_err();
+    assert_eq!(status.code(), Code::NotFound);
+}

--- a/crates/services/auth/tests/auth_it/scenarios/mod.rs
+++ b/crates/services/auth/tests/auth_it/scenarios/mod.rs
@@ -1,0 +1,6 @@
+//! Live scenarios driving the real Postgres + Redis graph through the gRPC handler.
+
+pub mod global_logout;
+pub mod lifecycle;
+pub mod persistence_roundtrip;
+pub mod refresh_reuse;

--- a/crates/services/auth/tests/auth_it/scenarios/persistence_roundtrip.rs
+++ b/crates/services/auth/tests/auth_it/scenarios/persistence_roundtrip.rs
@@ -1,0 +1,61 @@
+//! The durable write path: a login persists a session, a refresh token, and the
+//! immutable subject link; a refresh updates the rotation lineage in place.
+
+use crate::auth_it::harness::{random_user, Harness};
+
+#[tokio::test]
+async fn login_persists_session_refresh_and_link() {
+    let h = Harness::start().await;
+    let login = h.login(&random_user()).await.expect("login");
+    let account_id = login.account_id.clone();
+    let tokens = login.tokens.unwrap();
+
+    // Session row.
+    let session_id = uuid::Uuid::parse_str(&tokens.session_id).unwrap();
+    let session_account: uuid::Uuid =
+        sqlx::query_scalar("SELECT account_id FROM sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_one(&h.pool)
+            .await
+            .expect("session row exists");
+    assert_eq!(session_account.to_string(), account_id);
+
+    // Exactly one active refresh token for the session.
+    let refresh_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM refresh_tokens WHERE session_id = $1 AND status = 'active'")
+            .bind(session_id)
+            .fetch_one(&h.pool)
+            .await
+            .expect("count refresh tokens");
+    assert_eq!(refresh_count, 1);
+
+    // Immutable subject link.
+    assert_eq!(h.count_subject_links(&account_id).await, 1);
+}
+
+#[tokio::test]
+async fn refresh_marks_the_old_token_rotated_and_chains_lineage() {
+    let h = Harness::start().await;
+    let login = h.login(&random_user()).await.expect("login");
+    let tokens = login.tokens.unwrap();
+    let session_id = uuid::Uuid::parse_str(&tokens.session_id).unwrap();
+
+    h.refresh(&tokens.refresh_token).await.expect("refresh");
+
+    // After one rotation: one rotated (with a successor) + one active.
+    let rotated: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM refresh_tokens WHERE session_id = $1 AND status = 'rotated' AND replaced_by IS NOT NULL",
+    )
+    .bind(session_id)
+    .fetch_one(&h.pool)
+    .await
+    .expect("count rotated");
+    let active: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM refresh_tokens WHERE session_id = $1 AND status = 'active'")
+            .bind(session_id)
+            .fetch_one(&h.pool)
+            .await
+            .expect("count active");
+    assert_eq!(rotated, 1, "original is rotated with a successor");
+    assert_eq!(active, 1, "exactly one live token");
+}

--- a/crates/services/auth/tests/auth_it/scenarios/refresh_reuse.rs
+++ b/crates/services/auth/tests/auth_it/scenarios/refresh_reuse.rs
@@ -1,0 +1,47 @@
+//! Refresh rotation + reuse-detection against real Postgres + Redis.
+
+use tonic::Code;
+
+use crate::auth_it::harness::{random_user, Harness};
+
+#[tokio::test]
+async fn refresh_rotates_to_a_new_pair() {
+    let h = Harness::start().await;
+    let login = h.login(&random_user()).await.expect("login");
+    let first = login.tokens.unwrap();
+
+    let refreshed = h.refresh(&first.refresh_token).await.expect("refresh").tokens.unwrap();
+    assert_eq!(refreshed.session_id, first.session_id, "same session");
+    assert_ne!(refreshed.refresh_token, first.refresh_token, "refresh token rotates");
+    assert!(!refreshed.access_token.is_empty());
+
+    // The rotated successor still works.
+    let again = h.refresh(&refreshed.refresh_token).await.expect("second refresh");
+    assert!(again.tokens.is_some());
+}
+
+#[tokio::test]
+async fn reusing_a_rotated_refresh_token_revokes_the_whole_generation() {
+    let h = Harness::start().await;
+    let login = h.login(&random_user()).await.expect("login");
+    let account_id = login.account_id.clone();
+    let original = login.tokens.unwrap();
+
+    // Legitimate rotation: `original` is now spent.
+    let _rotated = h.refresh(&original.refresh_token).await.expect("rotate").tokens.unwrap();
+
+    // Re-presenting the spent token is treated as theft.
+    let status = h.refresh(&original.refresh_token).await.unwrap_err();
+    assert_eq!(status.code(), Code::Unauthenticated);
+
+    // The whole session is gone: no active sessions remain for the account.
+    assert_eq!(h.count_active_sessions(&account_id).await, 0);
+    assert!(h.list_sessions(&account_id).await.expect("list").sessions.is_empty());
+}
+
+#[tokio::test]
+async fn unknown_refresh_token_is_unauthenticated() {
+    let h = Harness::start().await;
+    let status = h.refresh("nonexistent-token").await.unwrap_err();
+    assert_eq!(status.code(), Code::Unauthenticated);
+}

--- a/crates/services/auth/tests/edge_token_verify.rs
+++ b/crates/services/auth/tests/edge_token_verify.rs
@@ -1,0 +1,136 @@
+//! Cross-crate proof: an edge token **minted** by this service's `Es256TokenMinter`
+//! is **verified** by the very `auth-context` decoder every downstream service runs
+//! on its inbound path. This is the contract that makes the split-token hot path
+//! work — issuance and verification must agree on algorithm, claims, and `kid`.
+//!
+//! No container required; it's pure crypto + claim mapping, so it runs in the
+//! default `cargo test -p auth`.
+
+use std::collections::HashMap;
+
+use auth::application::SessionPolicy;
+use auth::application::port::TokenMinter;
+use auth::domain::value_object::{AccessTokenClaims, AccountId, Generation, Permission, SessionId};
+use auth::infrastructure::token::{Es256TokenMinter, EsKeyMaterial};
+
+use auth_context::{
+    AuthContextConfig, ClaimsExtractor, CurrentPrincipal, JwksCache, JwtDecoder,
+};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{Algorithm, DecodingKey};
+use serde::Deserialize;
+use uuid::Uuid;
+
+const KID: &str = "auth-es256-1";
+const ISSUER: &str = "https://auth.core-platform";
+const AUDIENCE: &str = "core-platform";
+
+/// Generates an ephemeral P-256 keypair (PKCS#8 private PEM, SPKI public PEM).
+/// No key material is hardcoded.
+fn keypair() -> (Vec<u8>, Vec<u8>) {
+    use p256::ecdsa::SigningKey;
+    use p256::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+    let signing = SigningKey::random(&mut rand_core::OsRng);
+    let private_pem = signing.to_pkcs8_pem(LineEnding::LF).unwrap().as_bytes().to_vec();
+    let public_pem = signing.verifying_key().to_public_key_pem(LineEnding::LF).unwrap().into_bytes();
+    (private_pem, public_pem)
+}
+
+/// The claim subset a downstream service cares about. `auth-context` deserializes
+/// the token into this `C`, then the extractor lifts it to a `CurrentPrincipal`.
+#[derive(Debug, Clone, Deserialize)]
+struct EdgeClaims {
+    sub: String,
+    #[serde(default)]
+    perms: Vec<String>,
+}
+
+struct EdgeExtractor;
+
+impl ClaimsExtractor<EdgeClaims> for EdgeExtractor {
+    fn extract(
+        &self,
+        raw: EdgeClaims,
+    ) -> Result<CurrentPrincipal<EdgeClaims>, auth_context::AuthError> {
+        Ok(CurrentPrincipal {
+            user_id: auth_context::PrincipalId(raw.sub.clone()),
+            tenant_id: None,
+            permissions: raw.perms.iter().cloned().map(auth_context::Permission).collect(),
+            raw_claims: raw,
+        })
+    }
+}
+
+fn minter(private_pem: &[u8], public_pem: &[u8], audience: &str) -> Es256TokenMinter {
+    Es256TokenMinter::from_pem(EsKeyMaterial {
+        private_pem: private_pem.to_vec(),
+        public_pem: public_pem.to_vec(),
+        key_id: KID.to_owned(),
+        issuer: ISSUER.to_owned(),
+        audience: audience.to_owned(),
+    })
+    .unwrap()
+}
+
+async fn decoder(public_pem: &[u8]) -> JwtDecoder<EdgeClaims, EdgeExtractor> {
+    let cache = JwksCache::new();
+    let mut keys = HashMap::new();
+    keys.insert(KID.to_owned(), DecodingKey::from_ec_pem(public_pem).unwrap());
+    cache.replace(keys).await;
+
+    let config = AuthContextConfig {
+        expected_issuer: Some(ISSUER.to_owned()),
+        expected_audience: Some(AUDIENCE.to_owned()),
+        ..AuthContextConfig::default()
+    };
+    JwtDecoder::with_algorithms(&config, cache, EdgeExtractor, vec![Algorithm::ES256])
+}
+
+#[tokio::test]
+async fn minted_edge_token_is_verified_by_auth_context() {
+    let _ = SessionPolicy::new(
+        Duration::minutes(10),
+        Duration::minutes(30),
+        Duration::hours(8),
+        Duration::days(7),
+    );
+
+    let account = AccountId::from_uuid(Uuid::now_v7());
+    let session = SessionId::new();
+    let claims = AccessTokenClaims {
+        account_id: account,
+        session_id: session,
+        generation: Generation::from_i64(7),
+        permissions: vec![Permission::new("posts:write"), Permission::new("ROLE_ADMIN")],
+        issued_at: Utc::now(),
+        expires_at: Utc::now() + Duration::minutes(10),
+    };
+
+    let (private_pem, public_pem) = keypair();
+    let token = minter(&private_pem, &public_pem, AUDIENCE).mint_access(&claims).await.expect("mint");
+    let principal =
+        decoder(&public_pem).await.decode(&token).await.expect("auth-context verifies the token");
+
+    assert_eq!(principal.user_id.0, account.as_str());
+    let perms: Vec<&str> = principal.permissions.iter().map(|p| p.0.as_str()).collect();
+    assert_eq!(perms, vec!["posts:write", "ROLE_ADMIN"]);
+}
+
+#[tokio::test]
+async fn auth_context_rejects_a_token_for_a_different_audience() {
+    // Same key (so the signature is valid) but a different audience — our decoder
+    // must reject it on the `aud` check.
+    let (private_pem, public_pem) = keypair();
+    let other = minter(&private_pem, &public_pem, "some-other-service");
+
+    let claims = AccessTokenClaims {
+        account_id: AccountId::from_uuid(Uuid::now_v7()),
+        session_id: SessionId::new(),
+        generation: Generation::INITIAL,
+        permissions: vec![],
+        issued_at: Utc::now(),
+        expires_at: Utc::now() + Duration::minutes(10),
+    };
+    let token = other.mint_access(&claims).await.unwrap();
+    assert!(decoder(&public_pem).await.decode(&token).await.is_err());
+}

--- a/crates/services/auth/tests/integration.rs
+++ b/crates/services/auth/tests/integration.rs
@@ -1,0 +1,25 @@
+//! Live, container-backed integration suite for the auth service.
+//!
+//! Auth owns two stores, so this suite boots a real **PostgreSQL** and a real
+//! **Redis** container (via the shared `test-support` harness) and drives the
+//! production composition root ([`auth::app::App::compose`]) end-to-end through
+//! the gRPC handler. The *external* dependencies (the IdP and the `account`
+//! service) are stubbed at their port boundaries.
+//!
+//! The whole binary is gated behind the `integration-auth` feature so the default
+//! `cargo test -p auth` stays hermetic and Docker-free. Run the live suite:
+//!
+//! ```text
+//! cargo test -p auth --features integration-auth -- --nocapture
+//! ```
+//!
+//! Coverage:
+//! - **lifecycle** — login → introspect → logout invalidates the edge token.
+//! - **refresh_reuse** — rotation works; re-presenting a spent token revokes the
+//!   whole session generation.
+//! - **global_logout** — a generation bump invalidates every session's token.
+//! - **persistence_roundtrip** — sessions, refresh-token lineage, and the subject
+//!   link are durably written.
+#![cfg(feature = "integration-auth")]
+
+mod auth_it;


### PR DESCRIPTION
## What

Adds the **`auth`** service — the platform's **issuance / session / IdP-broker** boundary. It owns the *authentication act and its lifecycle* only, and is deliberately distinct from its two neighbours:

- **`account`** — the identity System of Record (who a person *is*).
- **`auth-context`** — the inbound *verification* library every service already runs.

Credentials (passwords / MFA) live in the IdP under a **federated Keycloak** model, so no credential type exists in this service. The whole surface is **IdP-agnostic**: migrating to Cognito/Okta/custom is a new infrastructure adapter with zero change to the domain/application layers.

## Design highlights

- **Split-token hot path.** Short-lived **ES256 edge tokens** are verified *locally* by downstream services via `auth-context` (pure CPU) — only login/refresh/logout reach this service. Long-lived **opaque refresh tokens** are server-side, single-use, and rotated on every exchange.
- **Reuse = compromise.** Re-presenting a rotated refresh token revokes the whole session **generation**.
- **Instant global logout** via a per-account generation counter in Redis Cluster — no per-request DB read, no write amplification.
- **Zero-downtime key rotation** — the minter verifies against a `kid`-keyed ring; **JWKS** is published for `auth-context` to fetch.

## Layers (contract-first vertical slice)

| Layer | Contents |
|---|---|
| `contracts/auth-api` + `proto/auth/v1` | `auth.v1` gRPC — normalized types only, **no IdP-specific fields** |
| `domain` | `Session` / `RefreshToken` / `SubjectLink` aggregates + 5 invariants (clock injected) |
| `application` | CQRS-style handlers over **8 `async_trait` ports**, fakes-tested |
| `infrastructure` | Keycloak OIDC · Postgres repos (sharded, optimistic lock) · Redis `SessionCache` · ES256 `TokenMinter` (ring + JWKS) · Kafka · `account` gRPC |
| `server` | `App` composition root · tonic handler · `service_runtime::serve` → `auth-server` (:50060) |

## Tests

- **82 unit** + cross-crate **edge-verify** (a token minted here is accepted by the same `auth-context` decoder downstream services run; wrong-audience rejected).
- **Live container suite** (`cargo test -p auth --features integration-auth`, **10 scenarios** over real Postgres + Redis): login → introspect → logout · refresh rotation + reuse-detection → generation revoke · global logout · durable round-trips. **Ran green.**
- clippy clean; `cargo check --workspace` green.

## Docs & security

- TIER-0 README (EN + FR, i18n drift gate green): SLO, blast-radius, failure modes, **key-rotation runbook**.
- Security review: **no findings above the confidence bar** — alg-pinned JWT verification (no `alg:none`/confusion), parameterized SQL throughout, CSPRNG refresh tokens stored as SHA-256, public-only JWKS.

## Notes / deferrals (documented)

- **Auto-provisioning** an `account` from IdP claims needs the email/profile (extending `NormalizedClaims`) — a product decision; `resolve_or_provision` is resolve-only for now.
- **Keycloak is not containerized** in the IT suite — the OIDC adapter is unit-tested; the live suite stubs the IdP at its port and exercises the session/token machinery over auth's own stores.
- Remaining README `<TODO>`s are deployment-specific values (team, on-call, concrete SLO numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)