### PR TITLE
feat(moderation): land trust, safety & compliance service on develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,6 +2494,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "moderation"
+version = "0.1.0"
+dependencies = [
+ "account-api",
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "cqrs",
+ "error",
+ "fred",
+ "http",
+ "moderation-api",
+ "postgres",
+ "prost-types",
+ "redis-storage",
+ "scylla",
+ "scylla-storage",
+ "serde",
+ "serde_json",
+ "service-runtime",
+ "sqlx",
+ "test-support",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-reflection",
+ "tracing",
+ "transport",
+ "uuid",
+ "validation",
+]
+
+[[package]]
+name = "moderation-api"
+version = "0.1.0"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "moderation-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "moderation",
+ "service-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/services/timeline",
     "crates/services/chat",
     "crates/services/auth",
+    "crates/services/moderation",
     "crates/apps/chat-server",
     "crates/apps/profile-server",
     "crates/apps/social-graph-server",
@@ -41,6 +42,7 @@ members = [
     "crates/apps/account-server",
     "crates/apps/timeline-server",
     "crates/apps/auth-server",
+    "crates/apps/moderation-server",
     "crates/apps/migrator",
     "crates/contracts/social-graph-api",
     "crates/contracts/account-api",
@@ -53,6 +55,7 @@ members = [
     "crates/contracts/profile-api",
     "crates/contracts/timeline-api",
     "crates/contracts/auth-api",
+    "crates/contracts/moderation-api",
 ]
 resolver = "2"
 
@@ -101,6 +104,7 @@ post-api = { path = "crates/contracts/post-api" }
 profile-api = { path = "crates/contracts/profile-api" }
 timeline-api = { path = "crates/contracts/timeline-api" }
 auth-api = { path = "crates/contracts/auth-api" }
+moderation-api = { path = "crates/contracts/moderation-api" }
 account          = { path = "crates/services/account" }
 chat             = { path = "crates/services/chat" }
 profile          = { path = "crates/services/profile" }
@@ -112,6 +116,7 @@ geo-discovery    = { path = "crates/services/geo-discovery" }
 notification     = { path = "crates/services/notification" }
 timeline         = { path = "crates/services/timeline" }
 auth             = { path = "crates/services/auth" }
+moderation       = { path = "crates/services/moderation" }
 
 
 # Communs

--- a/crates/apps/moderation-server/Cargo.toml
+++ b/crates/apps/moderation-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "moderation-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the moderation service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+moderation      = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/moderation-server/src/main.rs
+++ b/crates/apps/moderation-server/src/main.rs
@@ -1,0 +1,17 @@
+//! `moderation-server` — the deployable moderation binary. A one-liner over the
+//! shared fleet runtime: telemetry, externalized config + hot-reload, ingress
+//! layers, dynamic health, and graceful shutdown are all the runtime's job. The
+//! Plane A ingestion consumers self-spawn inside `ModerationService::build`.
+
+use std::net::SocketAddr;
+
+use moderation::service::ModerationService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("MODERATION_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50061".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<ModerationService>(addr).await
+}

--- a/crates/contracts/moderation-api/Cargo.toml
+++ b/crates/contracts/moderation-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name        = "moderation-api"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Generated gRPC contract for moderation.v1 — server + client stubs and reflection descriptor."
+
+[dependencies]
+tonic       = { workspace = true }
+tonic-prost = { workspace = true }
+prost       = { workspace = true }
+prost-types = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = { workspace = true }

--- a/crates/contracts/moderation-api/build.rs
+++ b/crates/contracts/moderation-api/build.rs
@@ -1,0 +1,21 @@
+//! Compiles the moderation.v1 contract into server + client stubs plus a
+//! reflection descriptor set, from the shared contracts/proto root (the single
+//! IDL source).
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("moderation_descriptor.bin");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(
+            &[
+                "../proto/moderation/v1/enums.proto",
+                "../proto/moderation/v1/messages.proto",
+                "../proto/moderation/v1/service.proto",
+            ],
+            &["../proto/"],
+        )?;
+    Ok(())
+}

--- a/crates/contracts/moderation-api/src/lib.rs
+++ b/crates/contracts/moderation-api/src/lib.rs
@@ -1,0 +1,21 @@
+//! Generated gRPC contract for `moderation.v1` (server + client stubs +
+//! descriptor), compiled from the shared `contracts/proto` IDL. Consumers depend
+//! on this crate instead of recompiling the `.proto` files.
+//!
+//! Contract rule (the normalization guarantee, mirroring `auth.v1`): the wire
+//! surface exposes only normalized integrity types — a [`SubjectRef`]
+//! (entity_type, entity_id, actor_id, surface), plus [`PolicyCategory`],
+//! [`ActionType`], and case/appeal ids — never classifier-vendor or
+//! content-internal fields. Moderation *decides*; it never re-exposes a content
+//! service's private shape.
+//!
+//! The synchronous surface is deliberately minimal: the `Screen` gate (Plane C),
+//! case/queue/appeal management (ops console), the DSA Statement-of-Reasons
+//! export, and the discouraged internal enforcement read. Enforcement events
+//! (Plane B) are NOT proto — they are serde structs published to
+//! `moderation.v1.events`. See `project_moderation_service_blueprint`.
+tonic::include_proto!("moderation.v1");
+
+/// Encoded protobuf descriptor set for gRPC server reflection.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("moderation_descriptor");

--- a/crates/contracts/proto/moderation/v1/enums.proto
+++ b/crates/contracts/proto/moderation/v1/enums.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package moderation.v1;
+
+option java_package = "com.coreplatform.moderation.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/moderation/v1;moderationv1";
+
+// What kind of entity a moderation subject points at. Moderation never stores the
+// content itself — it references it by (entity_type, entity_id) owned by the
+// originating content service.
+enum EntityType {
+    ENTITY_TYPE_UNSPECIFIED = 0;
+    ENTITY_TYPE_POST         = 1;
+    ENTITY_TYPE_COMMENT      = 2;
+    ENTITY_TYPE_CHAT_MESSAGE = 3;
+    ENTITY_TYPE_MEDIA        = 4;
+    // Actor-level subject (the account itself), e.g. for graduated penalties.
+    ENTITY_TYPE_ACCOUNT      = 5;
+    ENTITY_TYPE_PROFILE      = 6;
+}
+
+// Normalized integrity taxonomy. Deliberately policy-version-agnostic at the wire
+// level: the *thresholds and consequences* for each category live in the pinned
+// policy version, never in this contract. Catastrophic-harm categories (CSAM,
+// NCII, VIOLENT_EXTREMISM) are the only ones eligible for the synchronous,
+// fail-closed Screen gate.
+enum PolicyCategory {
+    POLICY_CATEGORY_UNSPECIFIED = 0;
+    POLICY_CATEGORY_SPAM               = 1;
+    POLICY_CATEGORY_HARASSMENT         = 2;
+    POLICY_CATEGORY_HATE               = 3;
+    POLICY_CATEGORY_VIOLENT_EXTREMISM  = 4; // TVEC
+    POLICY_CATEGORY_CSAM               = 5;
+    POLICY_CATEGORY_NCII               = 6; // non-consensual intimate imagery
+    POLICY_CATEGORY_SELF_HARM          = 7;
+    POLICY_CATEGORY_MISINFORMATION     = 8;
+    POLICY_CATEGORY_OTHER              = 9;
+}
+
+// The executable consequence of a decision. Graduated from least to most severe.
+// Moderation DECIDES the action; the owning service EXECUTES it (content services
+// flip visibility; `account` runs suspension/ban lifecycle).
+enum ActionType {
+    ACTION_TYPE_UNSPECIFIED = 0;
+    // No enforcement — the case is dismissed as non-violating.
+    ACTION_TYPE_NO_ACTION        = 1;
+    ACTION_TYPE_WARN             = 2;
+    ACTION_TYPE_REMOVE_CONTENT   = 3;
+    ACTION_TYPE_AGE_GATE         = 4;
+    // Shadow-reduce: content stays but its reach/visibility is limited.
+    ACTION_TYPE_VISIBILITY_LIMIT = 5;
+    // Actor-level: restrict the actor's ability to post/interact for a window.
+    ACTION_TYPE_RESTRICT_ACTOR   = 6;
+    ACTION_TYPE_SUSPEND          = 7;
+    ACTION_TYPE_BAN              = 8;
+}
+
+// Lifecycle of a review Case.
+enum CaseStatus {
+    CASE_STATUS_UNSPECIFIED = 0;
+    CASE_STATUS_OPEN      = 1;
+    CASE_STATUS_TRIAGED   = 2;
+    CASE_STATUS_ACTIONED  = 3;
+    CASE_STATUS_DISMISSED = 4;
+    CASE_STATUS_APPEALED  = 5;
+}
+
+// Lifecycle of an EnforcementAction. Carries a monotonic per-subject version so a
+// reversal can never race ahead of a re-application.
+enum EnforcementStatus {
+    ENFORCEMENT_STATUS_UNSPECIFIED = 0;
+    ENFORCEMENT_STATUS_ACTIVE   = 1;
+    ENFORCEMENT_STATUS_EXPIRED  = 2;
+    ENFORCEMENT_STATUS_REVERSED = 3;
+}
+
+// The result of a synchronous Screen (Plane C). For catastrophic-harm categories
+// the CALLER's per-category fail policy converts BLOCK — and an unavailable gate —
+// into a hard pre-publish block; ALLOW never means "approved", only "no known-bad
+// match" (asynchronous review still applies on Plane A).
+enum ScreenVerdict {
+    SCREEN_VERDICT_UNSPECIFIED = 0;
+    SCREEN_VERDICT_ALLOW  = 1;
+    SCREEN_VERDICT_BLOCK  = 2;
+    // Ambiguous match — route to expedited human review; caller holds visibility.
+    SCREEN_VERDICT_REVIEW = 3;
+}
+
+// Lifecycle of an Appeal against a decision.
+enum AppealStatus {
+    APPEAL_STATUS_UNSPECIFIED = 0;
+    APPEAL_STATUS_FILED        = 1;
+    APPEAL_STATUS_UNDER_REVIEW = 2;
+    APPEAL_STATUS_UPHELD       = 3; // original decision stands
+    APPEAL_STATUS_OVERTURNED   = 4; // a reversal decision is recorded
+}

--- a/crates/contracts/proto/moderation/v1/messages.proto
+++ b/crates/contracts/proto/moderation/v1/messages.proto
@@ -1,0 +1,233 @@
+syntax = "proto3";
+
+package moderation.v1;
+
+import "moderation/v1/enums.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.coreplatform.moderation.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/moderation/v1;moderationv1";
+
+// ── Shared value objects ──────────────────────────────────────────────────────
+
+// The thing being moderated. The linchpin reference type: moderation holds this,
+// not the content bytes. `actor_id` is the responsible account; `surface` is the
+// placement (e.g. "feed", "dm", "profile") for surface-scoped policy.
+message SubjectRef {
+    EntityType  entity_type = 1;
+    string      entity_id   = 2;
+    string      actor_id    = 3;
+    string      surface     = 4;
+}
+
+// A precomputed content fingerprint. Moderation matches these against the
+// known-bad corpus; it never receives raw content bytes (it is not a content
+// store). `algorithm` is e.g. "pdq", "md5", "photodna".
+message ContentHash {
+    string  algorithm = 1;
+    string  value     = 2;
+}
+
+// A single integrity signal contributing to a case (a classifier verdict or a
+// user-report-derived observation). Summarized for the review surface.
+message SignalSummary {
+    // Origin, e.g. "classifier:image-v3" or "report".
+    string                      source      = 1;
+    PolicyCategory              category    = 2;
+    // [0.0, 1.0] model/aggregate confidence.
+    float                       confidence  = 3;
+    google.protobuf.Timestamp   observed_at = 4;
+}
+
+// A review case as seen on the ops console.
+message CaseView {
+    string                      case_id   = 1;
+    SubjectRef                  subject   = 2;
+    CaseStatus                  status    = 3;
+    PolicyCategory              category  = 4;
+    // Triage routing hints.
+    string                      queue     = 5;
+    string                      priority  = 6;
+    string                      assignee  = 7; // reviewer id; empty if unassigned
+    repeated SignalSummary      signals   = 8;
+    google.protobuf.Timestamp   opened_at = 9;
+}
+
+// An immutable entry in the decision ledger (the legal evidence record). A
+// reversal is a NEW decision that references the original — never a mutation.
+message Decision {
+    string                      decision_id   = 1;
+    SubjectRef                  subject       = 2;
+    ActionType                  action        = 3;
+    PolicyCategory              category      = 4;
+    // The policy version this decision was made under (audit consistency).
+    string                      policy_version = 5;
+    string                      rationale     = 6;
+    // Reviewer id (human) or rule id (automated) — disambiguated by `automated`.
+    string                      decided_by    = 7;
+    bool                        automated     = 8;
+    // Set when this decision reverses an earlier one (appeal overturn / re-review).
+    string                      reverses_decision_id = 9;
+    google.protobuf.Timestamp   decided_at    = 10;
+}
+
+// The executable, lifecycle-bearing consequence of a decision.
+message EnforcementView {
+    string                      enforcement_id = 1;
+    SubjectRef                  subject        = 2;
+    ActionType                  action         = 3;
+    EnforcementStatus           status         = 4;
+    // Monotonic per-subject version; reversal must observe the current version.
+    int64                       version        = 5;
+    google.protobuf.Timestamp   applied_at     = 6;
+    // Unset for permanent actions (BAN); set for time-boxed restrictions.
+    google.protobuf.Timestamp   expires_at     = 7;
+}
+
+// An appeal against a decision.
+message AppealView {
+    string                      appeal_id    = 1;
+    string                      decision_id  = 2;
+    AppealStatus                status       = 3;
+    string                      statement    = 4; // the appellant's argument
+    google.protobuf.Timestamp   filed_at     = 5;
+    google.protobuf.Timestamp   resolved_at  = 6;
+}
+
+// ── Screen · Plane C (the narrow, fail-closed pre-publish gate) ───────────────
+
+message ScreenRequest {
+    SubjectRef               subject     = 1;
+    // Precomputed perceptual/cryptographic hashes to match against the corpus.
+    repeated ContentHash     hashes      = 2;
+    // Optional short text screened against the critical-term blocklist. Transient:
+    // it transits TLS for the lookup and is NEVER persisted by this service.
+    string                   text        = 3;
+    // Which catastrophic-harm categories to screen. Empty ⇒ all zero-tolerance.
+    repeated PolicyCategory  categories  = 4;
+}
+
+message ScreenResponse {
+    ScreenVerdict            verdict           = 1;
+    repeated PolicyCategory  matched_categories = 2;
+    // Corpus entry reference for the audit trail when a match occurs.
+    string                   match_reference   = 3;
+}
+
+// ── Case / queue management (ops console) ─────────────────────────────────────
+
+message OpenCaseRequest {
+    SubjectRef      subject  = 1;
+    PolicyCategory  category = 2;
+    string          reason   = 3;
+}
+
+message OpenCaseResponse {
+    CaseView  case    = 1;
+    // False when an existing case for this subject was returned (idempotent open).
+    bool      created = 2;
+}
+
+message AssignCaseRequest {
+    string  case_id     = 1;
+    string  reviewer_id = 2;
+}
+
+message AssignCaseResponse {
+    CaseView  case = 1;
+}
+
+message DecideCaseRequest {
+    string          case_id        = 1;
+    ActionType      action         = 2;
+    PolicyCategory  category       = 3;
+    string          rationale      = 4;
+    string          reviewer_id    = 5;
+    // Policy version the reviewer is deciding under (pinned for audit).
+    string          policy_version = 6;
+}
+
+message DecideCaseResponse {
+    Decision         decision    = 1;
+    // Present unless the action was NO_ACTION/dismiss.
+    EnforcementView  enforcement = 2;
+}
+
+message ListQueueRequest {
+    string      queue         = 1;
+    CaseStatus  status_filter = 2; // UNSPECIFIED ⇒ all open work
+    int32       page_size     = 3;
+    string      page_token    = 4;
+}
+
+message ListQueueResponse {
+    repeated CaseView  cases           = 1;
+    string             next_page_token = 2;
+}
+
+// ── Appeals ───────────────────────────────────────────────────────────────────
+
+message FileAppealRequest {
+    string  decision_id = 1;
+    string  actor_id    = 2;
+    string  statement   = 3;
+}
+
+message FileAppealResponse {
+    AppealView  appeal = 1;
+}
+
+message ResolveAppealRequest {
+    string  appeal_id   = 1;
+    // True ⇒ overturn (records a reversal decision); false ⇒ uphold.
+    bool    overturn    = 2;
+    string  rationale   = 3;
+    string  reviewer_id = 4;
+}
+
+message ResolveAppealResponse {
+    AppealView  appeal   = 1;
+    // The reversal decision, present only when the appeal was overturned.
+    Decision    reversal = 2;
+}
+
+// ── Compliance / back-office ──────────────────────────────────────────────────
+
+// The DSA Article 17 machine-readable Statement of Reasons for a single decision.
+message StatementOfReasons {
+    string                      decision_id   = 1;
+    SubjectRef                  subject       = 2;
+    PolicyCategory              category      = 3;
+    ActionType                  action        = 4;
+    string                      policy_version = 5;
+    // The factual basis for the decision.
+    string                      facts         = 6;
+    // The policy/legal ground relied upon.
+    string                      legal_ground  = 7;
+    bool                        automated     = 8;
+    // Whether the affected user was in scope of EU territorial obligations.
+    bool                        territorial_eu = 9;
+    google.protobuf.Timestamp   decided_at    = 10;
+}
+
+message GetStatementOfReasonsRequest {
+    string  decision_id = 1;
+}
+
+message GetStatementOfReasonsResponse {
+    StatementOfReasons  statement = 1;
+}
+
+// ── Enforcement state (INTERNAL — discouraged on the hot path) ────────────────
+
+message GetEnforcementStateRequest {
+    string  actor_id = 1;
+}
+
+message GetEnforcementStateResponse {
+    // Coarse "is this actor under any active restriction" — the same fact the
+    // Redis projection serves on the hot path. Prefer Plane B (events/projection).
+    bool                      actor_restricted    = 1;
+    repeated EnforcementView  active_enforcements = 2;
+}

--- a/crates/contracts/proto/moderation/v1/service.proto
+++ b/crates/contracts/proto/moderation/v1/service.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+package moderation.v1;
+
+import "moderation/v1/messages.proto";
+
+option java_package = "com.coreplatform.moderation.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/moderation/v1;moderationv1";
+
+// ModerationService is the platform's integrity decision-of-record and
+// enforcement brain (trust, safety & compliance).
+//
+// This SYNCHRONOUS surface is deliberately minimal. Moderation is overwhelmingly
+// asynchronous and post-hoc: content is reviewed off the write path (Plane A,
+// Kafka ingestion) and enforcement is read off the hot path via denormalized
+// state (Plane B, `moderation.v1.events` + a Redis projection). The only
+// synchronous, latency-bound entry point is the Screen gate (Plane C), and only
+// for catastrophic-harm categories.
+//
+// Boundary: moderation DECIDES; it does not store content (the content services
+// do) and it does not execute account suspension (`account` does). It consumes
+// classifier signals — it never runs ML inference inline. The wire surface
+// exposes only normalized integrity types (SubjectRef, PolicyCategory,
+// ActionType, ids) — never classifier-vendor or content-internal fields.
+service ModerationService {
+
+    // ── Plane C: pre-publish screening (fail-closed, catastrophic harm only) ──
+
+    // Synchronous, bounded-latency, deterministic screen against the known-bad
+    // corpus (hash match + critical-term blocklist). No ML inference inline.
+    // Called only by `media`/`post` for zero-tolerance categories; for those the
+    // caller's policy is fail-closed (BLOCK — and an unavailable gate — prevent
+    // publication). ALLOW means "no known-bad match", not "approved".
+    rpc Screen(ScreenRequest) returns (ScreenResponse);
+
+    // ── Case / queue lifecycle (ops console) ──────────────────────────────────
+
+    // Open (or idempotently return) a review case for a subject.
+    rpc OpenCase(OpenCaseRequest) returns (OpenCaseResponse);
+
+    // Assign a case to a reviewer.
+    rpc AssignCase(AssignCaseRequest) returns (AssignCaseResponse);
+
+    // Action or dismiss a case: records an immutable Decision under a pinned
+    // policy version and, unless dismissed, creates the EnforcementAction.
+    rpc DecideCase(DecideCaseRequest) returns (DecideCaseResponse);
+
+    // List the review queue (paged) for triage UIs.
+    rpc ListQueue(ListQueueRequest) returns (ListQueueResponse);
+
+    // ── Appeals ───────────────────────────────────────────────────────────────
+
+    // File an appeal against a decision (subject to the appeal window and
+    // appealability of the category).
+    rpc FileAppeal(FileAppealRequest) returns (FileAppealResponse);
+
+    // Resolve an appeal: uphold the original decision, or overturn it (which
+    // records a reversal decision and reverses the enforcement).
+    rpc ResolveAppeal(ResolveAppealRequest) returns (ResolveAppealResponse);
+
+    // ── Compliance / back-office ──────────────────────────────────────────────
+
+    // Return the DSA machine-readable Statement of Reasons for a decision.
+    rpc GetStatementOfReasons(GetStatementOfReasonsRequest) returns (GetStatementOfReasonsResponse);
+
+    // INTERNAL, discouraged on the hot path. Coarse enforcement state for an
+    // actor, for back-office/cold reads only — the fleet reads enforcement via
+    // Plane B (events + Redis projection), not this RPC.
+    rpc GetEnforcementState(GetEnforcementStateRequest) returns (GetEnforcementStateResponse);
+}

--- a/crates/services/moderation/Cargo.toml
+++ b/crates/services/moderation/Cargo.toml
@@ -1,0 +1,84 @@
+[package]
+name        = "moderation"
+version.workspace   = true
+edition.workspace   = true
+license.workspace   = true
+authors.workspace   = true
+repository.workspace = true
+description = "Moderation microservice — the platform's integrity decision-of-record and enforcement brain (trust, safety & compliance)."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# Only the canonical error namespace (MOD-XXXX) lives here today. Subsequent
+# phases add: domain/ (Phase 2: Case/Decision/EnforcementAction/PenaltyLedger/
+# Appeal/Report + the graduated-enforcement engine), application/ + AFIT ports
+# (Phase 3), infrastructure/ adapters incl. Postgres SoR / Scylla signal-history /
+# Redis enforcement-projection + Screen hash-corpus / Kafka ingestion consumers
+# (Phase 4), and the composition root + tonic/service-runtime wiring (Phase 5).
+# Dependencies grow per phase — kept minimal here.
+[dependencies]
+# ── Contracts ─────────────────────────────────────────────────────────────────
+moderation-api = { workspace = true }
+anyhow         = { workspace = true }
+
+# ── Shared platform infrastructure ────────────────────────────────────────────
+error      = { workspace = true }
+validation = { workspace = true }
+
+# ── Application layer (Phase 3): CQRS envelope/query bus + async ports ─────────
+cqrs        = { workspace = true }
+async-trait = { workspace = true }
+
+# ── Storage delegates (the three-store split: Postgres SoR · Scylla signal/
+#    evidence history · Redis hot-path enforcement projection + Screen corpus) ──
+postgres-storage = { workspace = true }
+scylla-storage   = { workspace = true }
+redis-storage    = { workspace = true }
+
+# ── Infrastructure adapters (Phase 4) ─────────────────────────────────────────
+transport   = { workspace = true }
+account-api = { workspace = true }
+sqlx        = { workspace = true }
+fred        = { workspace = true }
+scylla      = { workspace = true }
+tonic       = { workspace = true }
+tracing     = { workspace = true }
+
+# ── Server wiring (Phase 5) ───────────────────────────────────────────────────
+service-runtime  = { workspace = true }
+tonic-reflection = { workspace = true }
+prost-types      = { workspace = true }
+tokio            = { workspace = true }
+
+# ── Domain types (Phase 2) ────────────────────────────────────────────────────
+serde      = { workspace = true }
+serde_json = { workspace = true }
+uuid       = { workspace = true }
+chrono     = { workspace = true }
+
+# ── Error handling ────────────────────────────────────────────────────────────
+thiserror = { workspace = true }
+http      = { workspace = true }
+
+[features]
+# Gates the live, container-backed integration suite (tests/integration.rs). Off
+# by default so `cargo test -p moderation` stays a fast, infra-free unit run; the
+# live suite boots real Postgres + Scylla + Redis containers and is opt-in via
+# `cargo test -p moderation --features integration-moderation`.
+integration-moderation = []
+
+[dev-dependencies]
+# Live integration suite: shared container orchestration + migration runners.
+test-support     = { workspace = true }
+cqrs             = { workspace = true }
+postgres-storage = { workspace = true }
+redis-storage    = { workspace = true }
+scylla-storage   = { workspace = true }
+async-trait      = { workspace = true }
+tokio            = { workspace = true }
+sqlx             = { workspace = true }
+fred             = { workspace = true }
+tonic            = { workspace = true }
+uuid             = { workspace = true }
+chrono           = { workspace = true }
+serde_json       = { workspace = true }
+

--- a/crates/services/moderation/README.fr.md
+++ b/crates/services/moderation/README.fr.md
@@ -1,0 +1,306 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: 9d684f4ea1ed5851a9165ba14e8c35063cb9dbce3288952c8c8788ba92af32df
+  translated_at: 2026-06-26
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, variables
+> d'environnement, topics Kafka, identifiants) sont volontairement laissés en anglais.
+
+# `moderation` — Décider, appliquer et prouver les actions d'intégrité sans taxer chaque écriture du réseau
+
+> **Fiche service** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Équipe** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **Astreinte / escalade** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-0** — système de référence légal/conformité ; la porte `Screen` est dans le chemin de publication synchrone pour les catégories de préjudice catastrophique |
+> | **Déployable** | `crates/apps/moderation-server` (crate bibliothèque : `crates/services/moderation`) |
+> | **Datastores** | Postgres db `moderation` (SoR décision/dossier) · ScyllaDB keyspace `moderation` (historique signaux/preuves) · Redis Cluster (projection d'application + corpus de hash Screen) |
+> | **Asynchrone** | publie `moderation.v1.events` · consomme `post.v1.events`, `comment.*`, contenu chat, `moderation.reports`, `moderation.signals` (Kafka) |
+> | **Appelants amont** | `media`, `post` (porte Screen) ; console d'opérations interne (API dossier/file/appel) |
+> | **Dépendances aval** | `account` (gRPC — exécution des suspensions), services de classification (signaux), Postgres, ScyllaDB, Redis, Kafka |
+> | **SLO** | `<TODO>` dispo · `Screen` p99 `< <TODO> ms` · délai de revue async `< <TODO> s` |
+
+---
+
+## 🎯 Vue d'ensemble & rôle du service
+
+`moderation` est le microservice **confiance, sécurité & conformité** : il détient la *décision d'intégrité de référence* — quelle action a été prise contre quelle entité, sous quelle version de politique, avec quelles preuves — et il en est la source autoritaire et auditable pour le reste de la flotte et pour les régulateurs.
+
+Le problème difficile qu'il résout est de **modérer au volume d'écriture du réseau sans devenir un goulot de latence global**. Une conception naïve appelle une RPC de modération à chaque post, message et upload ; cela taxe chaque écriture et couple la disponibilité du contenu à une panne d'intégrité. Le motif qui résout cela est une **séparation en trois plans** : le chemin lourd de classification/revue est découplé du chemin chaud de décision.
+
+**Objectifs fondamentaux :** (1) le contenu est revu **a posteriori et de façon asynchrone** par défaut — zéro latence ajoutée sur le chemin d'écriture ; (2) le chemin chaud de *lecture* lit un **état d'application dénormalisé**, jamais une RPC de modération par élément ; (3) seule une porte `Screen` synchrone, étroite et **fail-closed** garde les catégories de préjudice catastrophique ; (4) chaque application est un enregistrement **immuable et auditable** suffisant pour les obligations DSA / NCMEC / forces de l'ordre.
+
+| Plan | Chemin | Contrat de latence | Usage |
+|---|---|---|---|
+| **A — Ingestion** | consommateurs Kafka async | aucune (hors chemin d'écriture) | ~99 % du contenu : publication optimiste, revue a posteriori |
+| **B — État d'application** | événements + projection Redis | local / O(1) | « cet acteur est-il restreint / ce contenu masqué » sur le chemin chaud de lecture |
+| **C — Porte Screen** | gRPC synchrone | borné, timeout strict | CSAM / NCII / TVEC uniquement — recherche de hash déterministe, fail-closed |
+
+---
+
+## 📐 Architecture & concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), CQRS là où c'est pertinent, une **séparation en trois stores**, Kafka pour l'ingestion et les événements d'application.
+
+```
+                         signalements           signaux classifieurs
+                              │                        │
+  post/comment/chat/media     ▼                        ▼
+  *.created  ─────────►  moderation.reports     moderation.signals
+       │                      │                        │
+       ▼                      ▼                        ▼
+  ┌──────────── Plan A : consommateurs d'ingestion (run_consumer) ─────────────┐
+  │  vérifs déterministes peu coûteuses (blocklist · hash connu · historique)   │
+  │  → fan-out vers classifieurs async → ouverture de Case au-delà d'un seuil   │
+  └───────────────┬───────────────────────────────────────────────┬───────────┘
+                  ▼                                                 ▼
+        moteur d'application graduée                        Scylla : historique
+        (PenaltyLedger · version de politique)              signaux / preuves (TWCS)
+                  │
+                  ▼
+        Postgres SoR : cases · decisions(WORM) · appeals · penalty_ledger · policy_versions
+                  │
+   ┌──────────────┼───────────────────────────────────────────────┐
+   ▼              ▼                                                 ▼
+ moderation.v1.events            projection Redis                Plan C : Screen
+ (dénorm Plan B :            mod:enf:{actor:<id>}  ◄── lecture     (corpus de hash / bloom,
+  timeline/chat/account)     vérifs synchrones O(1)  chaude        porte fail-closed)
+```
+
+**Cohérence de l'application.** Chaque `EnforcementAction` porte une **version monotone par sujet**, de sorte qu'une annulation ne peut jamais devancer une ré-application (la même discipline de génération que `auth` utilise pour les sessions). Les événements d'application sont **clés par `actor_id`** pour un ordonnancement par acteur.
+
+> **Invariants** (et où ils sont appliqués) :
+> - **Les décisions sont append-only** (`decisions` est le registre de preuves légal ; une annulation est une *nouvelle* décision, jamais une mutation) — domaine + Postgres.
+> - **Screen est déterministe et sans inférence** — uniquement recherches hash/blocklist ; le ML ne tourne jamais en ligne (frontière infrastructure).
+> - **Politique d'échec par catégorie** — CSAM/NCII/TVEC échouent **fermé** (bloquer en cas d'incertitude ou de panne de la porte) ; spam/limite échouent **ouvert** (reste en ligne, revu async) — couche application.
+> - **Idempotence de domaine** — Cases clés par UUIDv5 déterministe de l'identité du sujet ; la redélivrance est réelle (standard consommateur).
+
+---
+
+## 📊 Objectifs de niveau de service (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objectif | Fenêtre | Mesuré par |
+|---|---|---|---|
+| Disponibilité `Screen` (Plan C) | `<TODO 99.95%>` | 30j glissants | `<metric>` |
+| Latence `Screen` p99 | `< <TODO> ms` (recherche hash uniquement) | 1h | `<metric>` |
+| Délai de revue d'ingestion (Plan A) | `< <TODO> s` | live | lag `moderation-ingestion-consumer` |
+| Propagation d'application (décision → Plan B visible) | `< <TODO> s` | 1h | `<metric>` |
+| Durabilité du registre de décisions | aucune décision acquittée perdue | — | commit synchrone Postgres |
+
+**Budget d'erreur :** `<TODO>`. **En cas de consommation :** `<TODO: gel du déploiement | page>`. **Règle spéciale :** une panne soutenue de `Screen`/`HashCorpus` est un événement **fail-closed** — les uploads en catégories catastrophiques sont bloqués, pas dégradés ; page immédiate.
+
+---
+
+## 🔗 Dépendances & rayon d'impact &nbsp;·&nbsp; OPS
+
+**Aval — ce dont `moderation` a besoin pour fonctionner :**
+
+| Dépendance | Rôle | Si en panne → | Dégradation |
+|---|---|---|---|
+| Postgres | SoR décision/dossier | écritures au registre échouent | **Dure** — `UNAVAILABLE` pour les RPC dossier/décision/appel |
+| ScyllaDB | historique signaux/preuves | écritures d'historique échouent | **Douce** — décisions toujours enregistrées ; historique rattrapé |
+| Redis | projection d'application + corpus Screen | lectures Plan B/C échouent | **Dure pour Plan C** (fail-closed), **Douce pour Plan B** (les consommateurs re-dénormalisent) |
+| Kafka | événements d'ingestion + application | pas d'ingestion / pas de dénorm | **Douce** — le backlog se vide à la reprise ; contenu déjà en ligne |
+| `account` (gRPC) | exécution suspension/ban | actions de cycle de vie inapplicables | **Douce** — décision enregistrée, application réessayée |
+| services de classification | signaux ML | pas de signaux ML | **Douce** — le moteur tourne sur règles déterministes uniquement |
+
+**Amont — qui dépend de `moderation` (rayon d'impact en cas de panne) :**
+
+| Appelant | Utilise | Impact visible si `moderation` est en panne |
+|---|---|---|
+| `media`, `post` | `Screen` (Plan C) | uploads de catégories catastrophiques **bloqués** (fail-closed) ; contenu normal inchangé |
+| `timeline`, `chat`, `account` | `moderation.v1.events` (Plan B) | propagation d'application retardée ; état déjà appliqué inchangé |
+| console d'opérations | API dossier/file/appel | les modérateurs ne peuvent ni trier ni décider ; le backlog croît |
+
+> **Chemin critique ?** **Partiellement** — seule la porte `Screen` (Plan C) est synchrone (et uniquement pour `media`/`post`, uniquement pour les catégories catastrophiques). Tout le reste est async/dérivé.
+
+---
+
+## 🔌 Interfaces publiques & contrat d'API &nbsp;·&nbsp; CORE
+
+### gRPC — `moderation.v1.ModerationService` *(le contrat arrive en Phase 1)*
+
+```protobuf
+// Plan C — la porte de pré-publication étroite et fail-closed (media/post uniquement).
+rpc Screen (ScreenRequest) returns (ScreenResponse);
+
+// Console d'opérations — cycle de vie dossier / file / appel.
+rpc OpenCase   (..) returns (..);   rpc AssignCase (..) returns (..);
+rpc DecideCase (..) returns (..);   rpc ListQueue  (..) returns (..);
+rpc FileAppeal (..) returns (..);   rpc ResolveAppeal (..) returns (..);
+
+// Conformité / back-office.
+rpc GetStatementOfReasons (..) returns (..);   // export DSA SoR
+rpc GetEnforcementState   (..) returns (..);   // interne ; DÉCONSEILLÉ sur le chemin chaud
+```
+
+> **Règle de contrat / wire :** la surface n'expose que des types d'intégrité normalisés — `SubjectRef` (entity_type + entity_id + actor_id + surface), catégorie de politique, type d'action, identifiants de dossier/appel — jamais de champs spécifiques aux classifieurs ou internes au contenu.
+>
+> **Règle du chemin chaud :** la flotte lit l'application via le **Plan B** (événements + projection Redis), **pas** `GetEnforcementState`. La RPC n'existe que pour le back-office/lectures froides.
+>
+> **Autorisation (exigence de déploiement) :** les RPC d'opérations mutatives (`DecideCase`, `AssignCase`, `OpenCase`, `ResolveAppeal`) sont **privilégiées** — elles bannissent/suspendent/suppriment. Le service n'autorise pas lui-même l'appelant ; les RPC mutatives **doivent** être restreintes à des principaux modérateurs authentifiés en périphérie (autorisation gateway / contrôle de permission `auth-context`, ex. `moderation:decide`) avant exposition. `Screen` et `FileAppeal` sont orientées appelant ; le reste est réservé aux modérateurs.
+
+### Ports Rust (contrat hexagonal) *(Phase 3)*
+
+`SignalSource` · `Case/Decision/Penalty/Appeal Repository` · `EnforcementProjection` (Redis) · `HashCorpus` (Screen) · `ClassifierGateway` · `AccountDirectory` (gRPC) · `EventPublisher` — AFIT, sans `async_trait`, fakes en mémoire pour la couche application.
+
+### Contrat d'erreur
+
+Chaque faute implémente `error::AppError` avec un code stable `MOD-XXXX` (voir [`src/error.rs`](src/error.rs)) :
+
+| Plage | Classe |
+|---|---|
+| `MOD-1xxx` | cycle de vie dossier |
+| `MOD-2xxx` | registre de décisions (append-only) |
+| `MOD-3xxx` | action d'application |
+| `MOD-4xxx` | pénalité / strikes / politique |
+| `MOD-5xxx` | appel |
+| `MOD-6xxx` | réception des signalements |
+| `MOD-7xxx` | porte Screen / corpus de hash (Plan C) |
+| `MOD-8xxx` | dépendances d'intégrité externes (classifieurs / annuaire de comptes) |
+| `MOD-9xxx` | transversal (domaine/parse · concurrence · publication d'événement) |
+
+`DB-*` / `SDB-*` / `RDS-*` / `VAL-*` sont délégués depuis les crates de stockage et de validation.
+
+---
+
+## 📨 Événements & contrat asynchrone &nbsp;·&nbsp; CORE
+
+> Les topics Kafka sont une API. Un changement de schéma ici casse les consommateurs exactement comme un changement de proto.
+
+**Publie :**
+
+| Topic | Déclencheur | Clé | Consommateurs |
+|---|---|---|---|
+| `moderation.v1.events` | application appliquée/annulée, dossier ouvert/résolu, appel résolu | `actor_id` | `timeline`, `chat`, `account` (dénorm Plan B) |
+
+**Consomme :**
+
+| Topic | Groupe de consommateurs | Rôle | En cas de poison/épuisement |
+|---|---|---|---|
+| `post.v1.events` / `comment.*` / contenu chat | `moderation-ingestion-consumer` | Plan A : construire le sujet, screener à bas coût, ouvrir des dossiers | DLQ `<topic>.dlq` |
+| `moderation.reports` | `moderation-report-consumer` | signalements d'abus (dédup → dossier) | DLQ `moderation.reports.dlq` |
+| `moderation.signals` | `moderation-signal-consumer` | verdicts classifieurs → moteur gradué | DLQ `moderation.signals.dlq` |
+
+> **Contrat d'exécution (obligatoire) :** tous les consommateurs tournent sous `run_consumer` — commit manuel après un résultat terminal, retry borné avec backoff + jitter, DLQ à l'épuisement/poison, reconstruction depuis le dernier offset commité en cas d'erreur broker. **Idempotence :** Cases clés par UUIDv5 déterministe de l'identité du sujet ; les sauts intentionnels (bloqué, auto-cible, dédup) se replient en `Ok` pour commiter au lieu d'inonder la DLQ.
+
+---
+
+## 🌩️ Modes de défaillance & dégradation &nbsp;·&nbsp; OPS
+
+| Défaillance | Symptôme | Comportement du service | Action opérateur |
+|---|---|---|---|
+| Redis / corpus de hash en panne | `Screen` retourne `MOD-7002/7003` | **Fail-closed** pour CSAM/NCII/TVEC → les appelants bloquent l'upload | Page ; restaurer le corpus ; les uploads reprennent |
+| Postgres en panne | RPC dossier/décision `UNAVAILABLE` | Écritures du registre échouent ; **aucune décision silencieuse** | Page ; bascule ; le backlog d'ingestion se vide ensuite |
+| Lag Kafka (ingestion) | revue retardée | contenu déjà en ligne (optimiste) ; dossiers ouverts en retard | Vérifier broker / classifieur ; le lag se résorbe |
+| `account` gRPC en panne | suspensions non appliquées | décision enregistrée ; application réessayée | Vérifier `account` ; les retries convergent |
+| classifieur en panne | moins de signaux | le moteur tourne sur **règles déterministes uniquement** | Doux ; investiguer le classifieur |
+
+**Contre-pression & limites :** la porte `Screen` a un **timeout strict + disjoncteur** (Phase 7) pour qu'une panne de modération ne bloque pas `media`/`post` ; l'ingestion régule via le lag des consommateurs, pas en jetant des messages ; la profondeur de file est le signal de charge pour la capacité de revue humaine.
+
+---
+
+## 📦 Intégration & usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+moderation = { path = "crates/services/moderation" }
+```
+
+Bibliothèque uniquement. Implémente [`service_runtime::Service`](../../platform/service-runtime/README.md) sous `moderation::service::ModerationService` *(Phase 5)* — `build` câble les adaptateurs et auto-lance les consommateurs ingestion/report/signal, `register` ajoute les services gRPC, `health_probes` expose la vivacité sur Postgres + Scylla + Redis. Télémétrie, config + rechargement à chaud, limitation de débit en entrée, santé et arrêt gracieux sont gérés par le runtime.
+
+### Amorçage (`crates/apps/moderation-server`) *(forme de la Phase 5)*
+
+```rust
+use moderation::service::ModerationService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("MODERATION_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50061".to_owned()).parse()?;
+    service_runtime::serve::<ModerationService>(addr).await
+}
+```
+
+---
+
+## ⚙️ Configuration & environnement d'exécution &nbsp;·&nbsp; CORE
+
+### Variables spécifiques à `moderation` *(croissent par phase)*
+
+| Variable | Requis | Défaut | Description |
+|---|---|---|---|
+| `MODERATION_GRPC_ADDR` | Non | `0.0.0.0:50061` | adresse de bind gRPC |
+| `MODERATION_ACCOUNT_GRPC_ENDPOINT` | Non | `http://localhost:50059` | endpoint du service `account` (exécution des suspensions) |
+| `MODERATION_SCREEN_TIMEOUT_MS` | Non | `200` | timeout strict de la porte Plan C ; à l'expiration la porte retourne `MOD-7002` et l'appelant échoue fermé pour les catégories catastrophiques |
+
+### Variables d'infrastructure héritées
+
+| Variable | Requis | Défaut | Description |
+|---|---|---|---|
+| `POSTGRES_*` | **Oui** | — | connexion SoR décision/dossier |
+| `SCYLLA_*` | **Oui** | — | connexion historique signaux/preuves |
+| `REDIS_HOSTS` | **Oui** | — | projection d'application + corpus Screen |
+| `KAFKA_BROKERS` | **Oui** | — | événements ingestion + application |
+
+> Le réglage complet connexion/timeout/reconnexion vit dans les crates de stockage/transport partagées.
+
+### Fonctionnalités à la compilation
+- `integration-moderation` *(Phase 6)* — active la suite d'intégration adossée à des conteneurs.
+- `build.rs` compile `moderation.v1` et émet le jeu de descripteurs de réflexion *(Phase 1)*.
+
+---
+
+## 🚀 Déploiement, migrations & rollback &nbsp;·&nbsp; OPS
+
+- **Migrations :** `crates/services/moderation/migrations/*.{sql,cql}` (SoR Postgres + historique Scylla) *(Phase 4)*. À appliquer **avant** de déployer le nouveau binaire, via le conteneur init `migrator`.
+- **Déploiement :** rolling ; les changements risqués du moteur de politique sont gardés par une **version de politique** épinglée (une décision enregistre la version sous laquelle elle a été prise, donc les déploiements sont auditables et réversibles).
+- **Rollback :** le rollback du binaire est sûr ; le registre de décisions est append-only et compatible en avant. **Ne jamais** muter rétroactivement une décision — enregistrer une annulation.
+- **Pièges avec état :** le **schéma de hash Screen** et la **monotonie de version par sujet** ne doivent jamais changer une fois des données présentes.
+
+---
+
+## 📈 Télémétrie, performance & métriques &nbsp;·&nbsp; CORE
+
+- **Runtime :** Tokio multi-thread (consommateurs ingestion/report/signal + gRPC). Souscripteur tracing/OTel global installé avant `serve` ; contexte de trace W3C propagé à travers la frontière Kafka.
+
+| Signal | Pourquoi c'est important | Alerte suggérée |
+|---|---|---|
+| `Screen` p99 + taux d'erreur | santé de la porte préjudice catastrophique | dépassement ⇒ page (fail-closed bloque les uploads) |
+| lag consommateur d'ingestion | latence de revue a posteriori | croissance soutenue ⇒ investiguer |
+| lag de propagation d'application | fraîcheur de la dénorm Plan B | dépassement ⇒ investiguer |
+| taux de production DLQ (`*.dlq`) | poison / retry épuisé | tout taux soutenu ⇒ page |
+| erreurs d'écriture de décision | durabilité du registre | toute occurrence ⇒ page |
+
+---
+
+## 🛠️ Développement local &nbsp;·&nbsp; CORE
+
+```bash
+cargo build  -p moderation && cargo clippy -p moderation --all-targets
+cargo test   -p moderation
+# Phase 6+ : suite d'intégration live (lance Postgres + Scylla + Redis + Kafka)
+# cargo test -p moderation --features integration-moderation
+```
+
+> **Statut de build :** complet jusqu'à la Phase 7 — contrat proto, domaine, application + ports, adaptateurs d'infrastructure (Postgres/Scylla/Redis/Kafka), câblage runtime + consommateurs d'ingestion auto-lancés, suite d'intégration live adossée à des conteneurs, et durcissement (le timeout strict du `Screen`). Les erreurs `MOD-XXXX`, les tests unitaires et la suite `integration-moderation` sont tous verts. Les métadonnées d'organisation (équipe, astreinte, chiffres SLO) et l'autorisation au niveau gateway sont des `<TODO>` de déploiement.
+
+---
+
+## 🚨 Dépannage & runbook &nbsp;·&nbsp; CORE
+
+> Format : **symptôme → cause racine → mitigation.** Une entrée par classe d'incident réelle.
+
+**1. Uploads `media`/`post` échouant avec `MOD-7002`/`MOD-7003`.**
+Cause racine : la porte `Screen` ou le corpus de hash (Redis) est indisponible ; pour les catégories de préjudice catastrophique, la politique de l'appelant est **fail-closed**, donc les uploads sont bloqués par conception. Mitigation : restaurer le corpus Redis ; vérifier `MODERATION_SCREEN_TIMEOUT_MS` ; les uploads reprennent automatiquement une fois la porte saine.
+
+**2. Un contenu qui devrait être actionné est encore visible.**
+Cause racine : lag de dénormalisation Plan B (événement d'application pas encore consommé par `timeline`/`chat`) **ou** le backlog d'ingestion n'a pas encore atteint le sujet (le Plan A est a posteriori). Mitigation : vérifier le lag des consommateurs de `moderation.v1.events` en aval et le lag du consommateur d'ingestion ; confirmer que l'`EnforcementAction` existe dans Postgres et sa clé de projection Redis `mod:enf:{actor:<id>}`.
+
+**3. Le taux de production `*.dlq` grimpe.**
+Cause racine : signaux/signalements poison ou une dépendance épuisée. Mitigation : inspecter les en-têtes `x-dlq-*` ; si panne de dépendance, corriger et rejouer depuis la DLQ ; si réellement poison, laisser parqué et trier.

--- a/crates/services/moderation/README.md
+++ b/crates/services/moderation/README.md
@@ -1,0 +1,295 @@
+# `moderation` — Decide, enforce, and prove integrity actions without taxing every write in the network
+
+> **Service Card** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Owner** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **On-call / escalation** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-0** — legal/compliance system of record; the `Screen` gate is in the synchronous publish path for catastrophic-harm categories |
+> | **Deployable** | `crates/apps/moderation-server` (library crate: `crates/services/moderation`) |
+> | **Datastores** | Postgres db `moderation` (decision/case SoR) · ScyllaDB keyspace `moderation` (signal/evidence history) · Redis Cluster (enforcement projection + Screen hash corpus) |
+> | **Async** | publishes `moderation.v1.events` · consumes `post.v1.events`, `comment.*`, chat content, `moderation.reports`, `moderation.signals` (Kafka) |
+> | **Upstream callers** | `media`, `post` (Screen gate); internal ops console (case/queue/appeal API) |
+> | **Downstream deps** | `account` (gRPC — suspension execution), classifier services (signals), Postgres, ScyllaDB, Redis, Kafka |
+> | **SLO** | `<TODO>` avail · `Screen` p99 `< <TODO> ms` · async review lag `< <TODO> s` |
+
+---
+
+## 🎯 Overview & Service Role
+
+`moderation` is the **trust, safety & compliance** microservice: it owns the *integrity decision of record* — what action was taken against which entity, under which policy version, with what evidence — and is the authoritative, auditable source of that fact for the rest of the fleet and for regulators.
+
+The hard problem it solves is **doing moderation at the network's write-volume without becoming a global latency bottleneck**. A naive design calls a moderation RPC on every post, message, and upload; that taxes every write and couples content availability to an integrity outage. The resolving pattern is a **three-plane split**: the heavy classification/review path is decoupled from the hot decision path.
+
+**Core objectives:** (1) content is reviewed **post-hoc and asynchronously** by default — zero added latency on the user's write path; (2) the hot *read* path reads **denormalized enforcement state**, never a per-item moderation RPC; (3) only a narrow, **fail-closed** synchronous `Screen` gate guards catastrophic-harm categories; (4) every enforcement is an **immutable, auditable** record sufficient for DSA / NCMEC / law-enforcement obligations.
+
+| Plane | Path | Latency contract | Used for |
+|---|---|---|---|
+| **A — Ingestion** | async Kafka consumers | none (off the write path) | ~99% of content: optimistic publish, post-hoc review |
+| **B — Enforcement state** | events + Redis projection | local / O(1) | "is this actor restricted / content hidden" on the hot read path |
+| **C — Screen gate** | synchronous gRPC | bounded, hard-timeout | CSAM / NCII / TVEC only — deterministic hash lookup, fail-closed |
+
+---
+
+## 📐 Architecture & Concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), CQRS where it fits, a **three-store split**, Kafka for ingestion and enforcement events.
+
+```
+                         user reports          classifier signals
+                              │                        │
+  post/comment/chat/media     ▼                        ▼
+  *.created  ─────────►  moderation.reports     moderation.signals
+       │                      │                        │
+       ▼                      ▼                        ▼
+  ┌──────────────── Plane A: ingestion consumers (run_consumer) ───────────────┐
+  │  cheap deterministic checks (blocklist · known-bad hash · actor history)    │
+  │  → fan-out to async classifiers → open Case on threshold                    │
+  └───────────────┬───────────────────────────────────────────────┬───────────┘
+                  ▼                                                 ▼
+        graduated-enforcement engine                       Scylla: signal /
+        (PenaltyLedger · policy version)                   evidence history (TWCS)
+                  │
+                  ▼
+        Postgres SoR: cases · decisions(WORM) · appeals · penalty_ledger · policy_versions
+                  │
+   ┌──────────────┼───────────────────────────────────────────────┐
+   ▼              ▼                                                 ▼
+ moderation.v1.events            Redis projection                Plane C: Screen
+ (Plane B denorm:            mod:enf:{actor:<id>}  ◄── hot-read   (hash corpus / bloom,
+  timeline/chat/account)     synchronous O(1) checks              fail-closed gate)
+```
+
+**Enforcement consistency.** Each `EnforcementAction` carries a **monotonic version per subject**, so a reversal can never race ahead of a re-application (the same generation discipline `auth` uses for sessions). Enforcement events are **keyed by `actor_id`** for per-actor ordering.
+
+> **Invariants** (and where enforced):
+> - **Decisions are append-only** (`decisions` is the legal evidence ledger; a reversal is a *new* decision, never a mutation) — domain + Postgres.
+> - **Screen is deterministic and inference-free** — only hash/blocklist lookups; ML never runs inline (infrastructure boundary).
+> - **Per-category fail policy** — CSAM/NCII/TVEC fail **closed** (block on uncertainty or gate outage); spam/borderline fail **open** (stays up, reviewed async) — application layer.
+> - **Domain idempotency** — Cases keyed by deterministic UUIDv5 of subject identity; redelivery is real (consumer standard).
+
+---
+
+## 📊 Service Level Objectives (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objective | Window | Measured by |
+|---|---|---|---|
+| `Screen` availability (Plane C) | `<TODO 99.95%>` | 30d rolling | `<metric>` |
+| `Screen` latency p99 | `< <TODO> ms` (hash-lookup only) | 1h | `<metric>` |
+| Ingestion review lag (Plane A) | `< <TODO> s` | live | `moderation-ingestion-consumer` lag |
+| Enforcement propagation (decision → Plane B visible) | `< <TODO> s` | 1h | `<metric>` |
+| Decision-ledger durability | no acked decision lost | — | Postgres synchronous commit |
+
+**Error budget:** `<TODO>`. **On burn:** `<TODO: freeze rollout | page>`. **Special rule:** a sustained `Screen`/`HashCorpus` outage is a **fail-closed** event — uploads in catastrophic categories are blocked, not degraded; page immediately.
+
+---
+
+## 🔗 Dependencies & Blast Radius &nbsp;·&nbsp; OPS
+
+**Downstream — what `moderation` needs to function:**
+
+| Dependency | Purpose | If down → | Degradation |
+|---|---|---|---|
+| Postgres | decision/case SoR | writes to the ledger fail | **Hard** — `UNAVAILABLE` for case/decision/appeal RPCs |
+| ScyllaDB | signal/evidence history | history writes fail | **Soft** — decisions still recorded; history backfilled |
+| Redis | enforcement projection + Screen corpus | Plane B/C reads fail | **Hard for Plane C** (fail-closed), **Soft for Plane B** (consumers re-denormalize) |
+| Kafka | ingestion + enforcement events | no ingestion / no denorm | **Soft** — backlog drains on recovery; content already live |
+| `account` (gRPC) | suspension/ban execution | lifecycle actions can't apply | **Soft** — decision recorded, enforcement retried |
+| classifier services | ML signals | no ML signals | **Soft** — engine runs on deterministic rules only |
+
+**Upstream — who depends on `moderation` (blast radius if it fails):**
+
+| Caller | Uses | User-visible impact if `moderation` is down |
+|---|---|---|
+| `media`, `post` | `Screen` (Plane C) | catastrophic-category uploads **blocked** (fail-closed); normal content unaffected |
+| `timeline`, `chat`, `account` | `moderation.v1.events` (Plane B) | enforcement propagation delayed; already-applied state unchanged |
+| ops console | case/queue/appeal API | reviewers cannot triage/decide; backlog grows |
+
+> **Critical path?** **Partially** — only the Plane C `Screen` gate is synchronous (and only for `media`/`post`, only for catastrophic categories). Everything else is async/derived.
+
+---
+
+## 🔌 Public Interfaces & API Contract &nbsp;·&nbsp; CORE
+
+### gRPC — `moderation.v1.ModerationService` *(contract lands in Phase 1)*
+
+```protobuf
+// Plane C — the narrow, fail-closed pre-publish gate (media/post only).
+rpc Screen (ScreenRequest) returns (ScreenResponse);
+
+// Ops console — case / queue / appeal lifecycle.
+rpc OpenCase   (..) returns (..);   rpc AssignCase (..) returns (..);
+rpc DecideCase (..) returns (..);   rpc ListQueue  (..) returns (..);
+rpc FileAppeal (..) returns (..);   rpc ResolveAppeal (..) returns (..);
+
+// Compliance / back-office.
+rpc GetStatementOfReasons (..) returns (..);   // DSA SoR export
+rpc GetEnforcementState   (..) returns (..);   // internal; DISCOURAGED on hot path
+```
+
+> **Wire / contract rule:** the surface exposes only normalized integrity types — `SubjectRef` (entity_type + entity_id + actor_id + surface), policy category, action type, case/appeal ids — never classifier-vendor or content-internal fields.
+>
+> **Hot-path rule:** the fleet reads enforcement via **Plane B** (events + Redis projection), **not** `GetEnforcementState`. The RPC exists for back-office/cold reads only.
+>
+> **Authorization (deployment requirement):** the mutating ops RPCs (`DecideCase`, `AssignCase`, `OpenCase`, `ResolveAppeal`) are **privileged** — they ban/suspend/remove. The service does not self-authorize the caller; mutating RPCs **must** be restricted to authenticated reviewer principals at the edge (gateway authz / `auth-context` permission gate, e.g. `moderation:decide`) before exposure. `Screen` and `FileAppeal` are caller-facing; the rest are reviewer-only.
+
+### Rust ports (hexagonal contract) *(Phase 3)*
+
+`SignalSource` · `Case/Decision/Penalty/Appeal Repository` · `EnforcementProjection` (Redis) · `HashCorpus` (Screen) · `ClassifierGateway` · `AccountDirectory` (gRPC) · `EventPublisher` — AFIT, no `async_trait`, in-memory fakes for the application tier.
+
+### Error contract
+
+Every fault implements `error::AppError` with a stable `MOD-XXXX` code (see [`src/error.rs`](src/error.rs)):
+
+| Range | Class |
+|---|---|
+| `MOD-1xxx` | case lifecycle |
+| `MOD-2xxx` | decision ledger (append-only) |
+| `MOD-3xxx` | enforcement action |
+| `MOD-4xxx` | penalty / strikes / policy |
+| `MOD-5xxx` | appeal |
+| `MOD-6xxx` | report intake |
+| `MOD-7xxx` | Screen gate / hash corpus (Plane C) |
+| `MOD-8xxx` | external integrity deps (classifiers / account directory) |
+| `MOD-9xxx` | cross-cutting (domain/parse · concurrency · event publish) |
+
+`DB-*` / `SDB-*` / `RDS-*` / `VAL-*` are delegated from the storage and validation crates.
+
+---
+
+## 📨 Events & Async Contract &nbsp;·&nbsp; CORE
+
+> Kafka topics are an API. A schema change here breaks consumers exactly like a proto change.
+
+**Publishes:**
+
+| Topic | Trigger | Key | Consumers |
+|---|---|---|---|
+| `moderation.v1.events` | enforcement applied/reversed, case opened/resolved, appeal resolved | `actor_id` | `timeline`, `chat`, `account` (Plane B denorm) |
+
+**Consumes:**
+
+| Topic | Consumer group | Purpose | On poison/exhaustion |
+|---|---|---|---|
+| `post.v1.events` / `comment.*` / chat content | `moderation-ingestion-consumer` | Plane A: build subject, screen cheaply, open cases | DLQ `<topic>.dlq` |
+| `moderation.reports` | `moderation-report-consumer` | user abuse reports (dedup → case) | DLQ `moderation.reports.dlq` |
+| `moderation.signals` | `moderation-signal-consumer` | classifier verdicts → graduated engine | DLQ `moderation.signals.dlq` |
+
+> **Runtime contract (mandatory):** all consumers run under `run_consumer` — manual commit after a terminal outcome, bounded retry with backoff + jitter, DLQ on exhaustion/poison, rebuild-from-last-committed-offset on broker error. **Idempotency:** Cases keyed by deterministic UUIDv5 of subject identity; intentional skips (block-gated, self-target, dedup) fold into `Ok` so they commit rather than flood the DLQ.
+
+---
+
+## 🌩️ Failure Modes & Degradation &nbsp;·&nbsp; OPS
+
+| Failure | Symptom | Service behavior | Operator action |
+|---|---|---|---|
+| Redis / hash corpus down | `Screen` returns `MOD-7002/7003` | **Fail-closed** for CSAM/NCII/TVEC → callers block the upload | Page; restore corpus; uploads resume |
+| Postgres down | case/decision RPCs `UNAVAILABLE` | Ledger writes fail; **no silent decisions** | Page; failover; ingestion backlog drains after |
+| Kafka lag (ingestion) | review delayed | content already live (optimistic); cases open late | Check broker / classifier; lag self-drains |
+| `account` gRPC down | suspensions not applied | decision recorded; enforcement retried | Check `account`; retries converge |
+| classifier down | fewer signals | engine runs on **deterministic rules only** | Soft; investigate classifier |
+
+**Backpressure & limits:** the `Screen` gate has a **hard timeout + circuit breaker** (Phase 7) so a moderation outage can't wedge `media`/`post`; ingestion sheds via consumer lag, not by dropping; queue depth is the load signal for human-review capacity.
+
+---
+
+## 📦 Integration & Usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+moderation = { path = "crates/services/moderation" }
+```
+
+Library-only. Implements [`service_runtime::Service`](../../platform/service-runtime/README.md) as `moderation::service::ModerationService` *(Phase 5)* — `build` wires adapters and self-spawns the ingestion/report/signal consumers, `register` adds the gRPC services, `health_probes` exposes liveness over Postgres + Scylla + Redis. Telemetry, config + hot-reload, ingress rate-limiting, health, and graceful shutdown are owned by the runtime.
+
+### Bootstrap (`crates/apps/moderation-server`) *(Phase 5 shape)*
+
+```rust
+use moderation::service::ModerationService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("MODERATION_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50061".to_owned()).parse()?;
+    service_runtime::serve::<ModerationService>(addr).await
+}
+```
+
+---
+
+## ⚙️ Configuration & Runtime Environment &nbsp;·&nbsp; CORE
+
+### `moderation`-specific variables *(grow per phase)*
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MODERATION_GRPC_ADDR` | No | `0.0.0.0:50061` | gRPC bind address |
+| `MODERATION_ACCOUNT_GRPC_ENDPOINT` | No | `http://localhost:50059` | `account` service endpoint (suspension execution) |
+| `MODERATION_SCREEN_TIMEOUT_MS` | No | `200` | hard timeout for the Plane C gate; on elapse the gate returns `MOD-7002` and the caller fails closed for catastrophic categories |
+
+### Inherited infrastructure variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `POSTGRES_*` | **Yes** | — | decision/case SoR connection |
+| `SCYLLA_*` | **Yes** | — | signal/evidence history connection |
+| `REDIS_HOSTS` | **Yes** | — | enforcement projection + Screen corpus |
+| `KAFKA_BROKERS` | **Yes** | — | ingestion + enforcement events |
+
+> Full connection/timeout/reconnect tuning lives in the shared storage/transport crates.
+
+### Compile-time features
+- `integration-moderation` *(Phase 6)* — gates the container-backed integration suite.
+- `build.rs` compiles `moderation.v1` and emits the reflection descriptor set *(Phase 1)*.
+
+---
+
+## 🚀 Deployment, Migrations & Rollback &nbsp;·&nbsp; OPS
+
+- **Migrations:** `crates/services/moderation/migrations/*.{sql,cql}` (Postgres SoR + Scylla history) *(Phase 4)*. Apply **before** rolling the new binary, via the `migrator` init container.
+- **Rollout:** rolling; risky policy-engine changes gate behind a pinned **policy version** (a decision records the version it was made under, so rollouts are auditable and reversible).
+- **Rollback:** binary rollback is safe; the decision ledger is append-only and forward-compatible. **Never** retro-mutate a decision — record a reversal.
+- **Stateful gotchas:** the **Screen hash scheme** and the **subject-version** monotonicity must never change after data exists.
+
+---
+
+## 📈 Telemetry, Performance & Metrics &nbsp;·&nbsp; CORE
+
+- **Runtime:** multi-threaded Tokio (ingestion/report/signal consumers + gRPC). Global tracing/OTel subscriber installed before `serve`; W3C trace-context propagated across the Kafka boundary.
+
+| Signal | Why it matters | Suggested alert |
+|---|---|---|
+| `Screen` p99 + error rate | catastrophic-harm gate health | breach ⇒ page (fail-closed blocks uploads) |
+| ingestion consumer lag | post-hoc review latency | sustained growth ⇒ investigate |
+| enforcement propagation lag | Plane B denorm freshness | breach ⇒ investigate |
+| DLQ produce rate (`*.dlq`) | poison / retry-exhausted | any sustained rate ⇒ page |
+| decision write errors | ledger durability | any ⇒ page |
+
+---
+
+## 🛠️ Local Development &nbsp;·&nbsp; CORE
+
+```bash
+cargo build  -p moderation && cargo clippy -p moderation --all-targets
+cargo test   -p moderation
+# Phase 6+: live integration suite (boots Postgres + Scylla + Redis + Kafka)
+# cargo test -p moderation --features integration-moderation
+```
+
+> **Build status:** complete through Phase 7 — proto contract, domain, application + ports, infrastructure adapters (Postgres/Scylla/Redis/Kafka), runtime wiring + self-spawned ingestion consumers, a live container-backed integration suite, and hardening (the `Screen` hard timeout). `MOD-XXXX` errors, unit tests, and the `integration-moderation` suite are all green. Org metadata (owner, on-call, SLO numbers) and gateway authorization are deployment-time `<TODO>`s.
+
+---
+
+## 🚨 Troubleshooting & Runbook &nbsp;·&nbsp; CORE
+
+> Format: **symptom → root cause → mitigation.** One entry per real incident class.
+
+**1. `media`/`post` uploads failing with `MOD-7002`/`MOD-7003`.**
+Root cause: the `Screen` gate or hash corpus (Redis) is unavailable; for catastrophic-harm categories the caller's policy is **fail-closed**, so uploads are blocked by design. Mitigation: restore the Redis corpus; verify `MODERATION_SCREEN_TIMEOUT_MS`; uploads resume automatically once the gate is healthy.
+
+**2. Content that should be actioned is still visible.**
+Root cause: Plane B denormalization lag (enforcement event not yet consumed by `timeline`/`chat`) **or** the ingestion backlog hasn't reached the subject yet (Plane A is post-hoc). Mitigation: check `moderation.v1.events` consumer lag downstream and ingestion consumer lag; confirm the `EnforcementAction` exists in Postgres and its Redis projection key `mod:enf:{actor:<id>}`.
+
+**3. `*.dlq` produce rate climbing.**
+Root cause: poison signals/reports or an exhausted dependency. Mitigation: inspect `x-dlq-*` headers; if a dependency outage, fix and replay from DLQ; if genuinely poison, leave parked and triage.

--- a/crates/services/moderation/migrations/0001_create_moderation_history.cql
+++ b/crates/services/moderation/migrations/0001_create_moderation_history.cql
@@ -1,0 +1,31 @@
+-- Migration: 0001_create_moderation_history (ScyllaDB)
+-- Description: The high-volume, append-only evidence/history time-series — the
+--              denormalized audit feed projected from the moderation event stream.
+--              Postgres is the decision/case system of record; this store retains
+--              the firehose of moderation events per actor for transparency
+--              reporting, law-enforcement preservation, and model training.
+--              Bucketed and TWCS-compacted: write-heavy, time-ordered, never
+--              updated in place.
+
+CREATE KEYSPACE IF NOT EXISTS moderation
+    WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3};
+
+-- One row per moderation event, clustered newest-first within an actor's feed.
+-- `event` holds the serialized DomainEvent JSON; the typed columns make the feed
+-- queryable by time/category without deserializing every row.
+-- event_id is a UUIDv7 (time-ordered) tiebreaker — avoids v1/timeuuid.
+CREATE TABLE IF NOT EXISTS moderation.evidence_history (
+    actor_id     uuid,
+    occurred_at  timestamp,
+    event_id     uuid,
+    event_type   text,
+    entity_type  text,
+    entity_id    text,
+    category     text,
+    action       text,
+    event        text,
+    PRIMARY KEY ((actor_id), occurred_at, event_id)
+) WITH CLUSTERING ORDER BY (occurred_at DESC, event_id DESC)
+  AND compaction = {'class': 'TimeWindowCompactionStrategy',
+                    'compaction_window_unit': 'DAYS',
+                    'compaction_window_size': 1};

--- a/crates/services/moderation/migrations/0001_create_moderation_tables.sql
+++ b/crates/services/moderation/migrations/0001_create_moderation_tables.sql
@@ -1,0 +1,107 @@
+-- Migration: 0001_create_moderation_tables
+-- Description: Durable system of record for the moderation bounded context — the
+--              review-case workbench, the append-only decision ledger (the legal
+--              evidence record), the enforcement-action lifecycle, the per-actor
+--              penalty ledger, and the appeal lifecycle. Pure ANSI SQL, portable
+--              across PostgreSQL and CockroachDB. Every table carries an actor_id
+--              so an actor's moderation state co-locates on one shard.
+
+-- ── Cases ────────────────────────────────────────────────────────────────────
+-- One row per review subject. `id` is the deterministic UUIDv5 of the subject, so
+-- a redelivered content event upserts the same case instead of duplicating.
+-- Accrued evidence signals are stored as JSON (they are an unbounded list read as
+-- a whole, never queried field-wise).
+CREATE TABLE IF NOT EXISTS cases (
+    id            UUID         NOT NULL,
+    entity_type   TEXT         NOT NULL,
+    entity_id     TEXT         NOT NULL,
+    actor_id      UUID         NOT NULL,
+    surface       TEXT         NOT NULL,
+    status        TEXT         NOT NULL DEFAULT 'open',
+    category      TEXT         NOT NULL,
+    queue         TEXT         NOT NULL,
+    priority      TEXT         NOT NULL,
+    assignee      TEXT,
+    signals       JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    opened_at     TIMESTAMPTZ  NOT NULL,
+    version       BIGINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+);
+
+-- The triage queue read path: open work in a queue, newest first.
+CREATE INDEX IF NOT EXISTS idx_cases_queue_status
+    ON cases (queue, status, opened_at DESC);
+
+-- ── Decisions (append-only ledger) ───────────────────────────────────────────
+-- The legal evidence record. Rows are NEVER updated; a reversal is a new row that
+-- references the one it supersedes via `reverses`.
+CREATE TABLE IF NOT EXISTS decisions (
+    id             UUID         NOT NULL,
+    entity_type    TEXT         NOT NULL,
+    entity_id      TEXT         NOT NULL,
+    actor_id       UUID         NOT NULL,
+    surface        TEXT         NOT NULL,
+    action         TEXT         NOT NULL,
+    category       TEXT         NOT NULL,
+    policy_version TEXT         NOT NULL,
+    rationale      TEXT         NOT NULL,
+    author_kind    TEXT         NOT NULL, -- 'reviewer' | 'rule'
+    author_id      TEXT         NOT NULL,
+    reverses       UUID,
+    decided_at     TIMESTAMPTZ  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- Transparency reporting & an actor's decision history.
+CREATE INDEX IF NOT EXISTS idx_decisions_actor      ON decisions (actor_id, decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_decisions_category   ON decisions (category, decided_at DESC);
+
+-- ── Enforcement actions ──────────────────────────────────────────────────────
+-- The executable consequence of a decision. `version` is monotonic per subject so
+-- a reversal can never race ahead of a newer re-application.
+CREATE TABLE IF NOT EXISTS enforcements (
+    id            UUID         NOT NULL,
+    entity_type   TEXT         NOT NULL,
+    entity_id     TEXT         NOT NULL,
+    actor_id      UUID         NOT NULL,
+    surface       TEXT         NOT NULL,
+    action        TEXT         NOT NULL,
+    status        TEXT         NOT NULL DEFAULT 'active',
+    version       BIGINT       NOT NULL,
+    decision_id   UUID         NOT NULL,
+    applied_at    TIMESTAMPTZ  NOT NULL,
+    expires_at    TIMESTAMPTZ,
+    reversed_at   TIMESTAMPTZ,
+    PRIMARY KEY (id)
+);
+
+-- next_version(subject): MAX(version) over a subject's enforcements.
+CREATE INDEX IF NOT EXISTS idx_enforcements_subject
+    ON enforcements (entity_type, entity_id, surface, version DESC);
+-- Active enforcements for an actor (GetEnforcementState / appeal reversal).
+CREATE INDEX IF NOT EXISTS idx_enforcements_actor_status
+    ON enforcements (actor_id, status);
+
+-- ── Penalty ledgers ──────────────────────────────────────────────────────────
+-- One row per actor; the graduated-enforcement strike history (each strike's
+-- snapshotted points + decay deadline) is stored as JSON and evaluated in-domain.
+CREATE TABLE IF NOT EXISTS penalty_ledgers (
+    actor_id      UUID         NOT NULL,
+    strikes       JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    version       BIGINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (actor_id)
+);
+
+-- ── Appeals ──────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS appeals (
+    id            UUID         NOT NULL,
+    decision_id   UUID         NOT NULL,
+    actor_id      UUID         NOT NULL,
+    statement     TEXT         NOT NULL,
+    status        TEXT         NOT NULL DEFAULT 'filed',
+    filed_at      TIMESTAMPTZ  NOT NULL,
+    resolved_at   TIMESTAMPTZ,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_appeals_decision ON appeals (decision_id);

--- a/crates/services/moderation/src/app.rs
+++ b/crates/services/moderation/src/app.rs
@@ -1,0 +1,327 @@
+//! The moderation service's composition root.
+//!
+//! [`App::compose`] is *pure* wiring: the ten port handles in, the assembled gRPC
+//! handler out — it binds no socket and reads no environment, so the live
+//! integration harness and the binary entrypoint build the exact same graph.
+//! [`App::build`] is the I/O variant that constructs the concrete adapters from
+//! config + backend connections, then defers to `compose`. It also retains the
+//! ingestion handlers so [`crate::service`] can self-spawn the Plane A consumers.
+
+use std::sync::Arc;
+
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaClient, ScyllaConfig, ScyllaSessionBuilder};
+use sqlx::PgPool;
+use tonic::transport::Channel;
+use transport::kafka::config::client::KafkaClientConfig;
+use transport::kafka::config::producer::ProducerConfig;
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::application::command::{
+    AssignCaseHandler, DecideCaseHandler, FileAppealHandler, IngestReportHandler,
+    IngestSignalHandler, OpenCaseHandler, ResolveAppealHandler, ScreenHandler,
+};
+use crate::application::port::{
+    AccountDirectory, AppealRepository, CaseRepository, ClassifierGateway, DecisionRepository,
+    EnforcementProjection, EnforcementRepository, EventPublisher, PenaltyRepository, ScreenCorpus,
+};
+use crate::application::query::{
+    GetEnforcementStateHandler, GetStatementOfReasonsHandler, ListQueueHandler,
+};
+use crate::application::ModerationPolicy;
+use crate::config::ModerationConfig;
+use crate::infrastructure::cache::{RedisEnforcementProjection, RedisScreenCorpus};
+use crate::infrastructure::classifier::LogClassifierGateway;
+use crate::infrastructure::directory::GrpcAccountDirectory;
+use crate::infrastructure::event::{
+    FanoutEventPublisher, KafkaEventPublisher, LogEventPublisher,
+};
+use crate::infrastructure::grpc::ModerationServiceHandler;
+use crate::infrastructure::history::ScyllaEvidenceHistory;
+use crate::infrastructure::persistence::{
+    PgAppealRepository, PgCaseRepository, PgDecisionRepository, PgEnforcementRepository,
+    PgPenaltyRepository,
+};
+
+/// The ten ports the application layer depends on, plus the policy.
+pub struct AppDeps {
+    pub cases: Arc<dyn CaseRepository>,
+    pub decisions: Arc<dyn DecisionRepository>,
+    pub enforcements: Arc<dyn EnforcementRepository>,
+    pub penalties: Arc<dyn PenaltyRepository>,
+    pub appeals: Arc<dyn AppealRepository>,
+    pub projection: Arc<dyn EnforcementProjection>,
+    pub corpus: Arc<dyn ScreenCorpus>,
+    pub classifiers: Arc<dyn ClassifierGateway>,
+    pub accounts: Arc<dyn AccountDirectory>,
+    pub publisher: Arc<dyn EventPublisher>,
+    pub policy: ModerationPolicy,
+}
+
+/// Backend connection configs. `kafka` is optional: absent ⇒ the log publisher.
+pub struct Backends {
+    pub postgres: PostgresConfig,
+    pub scylla: ScyllaConfig,
+    pub redis: RedisConfig,
+    pub kafka: Option<KafkaClientConfig>,
+}
+
+/// A fully-wired moderation service. Retains the storage clients so the runtime
+/// builds liveness probes over the same connections, and the ingestion handlers
+/// so the service self-spawns the Plane A consumers.
+pub struct App {
+    pub handler: ModerationServiceHandler,
+    pub ingest_report: Arc<IngestReportHandler>,
+    pub ingest_signal: Arc<IngestSignalHandler>,
+    pub pool: PgPool,
+    pub scylla: Arc<ScyllaClient>,
+    pub redis: RedisClient,
+}
+
+impl App {
+    /// Pure composition: assemble the nine application handlers from the ports and
+    /// wrap them in the gRPC handler. No I/O — drives the unit/integration graph.
+    pub fn compose(deps: AppDeps) -> ModerationServiceHandler {
+        let screen = Arc::new(ScreenHandler::new(
+            Arc::clone(&deps.corpus),
+            Arc::clone(&deps.decisions),
+            Arc::clone(&deps.enforcements),
+            Arc::clone(&deps.penalties),
+            Arc::clone(&deps.projection),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let open_case =
+            Arc::new(OpenCaseHandler::new(Arc::clone(&deps.cases), Arc::clone(&deps.publisher)));
+        let assign_case = Arc::new(AssignCaseHandler::new(Arc::clone(&deps.cases)));
+        let decide_case = Arc::new(DecideCaseHandler::new(
+            Arc::clone(&deps.cases),
+            Arc::clone(&deps.decisions),
+            Arc::clone(&deps.enforcements),
+            Arc::clone(&deps.penalties),
+            Arc::clone(&deps.projection),
+            Arc::clone(&deps.accounts),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let list_queue = Arc::new(ListQueueHandler::new(Arc::clone(&deps.cases)));
+        let file_appeal = Arc::new(FileAppealHandler::new(
+            Arc::clone(&deps.decisions),
+            Arc::clone(&deps.appeals),
+            Arc::clone(&deps.cases),
+        ));
+        let resolve_appeal = Arc::new(ResolveAppealHandler::new(
+            Arc::clone(&deps.appeals),
+            Arc::clone(&deps.decisions),
+            Arc::clone(&deps.enforcements),
+            Arc::clone(&deps.cases),
+            Arc::clone(&deps.projection),
+            Arc::clone(&deps.publisher),
+        ));
+        let statement_of_reasons =
+            Arc::new(GetStatementOfReasonsHandler::new(Arc::clone(&deps.decisions)));
+        let enforcement_state = Arc::new(GetEnforcementStateHandler::new(
+            Arc::clone(&deps.projection),
+            Arc::clone(&deps.enforcements),
+        ));
+
+        ModerationServiceHandler::new(
+            screen,
+            open_case,
+            assign_case,
+            decide_case,
+            list_queue,
+            file_appeal,
+            resolve_appeal,
+            statement_of_reasons,
+            enforcement_state,
+        )
+    }
+
+    /// Builds the concrete adapter graph from config + backend connections.
+    pub async fn build(
+        config: ModerationConfig,
+        backends: Backends,
+    ) -> Result<App, Box<dyn std::error::Error>> {
+        let pool = PgPoolBuilder::build(backends.postgres).await?;
+        let tx = TransactionManager::new(pool.clone());
+        let scylla = Arc::new(ScyllaSessionBuilder::new(backends.scylla).build().await?);
+        let redis = RedisClientBuilder::new(backends.redis).build().await?;
+
+        // Kafka is the authoritative Plane B notification; the Scylla evidence
+        // history is a best-effort audit sink composed alongside it.
+        let primary: Arc<dyn EventPublisher> = match backends.kafka {
+            Some(cfg) => {
+                let producer = KafkaProducerBuilder::new(ProducerConfig::new(cfg)).build()?;
+                Arc::new(KafkaEventPublisher::new(producer))
+            }
+            None => Arc::new(LogEventPublisher),
+        };
+        let history: Arc<dyn EventPublisher> = Arc::new(ScyllaEvidenceHistory::new(scylla.clone()));
+        let publisher: Arc<dyn EventPublisher> =
+            Arc::new(FanoutEventPublisher::new(primary, vec![history]));
+
+        // Lazy connect: dials `account` on first use, so a cold start does not
+        // require the dependency to be up at boot.
+        let channel = Channel::from_shared(config.account_endpoint)?.connect_lazy();
+
+        let deps = AppDeps {
+            cases: Arc::new(PgCaseRepository::new(tx.clone())),
+            decisions: Arc::new(PgDecisionRepository::new(tx.clone())),
+            enforcements: Arc::new(PgEnforcementRepository::new(tx.clone())),
+            penalties: Arc::new(PgPenaltyRepository::new(tx.clone())),
+            appeals: Arc::new(PgAppealRepository::new(tx.clone())),
+            projection: Arc::new(RedisEnforcementProjection::new(redis.clone())),
+            corpus: Arc::new(RedisScreenCorpus::new(redis.clone())),
+            classifiers: Arc::new(LogClassifierGateway),
+            accounts: Arc::new(GrpcAccountDirectory::new(channel)),
+            publisher,
+            policy: config.policy,
+        };
+
+        // The ingestion handlers share the same ports; build them before `compose`
+        // consumes `deps`.
+        let ingest_report = Arc::new(IngestReportHandler::new(
+            Arc::clone(&deps.cases),
+            Arc::clone(&deps.publisher),
+            Arc::clone(&deps.classifiers),
+        ));
+        let ingest_signal = Arc::new(IngestSignalHandler::new(
+            Arc::clone(&deps.cases),
+            Arc::clone(&deps.publisher),
+        ));
+
+        let handler = App::compose(deps);
+        Ok(App { handler, ingest_report, ingest_signal, pool, scylla, redis })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::OpenCaseCommand;
+    use crate::application::fakes::Fixture;
+    use crate::domain::value_object::{ActorId, EntityType, PolicyCategory, SubjectRef};
+    use crate::infrastructure::grpc::proto;
+    use cqrs::Envelope;
+    use tonic::{Code, Request};
+    use uuid::Uuid;
+
+    /// Composes the gRPC handler over the in-memory fakes — the exact graph
+    /// `App::build` produces, minus the real backends.
+    fn handler_from_fakes(fx: &Fixture) -> ModerationServiceHandler {
+        App::compose(AppDeps {
+            cases: fx.cases.clone(),
+            decisions: fx.decisions.clone(),
+            enforcements: fx.enforcements.clone(),
+            penalties: fx.penalties.clone(),
+            appeals: fx.appeals.clone(),
+            projection: fx.projection.clone(),
+            corpus: fx.corpus.clone(),
+            classifiers: fx.classifiers.clone(),
+            accounts: fx.accounts.clone(),
+            publisher: fx.publisher.clone(),
+            policy: fx.policy.clone(),
+        })
+    }
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Media, "m1", ActorId::from_uuid(Uuid::from_u128(1)), "upload").unwrap()
+    }
+
+    #[tokio::test]
+    async fn screen_rpc_blocks_a_known_bad_hash() {
+        let fx = Fixture::new();
+        fx.corpus.add_known_bad("abc", vec![PolicyCategory::Csam], "ncmec:1");
+        let handler = handler_from_fakes(&fx);
+
+        let request = Request::new(proto::ScreenRequest {
+            subject: Some(proto::SubjectRef {
+                entity_type: proto::EntityType::Media as i32,
+                entity_id: "m1".into(),
+                actor_id: ActorId::from_uuid(Uuid::from_u128(1)).as_str(),
+                surface: "upload".into(),
+            }),
+            hashes: vec![proto::ContentHash { algorithm: "pdq".into(), value: "abc".into() }],
+            text: String::new(),
+            categories: vec![proto::PolicyCategory::Csam as i32],
+        });
+
+        let resp = handler.screen(request).await.unwrap().into_inner();
+        assert_eq!(resp.verdict, proto::ScreenVerdict::Block as i32);
+        assert_eq!(resp.match_reference, "ncmec:1");
+    }
+
+    #[tokio::test]
+    async fn screen_rpc_allows_clean_content() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::ScreenRequest {
+            subject: Some(proto::SubjectRef {
+                entity_type: proto::EntityType::Media as i32,
+                entity_id: "m1".into(),
+                actor_id: ActorId::from_uuid(Uuid::from_u128(1)).as_str(),
+                surface: "upload".into(),
+            }),
+            hashes: vec![proto::ContentHash { algorithm: "pdq".into(), value: "clean".into() }],
+            text: String::new(),
+            categories: vec![],
+        });
+        let resp = handler.screen(request).await.unwrap().into_inner();
+        assert_eq!(resp.verdict, proto::ScreenVerdict::Allow as i32);
+    }
+
+    #[tokio::test]
+    async fn open_then_decide_rpc_records_enforcement() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+
+        // Open via the application handler (deterministic case id) ...
+        let opened = fx
+            .open_case_handler()
+            .handle(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    OpenCaseCommand {
+                        subject: subject(),
+                        category: PolicyCategory::Harassment,
+                        queue: "default".into(),
+                        priority: "normal".into(),
+                    },
+                ),
+                crate::application::fakes::t0(),
+            )
+            .await
+            .unwrap();
+
+        // ... then decide via the gRPC handler.
+        let request = Request::new(proto::DecideCaseRequest {
+            case_id: opened.case.id().as_str(),
+            action: proto::ActionType::RemoveContent as i32,
+            category: proto::PolicyCategory::Harassment as i32,
+            rationale: "violation".into(),
+            reviewer_id: "rev-1".into(),
+            policy_version: "2026.06.1".into(),
+        });
+        let resp = handler.decide_case(request).await.unwrap().into_inner();
+        assert!(resp.decision.is_some());
+        assert!(resp.enforcement.is_some());
+    }
+
+    #[tokio::test]
+    async fn decide_unknown_case_is_not_found() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::DecideCaseRequest {
+            case_id: Uuid::now_v7().to_string(),
+            action: proto::ActionType::Warn as i32,
+            category: proto::PolicyCategory::Spam as i32,
+            rationale: "x".into(),
+            reviewer_id: "r".into(),
+            policy_version: "2026.06.1".into(),
+        });
+        let status = handler.decide_case(request).await.unwrap_err();
+        assert_eq!(status.code(), Code::NotFound);
+    }
+}

--- a/crates/services/moderation/src/application/command/appeal.rs
+++ b/crates/services/moderation/src/application/command/appeal.rs
@@ -1,0 +1,291 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::port::{
+    AppealRepository, CaseRepository, DecisionRepository, EnforcementProjection,
+    EnforcementRepository, EventPublisher,
+};
+use crate::domain::aggregate::{Appeal, Decision, DecisionAuthor, DecisionParams};
+use crate::domain::value_object::{ActionType, ActorId, AppealId, CaseId, DecisionId};
+use crate::error::ModerationError;
+
+// ─── FileAppeal ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct FileAppealCommand {
+    pub decision_id: DecisionId,
+    pub actor_id: ActorId,
+    pub statement: String,
+}
+
+pub struct FileAppealHandler {
+    decisions: Arc<dyn DecisionRepository>,
+    appeals: Arc<dyn AppealRepository>,
+    cases: Arc<dyn CaseRepository>,
+}
+
+impl FileAppealHandler {
+    pub fn new(
+        decisions: Arc<dyn DecisionRepository>,
+        appeals: Arc<dyn AppealRepository>,
+        cases: Arc<dyn CaseRepository>,
+    ) -> Self {
+        Self { decisions, appeals, cases }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<FileAppealCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<Appeal, ModerationError> {
+        let cmd = envelope.payload;
+        let decision = self
+            .decisions
+            .find_by_id(&cmd.decision_id)
+            .await?
+            .ok_or(ModerationError::DecisionNotFound { id: cmd.decision_id.as_str() })?;
+
+        // Some categories (legally-mandated CSAM removals) are not appealable.
+        if !decision.category().is_appealable() {
+            return Err(ModerationError::NotAppealable);
+        }
+
+        let appeal = Appeal::file(cmd.decision_id, cmd.actor_id, cmd.statement, now)?;
+        self.appeals.save(&appeal).await?;
+
+        // Move the subject's case into the Appealed state (best-effort: the case may
+        // have been opened on a different surface or already cleaned up).
+        let case_id = CaseId::for_subject(decision.subject());
+        if let Some(mut case) = self.cases.find_by_id(&case_id).await? {
+            case.mark_appealed()?;
+            self.cases.save(&case).await?;
+        }
+        Ok(appeal)
+    }
+}
+
+// ─── ResolveAppeal ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct ResolveAppealCommand {
+    pub appeal_id: AppealId,
+    pub overturn: bool,
+    pub rationale: String,
+    pub reviewer_id: String,
+}
+
+/// The resolved appeal and, on an overturn, the reversal decision recorded.
+#[derive(Debug, Clone)]
+pub struct ResolveAppealOutcome {
+    pub appeal: Appeal,
+    pub reversal: Option<Decision>,
+}
+
+/// Resolves an appeal. On overturn it records a reversal decision (a new
+/// append-only entry referencing the original), reverses the active enforcement
+/// the original decision created (clearing the hot-path projection for actor-level
+/// ones), closes the case, and publishes `EnforcementReversed` + `AppealResolved`.
+pub struct ResolveAppealHandler {
+    appeals: Arc<dyn AppealRepository>,
+    decisions: Arc<dyn DecisionRepository>,
+    enforcements: Arc<dyn EnforcementRepository>,
+    cases: Arc<dyn CaseRepository>,
+    projection: Arc<dyn EnforcementProjection>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl ResolveAppealHandler {
+    pub fn new(
+        appeals: Arc<dyn AppealRepository>,
+        decisions: Arc<dyn DecisionRepository>,
+        enforcements: Arc<dyn EnforcementRepository>,
+        cases: Arc<dyn CaseRepository>,
+        projection: Arc<dyn EnforcementProjection>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { appeals, decisions, enforcements, cases, projection, publisher }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<ResolveAppealCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<ResolveAppealOutcome, ModerationError> {
+        let cmd = envelope.payload;
+        let correlation_id = envelope.correlation_id;
+
+        let mut appeal = self
+            .appeals
+            .find_by_id(&cmd.appeal_id)
+            .await?
+            .ok_or(ModerationError::AppealNotFound { id: cmd.appeal_id.as_str() })?;
+        let original = self
+            .decisions
+            .find_by_id(&appeal.decision_id())
+            .await?
+            .ok_or(ModerationError::DecisionNotFound { id: appeal.decision_id().as_str() })?;
+
+        appeal.resolve(cmd.overturn, now, correlation_id)?;
+        self.appeals.save(&appeal).await?;
+
+        let mut reversal = None;
+        if cmd.overturn {
+            // 1. Record the reversal decision (append-only; references the original).
+            let rev = Decision::record_reversal(
+                DecisionParams {
+                    subject: original.subject().clone(),
+                    action: ActionType::NoAction,
+                    category: original.category(),
+                    policy_version: original.policy_version().clone(),
+                    rationale: cmd.rationale,
+                    author: DecisionAuthor::Reviewer(cmd.reviewer_id),
+                    decided_at: now,
+                },
+                original.id(),
+            )?;
+            self.decisions.append(&rev).await?;
+
+            // 2. Reverse the active enforcement(s) the original decision created.
+            let actor = original.subject().actor_id();
+            for mut enf in self.enforcements.list_active_for_actor(&actor).await? {
+                if enf.decision_id() == original.id() && enf.is_active(now) {
+                    enf.reverse(now, correlation_id)?;
+                    self.enforcements.save(&enf).await?;
+                    if enf.action().is_actor_level() {
+                        self.projection.clear_actor_restriction(&actor, enf.version()).await?;
+                    }
+                    self.publish_all(enf.drain_events()).await?;
+                }
+            }
+            reversal = Some(rev);
+        }
+
+        // 3. Close the case (overturned ⇒ dismissed; upheld ⇒ back to actioned).
+        let case_id = CaseId::for_subject(original.subject());
+        if let Some(mut case) = self.cases.find_by_id(&case_id).await? {
+            case.close_appeal(cmd.overturn)?;
+            self.cases.save(&case).await?;
+        }
+
+        self.publish_all(appeal.drain_events()).await?;
+        Ok(ResolveAppealOutcome { appeal, reversal })
+    }
+
+    async fn publish_all(
+        &self,
+        events: Vec<crate::domain::event::DomainEvent>,
+    ) -> Result<(), ModerationError> {
+        for event in &events {
+            self.publisher.publish(event).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::{DecideCaseCommand, OpenCaseCommand};
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{EntityType, PolicyCategory, SubjectRef};
+    use uuid::Uuid;
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap()
+    }
+
+    /// Drives a full open→decide(Suspend) so there is a real decision + active
+    /// actor-level enforcement to appeal against. Returns the decision id.
+    async fn actioned_decision(fx: &Fixture, category: PolicyCategory) -> DecisionId {
+        let open = Envelope::new(
+            Uuid::now_v7(),
+            OpenCaseCommand { subject: subject(), category, queue: "q".into(), priority: "p".into() },
+        );
+        let case = fx.open_case_handler().handle(open, t0()).await.unwrap().case;
+        let decide = Envelope::new(
+            Uuid::now_v7(),
+            DecideCaseCommand {
+                case_id: case.id(),
+                action: ActionType::Suspend,
+                category,
+                rationale: "violation".into(),
+                reviewer_id: "rev-1".into(),
+                policy_version: "2026.06.1".into(),
+            },
+        );
+        fx.decide_handler().handle(decide, t0()).await.unwrap().decision.id()
+    }
+
+    #[tokio::test]
+    async fn overturned_appeal_reverses_enforcement_and_clears_projection() {
+        let fx = Fixture::new();
+        let decision_id = actioned_decision(&fx, PolicyCategory::Harassment).await;
+        assert!(fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+
+        // File then overturn.
+        let file = Envelope::new(
+            Uuid::now_v7(),
+            FileAppealCommand { decision_id, actor_id: subject().actor_id(), statement: "unfair".into() },
+        );
+        let appeal = fx.file_appeal_handler().handle(file, t0()).await.unwrap();
+        fx.publisher.clear();
+
+        let resolve = Envelope::new(
+            Uuid::now_v7(),
+            ResolveAppealCommand {
+                appeal_id: appeal.id(),
+                overturn: true,
+                rationale: "reviewer erred".into(),
+                reviewer_id: "rev-2".into(),
+            },
+        );
+        let out = fx.resolve_appeal_handler().handle(resolve, t0()).await.unwrap();
+
+        assert!(out.reversal.is_some());
+        assert_eq!(out.reversal.unwrap().reverses(), Some(decision_id));
+        // Projection cleared; EnforcementReversed then AppealResolved emitted.
+        assert!(!fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+        assert_eq!(
+            fx.publisher.event_types(),
+            vec!["moderation.enforcement_reversed", "moderation.appeal_resolved"]
+        );
+    }
+
+    #[tokio::test]
+    async fn upheld_appeal_keeps_enforcement() {
+        let fx = Fixture::new();
+        let decision_id = actioned_decision(&fx, PolicyCategory::Harassment).await;
+        let file = Envelope::new(
+            Uuid::now_v7(),
+            FileAppealCommand { decision_id, actor_id: subject().actor_id(), statement: "unfair".into() },
+        );
+        let appeal = fx.file_appeal_handler().handle(file, t0()).await.unwrap();
+
+        let resolve = Envelope::new(
+            Uuid::now_v7(),
+            ResolveAppealCommand {
+                appeal_id: appeal.id(),
+                overturn: false,
+                rationale: "decision stands".into(),
+                reviewer_id: "rev-2".into(),
+            },
+        );
+        let out = fx.resolve_appeal_handler().handle(resolve, t0()).await.unwrap();
+        assert!(out.reversal.is_none());
+        assert!(fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn csam_decision_is_not_appealable() {
+        let fx = Fixture::new();
+        let decision_id = actioned_decision(&fx, PolicyCategory::Csam).await;
+        let file = Envelope::new(
+            Uuid::now_v7(),
+            FileAppealCommand { decision_id, actor_id: subject().actor_id(), statement: "x".into() },
+        );
+        let err = fx.file_appeal_handler().handle(file, t0()).await.unwrap_err();
+        assert!(matches!(err, ModerationError::NotAppealable));
+    }
+}

--- a/crates/services/moderation/src/application/command/decide_case.rs
+++ b/crates/services/moderation/src/application/command/decide_case.rs
@@ -1,0 +1,404 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::policy::ModerationPolicy;
+use crate::application::port::{
+    AccountDirectory, CaseRepository, DecisionRepository, EnforcementProjection,
+    EnforcementRepository, EventPublisher, PenaltyRepository,
+};
+use crate::domain::aggregate::{
+    Case, CaseOpenParams, Decision, DecisionAuthor, DecisionParams, EnforcementAction,
+    EnforcementParams,
+};
+use crate::domain::value_object::{ActionType, CaseId, PolicyCategory, PolicyVersion, SubjectRef};
+use crate::error::ModerationError;
+
+// ─── OpenCase (manual, idempotent) ────────────────────────────────────────────
+
+/// Manually open (or idempotently return) a case for a subject.
+#[derive(Debug, Clone)]
+pub struct OpenCaseCommand {
+    pub subject: SubjectRef,
+    pub category: PolicyCategory,
+    pub queue: String,
+    pub priority: String,
+}
+
+/// Whether a fresh case was created or an existing one returned.
+#[derive(Debug, Clone)]
+pub struct OpenedCase {
+    pub case: Case,
+    pub created: bool,
+}
+
+pub struct OpenCaseHandler {
+    cases: Arc<dyn CaseRepository>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl OpenCaseHandler {
+    pub fn new(cases: Arc<dyn CaseRepository>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { cases, publisher }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<OpenCaseCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<OpenedCase, ModerationError> {
+        let cmd = envelope.payload;
+        let id = CaseId::for_subject(&cmd.subject);
+        if let Some(existing) = self.cases.find_by_id(&id).await? {
+            return Ok(OpenedCase { case: existing, created: false });
+        }
+        let mut case = Case::open(CaseOpenParams {
+            subject: cmd.subject,
+            category: cmd.category,
+            queue: cmd.queue,
+            priority: cmd.priority,
+            opened_at: now,
+            correlation_id: envelope.correlation_id,
+        });
+        self.cases.save(&case).await?;
+        for event in &case.drain_events() {
+            self.publisher.publish(event).await?;
+        }
+        Ok(OpenedCase { case, created: true })
+    }
+}
+
+// ─── AssignCase ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct AssignCaseCommand {
+    pub case_id: CaseId,
+    pub reviewer_id: String,
+}
+
+pub struct AssignCaseHandler {
+    cases: Arc<dyn CaseRepository>,
+}
+
+impl AssignCaseHandler {
+    pub fn new(cases: Arc<dyn CaseRepository>) -> Self {
+        Self { cases }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<AssignCaseCommand>,
+    ) -> Result<Case, ModerationError> {
+        let cmd = envelope.payload;
+        let mut case = self
+            .cases
+            .find_by_id(&cmd.case_id)
+            .await?
+            .ok_or(ModerationError::CaseNotFound { id: cmd.case_id.as_str() })?;
+        case.assign(cmd.reviewer_id)?;
+        self.cases.save(&case).await?;
+        Ok(case)
+    }
+}
+
+// ─── DecideCase (the core flow) ───────────────────────────────────────────────
+
+/// Action or dismiss a case under a pinned policy version.
+#[derive(Debug, Clone)]
+pub struct DecideCaseCommand {
+    pub case_id: CaseId,
+    pub action: ActionType,
+    pub category: PolicyCategory,
+    pub rationale: String,
+    pub reviewer_id: String,
+    pub policy_version: String,
+}
+
+/// The decision recorded and, unless dismissed, the enforcement applied.
+#[derive(Debug, Clone)]
+pub struct DecideOutcome {
+    pub decision: Decision,
+    pub enforcement: Option<EnforcementAction>,
+}
+
+/// Records the decision, applies enforcement (with a monotonic per-subject
+/// version), reflects actor-level restrictions on the hot-path projection, strikes
+/// the actor's penalty ledger (graduated enforcement), resolves the case, and
+/// publishes the events — in that durable-first order.
+pub struct DecideCaseHandler {
+    cases: Arc<dyn CaseRepository>,
+    decisions: Arc<dyn DecisionRepository>,
+    enforcements: Arc<dyn EnforcementRepository>,
+    penalties: Arc<dyn PenaltyRepository>,
+    projection: Arc<dyn EnforcementProjection>,
+    accounts: Arc<dyn AccountDirectory>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: ModerationPolicy,
+}
+
+impl DecideCaseHandler {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        cases: Arc<dyn CaseRepository>,
+        decisions: Arc<dyn DecisionRepository>,
+        enforcements: Arc<dyn EnforcementRepository>,
+        penalties: Arc<dyn PenaltyRepository>,
+        projection: Arc<dyn EnforcementProjection>,
+        accounts: Arc<dyn AccountDirectory>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: ModerationPolicy,
+    ) -> Self {
+        Self { cases, decisions, enforcements, penalties, projection, accounts, publisher, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<DecideCaseCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<DecideOutcome, ModerationError> {
+        let cmd = envelope.payload;
+        let correlation_id = envelope.correlation_id;
+
+        let mut case = self
+            .cases
+            .find_by_id(&cmd.case_id)
+            .await?
+            .ok_or(ModerationError::CaseNotFound { id: cmd.case_id.as_str() })?;
+        let subject = case.subject().clone();
+        let policy_version = PolicyVersion::new(cmd.policy_version)?;
+
+        // Actor-level actions require the actor to exist, so a typo cannot create a
+        // dangling restriction.
+        if cmd.action.is_actor_level() && !self.accounts.actor_exists(&subject.actor_id()).await? {
+            return Err(ModerationError::DomainViolation {
+                field: "actor".into(),
+                message: "cannot enforce against an unknown actor".into(),
+            });
+        }
+
+        // 1. Append the immutable decision.
+        let decision = Decision::record(DecisionParams {
+            subject: subject.clone(),
+            action: cmd.action,
+            category: cmd.category,
+            policy_version,
+            rationale: cmd.rationale,
+            author: DecisionAuthor::Reviewer(cmd.reviewer_id),
+            decided_at: now,
+        })?;
+        self.decisions.append(&decision).await?;
+
+        // 2. Apply enforcement (unless the action is a dismissal).
+        let mut enforcement = None;
+        if cmd.action.is_enforced() {
+            let version = self.enforcements.next_version(&subject).await?;
+            let mut enf = EnforcementAction::apply(EnforcementParams {
+                subject: subject.clone(),
+                action: cmd.action,
+                decision_id: decision.id(),
+                version,
+                applied_at: now,
+                expires_at: self.policy.expiry_for(cmd.action, now),
+                correlation_id,
+            })?;
+            self.enforcements.save(&enf).await?;
+
+            if cmd.action.is_actor_level() {
+                self.projection
+                    .set_actor_restriction(&subject.actor_id(), version, enf.expires_at())
+                    .await?;
+            }
+
+            // 3. Strike the penalty ledger (drives graduated enforcement on repeat).
+            let mut ledger = self.penalties.load(&subject.actor_id()).await?;
+            ledger.record_strike(cmd.category, now, &self.policy.penalty);
+            self.penalties.save(&ledger).await?;
+
+            self.publish_all(enf.drain_events()).await?;
+            enforcement = Some(enf);
+        }
+
+        // 4. Resolve the case (emits CaseResolved).
+        case.resolve(decision.id(), cmd.action, now, correlation_id)?;
+        self.cases.save(&case).await?;
+        self.publish_all(case.drain_events()).await?;
+
+        Ok(DecideOutcome { decision, enforcement })
+    }
+
+    async fn publish_all(
+        &self,
+        events: Vec<crate::domain::event::DomainEvent>,
+    ) -> Result<(), ModerationError> {
+        for event in &events {
+            self.publisher.publish(event).await?;
+        }
+        Ok(())
+    }
+
+    /// Recommends the graduated action for an actor under the current policy — a
+    /// helper the reviewer UI can call to surface "history warrants X".
+    pub async fn recommended_action(
+        &self,
+        actor_id: &crate::domain::value_object::ActorId,
+        now: DateTime<Utc>,
+    ) -> Result<ActionType, ModerationError> {
+        let ledger = self.penalties.load(actor_id).await?;
+        Ok(ledger.recommended_action(now, &self.policy.penalty))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{ActorId, EntityType};
+    use uuid::Uuid;
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap()
+    }
+
+    async fn open_case(fx: &Fixture) -> CaseId {
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            OpenCaseCommand {
+                subject: subject(),
+                category: PolicyCategory::Harassment,
+                queue: "default".into(),
+                priority: "normal".into(),
+            },
+        );
+        fx.open_case_handler().handle(env, t0()).await.unwrap().case.id()
+    }
+
+    fn decide_env(case_id: CaseId, action: ActionType) -> Envelope<DecideCaseCommand> {
+        Envelope::new(
+            Uuid::now_v7(),
+            DecideCaseCommand {
+                case_id,
+                action,
+                category: PolicyCategory::Harassment,
+                rationale: "violates policy".into(),
+                reviewer_id: "rev-1".into(),
+                policy_version: "2026.06.1".into(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn open_case_is_idempotent() {
+        let fx = Fixture::new();
+        let env1 = Envelope::new(
+            Uuid::now_v7(),
+            OpenCaseCommand {
+                subject: subject(),
+                category: PolicyCategory::Spam,
+                queue: "q".into(),
+                priority: "p".into(),
+            },
+        );
+        let first = fx.open_case_handler().handle(env1.clone(), t0()).await.unwrap();
+        let second = fx.open_case_handler().handle(env1, t0()).await.unwrap();
+        assert!(first.created);
+        assert!(!second.created, "second open returns the existing case");
+        assert_eq!(first.case.id(), second.case.id());
+    }
+
+    #[tokio::test]
+    async fn decide_with_content_action_records_decision_and_enforcement() {
+        let fx = Fixture::new();
+        let case_id = open_case(&fx).await;
+        fx.publisher.clear();
+
+        let out = fx
+            .decide_handler()
+            .handle(decide_env(case_id, ActionType::RemoveContent), t0())
+            .await
+            .unwrap();
+
+        assert_eq!(out.decision.action(), ActionType::RemoveContent);
+        assert!(out.enforcement.is_some());
+        assert_eq!(fx.decisions.count(), 1);
+        // EnforcementApplied then CaseResolved.
+        assert_eq!(
+            fx.publisher.event_types(),
+            vec!["moderation.enforcement_applied", "moderation.case_resolved"]
+        );
+        // Content action ⇒ no actor restriction.
+        assert!(!fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn dismissal_records_decision_but_no_enforcement() {
+        let fx = Fixture::new();
+        let case_id = open_case(&fx).await;
+        fx.publisher.clear();
+
+        let out = fx
+            .decide_handler()
+            .handle(decide_env(case_id, ActionType::NoAction), t0())
+            .await
+            .unwrap();
+
+        assert!(out.enforcement.is_none());
+        assert_eq!(fx.decisions.count(), 1);
+        assert_eq!(fx.publisher.event_types(), vec!["moderation.case_resolved"]);
+    }
+
+    #[tokio::test]
+    async fn actor_level_action_sets_projection_and_strikes_ledger() {
+        let fx = Fixture::new();
+        let case_id = open_case(&fx).await;
+
+        fx.decide_handler()
+            .handle(decide_env(case_id, ActionType::Suspend), t0())
+            .await
+            .unwrap();
+
+        assert!(fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+        let ledger = fx.penalties.load(&subject().actor_id()).await.unwrap();
+        assert_eq!(ledger.active_strike_count(t0()), 1);
+    }
+
+    #[tokio::test]
+    async fn actor_level_action_rejected_for_unknown_actor() {
+        let fx = Fixture::new();
+        fx.accounts.set_known(false);
+        let case_id = open_case(&fx).await;
+        let err = fx
+            .decide_handler()
+            .handle(decide_env(case_id, ActionType::Ban), t0())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ModerationError::DomainViolation { .. }));
+        // Nothing enforced.
+        assert!(!fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn deciding_missing_case_errs() {
+        let fx = Fixture::new();
+        let err = fx
+            .decide_handler()
+            .handle(decide_env(CaseId::for_subject(&subject()), ActionType::Warn), t0())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ModerationError::CaseNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn enforcement_version_is_monotonic_per_subject() {
+        let fx = Fixture::new();
+        let case_id = open_case(&fx).await;
+        let out1 = fx.decide_handler().handle(decide_env(case_id, ActionType::VisibilityLimit), t0()).await.unwrap();
+        let v1 = out1.enforcement.unwrap().version();
+        // Re-open a fresh case for the same subject and decide again.
+        let case_id2 = open_case(&fx).await; // same deterministic id, already resolved → load
+        // The existing case is resolved; deciding again should fail (already resolved).
+        let err = fx.decide_handler().handle(decide_env(case_id2, ActionType::RemoveContent), t0()).await.unwrap_err();
+        assert!(matches!(err, ModerationError::CaseAlreadyResolved));
+        assert_eq!(v1.value(), 1);
+    }
+}

--- a/crates/services/moderation/src/application/command/ingest.rs
+++ b/crates/services/moderation/src/application/command/ingest.rs
@@ -1,0 +1,204 @@
+//! Plane A ingestion — the async, post-hoc path the Phase 4 Kafka consumers drive.
+//! Both handlers open-or-load the deterministic case for a subject and append an
+//! evidence signal, so redelivery is idempotent (the same content event upserts
+//! the same case).
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::port::{CaseRepository, ClassifierGateway, EventPublisher};
+use crate::domain::aggregate::{Case, CaseOpenParams, Report};
+use crate::domain::value_object::{
+    ActorId, CaseId, Confidence, PolicyCategory, Signal, SubjectRef,
+};
+use crate::error::ModerationError;
+
+/// Shared helper: load the subject's case or open a fresh one.
+async fn open_or_load(
+    cases: &Arc<dyn CaseRepository>,
+    subject: &SubjectRef,
+    category: PolicyCategory,
+    now: DateTime<Utc>,
+    correlation_id: uuid::Uuid,
+) -> Result<Case, ModerationError> {
+    let id = CaseId::for_subject(subject);
+    match cases.find_by_id(&id).await? {
+        Some(case) => Ok(case),
+        None => Ok(Case::open(CaseOpenParams {
+            subject: subject.clone(),
+            category,
+            queue: "default".into(),
+            priority: "normal".into(),
+            opened_at: now,
+            correlation_id,
+        })),
+    }
+}
+
+// ─── Ingest a user report ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct IngestReportCommand {
+    pub reporter_id: ActorId,
+    pub subject: SubjectRef,
+    pub category: PolicyCategory,
+    pub reason: String,
+}
+
+pub struct IngestReportHandler {
+    cases: Arc<dyn CaseRepository>,
+    publisher: Arc<dyn EventPublisher>,
+    classifiers: Arc<dyn ClassifierGateway>,
+}
+
+impl IngestReportHandler {
+    pub fn new(
+        cases: Arc<dyn CaseRepository>,
+        publisher: Arc<dyn EventPublisher>,
+        classifiers: Arc<dyn ClassifierGateway>,
+    ) -> Self {
+        Self { cases, publisher, classifiers }
+    }
+
+    /// Returns the (deterministic) id of the case the report fed into.
+    pub async fn handle(
+        &self,
+        envelope: Envelope<IngestReportCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<CaseId, ModerationError> {
+        let cmd = envelope.payload;
+
+        // The Report aggregate enforces the self-report invariant and dedup id.
+        let _report = Report::file(cmd.reporter_id, cmd.subject.clone(), cmd.category, cmd.reason, now)?;
+
+        let mut case = open_or_load(&self.cases, &cmd.subject, cmd.category, now, envelope.correlation_id).await?;
+        let signal = Signal::new("report", cmd.category, Confidence::clamped(0.5), now)?;
+
+        // A report on an already-resolved case is a no-op here (it would reopen via
+        // a separate re-review path); fold it into success so the consumer commits.
+        if case.add_signal(signal).is_ok() {
+            self.cases.save(&case).await?;
+            for event in &case.drain_events() {
+                self.publisher.publish(event).await?;
+            }
+        }
+
+        // Fan out to async classifiers (fire-and-forget).
+        self.classifiers.request_classification(&cmd.subject).await?;
+        Ok(case.id())
+    }
+}
+
+// ─── Ingest a classifier signal ───────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct IngestSignalCommand {
+    pub subject: SubjectRef,
+    pub source: String,
+    pub category: PolicyCategory,
+    pub confidence: Confidence,
+}
+
+pub struct IngestSignalHandler {
+    cases: Arc<dyn CaseRepository>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl IngestSignalHandler {
+    pub fn new(cases: Arc<dyn CaseRepository>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { cases, publisher }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<IngestSignalCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<CaseId, ModerationError> {
+        let cmd = envelope.payload;
+        let mut case = open_or_load(&self.cases, &cmd.subject, cmd.category, now, envelope.correlation_id).await?;
+        let signal = Signal::new(cmd.source, cmd.category, cmd.confidence, now)?;
+        if case.add_signal(signal).is_ok() {
+            self.cases.save(&case).await?;
+            for event in &case.drain_events() {
+                self.publisher.publish(event).await?;
+            }
+        }
+        Ok(case.id())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::EntityType;
+    use uuid::Uuid;
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Comment, "c1", ActorId::from_uuid(Uuid::from_u128(1)), "thread").unwrap()
+    }
+
+    fn report_env(reporter: u128) -> Envelope<IngestReportCommand> {
+        Envelope::new(
+            Uuid::now_v7(),
+            IngestReportCommand {
+                reporter_id: ActorId::from_uuid(Uuid::from_u128(reporter)),
+                subject: subject(),
+                category: PolicyCategory::Harassment,
+                reason: "abusive".into(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn first_report_opens_a_case_and_requests_classification() {
+        let fx = Fixture::new();
+        let id = fx.ingest_report_handler().handle(report_env(2), t0()).await.unwrap();
+        assert_eq!(id, CaseId::for_subject(&subject()));
+        assert_eq!(fx.cases.count(), 1);
+        assert_eq!(fx.publisher.event_types(), vec!["moderation.case_opened"]);
+        assert_eq!(fx.classifiers.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn redelivered_subject_reuses_the_same_case() {
+        let fx = Fixture::new();
+        fx.ingest_report_handler().handle(report_env(2), t0()).await.unwrap();
+        fx.ingest_report_handler().handle(report_env(3), t0()).await.unwrap();
+        // Same deterministic case, two signals, only one CaseOpened.
+        assert_eq!(fx.cases.count(), 1);
+        let opened = fx.publisher.event_types().iter().filter(|t| **t == "moderation.case_opened").count();
+        assert_eq!(opened, 1);
+        let case = fx.cases.find_by_id(&CaseId::for_subject(&subject())).await.unwrap().unwrap();
+        assert_eq!(case.signals().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn self_report_is_rejected() {
+        let fx = Fixture::new();
+        // reporter == subject actor (id 1)
+        let err = fx.ingest_report_handler().handle(report_env(1), t0()).await.unwrap_err();
+        assert!(matches!(err, ModerationError::SelfReportRejected));
+        assert_eq!(fx.cases.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn signal_ingestion_appends_to_the_case() {
+        let fx = Fixture::new();
+        let env = Envelope::new(
+            Uuid::now_v7(),
+            IngestSignalCommand {
+                subject: subject(),
+                source: "classifier:text-v2".into(),
+                category: PolicyCategory::Hate,
+                confidence: Confidence::new(0.92).unwrap(),
+            },
+        );
+        fx.ingest_signal_handler().handle(env, t0()).await.unwrap();
+        let case = fx.cases.find_by_id(&CaseId::for_subject(&subject())).await.unwrap().unwrap();
+        assert_eq!(case.signals().len(), 1);
+        assert_eq!(case.signals()[0].source(), "classifier:text-v2");
+    }
+}

--- a/crates/services/moderation/src/application/command/mod.rs
+++ b/crates/services/moderation/src/application/command/mod.rs
@@ -1,0 +1,23 @@
+//! Write use-cases. Like `auth`, these are explicit application-service handlers
+//! (not `cqrs::CommandHandler`) because they return rich outputs — a decision, an
+//! enforcement, a screen verdict — that a `Result<(), E>` command cannot carry.
+//! Each takes a [`cqrs::Envelope`] so the `correlation_id` threads into the domain
+//! events it emits, and an injected `now` for deterministic tests.
+
+pub mod appeal;
+pub mod decide_case;
+pub mod ingest;
+pub mod screen;
+
+pub use appeal::{
+    FileAppealCommand, FileAppealHandler, ResolveAppealCommand, ResolveAppealHandler,
+    ResolveAppealOutcome,
+};
+pub use decide_case::{
+    AssignCaseCommand, AssignCaseHandler, DecideCaseCommand, DecideCaseHandler, DecideOutcome,
+    OpenCaseCommand, OpenCaseHandler, OpenedCase,
+};
+pub use ingest::{
+    IngestReportCommand, IngestReportHandler, IngestSignalCommand, IngestSignalHandler,
+};
+pub use screen::{ScreenCommand, ScreenHandler, ScreenOutcome, ScreenVerdict};

--- a/crates/services/moderation/src/application/command/screen.rs
+++ b/crates/services/moderation/src/application/command/screen.rs
@@ -1,0 +1,242 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::policy::ModerationPolicy;
+use crate::application::port::{
+    ContentHash, DecisionRepository, EnforcementProjection, EnforcementRepository, EventPublisher,
+    PenaltyRepository, ScreenCorpus,
+};
+use crate::domain::aggregate::{
+    Decision, DecisionAuthor, DecisionParams, EnforcementAction, EnforcementParams,
+};
+use crate::domain::value_object::{ActionType, EnforcementId, PolicyCategory, SubjectRef};
+use crate::error::ModerationError;
+
+/// Plane C — the synchronous, fail-closed pre-publish screen.
+#[derive(Debug, Clone)]
+pub struct ScreenCommand {
+    pub subject: SubjectRef,
+    pub hashes: Vec<ContentHash>,
+    /// Optional short text for the critical-term blocklist. Transient — never
+    /// persisted.
+    pub text: Option<String>,
+    /// Categories to screen. Empty ⇒ the corpus screens all zero-tolerance ones.
+    pub categories: Vec<PolicyCategory>,
+}
+
+/// The screen result. `Block` means a known-bad match was found; the caller's
+/// per-category fail policy turns that (and any `ScreenUnavailable` error) into a
+/// hard pre-publish block. `Allow` means "no known-bad match", never "approved".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenVerdict {
+    Allow,
+    Block,
+    Review,
+}
+
+/// The outcome of a screen, including the automated evidence recorded on a match.
+#[derive(Debug, Clone)]
+pub struct ScreenOutcome {
+    pub verdict: ScreenVerdict,
+    pub matched_categories: Vec<PolicyCategory>,
+    pub match_reference: Option<String>,
+    /// The automated enforcement opened on a match (content removal).
+    pub enforcement_id: Option<EnforcementId>,
+}
+
+/// Screens content and, on a known-bad match, records the automated evidence: an
+/// append-only [`Decision`] (authored by the screen rule), a content
+/// `RemoveContent` [`EnforcementAction`], a strike against the actor (so the
+/// graduated engine escalates), and the `EnforcementApplied` event. A corpus error
+/// propagates as `ScreenUnavailable`/`HashCorpusUnavailable` — the caller fails
+/// closed.
+pub struct ScreenHandler {
+    corpus: Arc<dyn ScreenCorpus>,
+    decisions: Arc<dyn DecisionRepository>,
+    enforcements: Arc<dyn EnforcementRepository>,
+    penalties: Arc<dyn PenaltyRepository>,
+    projection: Arc<dyn EnforcementProjection>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: ModerationPolicy,
+}
+
+impl ScreenHandler {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        corpus: Arc<dyn ScreenCorpus>,
+        decisions: Arc<dyn DecisionRepository>,
+        enforcements: Arc<dyn EnforcementRepository>,
+        penalties: Arc<dyn PenaltyRepository>,
+        projection: Arc<dyn EnforcementProjection>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: ModerationPolicy,
+    ) -> Self {
+        Self { corpus, decisions, enforcements, penalties, projection, publisher, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<ScreenCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<ScreenOutcome, ModerationError> {
+        let cmd = envelope.payload;
+        let correlation_id = envelope.correlation_id;
+
+        // Hard timeout: a slow/stuck corpus must not wedge the publish path. On
+        // elapse we surface `ScreenUnavailable` and the caller fails closed for
+        // catastrophic categories.
+        let lookup = self.corpus.screen(&cmd.hashes, cmd.text.as_deref(), &cmd.categories);
+        let hit = match tokio::time::timeout(self.policy.screen_timeout, lookup).await {
+            Ok(result) => result?,
+            Err(_elapsed) => return Err(ModerationError::ScreenUnavailable),
+        };
+
+        let Some(m) = hit else {
+            return Ok(ScreenOutcome {
+                verdict: ScreenVerdict::Allow,
+                matched_categories: Vec::new(),
+                match_reference: None,
+                enforcement_id: None,
+            });
+        };
+
+        // The matched category drives the recorded decision; pick the first (the
+        // corpus returns the categories this content is known-bad for).
+        let category = m.categories.first().copied().unwrap_or(PolicyCategory::Other);
+
+        // 1. Append the automated decision (the legal evidence record).
+        let decision = Decision::record(DecisionParams {
+            subject: cmd.subject.clone(),
+            action: ActionType::RemoveContent,
+            category,
+            policy_version: self.policy.screen_policy_version.clone(),
+            rationale: format!("automated screen match: {}", m.reference),
+            author: DecisionAuthor::Rule("screen:hash-match".into()),
+            decided_at: now,
+        })?;
+        self.decisions.append(&decision).await?;
+
+        // 2. Apply the content removal enforcement and publish it.
+        let version = self.enforcements.next_version(&cmd.subject).await?;
+        let mut enforcement = EnforcementAction::apply(EnforcementParams {
+            subject: cmd.subject.clone(),
+            action: ActionType::RemoveContent,
+            decision_id: decision.id(),
+            version,
+            applied_at: now,
+            expires_at: None,
+            correlation_id,
+        })?;
+        let enforcement_id = enforcement.id();
+        self.enforcements.save(&enforcement).await?;
+        self.publish_all(enforcement.drain_events()).await?;
+
+        // 3. Strike the actor so graduated enforcement escalates on repeat offenders.
+        let mut ledger = self.penalties.load(&cmd.subject.actor_id()).await?;
+        ledger.record_strike(category, now, &self.policy.penalty);
+        // A catastrophic strike may now warrant an actor-level restriction; reflect
+        // it on the hot-path projection so the actor can't immediately re-offend.
+        if ledger.recommended_action(now, &self.policy.penalty).is_actor_level() {
+            self.projection
+                .set_actor_restriction(&cmd.subject.actor_id(), version, None)
+                .await?;
+        }
+        self.penalties.save(&ledger).await?;
+
+        Ok(ScreenOutcome {
+            verdict: ScreenVerdict::Block,
+            matched_categories: m.categories,
+            match_reference: Some(m.reference),
+            enforcement_id: Some(enforcement_id),
+        })
+    }
+
+    async fn publish_all(
+        &self,
+        events: Vec<crate::domain::event::DomainEvent>,
+    ) -> Result<(), ModerationError> {
+        for event in &events {
+            self.publisher.publish(event).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{ActorId, EntityType};
+    use uuid::Uuid;
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Media, "m1", ActorId::from_uuid(Uuid::from_u128(1)), "upload").unwrap()
+    }
+
+    fn env(cmd: ScreenCommand) -> Envelope<ScreenCommand> {
+        Envelope::new(Uuid::now_v7(), cmd)
+    }
+
+    fn cmd() -> ScreenCommand {
+        ScreenCommand {
+            subject: subject(),
+            hashes: vec![ContentHash { algorithm: "pdq".into(), value: "abc".into() }],
+            text: None,
+            categories: vec![PolicyCategory::Csam],
+        }
+    }
+
+    #[tokio::test]
+    async fn clean_content_allows_and_records_nothing() {
+        let fx = Fixture::new();
+        let out = fx.screen_handler().handle(env(cmd()), t0()).await.unwrap();
+        assert_eq!(out.verdict, ScreenVerdict::Allow);
+        assert!(out.enforcement_id.is_none());
+        assert_eq!(fx.publisher.count(), 0);
+        assert_eq!(fx.decisions.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn known_bad_match_blocks_and_records_evidence() {
+        let fx = Fixture::new();
+        fx.corpus.add_known_bad("abc", vec![PolicyCategory::Csam], "ncmec:123");
+
+        let out = fx.screen_handler().handle(env(cmd()), t0()).await.unwrap();
+
+        assert_eq!(out.verdict, ScreenVerdict::Block);
+        assert_eq!(out.matched_categories, vec![PolicyCategory::Csam]);
+        assert_eq!(out.match_reference.as_deref(), Some("ncmec:123"));
+        assert!(out.enforcement_id.is_some());
+        // One append-only decision + one EnforcementApplied event.
+        assert_eq!(fx.decisions.count(), 1);
+        assert_eq!(fx.publisher.event_types(), vec!["moderation.enforcement_applied"]);
+        // CSAM weight (6) hits the Ban tier ⇒ actor restricted on the projection.
+        assert!(fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn corpus_outage_propagates_as_screen_unavailable() {
+        let fx = Fixture::new();
+        fx.corpus.set_unavailable();
+        let err = fx.screen_handler().handle(env(cmd()), t0()).await.unwrap_err();
+        assert!(matches!(err, ModerationError::ScreenUnavailable));
+    }
+
+    #[tokio::test]
+    async fn slow_corpus_trips_the_hard_timeout() {
+        let mut fx = Fixture::new();
+        fx.policy.screen_timeout = std::time::Duration::from_millis(10);
+        fx.corpus.set_delay(std::time::Duration::from_millis(150));
+
+        let err = fx.screen_handler().handle(env(cmd()), t0()).await.unwrap_err();
+        assert!(
+            matches!(err, ModerationError::ScreenUnavailable),
+            "a corpus slower than the timeout must fail closed, not hang"
+        );
+        // Nothing recorded when the gate times out.
+        assert_eq!(fx.decisions.count(), 0);
+        assert_eq!(fx.publisher.count(), 0);
+    }
+}

--- a/crates/services/moderation/src/application/fakes.rs
+++ b/crates/services/moderation/src/application/fakes.rs
@@ -1,0 +1,541 @@
+//! In-memory fakes for every outbound port, plus a [`Fixture`] that wires them
+//! into the handlers. Test-only (`#[cfg(test)]`) — they prove the application
+//! layer works against the port contracts with no real backend, which is exactly
+//! what makes the abstraction credible before the Phase 4 adapters exist.
+
+// Fakes are constructed explicitly via `new()` / `Fixture::new()`; a `Default`
+// impl would add noise without a caller.
+#![allow(clippy::new_without_default)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use super::policy::ModerationPolicy;
+use super::port::{
+    AccountDirectory, AppealRepository, CaseRepository, ClassifierGateway, ContentHash,
+    CorpusMatch, DecisionRepository, EnforcementProjection, EnforcementRepository, EventPublisher,
+    PenaltyRepository, ScreenCorpus,
+};
+use crate::domain::aggregate::{Appeal, Case, Decision, EnforcementAction, PenaltyLedger};
+use crate::domain::event::DomainEvent;
+use crate::domain::value_object::{
+    ActorId, AppealId, CaseId, CaseStatus, DecisionId, EnforcementId, EnforcementStatus,
+    EnforcementVersion, PolicyCategory, SubjectRef,
+};
+use crate::error::ModerationError;
+
+/// A fixed reference instant for deterministic tests.
+pub fn t0() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+}
+
+// ─── CaseRepository ────────────────────────────────────────────────────────────
+
+pub struct InMemoryCaseRepository {
+    cases: Mutex<HashMap<CaseId, Case>>,
+}
+
+impl InMemoryCaseRepository {
+    pub fn new() -> Self {
+        Self { cases: Mutex::new(HashMap::new()) }
+    }
+
+    pub fn count(&self) -> usize {
+        self.cases.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl CaseRepository for InMemoryCaseRepository {
+    async fn save(&self, case: &Case) -> Result<(), ModerationError> {
+        let mut stored = case.clone();
+        let _ = stored.drain_events(); // events do not survive persistence
+        self.cases.lock().unwrap().insert(stored.id(), stored);
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &CaseId) -> Result<Option<Case>, ModerationError> {
+        Ok(self.cases.lock().unwrap().get(id).cloned())
+    }
+
+    async fn list_queue(
+        &self,
+        queue: &str,
+        status: Option<CaseStatus>,
+        limit: usize,
+    ) -> Result<Vec<Case>, ModerationError> {
+        Ok(self
+            .cases
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|c| c.queue() == queue && status.is_none_or(|s| c.status() == s))
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+}
+
+// ─── DecisionRepository (append-only) ──────────────────────────────────────────
+
+pub struct InMemoryDecisionRepository {
+    decisions: Mutex<HashMap<DecisionId, Decision>>,
+}
+
+impl InMemoryDecisionRepository {
+    pub fn new() -> Self {
+        Self { decisions: Mutex::new(HashMap::new()) }
+    }
+
+    pub fn count(&self) -> usize {
+        self.decisions.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl DecisionRepository for InMemoryDecisionRepository {
+    async fn append(&self, decision: &Decision) -> Result<(), ModerationError> {
+        self.decisions.lock().unwrap().insert(decision.id(), decision.clone());
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &DecisionId) -> Result<Option<Decision>, ModerationError> {
+        Ok(self.decisions.lock().unwrap().get(id).cloned())
+    }
+}
+
+// ─── EnforcementRepository ─────────────────────────────────────────────────────
+
+pub struct InMemoryEnforcementRepository {
+    enforcements: Mutex<HashMap<EnforcementId, EnforcementAction>>,
+}
+
+impl InMemoryEnforcementRepository {
+    pub fn new() -> Self {
+        Self { enforcements: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl EnforcementRepository for InMemoryEnforcementRepository {
+    async fn save(&self, enforcement: &EnforcementAction) -> Result<(), ModerationError> {
+        let mut stored = enforcement.clone();
+        let _ = stored.drain_events();
+        self.enforcements.lock().unwrap().insert(stored.id(), stored);
+        Ok(())
+    }
+
+    async fn find_by_id(
+        &self,
+        id: &EnforcementId,
+    ) -> Result<Option<EnforcementAction>, ModerationError> {
+        Ok(self.enforcements.lock().unwrap().get(id).cloned())
+    }
+
+    async fn next_version(
+        &self,
+        subject: &SubjectRef,
+    ) -> Result<EnforcementVersion, ModerationError> {
+        let key = subject.canonical_key();
+        let max = self
+            .enforcements
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|e| e.subject().canonical_key() == key)
+            .map(|e| e.version().value())
+            .max();
+        Ok(match max {
+            Some(v) => EnforcementVersion::from_i64(v).next(),
+            None => EnforcementVersion::INITIAL,
+        })
+    }
+
+    async fn list_active_for_actor(
+        &self,
+        actor_id: &ActorId,
+    ) -> Result<Vec<EnforcementAction>, ModerationError> {
+        Ok(self
+            .enforcements
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|e| e.actor_id() == *actor_id && e.status() == EnforcementStatus::Active)
+            .cloned()
+            .collect())
+    }
+}
+
+// ─── PenaltyRepository ─────────────────────────────────────────────────────────
+
+pub struct InMemoryPenaltyRepository {
+    ledgers: Mutex<HashMap<ActorId, PenaltyLedger>>,
+}
+
+impl InMemoryPenaltyRepository {
+    pub fn new() -> Self {
+        Self { ledgers: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl PenaltyRepository for InMemoryPenaltyRepository {
+    async fn load(&self, actor_id: &ActorId) -> Result<PenaltyLedger, ModerationError> {
+        Ok(self
+            .ledgers
+            .lock()
+            .unwrap()
+            .get(actor_id)
+            .cloned()
+            .unwrap_or_else(|| PenaltyLedger::empty(*actor_id)))
+    }
+
+    async fn save(&self, ledger: &PenaltyLedger) -> Result<(), ModerationError> {
+        self.ledgers.lock().unwrap().insert(ledger.actor_id(), ledger.clone());
+        Ok(())
+    }
+}
+
+// ─── AppealRepository ──────────────────────────────────────────────────────────
+
+pub struct InMemoryAppealRepository {
+    appeals: Mutex<HashMap<AppealId, Appeal>>,
+}
+
+impl InMemoryAppealRepository {
+    pub fn new() -> Self {
+        Self { appeals: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl AppealRepository for InMemoryAppealRepository {
+    async fn save(&self, appeal: &Appeal) -> Result<(), ModerationError> {
+        let mut stored = appeal.clone();
+        let _ = stored.drain_events();
+        self.appeals.lock().unwrap().insert(stored.id(), stored);
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &AppealId) -> Result<Option<Appeal>, ModerationError> {
+        Ok(self.appeals.lock().unwrap().get(id).cloned())
+    }
+}
+
+// ─── EnforcementProjection ─────────────────────────────────────────────────────
+
+pub struct InMemoryEnforcementProjection {
+    /// actor → (last version written, restricted).
+    state: Mutex<HashMap<ActorId, (EnforcementVersion, bool)>>,
+}
+
+impl InMemoryEnforcementProjection {
+    pub fn new() -> Self {
+        Self { state: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl EnforcementProjection for InMemoryEnforcementProjection {
+    async fn set_actor_restriction(
+        &self,
+        actor_id: &ActorId,
+        version: EnforcementVersion,
+        _expires_at: Option<DateTime<Utc>>,
+    ) -> Result<(), ModerationError> {
+        let mut state = self.state.lock().unwrap();
+        // Ignore a stale (lower-versioned) write.
+        if state.get(actor_id).is_none_or(|(v, _)| version >= *v) {
+            state.insert(*actor_id, (version, true));
+        }
+        Ok(())
+    }
+
+    async fn clear_actor_restriction(
+        &self,
+        actor_id: &ActorId,
+        version: EnforcementVersion,
+    ) -> Result<(), ModerationError> {
+        let mut state = self.state.lock().unwrap();
+        if state.get(actor_id).is_none_or(|(v, _)| version >= *v) {
+            state.insert(*actor_id, (version, false));
+        }
+        Ok(())
+    }
+
+    async fn is_actor_restricted(&self, actor_id: &ActorId) -> Result<bool, ModerationError> {
+        Ok(self.state.lock().unwrap().get(actor_id).map(|(_, r)| *r).unwrap_or(false))
+    }
+}
+
+// ─── ScreenCorpus ──────────────────────────────────────────────────────────────
+
+pub struct StubScreenCorpus {
+    known_bad: Mutex<HashMap<String, (Vec<PolicyCategory>, String)>>,
+    unavailable: Mutex<bool>,
+    /// When set, the lookup sleeps this long before answering — used to drive the
+    /// Screen hard-timeout path.
+    delay: Mutex<Option<std::time::Duration>>,
+}
+
+impl StubScreenCorpus {
+    pub fn new() -> Self {
+        Self {
+            known_bad: Mutex::new(HashMap::new()),
+            unavailable: Mutex::new(false),
+            delay: Mutex::new(None),
+        }
+    }
+
+    /// Registers a hash value as a known-bad match for the given categories.
+    pub fn add_known_bad(&self, hash_value: &str, categories: Vec<PolicyCategory>, reference: &str) {
+        self.known_bad
+            .lock()
+            .unwrap()
+            .insert(hash_value.to_owned(), (categories, reference.to_owned()));
+    }
+
+    pub fn set_unavailable(&self) {
+        *self.unavailable.lock().unwrap() = true;
+    }
+
+    /// Makes the corpus answer after `delay` — slower than the screen timeout, to
+    /// exercise the fail-closed-on-timeout path.
+    pub fn set_delay(&self, delay: std::time::Duration) {
+        *self.delay.lock().unwrap() = Some(delay);
+    }
+}
+
+#[async_trait]
+impl ScreenCorpus for StubScreenCorpus {
+    async fn screen(
+        &self,
+        hashes: &[ContentHash],
+        _text: Option<&str>,
+        _categories: &[PolicyCategory],
+    ) -> Result<Option<CorpusMatch>, ModerationError> {
+        let delay = *self.delay.lock().unwrap();
+        if let Some(d) = delay {
+            tokio::time::sleep(d).await;
+        }
+        if *self.unavailable.lock().unwrap() {
+            return Err(ModerationError::ScreenUnavailable);
+        }
+        let known = self.known_bad.lock().unwrap();
+        for h in hashes {
+            if let Some((categories, reference)) = known.get(&h.value) {
+                return Ok(Some(CorpusMatch {
+                    categories: categories.clone(),
+                    reference: reference.clone(),
+                }));
+            }
+        }
+        Ok(None)
+    }
+}
+
+// ─── ClassifierGateway ─────────────────────────────────────────────────────────
+
+pub struct StubClassifierGateway {
+    requests: Mutex<usize>,
+}
+
+impl StubClassifierGateway {
+    pub fn new() -> Self {
+        Self { requests: Mutex::new(0) }
+    }
+
+    pub fn request_count(&self) -> usize {
+        *self.requests.lock().unwrap()
+    }
+}
+
+#[async_trait]
+impl ClassifierGateway for StubClassifierGateway {
+    async fn request_classification(&self, _subject: &SubjectRef) -> Result<(), ModerationError> {
+        *self.requests.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+// ─── AccountDirectory ──────────────────────────────────────────────────────────
+
+pub struct StubAccountDirectory {
+    known: Mutex<bool>,
+}
+
+impl StubAccountDirectory {
+    pub fn new() -> Self {
+        Self { known: Mutex::new(true) }
+    }
+
+    pub fn set_known(&self, known: bool) {
+        *self.known.lock().unwrap() = known;
+    }
+}
+
+#[async_trait]
+impl AccountDirectory for StubAccountDirectory {
+    async fn actor_exists(&self, _actor_id: &ActorId) -> Result<bool, ModerationError> {
+        Ok(*self.known.lock().unwrap())
+    }
+}
+
+// ─── EventPublisher ────────────────────────────────────────────────────────────
+
+pub struct RecordingEventPublisher {
+    events: Mutex<Vec<DomainEvent>>,
+}
+
+impl RecordingEventPublisher {
+    pub fn new() -> Self {
+        Self { events: Mutex::new(Vec::new()) }
+    }
+
+    pub fn event_types(&self) -> Vec<&'static str> {
+        self.events.lock().unwrap().iter().map(|e| e.event_type()).collect()
+    }
+
+    pub fn count(&self) -> usize {
+        self.events.lock().unwrap().len()
+    }
+
+    /// Resets recorded events — used by tests that assert only on events emitted
+    /// after a setup phase (e.g. open-then-decide).
+    pub fn clear(&self) {
+        self.events.lock().unwrap().clear();
+    }
+}
+
+#[async_trait]
+impl EventPublisher for RecordingEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ModerationError> {
+        self.events.lock().unwrap().push(event.clone());
+        Ok(())
+    }
+}
+
+// ─── Fixture ───────────────────────────────────────────────────────────────────
+
+/// Bundles concrete fakes and builds handlers wired to them. Handlers receive the
+/// fakes as `Arc<dyn Port>`; tests keep the concrete `Arc`s to assert on recorded
+/// state (published events, projection flags, stored aggregates).
+pub struct Fixture {
+    pub cases: Arc<InMemoryCaseRepository>,
+    pub decisions: Arc<InMemoryDecisionRepository>,
+    pub enforcements: Arc<InMemoryEnforcementRepository>,
+    pub penalties: Arc<InMemoryPenaltyRepository>,
+    pub appeals: Arc<InMemoryAppealRepository>,
+    pub projection: Arc<InMemoryEnforcementProjection>,
+    pub corpus: Arc<StubScreenCorpus>,
+    pub classifiers: Arc<StubClassifierGateway>,
+    pub accounts: Arc<StubAccountDirectory>,
+    pub publisher: Arc<RecordingEventPublisher>,
+    pub policy: ModerationPolicy,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        Self {
+            cases: Arc::new(InMemoryCaseRepository::new()),
+            decisions: Arc::new(InMemoryDecisionRepository::new()),
+            enforcements: Arc::new(InMemoryEnforcementRepository::new()),
+            penalties: Arc::new(InMemoryPenaltyRepository::new()),
+            appeals: Arc::new(InMemoryAppealRepository::new()),
+            projection: Arc::new(InMemoryEnforcementProjection::new()),
+            corpus: Arc::new(StubScreenCorpus::new()),
+            classifiers: Arc::new(StubClassifierGateway::new()),
+            accounts: Arc::new(StubAccountDirectory::new()),
+            publisher: Arc::new(RecordingEventPublisher::new()),
+            policy: ModerationPolicy::test_default(),
+        }
+    }
+
+    pub fn screen_handler(&self) -> super::command::ScreenHandler {
+        super::command::ScreenHandler::new(
+            Arc::clone(&self.corpus) as _,
+            Arc::clone(&self.decisions) as _,
+            Arc::clone(&self.enforcements) as _,
+            Arc::clone(&self.penalties) as _,
+            Arc::clone(&self.projection) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn open_case_handler(&self) -> super::command::OpenCaseHandler {
+        super::command::OpenCaseHandler::new(
+            Arc::clone(&self.cases) as _,
+            Arc::clone(&self.publisher) as _,
+        )
+    }
+
+    pub fn assign_case_handler(&self) -> super::command::AssignCaseHandler {
+        super::command::AssignCaseHandler::new(Arc::clone(&self.cases) as _)
+    }
+
+    pub fn decide_handler(&self) -> super::command::DecideCaseHandler {
+        super::command::DecideCaseHandler::new(
+            Arc::clone(&self.cases) as _,
+            Arc::clone(&self.decisions) as _,
+            Arc::clone(&self.enforcements) as _,
+            Arc::clone(&self.penalties) as _,
+            Arc::clone(&self.projection) as _,
+            Arc::clone(&self.accounts) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn ingest_report_handler(&self) -> super::command::IngestReportHandler {
+        super::command::IngestReportHandler::new(
+            Arc::clone(&self.cases) as _,
+            Arc::clone(&self.publisher) as _,
+            Arc::clone(&self.classifiers) as _,
+        )
+    }
+
+    pub fn ingest_signal_handler(&self) -> super::command::IngestSignalHandler {
+        super::command::IngestSignalHandler::new(
+            Arc::clone(&self.cases) as _,
+            Arc::clone(&self.publisher) as _,
+        )
+    }
+
+    pub fn file_appeal_handler(&self) -> super::command::FileAppealHandler {
+        super::command::FileAppealHandler::new(
+            Arc::clone(&self.decisions) as _,
+            Arc::clone(&self.appeals) as _,
+            Arc::clone(&self.cases) as _,
+        )
+    }
+
+    pub fn resolve_appeal_handler(&self) -> super::command::ResolveAppealHandler {
+        super::command::ResolveAppealHandler::new(
+            Arc::clone(&self.appeals) as _,
+            Arc::clone(&self.decisions) as _,
+            Arc::clone(&self.enforcements) as _,
+            Arc::clone(&self.cases) as _,
+            Arc::clone(&self.projection) as _,
+            Arc::clone(&self.publisher) as _,
+        )
+    }
+
+    pub fn list_queue_handler(&self) -> super::query::ListQueueHandler {
+        super::query::ListQueueHandler::new(Arc::clone(&self.cases) as _)
+    }
+
+    pub fn enforcement_state_handler(&self) -> super::query::GetEnforcementStateHandler {
+        super::query::GetEnforcementStateHandler::new(
+            Arc::clone(&self.projection) as _,
+            Arc::clone(&self.enforcements) as _,
+        )
+    }
+
+    pub fn statement_of_reasons_handler(&self) -> super::query::GetStatementOfReasonsHandler {
+        super::query::GetStatementOfReasonsHandler::new(Arc::clone(&self.decisions) as _)
+    }
+}

--- a/crates/services/moderation/src/application/mod.rs
+++ b/crates/services/moderation/src/application/mod.rs
@@ -1,0 +1,31 @@
+//! The moderation application layer — use-case orchestration over the domain and
+//! ports.
+//!
+//! ## Handler shape
+//! Like `auth`, the write use-cases are explicit application-service handlers
+//! rather than `cqrs::CommandHandler`: they return rich outputs (a decision, an
+//! enforcement, a screen verdict) that a `Result<(), E>` command cannot carry.
+//! Each takes a [`cqrs::Envelope`] (so the `correlation_id` threads into the
+//! emitted domain events) and an injected `now` for deterministic tests. The
+//! genuinely read-only use-cases implement [`cqrs::QueryHandler`] and ride the
+//! query bus.
+//!
+//! ## Ports
+//! Every external dependency is an `async_trait` port in [`port`], injected as an
+//! `Arc<dyn …>` at the composition root, so the handlers never name a concrete
+//! adapter. In-memory fakes of every port back the unit tests.
+//!
+//! ## Durable-first ordering
+//! Handlers persist to the system of record *first*, then publish the Plane B
+//! event. The durable write is the source of truth; the event is the
+//! denormalization notification.
+
+pub mod command;
+pub mod policy;
+pub mod port;
+pub mod query;
+
+#[cfg(test)]
+pub mod fakes;
+
+pub use policy::ModerationPolicy;

--- a/crates/services/moderation/src/application/policy.rs
+++ b/crates/services/moderation/src/application/policy.rs
@@ -1,0 +1,61 @@
+//! Application-level policy: the tunables the use-cases inject into the domain
+//! engine. The [`PenaltyPolicy`] drives graduated enforcement; the enforcement
+//! TTLs decide how long time-boxed actor restrictions last; the screen policy
+//! version pins the automated decisions the Screen gate records.
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::domain::value_object::{ActionType, PenaltyPolicy, PolicyVersion};
+
+/// Resolved moderation policy, supplied at the composition root (pinned to a
+/// policy version in production).
+#[derive(Debug, Clone)]
+pub struct ModerationPolicy {
+    /// The graduated-enforcement ladder + decay + weights.
+    pub penalty: PenaltyPolicy,
+    /// How long a temporary actor restriction (`RestrictActor`) lasts.
+    pub restrict_actor_ttl: Duration,
+    /// How long a `Suspend` lasts before lapsing.
+    pub suspend_ttl: Duration,
+    /// The policy version stamped on automated decisions made by the Screen gate.
+    pub screen_policy_version: PolicyVersion,
+    /// Hard wall-clock bound on the Plane C corpus lookup. If the corpus does not
+    /// answer within this window the screen returns `ScreenUnavailable` — the
+    /// caller's per-category fail policy then blocks (catastrophic) or admits
+    /// (best-effort). This is what stops a slow/stuck corpus from wedging the
+    /// `media`/`post` publish path.
+    pub screen_timeout: std::time::Duration,
+}
+
+impl ModerationPolicy {
+    /// Production-shaped defaults.
+    pub fn standard() -> Self {
+        Self {
+            penalty: PenaltyPolicy::standard(),
+            restrict_actor_ttl: Duration::days(7),
+            suspend_ttl: Duration::days(30),
+            screen_policy_version: PolicyVersion::new("screen-corpus-1")
+                .expect("literal screen policy version is valid"),
+            screen_timeout: std::time::Duration::from_millis(200),
+        }
+    }
+
+    /// The expiry an enforcement of `action` should carry, applied at `now`.
+    /// `RestrictActor`/`Suspend` are time-boxed; `Ban` and content actions are
+    /// permanent (`None`).
+    pub fn expiry_for(&self, action: ActionType, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        match action {
+            ActionType::RestrictActor => Some(now + self.restrict_actor_ttl),
+            ActionType::Suspend => Some(now + self.suspend_ttl),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+impl ModerationPolicy {
+    /// Deterministic policy for tests (mirrors `standard`).
+    pub fn test_default() -> Self {
+        Self::standard()
+    }
+}

--- a/crates/services/moderation/src/application/port/account_directory.rs
+++ b/crates/services/moderation/src/application/port/account_directory.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::ActorId;
+use crate::error::ModerationError;
+
+/// Read port to the `account` service (gRPC adapter, Phase 4). Moderation
+/// **decides** actor-level actions; `account` **executes** the suspension/ban
+/// lifecycle by consuming the `EnforcementApplied` event. This port is the small
+/// synchronous slice moderation still needs: confirming an actor exists before
+/// recording an actor-level enforcement against them, so a typo'd id can't create
+/// a dangling restriction.
+#[async_trait]
+pub trait AccountDirectory: Send + Sync + 'static {
+    async fn actor_exists(&self, actor_id: &ActorId) -> Result<bool, ModerationError>;
+}

--- a/crates/services/moderation/src/application/port/classifier_gateway.rs
+++ b/crates/services/moderation/src/application/port/classifier_gateway.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::SubjectRef;
+use crate::error::ModerationError;
+
+/// Outbound gateway to the (future, internal) **classifier services**. Moderation
+/// *requests* asynchronous classification and consumes the resulting verdicts back
+/// as signals on `moderation.signals` — it never runs ML inference inline. The
+/// adapter is fire-and-forget: a request enqueues work, it does not block on a
+/// model. Until real classifiers exist this is stubbed, and the graduated engine
+/// runs on deterministic rules alone.
+#[async_trait]
+pub trait ClassifierGateway: Send + Sync + 'static {
+    /// Requests asynchronous classification of a subject. The verdict returns later
+    /// as a `moderation.signals` event, not as a response here.
+    async fn request_classification(&self, subject: &SubjectRef) -> Result<(), ModerationError>;
+}

--- a/crates/services/moderation/src/application/port/enforcement_projection.rs
+++ b/crates/services/moderation/src/application/port/enforcement_projection.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::domain::value_object::{ActorId, EnforcementVersion};
+use crate::error::ModerationError;
+
+/// The hot-path **enforcement projection** (Plane B) — a Redis-backed, O(1)
+/// "is this actor restricted right now" view that producing services consult
+/// synchronously (`mod:enf:{actor:<id>}`), instead of calling moderation per item.
+///
+/// Writes carry the [`EnforcementVersion`] so the adapter can reject a stale
+/// update (a reversal that arrives after a newer re-application must not clear the
+/// newer restriction). The projection is denormalized; the durable enforcement
+/// record in Postgres remains the source of truth.
+#[async_trait]
+pub trait EnforcementProjection: Send + Sync + 'static {
+    /// Marks an actor restricted at `version`, optionally with an expiry (after
+    /// which the restriction lapses). A write at a lower version than the stored
+    /// one is ignored.
+    async fn set_actor_restriction(
+        &self,
+        actor_id: &ActorId,
+        version: EnforcementVersion,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<(), ModerationError>;
+
+    /// Clears an actor's restriction, but only if `version` is at least the stored
+    /// one (a stale reversal is ignored).
+    async fn clear_actor_restriction(
+        &self,
+        actor_id: &ActorId,
+        version: EnforcementVersion,
+    ) -> Result<(), ModerationError>;
+
+    /// Whether the actor is currently restricted.
+    async fn is_actor_restricted(&self, actor_id: &ActorId) -> Result<bool, ModerationError>;
+}

--- a/crates/services/moderation/src/application/port/event_publisher.rs
+++ b/crates/services/moderation/src/application/port/event_publisher.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+use crate::domain::event::DomainEvent;
+use crate::error::ModerationError;
+
+/// Outbound port for publishing domain events to the `moderation.v1.events` Kafka
+/// topic (Phase 4 adapter), keyed by `actor_id` for per-actor ordering.
+///
+/// Handlers persist durably first, then publish — the durable write is the source
+/// of truth, the event is the Plane B denormalization notification. A publish
+/// failure surfaces so the caller can decide (the adapter may back an outbox).
+#[async_trait]
+pub trait EventPublisher: Send + Sync + 'static {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ModerationError>;
+}

--- a/crates/services/moderation/src/application/port/mod.rs
+++ b/crates/services/moderation/src/application/port/mod.rs
@@ -1,0 +1,21 @@
+//! Outbound ports — the only contracts the application layer holds against the
+//! outside world. Concrete adapters (Postgres, Scylla, Redis, the `account` gRPC
+//! client, the classifier gateway, the Kafka publisher) live in `infrastructure`
+//! (Phase 4) and are injected at the composition root. Each is an `async_trait` so
+//! it can be held as `Arc<dyn …>`; in-memory fakes back the unit tests.
+
+pub mod account_directory;
+pub mod classifier_gateway;
+pub mod enforcement_projection;
+pub mod event_publisher;
+pub mod repositories;
+pub mod screen_corpus;
+
+pub use account_directory::AccountDirectory;
+pub use classifier_gateway::ClassifierGateway;
+pub use enforcement_projection::EnforcementProjection;
+pub use event_publisher::EventPublisher;
+pub use repositories::{
+    AppealRepository, CaseRepository, DecisionRepository, EnforcementRepository, PenaltyRepository,
+};
+pub use screen_corpus::{ContentHash, CorpusMatch, ScreenCorpus};

--- a/crates/services/moderation/src/application/port/repositories.rs
+++ b/crates/services/moderation/src/application/port/repositories.rs
@@ -1,0 +1,82 @@
+//! Durable persistence ports for the moderation aggregates. Concrete adapters
+//! (Postgres for the decision/case SoR, Scylla for history) live in
+//! `infrastructure` (Phase 4) and are injected as `Arc<dyn …>` at the composition
+//! root.
+
+use async_trait::async_trait;
+
+use crate::domain::aggregate::{Appeal, Case, Decision, EnforcementAction, PenaltyLedger};
+use crate::domain::value_object::{
+    ActorId, AppealId, CaseId, CaseStatus, DecisionId, EnforcementId, EnforcementVersion, SubjectRef,
+};
+use crate::error::ModerationError;
+
+/// Persistence for the [`Case`] aggregate. `save` upserts with optimistic-lock
+/// semantics on the aggregate `version`; the deterministic [`CaseId`] makes a
+/// redelivered open idempotent.
+#[async_trait]
+pub trait CaseRepository: Send + Sync + 'static {
+    async fn save(&self, case: &Case) -> Result<(), ModerationError>;
+
+    async fn find_by_id(&self, id: &CaseId) -> Result<Option<Case>, ModerationError>;
+
+    /// The review queue (paged), optionally filtered by status. `None` status ⇒
+    /// all open work.
+    async fn list_queue(
+        &self,
+        queue: &str,
+        status: Option<CaseStatus>,
+        limit: usize,
+    ) -> Result<Vec<Case>, ModerationError>;
+}
+
+/// Persistence for the **append-only** decision ledger. There is deliberately no
+/// `update`: a decision is never mutated, only superseded by a new (reversal) one.
+#[async_trait]
+pub trait DecisionRepository: Send + Sync + 'static {
+    async fn append(&self, decision: &Decision) -> Result<(), ModerationError>;
+
+    async fn find_by_id(&self, id: &DecisionId) -> Result<Option<Decision>, ModerationError>;
+}
+
+/// Persistence for the [`EnforcementAction`] aggregate.
+#[async_trait]
+pub trait EnforcementRepository: Send + Sync + 'static {
+    async fn save(&self, enforcement: &EnforcementAction) -> Result<(), ModerationError>;
+
+    async fn find_by_id(
+        &self,
+        id: &EnforcementId,
+    ) -> Result<Option<EnforcementAction>, ModerationError>;
+
+    /// The next monotonic enforcement version for a subject (max existing + 1, or
+    /// [`EnforcementVersion::INITIAL`] when none exists). The monotonicity is what
+    /// keeps a stale reversal from racing ahead of a newer re-application.
+    async fn next_version(
+        &self,
+        subject: &SubjectRef,
+    ) -> Result<EnforcementVersion, ModerationError>;
+
+    /// Currently-active enforcements for an actor (for `GetEnforcementState`).
+    async fn list_active_for_actor(
+        &self,
+        actor_id: &ActorId,
+    ) -> Result<Vec<EnforcementAction>, ModerationError>;
+}
+
+/// Persistence for the [`PenaltyLedger`] aggregate. `load` returns an empty ledger
+/// for an actor with no history.
+#[async_trait]
+pub trait PenaltyRepository: Send + Sync + 'static {
+    async fn load(&self, actor_id: &ActorId) -> Result<PenaltyLedger, ModerationError>;
+
+    async fn save(&self, ledger: &PenaltyLedger) -> Result<(), ModerationError>;
+}
+
+/// Persistence for the [`Appeal`] aggregate.
+#[async_trait]
+pub trait AppealRepository: Send + Sync + 'static {
+    async fn save(&self, appeal: &Appeal) -> Result<(), ModerationError>;
+
+    async fn find_by_id(&self, id: &AppealId) -> Result<Option<Appeal>, ModerationError>;
+}

--- a/crates/services/moderation/src/application/port/screen_corpus.rs
+++ b/crates/services/moderation/src/application/port/screen_corpus.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::PolicyCategory;
+use crate::error::ModerationError;
+
+/// A precomputed content fingerprint supplied by the caller (e.g. `media`). The
+/// screen path never receives raw bytes — only these hashes and, optionally, short
+/// text for the critical-term blocklist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentHash {
+    /// e.g. `"pdq"`, `"md5"`, `"photodna"`.
+    pub algorithm: String,
+    pub value: String,
+}
+
+/// A positive hit against the known-bad corpus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorpusMatch {
+    /// The catastrophic-harm categories the content matched.
+    pub categories: Vec<PolicyCategory>,
+    /// Corpus entry reference, recorded on the decision for the audit trail.
+    pub reference: String,
+}
+
+/// The **Screen corpus** (Plane C) — the deterministic, bounded-latency lookup
+/// behind the pre-publish gate: perceptual/cryptographic hash matching plus a
+/// critical-term blocklist. No ML inference. The adapter (Redis/bloom, Phase 4)
+/// must be fast and is fail-closed for catastrophic categories: an error here is
+/// surfaced as [`ModerationError::ScreenUnavailable`]/`HashCorpusUnavailable`, and
+/// the *caller's* policy converts that into a hard block.
+#[async_trait]
+pub trait ScreenCorpus: Send + Sync + 'static {
+    /// Screens the given hashes (and optional text) against the corpus for the
+    /// requested categories. Returns `Some(match)` on a known-bad hit, `None`
+    /// when nothing matched (which means "no known-bad match", not "approved").
+    async fn screen(
+        &self,
+        hashes: &[ContentHash],
+        text: Option<&str>,
+        categories: &[PolicyCategory],
+    ) -> Result<Option<CorpusMatch>, ModerationError>;
+}

--- a/crates/services/moderation/src/application/query/enforcement_state.rs
+++ b/crates/services/moderation/src/application/query/enforcement_state.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::{EnforcementProjection, EnforcementRepository};
+use crate::domain::aggregate::EnforcementAction;
+use crate::domain::value_object::ActorId;
+use crate::error::ModerationError;
+
+/// INTERNAL, discouraged on the hot path — the fleet reads enforcement via Plane B
+/// (events + Redis projection), not this RPC. Exists for back-office/cold reads.
+#[derive(Debug, Clone)]
+pub struct GetEnforcementStateQuery {
+    pub actor_id: ActorId,
+}
+
+impl Query for GetEnforcementStateQuery {
+    type Response = EnforcementStateView;
+}
+
+/// Coarse "is this actor restricted" plus the active enforcement records.
+#[derive(Debug, Clone)]
+pub struct EnforcementStateView {
+    pub actor_restricted: bool,
+    pub active_enforcements: Vec<EnforcementAction>,
+}
+
+pub struct GetEnforcementStateHandler {
+    projection: Arc<dyn EnforcementProjection>,
+    enforcements: Arc<dyn EnforcementRepository>,
+}
+
+impl GetEnforcementStateHandler {
+    pub fn new(
+        projection: Arc<dyn EnforcementProjection>,
+        enforcements: Arc<dyn EnforcementRepository>,
+    ) -> Self {
+        Self { projection, enforcements }
+    }
+
+    /// Clock-injected core, for deterministic tests.
+    pub async fn handle_at(
+        &self,
+        envelope: Envelope<GetEnforcementStateQuery>,
+        now: DateTime<Utc>,
+    ) -> Result<EnforcementStateView, ModerationError> {
+        let actor_id = envelope.payload.actor_id;
+        let actor_restricted = self.projection.is_actor_restricted(&actor_id).await?;
+        let active_enforcements = self
+            .enforcements
+            .list_active_for_actor(&actor_id)
+            .await?
+            .into_iter()
+            .filter(|e| e.is_active(now))
+            .collect();
+        Ok(EnforcementStateView { actor_restricted, active_enforcements })
+    }
+}
+
+impl QueryHandler<GetEnforcementStateQuery> for GetEnforcementStateHandler {
+    type Error = ModerationError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<GetEnforcementStateQuery>,
+    ) -> Result<EnforcementStateView, Self::Error> {
+        self.handle_at(envelope, Utc::now()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::{DecideCaseCommand, OpenCaseCommand};
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{ActionType, EntityType, PolicyCategory, SubjectRef};
+    use uuid::Uuid;
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap()
+    }
+
+    #[tokio::test]
+    async fn reports_active_actor_restriction() {
+        let fx = Fixture::new();
+        let open = Envelope::new(
+            Uuid::now_v7(),
+            OpenCaseCommand { subject: subject(), category: PolicyCategory::Hate, queue: "q".into(), priority: "p".into() },
+        );
+        let case = fx.open_case_handler().handle(open, t0()).await.unwrap().case;
+        let decide = Envelope::new(
+            Uuid::now_v7(),
+            DecideCaseCommand {
+                case_id: case.id(),
+                action: ActionType::Suspend,
+                category: PolicyCategory::Hate,
+                rationale: "x".into(),
+                reviewer_id: "r".into(),
+                policy_version: "2026.06.1".into(),
+            },
+        );
+        fx.decide_handler().handle(decide, t0()).await.unwrap();
+
+        let q = Envelope::new(Uuid::now_v7(), GetEnforcementStateQuery { actor_id: subject().actor_id() });
+        let view = fx.enforcement_state_handler().handle_at(q, t0()).await.unwrap();
+        assert!(view.actor_restricted);
+        assert_eq!(view.active_enforcements.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn clean_actor_is_unrestricted() {
+        let fx = Fixture::new();
+        let q = Envelope::new(Uuid::now_v7(), GetEnforcementStateQuery { actor_id: subject().actor_id() });
+        let view = fx.enforcement_state_handler().handle_at(q, t0()).await.unwrap();
+        assert!(!view.actor_restricted);
+        assert!(view.active_enforcements.is_empty());
+    }
+}

--- a/crates/services/moderation/src/application/query/list_queue.rs
+++ b/crates/services/moderation/src/application/query/list_queue.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::CaseRepository;
+use crate::domain::aggregate::Case;
+use crate::domain::value_object::CaseStatus;
+use crate::error::ModerationError;
+
+/// List the review queue (paged) for triage UIs.
+#[derive(Debug, Clone)]
+pub struct ListQueueQuery {
+    pub queue: String,
+    pub status_filter: Option<CaseStatus>,
+    pub limit: usize,
+}
+
+impl Query for ListQueueQuery {
+    type Response = Vec<Case>;
+}
+
+pub struct ListQueueHandler {
+    cases: Arc<dyn CaseRepository>,
+}
+
+impl ListQueueHandler {
+    pub fn new(cases: Arc<dyn CaseRepository>) -> Self {
+        Self { cases }
+    }
+}
+
+impl QueryHandler<ListQueueQuery> for ListQueueHandler {
+    type Error = ModerationError;
+
+    async fn handle(&self, envelope: Envelope<ListQueueQuery>) -> Result<Vec<Case>, Self::Error> {
+        let q = envelope.payload;
+        self.cases.list_queue(&q.queue, q.status_filter, q.limit).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::OpenCaseCommand;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{ActorId, EntityType, PolicyCategory, SubjectRef};
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn lists_open_cases_in_the_queue() {
+        let fx = Fixture::new();
+        for n in 0..3u128 {
+            let subject = SubjectRef::new(EntityType::Post, format!("p{n}"), ActorId::from_uuid(Uuid::from_u128(n + 1)), "feed").unwrap();
+            let env = Envelope::new(
+                Uuid::now_v7(),
+                OpenCaseCommand { subject, category: PolicyCategory::Spam, queue: "default".into(), priority: "normal".into() },
+            );
+            fx.open_case_handler().handle(env, t0()).await.unwrap();
+        }
+        let q = Envelope::new(
+            Uuid::now_v7(),
+            ListQueueQuery { queue: "default".into(), status_filter: Some(CaseStatus::Open), limit: 10 },
+        );
+        let cases = fx.list_queue_handler().handle(q).await.unwrap();
+        assert_eq!(cases.len(), 3);
+    }
+}

--- a/crates/services/moderation/src/application/query/mod.rs
+++ b/crates/services/moderation/src/application/query/mod.rs
@@ -1,0 +1,14 @@
+//! Read use-cases. These are genuinely read-only, so they implement
+//! [`cqrs::QueryHandler`] and ride the query bus like the rest of the fleet.
+
+pub mod enforcement_state;
+pub mod list_queue;
+pub mod statement_of_reasons;
+
+pub use enforcement_state::{
+    EnforcementStateView, GetEnforcementStateHandler, GetEnforcementStateQuery,
+};
+pub use list_queue::{ListQueueHandler, ListQueueQuery};
+pub use statement_of_reasons::{
+    GetStatementOfReasonsHandler, GetStatementOfReasonsQuery, StatementOfReasons,
+};

--- a/crates/services/moderation/src/application/query/statement_of_reasons.rs
+++ b/crates/services/moderation/src/application/query/statement_of_reasons.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::DecisionRepository;
+use crate::domain::value_object::{ActionType, DecisionId, PolicyCategory, SubjectRef};
+use crate::error::ModerationError;
+
+/// Fetch the DSA Statement of Reasons for a decision (compliance/back-office).
+#[derive(Debug, Clone)]
+pub struct GetStatementOfReasonsQuery {
+    pub decision_id: DecisionId,
+}
+
+impl Query for GetStatementOfReasonsQuery {
+    type Response = StatementOfReasons;
+}
+
+/// The DSA Article 17 machine-readable statement, derived from the decision ledger.
+#[derive(Debug, Clone)]
+pub struct StatementOfReasons {
+    pub decision_id: DecisionId,
+    pub subject: SubjectRef,
+    pub category: PolicyCategory,
+    pub action: ActionType,
+    pub policy_version: String,
+    pub facts: String,
+    pub automated: bool,
+    pub decided_at: DateTime<Utc>,
+}
+
+pub struct GetStatementOfReasonsHandler {
+    decisions: Arc<dyn DecisionRepository>,
+}
+
+impl GetStatementOfReasonsHandler {
+    pub fn new(decisions: Arc<dyn DecisionRepository>) -> Self {
+        Self { decisions }
+    }
+}
+
+impl QueryHandler<GetStatementOfReasonsQuery> for GetStatementOfReasonsHandler {
+    type Error = ModerationError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<GetStatementOfReasonsQuery>,
+    ) -> Result<StatementOfReasons, Self::Error> {
+        let id = envelope.payload.decision_id;
+        let decision = self
+            .decisions
+            .find_by_id(&id)
+            .await?
+            .ok_or(ModerationError::DecisionNotFound { id: id.as_str() })?;
+        Ok(StatementOfReasons {
+            decision_id: decision.id(),
+            subject: decision.subject().clone(),
+            category: decision.category(),
+            action: decision.action(),
+            policy_version: decision.policy_version().as_str().to_owned(),
+            facts: decision.rationale().to_owned(),
+            automated: decision.is_automated(),
+            decided_at: decision.decided_at(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::command::{DecideCaseCommand, OpenCaseCommand};
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{ActorId, EntityType};
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn builds_statement_from_a_recorded_decision() {
+        let fx = Fixture::new();
+        let subject = SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap();
+        let open = Envelope::new(
+            Uuid::now_v7(),
+            OpenCaseCommand { subject, category: PolicyCategory::Hate, queue: "q".into(), priority: "p".into() },
+        );
+        let case = fx.open_case_handler().handle(open, t0()).await.unwrap().case;
+        let decide = Envelope::new(
+            Uuid::now_v7(),
+            DecideCaseCommand {
+                case_id: case.id(),
+                action: ActionType::RemoveContent,
+                category: PolicyCategory::Hate,
+                rationale: "violates hate policy".into(),
+                reviewer_id: "rev-1".into(),
+                policy_version: "2026.06.1".into(),
+            },
+        );
+        let decision_id = fx.decide_handler().handle(decide, t0()).await.unwrap().decision.id();
+
+        let q = Envelope::new(Uuid::now_v7(), GetStatementOfReasonsQuery { decision_id });
+        let sor = fx.statement_of_reasons_handler().handle(q).await.unwrap();
+        assert_eq!(sor.action, ActionType::RemoveContent);
+        assert_eq!(sor.category, PolicyCategory::Hate);
+        assert_eq!(sor.policy_version, "2026.06.1");
+        assert_eq!(sor.facts, "violates hate policy");
+        assert!(!sor.automated);
+    }
+
+    #[tokio::test]
+    async fn missing_decision_errs() {
+        let fx = Fixture::new();
+        let q = Envelope::new(Uuid::now_v7(), GetStatementOfReasonsQuery { decision_id: DecisionId::new() });
+        let err = fx.statement_of_reasons_handler().handle(q).await.unwrap_err();
+        assert!(matches!(err, ModerationError::DecisionNotFound { .. }));
+    }
+}

--- a/crates/services/moderation/src/config.rs
+++ b/crates/services/moderation/src/config.rs
@@ -1,0 +1,49 @@
+//! Environment-sourced configuration for the moderation service. Resolved once at
+//! boot and threaded into the composition root ([`crate::app::App::build`]).
+//! Backend connection configs (Postgres / Scylla / Redis / Kafka) are resolved
+//! separately via their own `from_env`.
+
+use chrono::Duration;
+
+use crate::application::ModerationPolicy;
+use crate::domain::value_object::PolicyVersion;
+
+/// Fully-resolved moderation configuration.
+pub struct ModerationConfig {
+    pub policy: ModerationPolicy,
+    /// gRPC endpoint of the `account` service, e.g. `http://account:50059`.
+    pub account_endpoint: String,
+}
+
+impl ModerationConfig {
+    /// Resolves configuration from the environment. Every value has a
+    /// production-shaped default; the penalty ladder defaults to
+    /// [`ModerationPolicy::standard`] with the TTLs overridable.
+    pub fn from_env() -> anyhow::Result<Self> {
+        let mut policy = ModerationPolicy::standard();
+        policy.restrict_actor_ttl =
+            Duration::seconds(env_secs("MODERATION_RESTRICT_TTL_SECS", 604_800)); // 7d
+        policy.suspend_ttl =
+            Duration::seconds(env_secs("MODERATION_SUSPEND_TTL_SECS", 2_592_000)); // 30d
+        if let Ok(v) = std::env::var("MODERATION_SCREEN_POLICY_VERSION")
+            && !v.trim().is_empty()
+        {
+            policy.screen_policy_version = PolicyVersion::new(v)?;
+        }
+        policy.screen_timeout =
+            std::time::Duration::from_millis(env_secs("MODERATION_SCREEN_TIMEOUT_MS", 200) as u64);
+
+        Ok(Self {
+            policy,
+            account_endpoint: env_or("MODERATION_ACCOUNT_GRPC_ENDPOINT", "http://localhost:50059"),
+        })
+    }
+}
+
+fn env_or(key: &str, default: impl Into<String>) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.into())
+}
+
+fn env_secs(key: &str, default: i64) -> i64 {
+    std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}

--- a/crates/services/moderation/src/domain/aggregate/appeal.rs
+++ b/crates/services/moderation/src/domain/aggregate/appeal.rs
@@ -1,0 +1,219 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::event::{AppealResolved, DomainEvent};
+use crate::domain::value_object::{ActorId, AppealId, AppealStatus, DecisionId};
+use crate::error::ModerationError;
+
+/// The **Appeal** aggregate — a challenge to a [`Decision`].
+///
+/// Whether a category is appealable at all is checked by the application layer
+/// against the decision's category (legally-mandated removals are not appealable);
+/// this aggregate owns the lifecycle once an appeal is admitted. Resolving an
+/// appeal emits [`AppealResolved`]; an overturn additionally drives a reversal
+/// decision + enforcement reversal in the application layer.
+///
+/// [`Decision`]: crate::domain::aggregate::Decision
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Appeal {
+    id: AppealId,
+    decision_id: DecisionId,
+    actor_id: ActorId,
+    statement: String,
+    status: AppealStatus,
+    filed_at: DateTime<Utc>,
+    resolved_at: Option<DateTime<Utc>>,
+
+    #[serde(skip)]
+    pending_events: Vec<DomainEvent>,
+}
+
+impl Appeal {
+    /// Files an appeal. Rejects an empty statement — the appellant must state a
+    /// case.
+    pub fn file(
+        decision_id: DecisionId,
+        actor_id: ActorId,
+        statement: impl Into<String>,
+        filed_at: DateTime<Utc>,
+    ) -> Result<Self, ModerationError> {
+        let statement = statement.into();
+        if statement.trim().is_empty() {
+            return Err(ModerationError::DomainViolation {
+                field: "appeal.statement".into(),
+                message: "an appeal must include a statement".into(),
+            });
+        }
+        Ok(Self {
+            id: AppealId::new(),
+            decision_id,
+            actor_id,
+            statement,
+            status: AppealStatus::Filed,
+            filed_at,
+            resolved_at: None,
+            pending_events: Vec::new(),
+        })
+    }
+
+    /// Reconstructs from storage (no events emitted).
+    #[allow(clippy::too_many_arguments)]
+    pub fn reconstitute(
+        id: AppealId,
+        decision_id: DecisionId,
+        actor_id: ActorId,
+        statement: String,
+        status: AppealStatus,
+        filed_at: DateTime<Utc>,
+        resolved_at: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            id,
+            decision_id,
+            actor_id,
+            statement,
+            status,
+            filed_at,
+            resolved_at,
+            pending_events: Vec::new(),
+        }
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    pub fn id(&self) -> AppealId {
+        self.id
+    }
+
+    pub fn decision_id(&self) -> DecisionId {
+        self.decision_id
+    }
+
+    pub fn actor_id(&self) -> ActorId {
+        self.actor_id
+    }
+
+    pub fn statement(&self) -> &str {
+        &self.statement
+    }
+
+    pub fn status(&self) -> AppealStatus {
+        self.status
+    }
+
+    pub fn filed_at(&self) -> DateTime<Utc> {
+        self.filed_at
+    }
+
+    pub fn resolved_at(&self) -> Option<DateTime<Utc>> {
+        self.resolved_at
+    }
+
+    // ─── Commands ────────────────────────────────────────────────────────────
+
+    /// Moves a filed appeal into review.
+    pub fn start_review(&mut self) -> Result<(), ModerationError> {
+        self.transition_to(AppealStatus::UnderReview)
+    }
+
+    /// Resolves the appeal: `overturn = true` overturns the decision, `false`
+    /// upholds it. Emits [`AppealResolved`].
+    pub fn resolve(
+        &mut self,
+        overturn: bool,
+        now: DateTime<Utc>,
+        correlation_id: Uuid,
+    ) -> Result<(), ModerationError> {
+        let target = if overturn {
+            AppealStatus::Overturned
+        } else {
+            AppealStatus::Upheld
+        };
+        self.transition_to(target)?;
+        self.resolved_at = Some(now);
+        self.pending_events.push(DomainEvent::AppealResolved(AppealResolved {
+            appeal_id: self.id,
+            decision_id: self.decision_id,
+            actor_id: self.actor_id,
+            overturned: overturn,
+            occurred_at: now,
+            correlation_id,
+        }));
+        Ok(())
+    }
+
+    /// Drains accumulated events for the unit-of-work to publish.
+    pub fn drain_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    fn transition_to(&mut self, next: AppealStatus) -> Result<(), ModerationError> {
+        if self.status.is_terminal() {
+            return Err(ModerationError::AppealAlreadyResolved);
+        }
+        if !self.status.can_transition_to(next) {
+            return Err(ModerationError::DomainViolation {
+                field: "appeal.status".into(),
+                message: format!("illegal appeal transition {} → {}", self.status, next),
+            });
+        }
+        self.status = next;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn appeal() -> Appeal {
+        Appeal::file(
+            DecisionId::new(),
+            ActorId::from_uuid(Uuid::from_u128(1)),
+            "this was not harassment",
+            t0(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn file_requires_statement() {
+        assert!(matches!(
+            Appeal::file(DecisionId::new(), ActorId::from_uuid(Uuid::nil()), "   ", t0()).unwrap_err(),
+            ModerationError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn overturn_emits_event() {
+        let mut a = appeal();
+        a.start_review().unwrap();
+        a.resolve(true, t0(), Uuid::now_v7()).unwrap();
+        assert_eq!(a.status(), AppealStatus::Overturned);
+        let events = a.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "moderation.appeal_resolved");
+    }
+
+    #[test]
+    fn uphold_directly_from_filed_is_allowed() {
+        let mut a = appeal();
+        a.resolve(false, t0(), Uuid::now_v7()).unwrap();
+        assert_eq!(a.status(), AppealStatus::Upheld);
+    }
+
+    #[test]
+    fn cannot_resolve_twice() {
+        let mut a = appeal();
+        a.resolve(false, t0(), Uuid::now_v7()).unwrap();
+        assert!(matches!(
+            a.resolve(true, t0(), Uuid::now_v7()).unwrap_err(),
+            ModerationError::AppealAlreadyResolved
+        ));
+    }
+}

--- a/crates/services/moderation/src/domain/aggregate/case.rs
+++ b/crates/services/moderation/src/domain/aggregate/case.rs
@@ -1,0 +1,358 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::event::{CaseOpened, CaseResolved, DomainEvent};
+use crate::domain::value_object::{
+    ActionType, CaseId, CaseStatus, DecisionId, PolicyCategory, Signal, SubjectRef,
+};
+use crate::error::ModerationError;
+
+/// Parameters to open a case.
+#[derive(Debug, Clone)]
+pub struct CaseOpenParams {
+    pub subject: SubjectRef,
+    pub category: PolicyCategory,
+    pub queue: String,
+    pub priority: String,
+    pub opened_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// The **Case** aggregate root — a unit of review work about a subject.
+///
+/// Its id is **deterministic** ([`CaseId::for_subject`]), so opening a case for the
+/// same subject twice (e.g. a redelivered content event) yields the same case and
+/// upserts rather than duplicating — the idempotency the Consumer Runtime Standard
+/// requires. A case accrues [`Signal`]s, gets triaged/assigned, and is finally
+/// resolved (actioned or dismissed) — which records a [`Decision`] elsewhere and
+/// emits [`CaseResolved`]. An appeal can reopen an actioned case.
+///
+/// [`Decision`]: crate::domain::aggregate::Decision
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Case {
+    id: CaseId,
+    subject: SubjectRef,
+    status: CaseStatus,
+    category: PolicyCategory,
+    queue: String,
+    priority: String,
+    assignee: Option<String>,
+    signals: Vec<Signal>,
+    opened_at: DateTime<Utc>,
+    version: i64,
+
+    #[serde(skip)]
+    pending_events: Vec<DomainEvent>,
+}
+
+impl Case {
+    /// Opens a new `Open` case, emitting [`CaseOpened`].
+    pub fn open(params: CaseOpenParams) -> Self {
+        let id = CaseId::for_subject(&params.subject);
+        let event = DomainEvent::CaseOpened(CaseOpened {
+            case_id: id,
+            subject: params.subject.clone(),
+            actor_id: params.subject.actor_id(),
+            category: params.category,
+            occurred_at: params.opened_at,
+            correlation_id: params.correlation_id,
+        });
+        Self {
+            id,
+            subject: params.subject,
+            status: CaseStatus::Open,
+            category: params.category,
+            queue: params.queue,
+            priority: params.priority,
+            assignee: None,
+            signals: Vec::new(),
+            opened_at: params.opened_at,
+            version: 0,
+            pending_events: vec![event],
+        }
+    }
+
+    /// Reconstructs from storage (no events emitted).
+    #[allow(clippy::too_many_arguments)]
+    pub fn reconstitute(
+        id: CaseId,
+        subject: SubjectRef,
+        status: CaseStatus,
+        category: PolicyCategory,
+        queue: String,
+        priority: String,
+        assignee: Option<String>,
+        signals: Vec<Signal>,
+        opened_at: DateTime<Utc>,
+        version: i64,
+    ) -> Self {
+        Self {
+            id,
+            subject,
+            status,
+            category,
+            queue,
+            priority,
+            assignee,
+            signals,
+            opened_at,
+            version,
+            pending_events: Vec::new(),
+        }
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    pub fn id(&self) -> CaseId {
+        self.id
+    }
+
+    pub fn subject(&self) -> &SubjectRef {
+        &self.subject
+    }
+
+    pub fn status(&self) -> CaseStatus {
+        self.status
+    }
+
+    pub fn category(&self) -> PolicyCategory {
+        self.category
+    }
+
+    pub fn queue(&self) -> &str {
+        &self.queue
+    }
+
+    pub fn priority(&self) -> &str {
+        &self.priority
+    }
+
+    pub fn assignee(&self) -> Option<&str> {
+        self.assignee.as_deref()
+    }
+
+    pub fn signals(&self) -> &[Signal] {
+        &self.signals
+    }
+
+    pub fn opened_at(&self) -> DateTime<Utc> {
+        self.opened_at
+    }
+
+    pub fn version(&self) -> i64 {
+        self.version
+    }
+
+    // ─── Commands ────────────────────────────────────────────────────────────
+
+    /// Appends an evidence signal. Rejected once the case is resolved.
+    pub fn add_signal(&mut self, signal: Signal) -> Result<(), ModerationError> {
+        self.ensure_not_resolved()?;
+        self.signals.push(signal);
+        self.touch();
+        Ok(())
+    }
+
+    /// Assigns a reviewer, moving an `Open` case to `Triaged`.
+    pub fn assign(&mut self, reviewer_id: impl Into<String>) -> Result<(), ModerationError> {
+        self.ensure_not_resolved()?;
+        self.assignee = Some(reviewer_id.into());
+        if self.status == CaseStatus::Open {
+            self.transition_to(CaseStatus::Triaged)?;
+        }
+        self.touch();
+        Ok(())
+    }
+
+    /// Resolves the case under `decision_id`: `Actioned` when the action enforces,
+    /// `Dismissed` when it is `NoAction`. Emits [`CaseResolved`].
+    pub fn resolve(
+        &mut self,
+        decision_id: DecisionId,
+        action: ActionType,
+        now: DateTime<Utc>,
+        correlation_id: Uuid,
+    ) -> Result<(), ModerationError> {
+        self.ensure_not_resolved()?;
+        let target = if action.is_enforced() {
+            CaseStatus::Actioned
+        } else {
+            CaseStatus::Dismissed
+        };
+        self.transition_to(target)?;
+        self.touch();
+        self.pending_events.push(DomainEvent::CaseResolved(CaseResolved {
+            case_id: self.id,
+            decision_id,
+            actor_id: self.subject.actor_id(),
+            action,
+            category: self.category,
+            occurred_at: now,
+            correlation_id,
+        }));
+        Ok(())
+    }
+
+    /// Marks an actioned case as under appeal.
+    pub fn mark_appealed(&mut self) -> Result<(), ModerationError> {
+        self.transition_to(CaseStatus::Appealed)?;
+        self.touch();
+        Ok(())
+    }
+
+    /// Closes an appeal: `Dismissed` if overturned, back to `Actioned` if upheld.
+    pub fn close_appeal(&mut self, overturned: bool) -> Result<(), ModerationError> {
+        let target = if overturned {
+            CaseStatus::Dismissed
+        } else {
+            CaseStatus::Actioned
+        };
+        self.transition_to(target)?;
+        self.touch();
+        Ok(())
+    }
+
+    /// Drains accumulated events for the unit-of-work to publish.
+    pub fn drain_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    // ─── Internals ───────────────────────────────────────────────────────────
+
+    fn ensure_not_resolved(&self) -> Result<(), ModerationError> {
+        if self.status.is_resolved() {
+            return Err(ModerationError::CaseAlreadyResolved);
+        }
+        Ok(())
+    }
+
+    fn transition_to(&mut self, next: CaseStatus) -> Result<(), ModerationError> {
+        if !self.status.can_transition_to(next) {
+            return Err(ModerationError::InvalidCaseTransition {
+                from: self.status.to_string(),
+                to: next.to_string(),
+            });
+        }
+        self.status = next;
+        Ok(())
+    }
+
+    fn touch(&mut self) {
+        self.version += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_object::{ActorId, Confidence, EntityType};
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap()
+    }
+
+    fn params() -> CaseOpenParams {
+        CaseOpenParams {
+            subject: subject(),
+            category: PolicyCategory::Harassment,
+            queue: "default".into(),
+            priority: "normal".into(),
+            opened_at: t0(),
+            correlation_id: Uuid::now_v7(),
+        }
+    }
+
+    fn sig() -> Signal {
+        Signal::new("report", PolicyCategory::Harassment, Confidence::new(0.7).unwrap(), t0()).unwrap()
+    }
+
+    #[test]
+    fn open_is_deterministic_and_emits_event() {
+        let mut c = Case::open(params());
+        assert_eq!(c.id(), CaseId::for_subject(&subject()));
+        assert_eq!(c.status(), CaseStatus::Open);
+        let events = c.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "moderation.case_opened");
+    }
+
+    #[test]
+    fn assign_triages_an_open_case() {
+        let mut c = Case::open(params());
+        c.assign("rev-1").unwrap();
+        assert_eq!(c.status(), CaseStatus::Triaged);
+        assert_eq!(c.assignee(), Some("rev-1"));
+    }
+
+    #[test]
+    fn resolve_with_enforcing_action_actions_the_case() {
+        let mut c = Case::open(params());
+        c.drain_events();
+        c.resolve(DecisionId::new(), ActionType::RemoveContent, t0(), Uuid::now_v7()).unwrap();
+        assert_eq!(c.status(), CaseStatus::Actioned);
+        let events = c.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "moderation.case_resolved");
+    }
+
+    #[test]
+    fn resolve_with_no_action_dismisses() {
+        let mut c = Case::open(params());
+        c.resolve(DecisionId::new(), ActionType::NoAction, t0(), Uuid::now_v7()).unwrap();
+        assert_eq!(c.status(), CaseStatus::Dismissed);
+    }
+
+    #[test]
+    fn cannot_resolve_twice() {
+        let mut c = Case::open(params());
+        c.resolve(DecisionId::new(), ActionType::Warn, t0(), Uuid::now_v7()).unwrap();
+        assert!(matches!(
+            c.resolve(DecisionId::new(), ActionType::Ban, t0(), Uuid::now_v7()).unwrap_err(),
+            ModerationError::CaseAlreadyResolved
+        ));
+    }
+
+    #[test]
+    fn cannot_add_signal_after_resolution() {
+        let mut c = Case::open(params());
+        c.resolve(DecisionId::new(), ActionType::Warn, t0(), Uuid::now_v7()).unwrap();
+        assert!(matches!(
+            c.add_signal(sig()).unwrap_err(),
+            ModerationError::CaseAlreadyResolved
+        ));
+    }
+
+    #[test]
+    fn appeal_reopens_then_closes() {
+        let mut c = Case::open(params());
+        c.resolve(DecisionId::new(), ActionType::RemoveContent, t0(), Uuid::now_v7()).unwrap();
+        c.mark_appealed().unwrap();
+        assert_eq!(c.status(), CaseStatus::Appealed);
+        // upheld ⇒ back to actioned
+        c.close_appeal(false).unwrap();
+        assert_eq!(c.status(), CaseStatus::Actioned);
+    }
+
+    #[test]
+    fn overturned_appeal_dismisses() {
+        let mut c = Case::open(params());
+        c.resolve(DecisionId::new(), ActionType::RemoveContent, t0(), Uuid::now_v7()).unwrap();
+        c.mark_appealed().unwrap();
+        c.close_appeal(true).unwrap();
+        assert_eq!(c.status(), CaseStatus::Dismissed);
+    }
+
+    #[test]
+    fn signals_accrue_while_open() {
+        let mut c = Case::open(params());
+        c.add_signal(sig()).unwrap();
+        c.add_signal(sig()).unwrap();
+        assert_eq!(c.signals().len(), 2);
+        assert_eq!(c.version(), 2);
+    }
+}

--- a/crates/services/moderation/src/domain/aggregate/decision.rs
+++ b/crates/services/moderation/src/domain/aggregate/decision.rs
@@ -1,0 +1,221 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{
+    ActionType, DecisionId, PolicyCategory, PolicyVersion, SubjectRef,
+};
+use crate::error::ModerationError;
+
+/// Who (or what) made a decision.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DecisionAuthor {
+    /// A human reviewer (their id).
+    Reviewer(String),
+    /// An automated rule (its id).
+    Rule(String),
+}
+
+impl DecisionAuthor {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Reviewer(id) | Self::Rule(id) => id,
+        }
+    }
+
+    pub fn is_automated(&self) -> bool {
+        matches!(self, Self::Rule(_))
+    }
+}
+
+/// An entry in the **decision ledger** — the legal evidence record of an integrity
+/// action. It is *append-only*: once recorded it is never mutated. A change of
+/// mind (an appeal overturn, a re-review) is expressed as a **new** decision via
+/// [`Decision::record_reversal`], which references the one it supersedes through
+/// `reverses`. The immutability is enforced structurally: this type exposes no
+/// setters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Decision {
+    id: DecisionId,
+    subject: SubjectRef,
+    action: ActionType,
+    category: PolicyCategory,
+    policy_version: PolicyVersion,
+    rationale: String,
+    author: DecisionAuthor,
+    /// Set when this decision reverses an earlier one.
+    reverses: Option<DecisionId>,
+    decided_at: DateTime<Utc>,
+}
+
+/// Inputs to record a fresh decision.
+#[derive(Debug, Clone)]
+pub struct DecisionParams {
+    pub subject: SubjectRef,
+    pub action: ActionType,
+    pub category: PolicyCategory,
+    pub policy_version: PolicyVersion,
+    pub rationale: String,
+    pub author: DecisionAuthor,
+    pub decided_at: DateTime<Utc>,
+}
+
+impl Decision {
+    /// Records a new decision. Rejects an empty rationale — the evidence record
+    /// must always carry a reason.
+    pub fn record(params: DecisionParams) -> Result<Self, ModerationError> {
+        Self::build(params, None)
+    }
+
+    /// Records a decision that reverses `reverses` (e.g. an appeal overturn). The
+    /// original is left untouched; this is a separate ledger entry.
+    pub fn record_reversal(
+        params: DecisionParams,
+        reverses: DecisionId,
+    ) -> Result<Self, ModerationError> {
+        Self::build(params, Some(reverses))
+    }
+
+    fn build(params: DecisionParams, reverses: Option<DecisionId>) -> Result<Self, ModerationError> {
+        if params.rationale.trim().is_empty() {
+            return Err(ModerationError::DomainViolation {
+                field: "decision.rationale".into(),
+                message: "a decision must record a rationale".into(),
+            });
+        }
+        Ok(Self {
+            id: DecisionId::new(),
+            subject: params.subject,
+            action: params.action,
+            category: params.category,
+            policy_version: params.policy_version,
+            rationale: params.rationale,
+            author: params.author,
+            reverses,
+            decided_at: params.decided_at,
+        })
+    }
+
+    /// Reconstructs a decision from storage (no validation).
+    #[allow(clippy::too_many_arguments)]
+    pub fn reconstitute(
+        id: DecisionId,
+        subject: SubjectRef,
+        action: ActionType,
+        category: PolicyCategory,
+        policy_version: PolicyVersion,
+        rationale: String,
+        author: DecisionAuthor,
+        reverses: Option<DecisionId>,
+        decided_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id,
+            subject,
+            action,
+            category,
+            policy_version,
+            rationale,
+            author,
+            reverses,
+            decided_at,
+        }
+    }
+
+    pub fn id(&self) -> DecisionId {
+        self.id
+    }
+
+    pub fn subject(&self) -> &SubjectRef {
+        &self.subject
+    }
+
+    pub fn action(&self) -> ActionType {
+        self.action
+    }
+
+    pub fn category(&self) -> PolicyCategory {
+        self.category
+    }
+
+    pub fn policy_version(&self) -> &PolicyVersion {
+        &self.policy_version
+    }
+
+    pub fn rationale(&self) -> &str {
+        &self.rationale
+    }
+
+    pub fn author(&self) -> &DecisionAuthor {
+        &self.author
+    }
+
+    pub fn is_automated(&self) -> bool {
+        self.author.is_automated()
+    }
+
+    pub fn reverses(&self) -> Option<DecisionId> {
+        self.reverses
+    }
+
+    pub fn decided_at(&self) -> DateTime<Utc> {
+        self.decided_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_object::{ActorId, EntityType};
+    use uuid::Uuid;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn params(rationale: &str) -> DecisionParams {
+        DecisionParams {
+            subject: SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap(),
+            action: ActionType::RemoveContent,
+            category: PolicyCategory::Hate,
+            policy_version: PolicyVersion::new("2026.06.1").unwrap(),
+            rationale: rationale.into(),
+            author: DecisionAuthor::Reviewer("rev-7".into()),
+            decided_at: t0(),
+        }
+    }
+
+    #[test]
+    fn record_requires_rationale() {
+        assert!(matches!(
+            Decision::record(params("  ")).unwrap_err(),
+            ModerationError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn fresh_decision_has_no_reversal_and_unique_id() {
+        let d1 = Decision::record(params("violates hate policy")).unwrap();
+        let d2 = Decision::record(params("violates hate policy")).unwrap();
+        assert!(d1.reverses().is_none());
+        assert_ne!(d1.id(), d2.id());
+        assert!(!d1.is_automated());
+    }
+
+    #[test]
+    fn reversal_references_the_original() {
+        let original = Decision::record(params("removed in error")).unwrap();
+        let mut p = params("overturned on appeal");
+        p.action = ActionType::NoAction;
+        let reversal = Decision::record_reversal(p, original.id()).unwrap();
+        assert_eq!(reversal.reverses(), Some(original.id()));
+    }
+
+    #[test]
+    fn automated_author_is_flagged() {
+        let mut p = params("auto-removed: known-bad hash");
+        p.author = DecisionAuthor::Rule("hash-match-v1".into());
+        let d = Decision::record(p).unwrap();
+        assert!(d.is_automated());
+        assert_eq!(d.author().id(), "hash-match-v1");
+    }
+}

--- a/crates/services/moderation/src/domain/aggregate/enforcement.rs
+++ b/crates/services/moderation/src/domain/aggregate/enforcement.rs
@@ -1,0 +1,327 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::event::{DomainEvent, EnforcementApplied, EnforcementReversed};
+use crate::domain::value_object::{
+    ActionType, ActorId, DecisionId, EnforcementId, EnforcementStatus, EnforcementVersion,
+    SubjectRef,
+};
+use crate::error::ModerationError;
+
+/// Parameters to apply a new enforcement action.
+#[derive(Debug, Clone)]
+pub struct EnforcementParams {
+    pub subject: SubjectRef,
+    pub action: ActionType,
+    /// The decision that authorized this enforcement.
+    pub decision_id: DecisionId,
+    /// The next monotonic version for this subject (supplied by the application
+    /// after reading the current max).
+    pub version: EnforcementVersion,
+    pub applied_at: DateTime<Utc>,
+    /// `None` for permanent actions (e.g. `Ban`); set for time-boxed ones.
+    pub expires_at: Option<DateTime<Utc>>,
+    pub correlation_id: Uuid,
+}
+
+/// The **EnforcementAction** aggregate — the executable, lifecycle-bearing
+/// consequence of a [`Decision`](crate::domain::aggregate::Decision).
+///
+/// # Invariants (enforced here)
+/// 1. An enforcement is created `Active` and emits [`EnforcementApplied`].
+/// 2. It can be reversed only while `Active`; reversing again is rejected
+///    (`EnforcementAlreadyReversed`). Reversal emits [`EnforcementReversed`].
+/// 3. It can expire only while `Active` and only at/after `expires_at`.
+/// 4. It carries a monotonic per-subject `version`; the reversal event re-publishes
+///    that version so a consumer can reject a stale reversal (the cross-aggregate
+///    race guard lives in the projection, this is the value it checks).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnforcementAction {
+    id: EnforcementId,
+    subject: SubjectRef,
+    action: ActionType,
+    status: EnforcementStatus,
+    version: EnforcementVersion,
+    decision_id: DecisionId,
+    applied_at: DateTime<Utc>,
+    expires_at: Option<DateTime<Utc>>,
+    reversed_at: Option<DateTime<Utc>>,
+
+    #[serde(skip)]
+    pending_events: Vec<DomainEvent>,
+}
+
+impl EnforcementAction {
+    /// Applies a new enforcement. Rejects a non-enforcing action (`NoAction` is a
+    /// dismissal — it produces a decision but never an enforcement) and an
+    /// `expires_at` that is not after `applied_at`.
+    pub fn apply(params: EnforcementParams) -> Result<Self, ModerationError> {
+        if !params.action.is_enforced() {
+            return Err(ModerationError::DomainViolation {
+                field: "enforcement.action".into(),
+                message: "no_action does not produce an enforcement".into(),
+            });
+        }
+        if let Some(exp) = params.expires_at
+            && exp <= params.applied_at
+        {
+            return Err(ModerationError::DomainViolation {
+                field: "enforcement.expires_at".into(),
+                message: "expiry must be after the applied time".into(),
+            });
+        }
+
+        let id = EnforcementId::new();
+        let event = DomainEvent::EnforcementApplied(EnforcementApplied {
+            enforcement_id: id,
+            subject: params.subject.clone(),
+            actor_id: params.subject.actor_id(),
+            action: params.action,
+            version: params.version,
+            applied_at: params.applied_at,
+            expires_at: params.expires_at,
+            occurred_at: params.applied_at,
+            correlation_id: params.correlation_id,
+        });
+
+        Ok(Self {
+            id,
+            subject: params.subject,
+            action: params.action,
+            status: EnforcementStatus::Active,
+            version: params.version,
+            decision_id: params.decision_id,
+            applied_at: params.applied_at,
+            expires_at: params.expires_at,
+            reversed_at: None,
+            pending_events: vec![event],
+        })
+    }
+
+    /// Reconstructs from storage (no events emitted).
+    #[allow(clippy::too_many_arguments)]
+    pub fn reconstitute(
+        id: EnforcementId,
+        subject: SubjectRef,
+        action: ActionType,
+        status: EnforcementStatus,
+        version: EnforcementVersion,
+        decision_id: DecisionId,
+        applied_at: DateTime<Utc>,
+        expires_at: Option<DateTime<Utc>>,
+        reversed_at: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            id,
+            subject,
+            action,
+            status,
+            version,
+            decision_id,
+            applied_at,
+            expires_at,
+            reversed_at,
+            pending_events: Vec::new(),
+        }
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    pub fn id(&self) -> EnforcementId {
+        self.id
+    }
+
+    pub fn subject(&self) -> &SubjectRef {
+        &self.subject
+    }
+
+    pub fn actor_id(&self) -> ActorId {
+        self.subject.actor_id()
+    }
+
+    pub fn action(&self) -> ActionType {
+        self.action
+    }
+
+    pub fn status(&self) -> EnforcementStatus {
+        self.status
+    }
+
+    pub fn version(&self) -> EnforcementVersion {
+        self.version
+    }
+
+    pub fn decision_id(&self) -> DecisionId {
+        self.decision_id
+    }
+
+    pub fn applied_at(&self) -> DateTime<Utc> {
+        self.applied_at
+    }
+
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.expires_at
+    }
+
+    pub fn reversed_at(&self) -> Option<DateTime<Utc>> {
+        self.reversed_at
+    }
+
+    /// Whether the enforcement is in force at `now` (Active and not past expiry).
+    pub fn is_active(&self, now: DateTime<Utc>) -> bool {
+        self.status == EnforcementStatus::Active && !self.has_reached_expiry(now)
+    }
+
+    fn has_reached_expiry(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at.is_some_and(|exp| now >= exp)
+    }
+
+    // ─── Commands ────────────────────────────────────────────────────────────
+
+    /// Invariant 2: reverses an active enforcement (appeal overturn / re-review),
+    /// emitting [`EnforcementReversed`].
+    pub fn reverse(&mut self, now: DateTime<Utc>, correlation_id: Uuid) -> Result<(), ModerationError> {
+        match self.status {
+            EnforcementStatus::Reversed => return Err(ModerationError::EnforcementAlreadyReversed),
+            EnforcementStatus::Expired => {
+                return Err(ModerationError::InvalidEnforcementTransition {
+                    from: self.status.to_string(),
+                    to: EnforcementStatus::Reversed.to_string(),
+                });
+            }
+            EnforcementStatus::Active => {}
+        }
+        self.status = EnforcementStatus::Reversed;
+        self.reversed_at = Some(now);
+        self.pending_events.push(DomainEvent::EnforcementReversed(EnforcementReversed {
+            enforcement_id: self.id,
+            subject: self.subject.clone(),
+            actor_id: self.subject.actor_id(),
+            version: self.version,
+            occurred_at: now,
+            correlation_id,
+        }));
+        Ok(())
+    }
+
+    /// Invariant 3: marks an active, past-expiry enforcement `Expired`. No event —
+    /// expiry is the absence of enforcement, not a fact to react to.
+    pub fn mark_expired(&mut self, now: DateTime<Utc>) -> Result<(), ModerationError> {
+        if self.status != EnforcementStatus::Active {
+            return Err(ModerationError::InvalidEnforcementTransition {
+                from: self.status.to_string(),
+                to: EnforcementStatus::Expired.to_string(),
+            });
+        }
+        if !self.has_reached_expiry(now) {
+            return Err(ModerationError::DomainViolation {
+                field: "enforcement".into(),
+                message: "enforcement has not reached its expiry".into(),
+            });
+        }
+        self.status = EnforcementStatus::Expired;
+        Ok(())
+    }
+
+    /// Drains accumulated events for the unit-of-work to publish.
+    pub fn drain_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_object::EntityType;
+    use chrono::Duration;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap()
+    }
+
+    fn params(action: ActionType, expires_at: Option<DateTime<Utc>>) -> EnforcementParams {
+        EnforcementParams {
+            subject: subject(),
+            action,
+            decision_id: DecisionId::new(),
+            version: EnforcementVersion::INITIAL,
+            applied_at: t0(),
+            expires_at,
+            correlation_id: Uuid::now_v7(),
+        }
+    }
+
+    #[test]
+    fn apply_starts_active_and_emits_event() {
+        let mut e = EnforcementAction::apply(params(ActionType::RemoveContent, None)).unwrap();
+        assert_eq!(e.status(), EnforcementStatus::Active);
+        assert!(e.is_active(t0()));
+        let events = e.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "moderation.enforcement_applied");
+        assert_eq!(events[0].actor_id(), subject().actor_id());
+        assert!(e.drain_events().is_empty(), "events drain once");
+    }
+
+    #[test]
+    fn no_action_cannot_be_enforced() {
+        assert!(matches!(
+            EnforcementAction::apply(params(ActionType::NoAction, None)).unwrap_err(),
+            ModerationError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn expiry_must_be_after_applied() {
+        let bad = Some(t0() - Duration::seconds(1));
+        assert!(matches!(
+            EnforcementAction::apply(params(ActionType::RestrictActor, bad)).unwrap_err(),
+            ModerationError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn reverse_emits_event_and_is_terminal() {
+        let mut e = EnforcementAction::apply(params(ActionType::Suspend, None)).unwrap();
+        e.drain_events();
+        e.reverse(t0() + Duration::hours(1), Uuid::now_v7()).unwrap();
+        assert_eq!(e.status(), EnforcementStatus::Reversed);
+        let events = e.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "moderation.enforcement_reversed");
+        // double reverse rejected
+        assert!(matches!(
+            e.reverse(t0(), Uuid::now_v7()).unwrap_err(),
+            ModerationError::EnforcementAlreadyReversed
+        ));
+    }
+
+    #[test]
+    fn time_boxed_enforcement_becomes_inactive_then_expirable() {
+        let exp = t0() + Duration::hours(24);
+        let mut e = EnforcementAction::apply(params(ActionType::RestrictActor, Some(exp))).unwrap();
+        assert!(e.is_active(t0()));
+        assert!(!e.is_active(exp), "inactive once expiry reached");
+        // cannot mark expired before expiry
+        assert!(e.mark_expired(t0()).is_err());
+        // can after
+        e.mark_expired(exp).unwrap();
+        assert_eq!(e.status(), EnforcementStatus::Expired);
+    }
+
+    #[test]
+    fn cannot_reverse_an_expired_enforcement() {
+        let exp = t0() + Duration::hours(1);
+        let mut e = EnforcementAction::apply(params(ActionType::RestrictActor, Some(exp))).unwrap();
+        e.mark_expired(exp).unwrap();
+        assert!(matches!(
+            e.reverse(exp, Uuid::now_v7()).unwrap_err(),
+            ModerationError::InvalidEnforcementTransition { .. }
+        ));
+    }
+}

--- a/crates/services/moderation/src/domain/aggregate/mod.rs
+++ b/crates/services/moderation/src/domain/aggregate/mod.rs
@@ -1,0 +1,24 @@
+//! Aggregates for the moderation domain — the consistency boundaries that own
+//! their invariants and emit domain events.
+//!
+//! * [`Case`] — the review-work root (deterministic id, signal accrual, lifecycle).
+//! * [`Decision`] — the append-only ledger record (immutable; the legal evidence).
+//! * [`EnforcementAction`] — the executable consequence (lifecycle + per-subject
+//!   version).
+//! * [`PenaltyLedger`] — the graduated-enforcement engine (strike decay → action).
+//! * [`Appeal`] — the challenge lifecycle.
+//! * [`Report`] — the user-report intake record (deterministic id, dedup).
+
+pub mod appeal;
+pub mod case;
+pub mod decision;
+pub mod enforcement;
+pub mod penalty_ledger;
+pub mod report;
+
+pub use appeal::Appeal;
+pub use case::{Case, CaseOpenParams};
+pub use decision::{Decision, DecisionAuthor, DecisionParams};
+pub use enforcement::{EnforcementAction, EnforcementParams};
+pub use penalty_ledger::PenaltyLedger;
+pub use report::Report;

--- a/crates/services/moderation/src/domain/aggregate/penalty_ledger.rs
+++ b/crates/services/moderation/src/domain/aggregate/penalty_ledger.rs
@@ -1,0 +1,185 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{
+    ActionType, ActorId, PenaltyPolicy, PolicyCategory, Strike,
+};
+
+/// The **PenaltyLedger** aggregate — the graduated-enforcement engine for an
+/// actor. It accumulates [`Strike`]s (each with a snapshotted point value and a
+/// decay deadline) and, given a [`PenaltyPolicy`], deterministically recommends
+/// the actor-level action the accumulated history warrants.
+///
+/// This is the brain of the service, and it is pure: the same ledger + the same
+/// policy + the same `now` always yields the same recommendation, which is what
+/// makes graduated enforcement auditable and unit-testable. The engine recommends;
+/// the application layer decides whether to act on the recommendation.
+///
+/// Decay is intrinsic: only strikes whose `expires_at` is still in the future at
+/// `now` count toward the active total, so an actor's standing recovers over time
+/// without any sweep job mutating the ledger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PenaltyLedger {
+    actor_id: ActorId,
+    strikes: Vec<Strike>,
+    version: i64,
+}
+
+impl PenaltyLedger {
+    /// An empty ledger for an actor with no history.
+    pub fn empty(actor_id: ActorId) -> Self {
+        Self { actor_id, strikes: Vec::new(), version: 0 }
+    }
+
+    /// Reconstructs from storage.
+    pub fn reconstitute(actor_id: ActorId, strikes: Vec<Strike>, version: i64) -> Self {
+        Self { actor_id, strikes, version }
+    }
+
+    pub fn actor_id(&self) -> ActorId {
+        self.actor_id
+    }
+
+    pub fn version(&self) -> i64 {
+        self.version
+    }
+
+    pub fn strikes(&self) -> &[Strike] {
+        &self.strikes
+    }
+
+    /// Records a strike in `category`, weighting it per the policy in force *now*
+    /// and stamping its decay deadline. Points and the deadline are snapshotted so
+    /// a later policy change does not retroactively re-weight it.
+    pub fn record_strike(
+        &mut self,
+        category: PolicyCategory,
+        now: DateTime<Utc>,
+        policy: &PenaltyPolicy,
+    ) {
+        let points = policy.weight_for(category);
+        let expires_at = now + policy.decay_window();
+        self.strikes.push(Strike::new(category, points, now, expires_at));
+        self.version += 1;
+    }
+
+    /// The sum of points from strikes that have not yet decayed at `now`.
+    pub fn active_points(&self, now: DateTime<Utc>) -> u32 {
+        self.strikes
+            .iter()
+            .filter(|s| s.is_active(now))
+            .map(|s| s.points())
+            .sum()
+    }
+
+    /// The number of strikes still counting at `now`.
+    pub fn active_strike_count(&self, now: DateTime<Utc>) -> usize {
+        self.strikes.iter().filter(|s| s.is_active(now)).count()
+    }
+
+    /// The actor-level action the accumulated, non-decayed history warrants under
+    /// `policy`. `NoAction` when below the lowest escalation tier.
+    pub fn recommended_action(&self, now: DateTime<Utc>, policy: &PenaltyPolicy) -> ActionType {
+        policy.recommended_action(self.active_points(now))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use uuid::Uuid;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn ledger() -> PenaltyLedger {
+        PenaltyLedger::empty(ActorId::from_uuid(Uuid::from_u128(42)))
+    }
+
+    #[test]
+    fn empty_ledger_recommends_no_action() {
+        let l = ledger();
+        let p = PenaltyPolicy::standard();
+        assert_eq!(l.active_points(t0()), 0);
+        assert_eq!(l.recommended_action(t0(), &p), ActionType::NoAction);
+    }
+
+    #[test]
+    fn strikes_accumulate_and_escalate() {
+        let mut l = ledger();
+        let p = PenaltyPolicy::standard(); // spam=1, harassment=2, hate=3; ladder 1→Warn 3→Restrict 5→Suspend 6→Ban
+        l.record_strike(PolicyCategory::Spam, t0(), &p); // 1 pt
+        assert_eq!(l.recommended_action(t0(), &p), ActionType::Warn);
+        l.record_strike(PolicyCategory::Harassment, t0(), &p); // +2 = 3 pts
+        assert_eq!(l.active_points(t0()), 3);
+        assert_eq!(l.recommended_action(t0(), &p), ActionType::RestrictActor);
+        l.record_strike(PolicyCategory::Harassment, t0(), &p); // +2 = 5 pts
+        assert_eq!(l.recommended_action(t0(), &p), ActionType::Suspend);
+    }
+
+    #[test]
+    fn a_single_catastrophic_strike_reaches_ban() {
+        let mut l = ledger();
+        let p = PenaltyPolicy::standard(); // csam weight 6, ban threshold 6
+        l.record_strike(PolicyCategory::Csam, t0(), &p);
+        assert_eq!(l.active_points(t0()), 6);
+        assert_eq!(l.recommended_action(t0(), &p), ActionType::Ban);
+    }
+
+    #[test]
+    fn decayed_strikes_stop_counting() {
+        let mut l = ledger();
+        let p = PenaltyPolicy::standard(); // 90-day decay
+        l.record_strike(PolicyCategory::Hate, t0(), &p); // 3 pts
+        assert_eq!(l.recommended_action(t0(), &p), ActionType::RestrictActor);
+
+        // Just before decay: still counts.
+        let before = t0() + Duration::days(90) - Duration::seconds(1);
+        assert_eq!(l.active_points(before), 3);
+
+        // At/after the decay deadline: drops to zero ⇒ standing recovers.
+        let after = t0() + Duration::days(90);
+        assert_eq!(l.active_points(after), 0);
+        assert_eq!(l.active_strike_count(after), 0);
+        assert_eq!(l.recommended_action(after, &p), ActionType::NoAction);
+    }
+
+    #[test]
+    fn snapshot_weight_survives_a_policy_change() {
+        let mut l = ledger();
+        let lenient = PenaltyPolicy::new(
+            Duration::days(90),
+            1,
+            vec![(PolicyCategory::Spam, 1)],
+            vec![(1, ActionType::Warn), (5, ActionType::Suspend)],
+        )
+        .unwrap();
+        l.record_strike(PolicyCategory::Spam, t0(), &lenient); // snapshotted at 1 pt
+
+        // A later, harsher policy weights spam at 5 — but the existing strike keeps
+        // its snapshotted value; only future strikes get the new weight.
+        let harsh = PenaltyPolicy::new(
+            Duration::days(90),
+            1,
+            vec![(PolicyCategory::Spam, 5)],
+            vec![(1, ActionType::Warn), (5, ActionType::Suspend)],
+        )
+        .unwrap();
+        assert_eq!(l.active_points(t0()), 1, "existing strike keeps snapshot weight");
+        l.record_strike(PolicyCategory::Spam, t0(), &harsh); // +5 = 6
+        assert_eq!(l.active_points(t0()), 6);
+        assert_eq!(l.recommended_action(t0(), &harsh), ActionType::Suspend);
+    }
+
+    #[test]
+    fn recording_bumps_version() {
+        let mut l = ledger();
+        let p = PenaltyPolicy::standard();
+        assert_eq!(l.version(), 0);
+        l.record_strike(PolicyCategory::Spam, t0(), &p);
+        l.record_strike(PolicyCategory::Spam, t0(), &p);
+        assert_eq!(l.version(), 2);
+    }
+}

--- a/crates/services/moderation/src/domain/aggregate/report.rs
+++ b/crates/services/moderation/src/domain/aggregate/report.rs
@@ -1,0 +1,115 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{ActorId, PolicyCategory, ReportId, SubjectRef};
+use crate::error::ModerationError;
+
+/// The **Report** aggregate — a user-submitted abuse report. It is an *input* to
+/// the ingestion pipeline (it feeds a [`Case`](crate::domain::aggregate::Case)),
+/// not a decision, so it emits no events. Its id is **deterministic**
+/// ([`ReportId::for_report`]) so a reporter submitting the same report twice
+/// collapses to one record (dedup).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Report {
+    id: ReportId,
+    reporter_id: ActorId,
+    subject: SubjectRef,
+    category: PolicyCategory,
+    reason: String,
+    reported_at: DateTime<Utc>,
+}
+
+impl Report {
+    /// Files a report. Rejects a self-report — a reporter may not report their own
+    /// content (the actor behind the subject is the reporter).
+    pub fn file(
+        reporter_id: ActorId,
+        subject: SubjectRef,
+        category: PolicyCategory,
+        reason: impl Into<String>,
+        reported_at: DateTime<Utc>,
+    ) -> Result<Self, ModerationError> {
+        if reporter_id == subject.actor_id() {
+            return Err(ModerationError::SelfReportRejected);
+        }
+        let id = ReportId::for_report(reporter_id, &subject);
+        Ok(Self {
+            id,
+            reporter_id,
+            subject,
+            category,
+            reason: reason.into(),
+            reported_at,
+        })
+    }
+
+    /// Reconstructs from storage.
+    pub fn reconstitute(
+        id: ReportId,
+        reporter_id: ActorId,
+        subject: SubjectRef,
+        category: PolicyCategory,
+        reason: String,
+        reported_at: DateTime<Utc>,
+    ) -> Self {
+        Self { id, reporter_id, subject, category, reason, reported_at }
+    }
+
+    pub fn id(&self) -> ReportId {
+        self.id
+    }
+
+    pub fn reporter_id(&self) -> ActorId {
+        self.reporter_id
+    }
+
+    pub fn subject(&self) -> &SubjectRef {
+        &self.subject
+    }
+
+    pub fn category(&self) -> PolicyCategory {
+        self.category
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    pub fn reported_at(&self) -> DateTime<Utc> {
+        self.reported_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_object::EntityType;
+    use uuid::Uuid;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    fn subject_by(author: u128) -> SubjectRef {
+        SubjectRef::new(EntityType::Comment, "c1", ActorId::from_uuid(Uuid::from_u128(author)), "thread").unwrap()
+    }
+
+    #[test]
+    fn rejects_self_report() {
+        let me = ActorId::from_uuid(Uuid::from_u128(5));
+        let my_content = subject_by(5);
+        assert!(matches!(
+            Report::file(me, my_content, PolicyCategory::Spam, "x", t0()).unwrap_err(),
+            ModerationError::SelfReportRejected
+        ));
+    }
+
+    #[test]
+    fn dedups_same_reporter_and_subject() {
+        let reporter = ActorId::from_uuid(Uuid::from_u128(9));
+        let target = subject_by(1);
+        let r1 = Report::file(reporter, target.clone(), PolicyCategory::Hate, "a", t0()).unwrap();
+        let r2 = Report::file(reporter, target, PolicyCategory::Hate, "different reason", t0()).unwrap();
+        assert_eq!(r1.id(), r2.id(), "id is content-addressed for dedup");
+    }
+}

--- a/crates/services/moderation/src/domain/event.rs
+++ b/crates/services/moderation/src/domain/event.rs
@@ -1,0 +1,116 @@
+//! Domain events the moderation context publishes to the `moderation.v1.events`
+//! Kafka topic.
+//!
+//! Events are serde structs (JSON on the wire), matching the fleet convention —
+//! they are deliberately **not** proto messages (the proto contract is the
+//! synchronous RPC surface only). Every event carries `actor_id`, which the
+//! infrastructure publisher (Phase 4) uses as the partition key so all events for
+//! one actor stay ordered — a reversal can never be delivered ahead of the
+//! application it reverses. This is the Plane B denormalization feed: `timeline`,
+//! `chat`, and `account` consume it to apply enforcement on the hot read path.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::value_object::{
+    ActionType, ActorId, AppealId, CaseId, DecisionId, EnforcementId, EnforcementVersion,
+    PolicyCategory, SubjectRef,
+};
+
+/// A review case was opened for a subject.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CaseOpened {
+    pub case_id: CaseId,
+    pub subject: SubjectRef,
+    pub actor_id: ActorId,
+    pub category: PolicyCategory,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// A case was actioned or dismissed (a decision was recorded).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CaseResolved {
+    pub case_id: CaseId,
+    pub decision_id: DecisionId,
+    pub actor_id: ActorId,
+    pub action: ActionType,
+    pub category: PolicyCategory,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// An enforcement action was applied — the Plane B signal that downstream
+/// services denormalize to flip visibility / restrict the actor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnforcementApplied {
+    pub enforcement_id: EnforcementId,
+    pub subject: SubjectRef,
+    pub actor_id: ActorId,
+    pub action: ActionType,
+    pub version: EnforcementVersion,
+    pub applied_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// An enforcement action was reversed (appeal overturn / re-review). Carries the
+/// version so a consumer can reject a stale reversal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnforcementReversed {
+    pub enforcement_id: EnforcementId,
+    pub subject: SubjectRef,
+    pub actor_id: ActorId,
+    pub version: EnforcementVersion,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// An appeal was resolved (upheld or overturned).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AppealResolved {
+    pub appeal_id: AppealId,
+    pub decision_id: DecisionId,
+    pub actor_id: ActorId,
+    pub overturned: bool,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
+/// Sealed sum type of every domain event moderation publishes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DomainEvent {
+    CaseOpened(CaseOpened),
+    CaseResolved(CaseResolved),
+    EnforcementApplied(EnforcementApplied),
+    EnforcementReversed(EnforcementReversed),
+    AppealResolved(AppealResolved),
+}
+
+impl DomainEvent {
+    /// Dotted routing key used as the Kafka message type header.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::CaseOpened(_) => "moderation.case_opened",
+            Self::CaseResolved(_) => "moderation.case_resolved",
+            Self::EnforcementApplied(_) => "moderation.enforcement_applied",
+            Self::EnforcementReversed(_) => "moderation.enforcement_reversed",
+            Self::AppealResolved(_) => "moderation.appeal_resolved",
+        }
+    }
+
+    /// The actor this event concerns — the Kafka partition key, guaranteeing
+    /// per-actor ordering across all moderation events.
+    pub fn actor_id(&self) -> ActorId {
+        match self {
+            Self::CaseOpened(e) => e.actor_id,
+            Self::CaseResolved(e) => e.actor_id,
+            Self::EnforcementApplied(e) => e.actor_id,
+            Self::EnforcementReversed(e) => e.actor_id,
+            Self::AppealResolved(e) => e.actor_id,
+        }
+    }
+}

--- a/crates/services/moderation/src/domain/mod.rs
+++ b/crates/services/moderation/src/domain/mod.rs
@@ -1,0 +1,26 @@
+//! The moderation bounded context's domain layer — pure, free of I/O.
+//!
+//! It owns the *integrity decision and its consequences*: the [`Case`] review
+//! lifecycle, the append-only [`Decision`] ledger (the legal evidence record),
+//! the [`EnforcementAction`] with its monotonic per-subject version, the
+//! [`PenaltyLedger`] graduated-enforcement engine, the [`Appeal`] lifecycle, and
+//! the [`Report`] intake record. Content bytes live in the content services;
+//! account lifecycle lives in `account`; ML inference lives in the classifier
+//! services — none of those are modelled here.
+//!
+//! ## Clock injection
+//! Every time-dependent invariant (strike decay, enforcement expiry, appeal
+//! windows) takes `now: DateTime<Utc>` as a parameter rather than reading the
+//! wall clock, so the state machines are deterministically unit-testable. The
+//! application layer supplies the clock.
+//!
+//! [`Case`]: aggregate::Case
+//! [`Decision`]: aggregate::Decision
+//! [`EnforcementAction`]: aggregate::EnforcementAction
+//! [`PenaltyLedger`]: aggregate::PenaltyLedger
+//! [`Appeal`]: aggregate::Appeal
+//! [`Report`]: aggregate::Report
+
+pub mod aggregate;
+pub mod event;
+pub mod value_object;

--- a/crates/services/moderation/src/domain/value_object/action_type.rs
+++ b/crates/services/moderation/src/domain/value_object/action_type.rs
@@ -1,0 +1,162 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// The executable consequence of a decision, ordered least-to-most severe.
+///
+/// Moderation **decides** the action; the owning service **executes** it (content
+/// services flip visibility; `account` runs suspension/ban lifecycle). The
+/// [`ActionType::severity_rank`] ordering is what the graduated-enforcement engine
+/// uses to escalate — never a hard-coded threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionType {
+    /// No enforcement — the case is dismissed as non-violating.
+    NoAction,
+    Warn,
+    /// Shadow-reduce: content stays but its reach/visibility is limited.
+    VisibilityLimit,
+    AgeGate,
+    RemoveContent,
+    /// Actor-level: restrict the actor's ability to post/interact for a window.
+    RestrictActor,
+    Suspend,
+    Ban,
+}
+
+impl ActionType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NoAction => "no_action",
+            Self::Warn => "warn",
+            Self::VisibilityLimit => "visibility_limit",
+            Self::AgeGate => "age_gate",
+            Self::RemoveContent => "remove_content",
+            Self::RestrictActor => "restrict_actor",
+            Self::Suspend => "suspend",
+            Self::Ban => "ban",
+        }
+    }
+
+    /// Monotonic severity used to escalate and to pick the more severe of two
+    /// candidate actions. Higher = harsher.
+    pub fn severity_rank(&self) -> u8 {
+        match self {
+            Self::NoAction => 0,
+            Self::Warn => 1,
+            Self::VisibilityLimit => 2,
+            Self::AgeGate => 3,
+            Self::RemoveContent => 4,
+            Self::RestrictActor => 5,
+            Self::Suspend => 6,
+            Self::Ban => 7,
+        }
+    }
+
+    /// Whether the action targets the actor (account) rather than a single piece
+    /// of content. Actor-level actions are executed by `account`.
+    pub fn is_actor_level(&self) -> bool {
+        matches!(self, Self::RestrictActor | Self::Suspend | Self::Ban)
+    }
+
+    /// Whether the action results in an [`EnforcementAction`] at all. `NoAction`
+    /// is a dismissal — it records a [`Decision`] but creates no enforcement.
+    ///
+    /// [`EnforcementAction`]: crate::domain::aggregate::EnforcementAction
+    /// [`Decision`]: crate::domain::aggregate::Decision
+    pub fn is_enforced(&self) -> bool {
+        !matches!(self, Self::NoAction)
+    }
+
+    /// The harsher of two actions (by severity rank).
+    pub fn max(self, other: ActionType) -> ActionType {
+        if other.severity_rank() > self.severity_rank() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+impl fmt::Display for ActionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for ActionType {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "no_action" => Ok(Self::NoAction),
+            "warn" => Ok(Self::Warn),
+            "visibility_limit" => Ok(Self::VisibilityLimit),
+            "age_gate" => Ok(Self::AgeGate),
+            "remove_content" => Ok(Self::RemoveContent),
+            "restrict_actor" => Ok(Self::RestrictActor),
+            "suspend" => Ok(Self::Suspend),
+            "ban" => Ok(Self::Ban),
+            other => Err(ModerationError::DomainViolation {
+                field: "action_type".into(),
+                message: format!("unknown action type: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_is_strictly_ordered() {
+        let ordered = [
+            ActionType::NoAction,
+            ActionType::Warn,
+            ActionType::VisibilityLimit,
+            ActionType::AgeGate,
+            ActionType::RemoveContent,
+            ActionType::RestrictActor,
+            ActionType::Suspend,
+            ActionType::Ban,
+        ];
+        for w in ordered.windows(2) {
+            assert!(w[0].severity_rank() < w[1].severity_rank());
+        }
+    }
+
+    #[test]
+    fn max_picks_the_harsher() {
+        assert_eq!(ActionType::Warn.max(ActionType::Ban), ActionType::Ban);
+        assert_eq!(ActionType::Suspend.max(ActionType::Warn), ActionType::Suspend);
+        assert_eq!(ActionType::NoAction.max(ActionType::NoAction), ActionType::NoAction);
+    }
+
+    #[test]
+    fn actor_level_and_enforced_predicates() {
+        assert!(ActionType::Ban.is_actor_level());
+        assert!(!ActionType::RemoveContent.is_actor_level());
+        assert!(!ActionType::NoAction.is_enforced());
+        assert!(ActionType::Warn.is_enforced());
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for a in [
+            ActionType::NoAction,
+            ActionType::Warn,
+            ActionType::VisibilityLimit,
+            ActionType::AgeGate,
+            ActionType::RemoveContent,
+            ActionType::RestrictActor,
+            ActionType::Suspend,
+            ActionType::Ban,
+        ] {
+            assert_eq!(ActionType::try_from(a.as_str()).unwrap(), a);
+        }
+        assert!(ActionType::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/appeal_status.rs
+++ b/crates/services/moderation/src/domain/value_object/appeal_status.rs
@@ -1,0 +1,95 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// Lifecycle state of an [`Appeal`](crate::domain::aggregate::Appeal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppealStatus {
+    Filed,
+    UnderReview,
+    /// The original decision stands. Terminal.
+    Upheld,
+    /// The decision is overturned; a reversal decision is recorded. Terminal.
+    Overturned,
+}
+
+impl AppealStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Filed => "filed",
+            Self::UnderReview => "under_review",
+            Self::Upheld => "upheld",
+            Self::Overturned => "overturned",
+        }
+    }
+
+    pub fn can_transition_to(&self, next: AppealStatus) -> bool {
+        use AppealStatus::*;
+        matches!(
+            (self, next),
+            (Filed, UnderReview)
+                | (Filed, Upheld)
+                | (Filed, Overturned)
+                | (UnderReview, Upheld)
+                | (UnderReview, Overturned)
+        )
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Upheld | Self::Overturned)
+    }
+}
+
+impl fmt::Display for AppealStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for AppealStatus {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "filed" => Ok(Self::Filed),
+            "under_review" => Ok(Self::UnderReview),
+            "upheld" => Ok(Self::Upheld),
+            "overturned" => Ok(Self::Overturned),
+            other => Err(ModerationError::DomainViolation {
+                field: "appeal_status".into(),
+                message: format!("unknown appeal status: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitions() {
+        assert!(AppealStatus::Filed.can_transition_to(AppealStatus::UnderReview));
+        assert!(AppealStatus::Filed.can_transition_to(AppealStatus::Overturned));
+        assert!(AppealStatus::UnderReview.can_transition_to(AppealStatus::Upheld));
+        for from in [AppealStatus::Upheld, AppealStatus::Overturned] {
+            assert!(!from.can_transition_to(AppealStatus::UnderReview));
+        }
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for s in [
+            AppealStatus::Filed,
+            AppealStatus::UnderReview,
+            AppealStatus::Upheld,
+            AppealStatus::Overturned,
+        ] {
+            assert_eq!(AppealStatus::try_from(s.as_str()).unwrap(), s);
+        }
+        assert!(AppealStatus::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/case_status.rs
+++ b/crates/services/moderation/src/domain/value_object/case_status.rs
@@ -1,0 +1,113 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// Lifecycle state of a [`Case`](crate::domain::aggregate::Case).
+///
+/// `Dismissed` is terminal. `Actioned` is terminal *except* that an appeal can
+/// move it to `Appealed`, from which it returns to `Actioned` (upheld) or
+/// `Dismissed` (overturned).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaseStatus {
+    Open,
+    Triaged,
+    Actioned,
+    Dismissed,
+    Appealed,
+}
+
+impl CaseStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Triaged => "triaged",
+            Self::Actioned => "actioned",
+            Self::Dismissed => "dismissed",
+            Self::Appealed => "appealed",
+        }
+    }
+
+    /// Returns `true` if `self → next` is a permitted transition.
+    pub fn can_transition_to(&self, next: CaseStatus) -> bool {
+        use CaseStatus::*;
+        matches!(
+            (self, next),
+            (Open, Triaged)
+                | (Open, Actioned)
+                | (Open, Dismissed)
+                | (Triaged, Actioned)
+                | (Triaged, Dismissed)
+                | (Actioned, Appealed)
+                | (Appealed, Actioned)
+                | (Appealed, Dismissed)
+        )
+    }
+
+    /// A case that holds no further open work (an appeal may still reopen an
+    /// `Actioned` case, so it is *not* considered fully terminal here).
+    pub fn is_resolved(&self) -> bool {
+        matches!(self, Self::Actioned | Self::Dismissed)
+    }
+}
+
+impl fmt::Display for CaseStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for CaseStatus {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "open" => Ok(Self::Open),
+            "triaged" => Ok(Self::Triaged),
+            "actioned" => Ok(Self::Actioned),
+            "dismissed" => Ok(Self::Dismissed),
+            "appealed" => Ok(Self::Appealed),
+            other => Err(ModerationError::DomainViolation {
+                field: "case_status".into(),
+                message: format!("unknown case status: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legal_transitions() {
+        assert!(CaseStatus::Open.can_transition_to(CaseStatus::Triaged));
+        assert!(CaseStatus::Open.can_transition_to(CaseStatus::Dismissed));
+        assert!(CaseStatus::Triaged.can_transition_to(CaseStatus::Actioned));
+        assert!(CaseStatus::Actioned.can_transition_to(CaseStatus::Appealed));
+        assert!(CaseStatus::Appealed.can_transition_to(CaseStatus::Dismissed));
+    }
+
+    #[test]
+    fn illegal_transitions() {
+        assert!(!CaseStatus::Dismissed.can_transition_to(CaseStatus::Actioned));
+        assert!(!CaseStatus::Open.can_transition_to(CaseStatus::Appealed));
+        assert!(!CaseStatus::Actioned.can_transition_to(CaseStatus::Dismissed));
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for s in [
+            CaseStatus::Open,
+            CaseStatus::Triaged,
+            CaseStatus::Actioned,
+            CaseStatus::Dismissed,
+            CaseStatus::Appealed,
+        ] {
+            assert_eq!(CaseStatus::try_from(s.as_str()).unwrap(), s);
+        }
+        assert!(CaseStatus::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/confidence.rs
+++ b/crates/services/moderation/src/domain/value_object/confidence.rs
@@ -1,0 +1,72 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// A classifier/aggregate confidence in `[0.0, 1.0]`.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Confidence(f64);
+
+impl Confidence {
+    /// Constructs a confidence, rejecting NaN and out-of-range values.
+    pub fn new(value: f64) -> Result<Self, ModerationError> {
+        if value.is_nan() || !(0.0..=1.0).contains(&value) {
+            return Err(ModerationError::DomainViolation {
+                field: "confidence".into(),
+                message: format!("confidence must be within [0.0, 1.0], got {value}"),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Clamps into range instead of failing (for trusted, lossy upstreams).
+    pub fn clamped(value: f64) -> Self {
+        let v = if value.is_nan() { 0.0 } else { value.clamp(0.0, 1.0) };
+        Self(v)
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+
+    /// Whether this meets or exceeds a decision threshold.
+    pub fn at_least(&self, threshold: f64) -> bool {
+        self.0 >= threshold
+    }
+}
+
+impl fmt::Display for Confidence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.4}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_in_range_rejects_out_of_range() {
+        assert!(Confidence::new(0.0).is_ok());
+        assert!(Confidence::new(1.0).is_ok());
+        assert!(Confidence::new(0.73).is_ok());
+        assert!(Confidence::new(-0.1).is_err());
+        assert!(Confidence::new(1.1).is_err());
+        assert!(Confidence::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn clamped_never_escapes_range() {
+        assert_eq!(Confidence::clamped(2.0).value(), 1.0);
+        assert_eq!(Confidence::clamped(-1.0).value(), 0.0);
+        assert_eq!(Confidence::clamped(f64::NAN).value(), 0.0);
+    }
+
+    #[test]
+    fn threshold_check() {
+        assert!(Confidence::new(0.9).unwrap().at_least(0.8));
+        assert!(!Confidence::new(0.5).unwrap().at_least(0.8));
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/enforcement_status.rs
+++ b/crates/services/moderation/src/domain/value_object/enforcement_status.rs
@@ -1,0 +1,91 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// Lifecycle state of an
+/// [`EnforcementAction`](crate::domain::aggregate::EnforcementAction). `Active` is
+/// the only non-terminal state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnforcementStatus {
+    Active,
+    /// Reached its time-boxed expiry. Terminal.
+    Expired,
+    /// Lifted by a reversal (appeal overturn / re-review). Terminal.
+    Reversed,
+}
+
+impl EnforcementStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Expired => "expired",
+            Self::Reversed => "reversed",
+        }
+    }
+
+    pub fn can_transition_to(&self, next: EnforcementStatus) -> bool {
+        use EnforcementStatus::*;
+        matches!((self, next), (Active, Expired) | (Active, Reversed))
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Expired | Self::Reversed)
+    }
+}
+
+impl fmt::Display for EnforcementStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for EnforcementStatus {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "active" => Ok(Self::Active),
+            "expired" => Ok(Self::Expired),
+            "reversed" => Ok(Self::Reversed),
+            other => Err(ModerationError::DomainViolation {
+                field: "enforcement_status".into(),
+                message: format!("unknown enforcement status: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_active_transitions() {
+        assert!(EnforcementStatus::Active.can_transition_to(EnforcementStatus::Expired));
+        assert!(EnforcementStatus::Active.can_transition_to(EnforcementStatus::Reversed));
+        for from in [EnforcementStatus::Expired, EnforcementStatus::Reversed] {
+            for to in [
+                EnforcementStatus::Active,
+                EnforcementStatus::Expired,
+                EnforcementStatus::Reversed,
+            ] {
+                assert!(!from.can_transition_to(to));
+            }
+        }
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for s in [
+            EnforcementStatus::Active,
+            EnforcementStatus::Expired,
+            EnforcementStatus::Reversed,
+        ] {
+            assert_eq!(EnforcementStatus::try_from(s.as_str()).unwrap(), s);
+        }
+        assert!(EnforcementStatus::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/enforcement_version.rs
+++ b/crates/services/moderation/src/domain/value_object/enforcement_version.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Monotonic per-subject enforcement epoch.
+///
+/// Each new [`EnforcementAction`](crate::domain::aggregate::EnforcementAction) on
+/// a subject is stamped with the next version. A reversal must observe the current
+/// version, so a stale reversal can never race ahead of a newer re-application
+/// (the optimistic guard lives in the projection/repository; this type is the
+/// value it compares). Backed by `i64` to match the Postgres `bigint` column and
+/// the proto `int64` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EnforcementVersion(i64);
+
+impl EnforcementVersion {
+    /// The version the first enforcement on a subject is stamped with.
+    pub const INITIAL: EnforcementVersion = EnforcementVersion(1);
+
+    pub fn from_i64(value: i64) -> Self {
+        Self(value)
+    }
+
+    pub fn value(&self) -> i64 {
+        self.0
+    }
+
+    /// The next version. Saturating, so a (practically impossible) overflow
+    /// degrades safely rather than wrapping backwards.
+    #[must_use]
+    pub fn next(&self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+impl Default for EnforcementVersion {
+    fn default() -> Self {
+        Self::INITIAL
+    }
+}
+
+impl fmt::Display for EnforcementVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_is_strictly_increasing_and_saturates() {
+        let v = EnforcementVersion::INITIAL;
+        assert_eq!(v.value(), 1);
+        assert!(v.next() > v);
+        assert_eq!(v.next().value(), 2);
+        let max = EnforcementVersion::from_i64(i64::MAX);
+        assert_eq!(max.next(), max);
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/entity_type.rs
+++ b/crates/services/moderation/src/domain/value_object/entity_type.rs
@@ -1,0 +1,77 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// The kind of entity a moderation subject points at. Moderation references
+/// content by `(entity_type, entity_id)`; it never stores the content itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityType {
+    Post,
+    Comment,
+    ChatMessage,
+    Media,
+    /// The account itself (actor-level subject, e.g. for graduated penalties).
+    Account,
+    Profile,
+}
+
+impl EntityType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Post => "post",
+            Self::Comment => "comment",
+            Self::ChatMessage => "chat_message",
+            Self::Media => "media",
+            Self::Account => "account",
+            Self::Profile => "profile",
+        }
+    }
+}
+
+impl fmt::Display for EntityType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for EntityType {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "post" => Ok(Self::Post),
+            "comment" => Ok(Self::Comment),
+            "chat_message" => Ok(Self::ChatMessage),
+            "media" => Ok(Self::Media),
+            "account" => Ok(Self::Account),
+            "profile" => Ok(Self::Profile),
+            other => Err(ModerationError::DomainViolation {
+                field: "entity_type".into(),
+                message: format!("unknown entity type: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_round_trip() {
+        for e in [
+            EntityType::Post,
+            EntityType::Comment,
+            EntityType::ChatMessage,
+            EntityType::Media,
+            EntityType::Account,
+            EntityType::Profile,
+        ] {
+            assert_eq!(EntityType::try_from(e.as_str()).unwrap(), e);
+        }
+        assert!(EntityType::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/ids.rs
+++ b/crates/services/moderation/src/domain/value_object/ids.rs
@@ -1,0 +1,269 @@
+//! Identifier value objects for the moderation domain.
+//!
+//! Two flavours, deliberately chosen per aggregate:
+//! * **UUIDv7** (time-ordered, freshly minted) for records created exactly once:
+//!   [`DecisionId`], [`EnforcementId`], [`AppealId`].
+//! * **UUIDv5** (deterministic, content-addressed) for entities that MUST
+//!   deduplicate under at-least-once redelivery: [`CaseId`] (keyed by the
+//!   subject) and [`ReportId`] (keyed by reporter + subject). Recomputing the id
+//!   from the same inputs yields the same UUID, so a redelivered event upserts
+//!   the same row instead of creating a duplicate (the idempotency rule of the
+//!   Consumer Runtime Standard).
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::value_object::SubjectRef;
+use crate::error::ModerationError;
+
+/// Fixed namespace for all of moderation's deterministic (v5) identifiers.
+/// The bytes spell `MODERATIONNSUUID`; it never changes (changing it would
+/// re-key every deterministic id and break dedup).
+pub const MODERATION_NAMESPACE: Uuid = Uuid::from_bytes(*b"MODERATIONNSUUID");
+
+/// The responsible account behind a subject (a content author or the account
+/// itself). Backed by a UUID to match the rest of the fleet's account ids.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ActorId(Uuid);
+
+impl ActorId {
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl fmt::Debug for ActorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ActorId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for ActorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+impl TryFrom<&str> for ActorId {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| ModerationError::InvalidIdentifier(s.to_owned()))
+    }
+}
+
+/// Macro: a freshly-minted UUIDv7 identifier newtype (record created once).
+macro_rules! uuid_v7_id {
+    ($name:ident, $label:literal) => {
+        #[doc = concat!("Opaque ", $label, " identifier (UUIDv7, time-ordered).")]
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            /// Generates a fresh UUIDv7 identifier.
+            pub fn new() -> Self {
+                Self(Uuid::now_v7())
+            }
+
+            /// Wraps an existing UUID from a trusted source (storage row).
+            pub fn from_uuid(id: Uuid) -> Self {
+                Self(id)
+            }
+
+            pub fn as_uuid(&self) -> Uuid {
+                self.0
+            }
+
+            pub fn as_str(&self) -> String {
+                self.0.hyphenated().to_string()
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, concat!(stringify!($name), "({})"), self.0.hyphenated())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0.hyphenated())
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = ModerationError;
+
+            fn try_from(s: &str) -> Result<Self, Self::Error> {
+                Uuid::parse_str(s)
+                    .map(Self)
+                    .map_err(|_| ModerationError::InvalidIdentifier(s.to_owned()))
+            }
+        }
+    };
+}
+
+uuid_v7_id!(DecisionId, "decision");
+uuid_v7_id!(EnforcementId, "enforcement action");
+uuid_v7_id!(AppealId, "appeal");
+
+/// Review-case identifier. **Deterministic** (UUIDv5 of the subject) so opening a
+/// case for the same subject twice — e.g. a redelivered content event — yields
+/// the same id and upserts rather than duplicating.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CaseId(Uuid);
+
+impl CaseId {
+    /// Derives the deterministic case id for a subject.
+    pub fn for_subject(subject: &SubjectRef) -> Self {
+        Self(Uuid::new_v5(
+            &MODERATION_NAMESPACE,
+            subject.canonical_key().as_bytes(),
+        ))
+    }
+
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl fmt::Debug for CaseId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CaseId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for CaseId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+/// User-report identifier. **Deterministic** (UUIDv5 of reporter + subject) so a
+/// reporter filing the same report twice collapses to one record.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ReportId(Uuid);
+
+impl ReportId {
+    /// Derives the deterministic report id for a (reporter, subject) pair.
+    pub fn for_report(reporter: ActorId, subject: &SubjectRef) -> Self {
+        let name = format!("{}|{}", reporter, subject.canonical_key());
+        Self(Uuid::new_v5(&MODERATION_NAMESPACE, name.as_bytes()))
+    }
+
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl fmt::Debug for ReportId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ReportId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for ReportId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_object::EntityType;
+
+    fn subject() -> SubjectRef {
+        SubjectRef::new(
+            EntityType::Post,
+            "post-123",
+            ActorId::from_uuid(Uuid::nil()),
+            "feed",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn v7_ids_are_unique_and_versioned() {
+        let a = DecisionId::new();
+        let b = DecisionId::new();
+        assert_ne!(a, b);
+        assert_eq!(a.as_uuid().get_version_num(), 7);
+    }
+
+    #[test]
+    fn case_id_is_deterministic_per_subject() {
+        let s = subject();
+        assert_eq!(CaseId::for_subject(&s), CaseId::for_subject(&s));
+        assert_eq!(CaseId::for_subject(&s).as_uuid().get_version_num(), 5);
+    }
+
+    #[test]
+    fn case_id_differs_by_subject() {
+        let s1 = subject();
+        let s2 = SubjectRef::new(
+            EntityType::Post,
+            "post-999",
+            ActorId::from_uuid(Uuid::nil()),
+            "feed",
+        )
+        .unwrap();
+        assert_ne!(CaseId::for_subject(&s1), CaseId::for_subject(&s2));
+    }
+
+    #[test]
+    fn report_id_dedups_same_reporter_and_subject() {
+        let r = ActorId::from_uuid(Uuid::from_u128(7));
+        let s = subject();
+        assert_eq!(ReportId::for_report(r, &s), ReportId::for_report(r, &s));
+        // different reporter ⇒ different id
+        let r2 = ActorId::from_uuid(Uuid::from_u128(8));
+        assert_ne!(ReportId::for_report(r, &s), ReportId::for_report(r2, &s));
+    }
+
+    #[test]
+    fn id_parse_rejects_garbage() {
+        assert!(matches!(
+            DecisionId::try_from("nope").unwrap_err(),
+            ModerationError::InvalidIdentifier(_)
+        ));
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/mod.rs
+++ b/crates/services/moderation/src/domain/value_object/mod.rs
@@ -1,0 +1,33 @@
+//! Value objects for the moderation domain — small, validated, immutable types
+//! the aggregates are built from. Each enforces its own invariants at
+//! construction so an invalid value is unrepresentable upstream.
+
+pub mod action_type;
+pub mod appeal_status;
+pub mod case_status;
+pub mod confidence;
+pub mod enforcement_status;
+pub mod enforcement_version;
+pub mod entity_type;
+pub mod ids;
+pub mod penalty_policy;
+pub mod policy_category;
+pub mod policy_version;
+pub mod signal;
+pub mod strike;
+pub mod subject_ref;
+
+pub use action_type::ActionType;
+pub use appeal_status::AppealStatus;
+pub use case_status::CaseStatus;
+pub use confidence::Confidence;
+pub use enforcement_status::EnforcementStatus;
+pub use enforcement_version::EnforcementVersion;
+pub use entity_type::EntityType;
+pub use ids::{ActorId, AppealId, CaseId, DecisionId, EnforcementId, ReportId, MODERATION_NAMESPACE};
+pub use penalty_policy::PenaltyPolicy;
+pub use policy_category::PolicyCategory;
+pub use policy_version::PolicyVersion;
+pub use signal::Signal;
+pub use strike::Strike;
+pub use subject_ref::SubjectRef;

--- a/crates/services/moderation/src/domain/value_object/penalty_policy.rs
+++ b/crates/services/moderation/src/domain/value_object/penalty_policy.rs
@@ -1,0 +1,157 @@
+use chrono::Duration;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{ActionType, PolicyCategory};
+use crate::error::ModerationError;
+
+/// The tunable inputs to the graduated-enforcement engine, supplied by the pinned
+/// policy version. Keeping these *out* of the domain types (and in a value object
+/// the application injects) is what makes the
+/// [`PenaltyLedger`](crate::domain::aggregate::PenaltyLedger) deterministic and
+/// auditable: the same ledger + the same policy always yields the same
+/// recommendation.
+///
+/// Three knobs:
+/// * `decay_window` — how long a strike counts toward the active total.
+/// * per-category point `weights` (with a `default_weight` fallback) — how heavily
+///   each category is penalised.
+/// * `escalation` tiers — `(min_active_points, action)` pairs; the recommended
+///   action is the harshest tier whose threshold the actor has reached.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PenaltyPolicy {
+    decay_window: Duration,
+    default_weight: u32,
+    weights: Vec<(PolicyCategory, u32)>,
+    /// Sorted ascending by threshold on construction.
+    escalation: Vec<(u32, ActionType)>,
+}
+
+impl PenaltyPolicy {
+    /// Constructs a policy. Rejects an empty escalation ladder or a zero decay
+    /// window; normalises the ladder into ascending threshold order.
+    pub fn new(
+        decay_window: Duration,
+        default_weight: u32,
+        weights: Vec<(PolicyCategory, u32)>,
+        mut escalation: Vec<(u32, ActionType)>,
+    ) -> Result<Self, ModerationError> {
+        if decay_window <= Duration::zero() {
+            return Err(ModerationError::DomainViolation {
+                field: "penalty_policy.decay_window".into(),
+                message: "decay window must be positive".into(),
+            });
+        }
+        if escalation.is_empty() {
+            return Err(ModerationError::DomainViolation {
+                field: "penalty_policy.escalation".into(),
+                message: "escalation ladder must have at least one tier".into(),
+            });
+        }
+        escalation.sort_by_key(|(threshold, _)| *threshold);
+        Ok(Self { decay_window, default_weight, weights, escalation })
+    }
+
+    /// A sensible default ladder for bootstrapping and tests. Real deployments
+    /// supply their own, pinned to a policy version.
+    pub fn standard() -> Self {
+        // Safe to unwrap: the literal arguments satisfy every invariant.
+        Self::new(
+            Duration::days(90),
+            1,
+            vec![
+                (PolicyCategory::Spam, 1),
+                (PolicyCategory::Harassment, 2),
+                (PolicyCategory::Hate, 3),
+                (PolicyCategory::ViolentExtremism, 6),
+                (PolicyCategory::Csam, 6),
+                (PolicyCategory::Ncii, 6),
+            ],
+            vec![
+                (1, ActionType::Warn),
+                (3, ActionType::RestrictActor),
+                (5, ActionType::Suspend),
+                (6, ActionType::Ban),
+            ],
+        )
+        .expect("standard penalty policy is valid")
+    }
+
+    pub fn decay_window(&self) -> Duration {
+        self.decay_window
+    }
+
+    /// Point weight for a category, falling back to `default_weight`.
+    pub fn weight_for(&self, category: PolicyCategory) -> u32 {
+        self.weights
+            .iter()
+            .find(|(c, _)| *c == category)
+            .map(|(_, w)| *w)
+            .unwrap_or(self.default_weight)
+    }
+
+    /// The recommended action for a given active point total: the harshest tier
+    /// whose threshold is met. Below the lowest threshold ⇒ `NoAction`.
+    pub fn recommended_action(&self, active_points: u32) -> ActionType {
+        self.escalation
+            .iter()
+            .filter(|(threshold, _)| active_points >= *threshold)
+            .map(|(_, action)| *action)
+            .next_back()
+            .unwrap_or(ActionType::NoAction)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_degenerate_inputs() {
+        assert!(PenaltyPolicy::new(Duration::zero(), 1, vec![], vec![(1, ActionType::Warn)]).is_err());
+        assert!(PenaltyPolicy::new(Duration::days(1), 1, vec![], vec![]).is_err());
+    }
+
+    #[test]
+    fn weight_falls_back_to_default() {
+        let p = PenaltyPolicy::new(
+            Duration::days(30),
+            2,
+            vec![(PolicyCategory::Csam, 9)],
+            vec![(1, ActionType::Warn)],
+        )
+        .unwrap();
+        assert_eq!(p.weight_for(PolicyCategory::Csam), 9);
+        assert_eq!(p.weight_for(PolicyCategory::Spam), 2); // default
+    }
+
+    #[test]
+    fn recommended_action_climbs_the_ladder() {
+        let p = PenaltyPolicy::standard();
+        assert_eq!(p.recommended_action(0), ActionType::NoAction);
+        assert_eq!(p.recommended_action(1), ActionType::Warn);
+        assert_eq!(p.recommended_action(2), ActionType::Warn);
+        assert_eq!(p.recommended_action(3), ActionType::RestrictActor);
+        assert_eq!(p.recommended_action(5), ActionType::Suspend);
+        assert_eq!(p.recommended_action(6), ActionType::Ban);
+        assert_eq!(p.recommended_action(100), ActionType::Ban);
+    }
+
+    #[test]
+    fn escalation_is_normalised_to_ascending_order() {
+        // Provide tiers out of order; recommendation must still be monotone.
+        let p = PenaltyPolicy::new(
+            Duration::days(30),
+            1,
+            vec![],
+            vec![
+                (5, ActionType::Suspend),
+                (1, ActionType::Warn),
+                (3, ActionType::RestrictActor),
+            ],
+        )
+        .unwrap();
+        assert_eq!(p.recommended_action(1), ActionType::Warn);
+        assert_eq!(p.recommended_action(4), ActionType::RestrictActor);
+        assert_eq!(p.recommended_action(5), ActionType::Suspend);
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/policy_category.rs
+++ b/crates/services/moderation/src/domain/value_object/policy_category.rs
@@ -1,0 +1,138 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// Normalized integrity taxonomy. Policy-version-agnostic at the type level: the
+/// *thresholds and consequences* for each category live in the pinned policy
+/// version (see [`PenaltyPolicy`](crate::domain::value_object::PenaltyPolicy)),
+/// never hard-coded here. Only the two structural predicates below — which
+/// categories are zero-tolerance and which are appealable — are intrinsic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyCategory {
+    Spam,
+    Harassment,
+    Hate,
+    /// Terrorist & violent extremist content.
+    ViolentExtremism,
+    /// Child sexual abuse material.
+    Csam,
+    /// Non-consensual intimate imagery.
+    Ncii,
+    SelfHarm,
+    Misinformation,
+    Other,
+}
+
+impl PolicyCategory {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Spam => "spam",
+            Self::Harassment => "harassment",
+            Self::Hate => "hate",
+            Self::ViolentExtremism => "violent_extremism",
+            Self::Csam => "csam",
+            Self::Ncii => "ncii",
+            Self::SelfHarm => "self_harm",
+            Self::Misinformation => "misinformation",
+            Self::Other => "other",
+        }
+    }
+
+    /// Catastrophic-harm categories that are eligible for the synchronous,
+    /// fail-closed Screen gate (Plane C) and that must never be published
+    /// optimistically. The hot path treats an unavailable screen for these as a
+    /// hard block.
+    pub fn is_zero_tolerance(&self) -> bool {
+        matches!(self, Self::Csam | Self::Ncii | Self::ViolentExtremism)
+    }
+
+    /// Whether a decision in this category is user-appealable. Legally-mandated
+    /// removals (CSAM) are not appealable through the normal flow.
+    pub fn is_appealable(&self) -> bool {
+        !matches!(self, Self::Csam)
+    }
+}
+
+impl fmt::Display for PolicyCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for PolicyCategory {
+    type Error = ModerationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "spam" => Ok(Self::Spam),
+            "harassment" => Ok(Self::Harassment),
+            "hate" => Ok(Self::Hate),
+            "violent_extremism" => Ok(Self::ViolentExtremism),
+            "csam" => Ok(Self::Csam),
+            "ncii" => Ok(Self::Ncii),
+            "self_harm" => Ok(Self::SelfHarm),
+            "misinformation" => Ok(Self::Misinformation),
+            "other" => Ok(Self::Other),
+            other => Err(ModerationError::UnknownPolicyCategory {
+                category: other.to_owned(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_tolerance_set_is_exactly_the_catastrophic_three() {
+        for c in [
+            PolicyCategory::Csam,
+            PolicyCategory::Ncii,
+            PolicyCategory::ViolentExtremism,
+        ] {
+            assert!(c.is_zero_tolerance(), "{c} must be zero-tolerance");
+        }
+        for c in [
+            PolicyCategory::Spam,
+            PolicyCategory::Harassment,
+            PolicyCategory::Hate,
+            PolicyCategory::SelfHarm,
+            PolicyCategory::Misinformation,
+            PolicyCategory::Other,
+        ] {
+            assert!(!c.is_zero_tolerance(), "{c} must not be zero-tolerance");
+        }
+    }
+
+    #[test]
+    fn csam_is_not_appealable() {
+        assert!(!PolicyCategory::Csam.is_appealable());
+        assert!(PolicyCategory::Harassment.is_appealable());
+        assert!(PolicyCategory::Ncii.is_appealable());
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for c in [
+            PolicyCategory::Spam,
+            PolicyCategory::Harassment,
+            PolicyCategory::Hate,
+            PolicyCategory::ViolentExtremism,
+            PolicyCategory::Csam,
+            PolicyCategory::Ncii,
+            PolicyCategory::SelfHarm,
+            PolicyCategory::Misinformation,
+            PolicyCategory::Other,
+        ] {
+            assert_eq!(PolicyCategory::try_from(c.as_str()).unwrap(), c);
+        }
+        assert!(matches!(
+            PolicyCategory::try_from("nope").unwrap_err(),
+            ModerationError::UnknownPolicyCategory { .. }
+        ));
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/policy_version.rs
+++ b/crates/services/moderation/src/domain/value_object/policy_version.rs
@@ -1,0 +1,50 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ModerationError;
+
+/// The identifier of the policy ruleset a decision was made under (e.g.
+/// `"2026.06.1"`). Moderation does not store policy *text* — it pins the
+/// *version*, which is what makes a decision auditable and a rollout reversible:
+/// every [`Decision`](crate::domain::aggregate::Decision) records the version it
+/// was decided under.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PolicyVersion(String);
+
+impl PolicyVersion {
+    /// Constructs a policy version, rejecting an empty/blank identifier.
+    pub fn new(value: impl Into<String>) -> Result<Self, ModerationError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(ModerationError::DomainViolation {
+                field: "policy_version".into(),
+                message: "policy version must not be empty".into(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PolicyVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_blank() {
+        assert!(PolicyVersion::new("").is_err());
+        assert!(PolicyVersion::new("   ").is_err());
+        assert_eq!(PolicyVersion::new("2026.06.1").unwrap().as_str(), "2026.06.1");
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/signal.rs
+++ b/crates/services/moderation/src/domain/value_object/signal.rs
@@ -1,0 +1,79 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{Confidence, PolicyCategory};
+use crate::error::ModerationError;
+
+/// A single integrity signal contributing to a [`Case`](crate::domain::aggregate::Case):
+/// a classifier verdict or a user-report-derived observation. Signals are inputs
+/// to a decision, never the decision itself.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Signal {
+    /// Origin, e.g. `"classifier:image-v3"` or `"report"`.
+    source: String,
+    category: PolicyCategory,
+    confidence: Confidence,
+    observed_at: DateTime<Utc>,
+}
+
+impl Signal {
+    pub fn new(
+        source: impl Into<String>,
+        category: PolicyCategory,
+        confidence: Confidence,
+        observed_at: DateTime<Utc>,
+    ) -> Result<Self, ModerationError> {
+        let source = source.into();
+        if source.trim().is_empty() {
+            return Err(ModerationError::SignalRejected {
+                reason: "signal source must not be empty".into(),
+            });
+        }
+        Ok(Self { source, category, confidence, observed_at })
+    }
+
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub fn category(&self) -> PolicyCategory {
+        self.category
+    }
+
+    pub fn confidence(&self) -> Confidence {
+        self.confidence
+    }
+
+    pub fn observed_at(&self) -> DateTime<Utc> {
+        self.observed_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z").unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn rejects_empty_source() {
+        let err = Signal::new("", PolicyCategory::Spam, Confidence::new(0.9).unwrap(), t0()).unwrap_err();
+        assert!(matches!(err, ModerationError::SignalRejected { .. }));
+    }
+
+    #[test]
+    fn carries_fields() {
+        let s = Signal::new(
+            "classifier:text-v2",
+            PolicyCategory::Harassment,
+            Confidence::new(0.8).unwrap(),
+            t0(),
+        )
+        .unwrap();
+        assert_eq!(s.source(), "classifier:text-v2");
+        assert_eq!(s.category(), PolicyCategory::Harassment);
+        assert!(s.confidence().at_least(0.8));
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/strike.rs
+++ b/crates/services/moderation/src/domain/value_object/strike.rs
@@ -1,0 +1,49 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::PolicyCategory;
+
+/// A single penalty point-bearing mark against an actor, recorded when a decision
+/// enforces against them. Points and the decay deadline are **snapshotted** at
+/// record time (from the policy then in force) so that a later policy change does
+/// not retroactively re-weight history.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Strike {
+    category: PolicyCategory,
+    points: u32,
+    recorded_at: DateTime<Utc>,
+    /// When this strike stops counting toward the active total (decay).
+    expires_at: DateTime<Utc>,
+}
+
+impl Strike {
+    pub fn new(
+        category: PolicyCategory,
+        points: u32,
+        recorded_at: DateTime<Utc>,
+        expires_at: DateTime<Utc>,
+    ) -> Self {
+        Self { category, points, recorded_at, expires_at }
+    }
+
+    pub fn category(&self) -> PolicyCategory {
+        self.category
+    }
+
+    pub fn points(&self) -> u32 {
+        self.points
+    }
+
+    pub fn recorded_at(&self) -> DateTime<Utc> {
+        self.recorded_at
+    }
+
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    /// Whether this strike still counts toward the active total at `now`.
+    pub fn is_active(&self, now: DateTime<Utc>) -> bool {
+        now < self.expires_at
+    }
+}

--- a/crates/services/moderation/src/domain/value_object/subject_ref.rs
+++ b/crates/services/moderation/src/domain/value_object/subject_ref.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{ActorId, EntityType};
+use crate::error::ModerationError;
+
+/// The thing being moderated — the linchpin reference type. Moderation holds
+/// *this*, never the content bytes. `actor_id` is the responsible account;
+/// `surface` is the placement (e.g. `"feed"`, `"dm"`, `"profile"`) for
+/// surface-scoped policy.
+///
+/// The [`SubjectRef::canonical_key`] is the stable string used to derive the
+/// deterministic [`CaseId`](crate::domain::value_object::CaseId), so its format is
+/// part of the dedup contract and must not change once data exists.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SubjectRef {
+    entity_type: EntityType,
+    entity_id: String,
+    actor_id: ActorId,
+    surface: String,
+}
+
+impl SubjectRef {
+    /// Constructs a subject, rejecting a blank `entity_id`. A blank `surface` is
+    /// allowed (some subjects, e.g. account-level, have no placement).
+    pub fn new(
+        entity_type: EntityType,
+        entity_id: impl Into<String>,
+        actor_id: ActorId,
+        surface: impl Into<String>,
+    ) -> Result<Self, ModerationError> {
+        let entity_id = entity_id.into();
+        if entity_id.trim().is_empty() {
+            return Err(ModerationError::InvalidSubjectRef(
+                "entity_id must not be empty".into(),
+            ));
+        }
+        Ok(Self {
+            entity_type,
+            entity_id,
+            actor_id,
+            surface: surface.into(),
+        })
+    }
+
+    pub fn entity_type(&self) -> EntityType {
+        self.entity_type
+    }
+
+    pub fn entity_id(&self) -> &str {
+        &self.entity_id
+    }
+
+    pub fn actor_id(&self) -> ActorId {
+        self.actor_id
+    }
+
+    pub fn surface(&self) -> &str {
+        &self.surface
+    }
+
+    /// Stable string identity of the *content* this subject points at, used to
+    /// derive the deterministic case id. Intentionally excludes `actor_id` (it is
+    /// derivable from the content and a case is about the entity, not the actor)
+    /// and `surface` is included since the same entity on different surfaces is a
+    /// distinct moderation subject.
+    pub fn canonical_key(&self) -> String {
+        format!("{}|{}|{}", self.entity_type.as_str(), self.entity_id, self.surface)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn actor() -> ActorId {
+        ActorId::from_uuid(Uuid::from_u128(1))
+    }
+
+    #[test]
+    fn rejects_blank_entity_id() {
+        assert!(matches!(
+            SubjectRef::new(EntityType::Post, "  ", actor(), "feed").unwrap_err(),
+            ModerationError::InvalidSubjectRef(_)
+        ));
+    }
+
+    #[test]
+    fn canonical_key_is_stable_and_surface_sensitive() {
+        let feed = SubjectRef::new(EntityType::Post, "p1", actor(), "feed").unwrap();
+        let dm = SubjectRef::new(EntityType::Post, "p1", actor(), "dm").unwrap();
+        assert_eq!(feed.canonical_key(), "post|p1|feed");
+        assert_ne!(feed.canonical_key(), dm.canonical_key());
+    }
+
+    #[test]
+    fn canonical_key_ignores_actor() {
+        let a = SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(1)), "feed").unwrap();
+        let b = SubjectRef::new(EntityType::Post, "p1", ActorId::from_uuid(Uuid::from_u128(2)), "feed").unwrap();
+        assert_eq!(a.canonical_key(), b.canonical_key());
+    }
+}

--- a/crates/services/moderation/src/error.rs
+++ b/crates/services/moderation/src/error.rs
@@ -1,0 +1,350 @@
+use error::{AppError, Severity};
+use http::StatusCode;
+use thiserror::Error;
+
+/// Canonical domain and application error type for the moderation microservice.
+///
+/// The `MOD-XXXX` namespace is grouped by concern so a code alone localizes the
+/// fault: 1xxx case lifecycle, 2xxx decision ledger, 3xxx enforcement, 4xxx
+/// penalty/strikes/policy, 5xxx appeal, 6xxx report intake, 7xxx Screen gate
+/// (Plane C), 8xxx external integrity deps (classifiers / account directory),
+/// 9xxx cross-cutting (domain/parse, concurrency, event publication).
+///
+/// ## Code catalogue
+///
+/// | Code     | Variant                       | HTTP | Severity | Retryable |
+/// |----------|-------------------------------|------|----------|-----------|
+/// | MOD-1001 | CaseNotFound                  | 404  | Low      | No        |
+/// | MOD-1002 | InvalidCaseTransition         | 422  | Medium   | No        |
+/// | MOD-1003 | CaseAlreadyResolved           | 409  | Low      | No        |
+/// | MOD-2001 | DecisionNotFound              | 404  | Low      | No        |
+/// | MOD-2002 | DecisionImmutable             | 409  | **High** | No        |
+/// | MOD-3001 | EnforcementNotFound           | 404  | Low      | No        |
+/// | MOD-3002 | EnforcementAlreadyReversed    | 409  | Low      | No        |
+/// | MOD-3003 | InvalidEnforcementTransition  | 422  | Medium   | No        |
+/// | MOD-4001 | PolicyVersionNotFound         | 404  | Medium   | No        |
+/// | MOD-4002 | UnknownPolicyCategory         | 422  | Medium   | No        |
+/// | MOD-5001 | AppealNotFound                | 404  | Low      | No        |
+/// | MOD-5002 | AppealAlreadyResolved         | 409  | Low      | No        |
+/// | MOD-5003 | AppealWindowClosed            | 422  | Low      | No        |
+/// | MOD-5004 | NotAppealable                 | 422  | Medium   | No        |
+/// | MOD-6001 | ReportNotFound                | 404  | Low      | No        |
+/// | MOD-6002 | DuplicateReport               | 409  | Low      | No        |
+/// | MOD-6003 | SelfReportRejected            | 422  | Low      | No        |
+/// | MOD-7001 | ContentBlocked                | 451  | **High** | No        |
+/// | MOD-7002 | ScreenUnavailable             | 503  | **High** | **Yes**   |
+/// | MOD-7003 | HashCorpusUnavailable         | 503  | **High** | **Yes**   |
+/// | MOD-8001 | ClassifierUnavailable         | 503  | Medium   | **Yes**   |
+/// | MOD-8002 | SignalRejected                | 422  | Medium   | No        |
+/// | MOD-8003 | AccountDirectoryUnavailable   | 503  | High     | **Yes**   |
+/// | MOD-9001 | DomainViolation               | 422  | Medium   | No        |
+/// | MOD-9002 | InvalidSubjectRef             | 422  | Low      | No        |
+/// | MOD-9003 | InvalidIdentifier             | 422  | Low      | No        |
+/// | MOD-9004 | ConcurrentModification        | 409  | **High** | **Yes**   |
+/// | MOD-9005 | EventPublishFailed            | 500  | Medium   | No        |
+/// | DB-*     | Postgres records (delegated)  | var  | var      | var       |
+/// | SDB-*    | Scylla history (delegated)    | var  | var      | var       |
+/// | RDS-*    | Redis projection (delegated)  | var  | var      | var       |
+/// | VAL-*    | Validation (delegated)        | 422  | Low      | No        |
+///
+/// > **Fail-closed semantics (Plane C):** `ScreenUnavailable` / `ContentBlocked`
+/// > are not soft failures for catastrophic-harm categories (CSAM/NCII/TVEC). The
+/// > *caller's* per-category fail policy converts an unavailable gate into a hard
+/// > block — never an optimistic publish. See the blueprint's fail matrix.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ModerationError {
+    // ── Storage delegates (the three-store split) ─────────────────────────────
+    /// Postgres — the decision/case System of Record (`decisions`, `cases`,
+    /// `appeals`, `penalty_ledger`, `policy_versions`).
+    #[error(transparent)]
+    Records(#[from] postgres_storage::StorageError),
+
+    /// Scylla — the high-volume signal/evidence time-series (per-actor violation
+    /// history + retained classifier signals).
+    #[error(transparent)]
+    History(#[from] scylla_storage::ScyllaStorageError),
+
+    /// Redis — the hot-path enforcement projection + Screen hash corpus.
+    #[error(transparent)]
+    Cache(#[from] redis_storage::RedisStorageError),
+
+    #[error(transparent)]
+    Validation(#[from] validation::ValidationError),
+
+    // ── Case lifecycle (MOD-1xxx) ─────────────────────────────────────────────
+    #[error("case not found: {id}")]
+    CaseNotFound { id: String },
+
+    #[error("case transition from '{from}' to '{to}' is not permitted")]
+    InvalidCaseTransition { from: String, to: String },
+
+    #[error("case has already been resolved")]
+    CaseAlreadyResolved,
+
+    // ── Decision ledger (MOD-2xxx) — append-only / WORM ───────────────────────
+    #[error("decision not found: {id}")]
+    DecisionNotFound { id: String },
+
+    /// The decision ledger is the legal evidence record; it is append-only and a
+    /// written decision can never be mutated (a reversal is a *new* decision).
+    #[error("decision records are immutable; record a reversal instead")]
+    DecisionImmutable,
+
+    // ── Enforcement (MOD-3xxx) ────────────────────────────────────────────────
+    #[error("enforcement action not found: {id}")]
+    EnforcementNotFound { id: String },
+
+    #[error("enforcement action has already been reversed")]
+    EnforcementAlreadyReversed,
+
+    #[error("enforcement transition from '{from}' to '{to}' is not permitted")]
+    InvalidEnforcementTransition { from: String, to: String },
+
+    // ── Penalty / strikes / policy (MOD-4xxx) ─────────────────────────────────
+    #[error("policy version not found: {version}")]
+    PolicyVersionNotFound { version: String },
+
+    #[error("unknown policy category: '{category}'")]
+    UnknownPolicyCategory { category: String },
+
+    // ── Appeal (MOD-5xxx) ─────────────────────────────────────────────────────
+    #[error("appeal not found: {id}")]
+    AppealNotFound { id: String },
+
+    #[error("appeal has already been resolved")]
+    AppealAlreadyResolved,
+
+    #[error("the appeal window for this decision has closed")]
+    AppealWindowClosed,
+
+    /// Some enforcement categories (e.g. legally-mandated CSAM removals) are not
+    /// user-appealable by policy.
+    #[error("this decision is not appealable under policy")]
+    NotAppealable,
+
+    // ── Report intake (MOD-6xxx) ──────────────────────────────────────────────
+    #[error("report not found: {id}")]
+    ReportNotFound { id: String },
+
+    /// A duplicate of an already-ingested report (deduplicated by deterministic
+    /// key); typically folded into an `Ok` at the application layer.
+    #[error("duplicate report; already ingested")]
+    DuplicateReport,
+
+    #[error("a reporter may not report their own content")]
+    SelfReportRejected,
+
+    // ── Screen gate · Plane C (MOD-7xxx) ──────────────────────────────────────
+    /// A positive match against the known-bad corpus for a catastrophic-harm
+    /// category — the content must never become visible. `451 Unavailable For
+    /// Legal Reasons`.
+    #[error("content blocked at screening for category '{category}'")]
+    ContentBlocked { category: String },
+
+    #[error("the screening gate is unavailable")]
+    ScreenUnavailable,
+
+    #[error("the known-bad hash corpus is unavailable")]
+    HashCorpusUnavailable,
+
+    // ── External integrity deps (MOD-8xxx) ────────────────────────────────────
+    #[error("classifier service is unavailable")]
+    ClassifierUnavailable,
+
+    #[error("classifier signal rejected: {reason}")]
+    SignalRejected { reason: String },
+
+    #[error("account directory service is unavailable")]
+    AccountDirectoryUnavailable,
+
+    // ── Cross-cutting (MOD-9xxx) ──────────────────────────────────────────────
+    #[error("domain invariant violated on '{field}': {message}")]
+    DomainViolation { field: String, message: String },
+
+    #[error("invalid subject reference: '{0}'")]
+    InvalidSubjectRef(String),
+
+    #[error("invalid identifier: '{0}'")]
+    InvalidIdentifier(String),
+
+    #[error("concurrent modification detected; reload and retry")]
+    ConcurrentModification,
+
+    #[error("failed to publish moderation event: {0}")]
+    EventPublishFailed(String),
+}
+
+impl AppError for ModerationError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            ModerationError::Records(e) => e.error_code(),
+            ModerationError::History(e) => e.error_code(),
+            ModerationError::Cache(e) => e.error_code(),
+            ModerationError::Validation(e) => e.error_code(),
+
+            ModerationError::CaseNotFound { .. } => "MOD-1001",
+            ModerationError::InvalidCaseTransition { .. } => "MOD-1002",
+            ModerationError::CaseAlreadyResolved => "MOD-1003",
+
+            ModerationError::DecisionNotFound { .. } => "MOD-2001",
+            ModerationError::DecisionImmutable => "MOD-2002",
+
+            ModerationError::EnforcementNotFound { .. } => "MOD-3001",
+            ModerationError::EnforcementAlreadyReversed => "MOD-3002",
+            ModerationError::InvalidEnforcementTransition { .. } => "MOD-3003",
+
+            ModerationError::PolicyVersionNotFound { .. } => "MOD-4001",
+            ModerationError::UnknownPolicyCategory { .. } => "MOD-4002",
+
+            ModerationError::AppealNotFound { .. } => "MOD-5001",
+            ModerationError::AppealAlreadyResolved => "MOD-5002",
+            ModerationError::AppealWindowClosed => "MOD-5003",
+            ModerationError::NotAppealable => "MOD-5004",
+
+            ModerationError::ReportNotFound { .. } => "MOD-6001",
+            ModerationError::DuplicateReport => "MOD-6002",
+            ModerationError::SelfReportRejected => "MOD-6003",
+
+            ModerationError::ContentBlocked { .. } => "MOD-7001",
+            ModerationError::ScreenUnavailable => "MOD-7002",
+            ModerationError::HashCorpusUnavailable => "MOD-7003",
+
+            ModerationError::ClassifierUnavailable => "MOD-8001",
+            ModerationError::SignalRejected { .. } => "MOD-8002",
+            ModerationError::AccountDirectoryUnavailable => "MOD-8003",
+
+            ModerationError::DomainViolation { .. } => "MOD-9001",
+            ModerationError::InvalidSubjectRef(_) => "MOD-9002",
+            ModerationError::InvalidIdentifier(_) => "MOD-9003",
+            ModerationError::ConcurrentModification => "MOD-9004",
+            ModerationError::EventPublishFailed(_) => "MOD-9005",
+        }
+    }
+
+    fn http_status(&self) -> StatusCode {
+        match self {
+            ModerationError::Records(e) => e.http_status(),
+            ModerationError::History(e) => e.http_status(),
+            ModerationError::Cache(e) => e.http_status(),
+            ModerationError::Validation(e) => e.http_status(),
+
+            ModerationError::CaseNotFound { .. }
+            | ModerationError::DecisionNotFound { .. }
+            | ModerationError::EnforcementNotFound { .. }
+            | ModerationError::PolicyVersionNotFound { .. }
+            | ModerationError::AppealNotFound { .. }
+            | ModerationError::ReportNotFound { .. } => StatusCode::NOT_FOUND,
+
+            ModerationError::CaseAlreadyResolved
+            | ModerationError::DecisionImmutable
+            | ModerationError::EnforcementAlreadyReversed
+            | ModerationError::AppealAlreadyResolved
+            | ModerationError::DuplicateReport
+            | ModerationError::ConcurrentModification => StatusCode::CONFLICT,
+
+            ModerationError::ContentBlocked { .. } => StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
+
+            ModerationError::ScreenUnavailable
+            | ModerationError::HashCorpusUnavailable
+            | ModerationError::ClassifierUnavailable
+            | ModerationError::AccountDirectoryUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+
+            ModerationError::EventPublishFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+
+            _ => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            ModerationError::Records(e) => e.severity(),
+            ModerationError::History(e) => e.severity(),
+            ModerationError::Cache(e) => e.severity(),
+            ModerationError::Validation(e) => e.severity(),
+
+            ModerationError::DecisionImmutable
+            | ModerationError::ContentBlocked { .. }
+            | ModerationError::ScreenUnavailable
+            | ModerationError::HashCorpusUnavailable
+            | ModerationError::AccountDirectoryUnavailable
+            | ModerationError::ConcurrentModification => Severity::High,
+
+            ModerationError::InvalidCaseTransition { .. }
+            | ModerationError::InvalidEnforcementTransition { .. }
+            | ModerationError::PolicyVersionNotFound { .. }
+            | ModerationError::UnknownPolicyCategory { .. }
+            | ModerationError::NotAppealable
+            | ModerationError::ClassifierUnavailable
+            | ModerationError::SignalRejected { .. }
+            | ModerationError::DomainViolation { .. }
+            | ModerationError::EventPublishFailed(_) => Severity::Medium,
+
+            _ => Severity::Low,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            ModerationError::Records(e) => e.is_retryable(),
+            ModerationError::History(e) => e.is_retryable(),
+            ModerationError::Cache(e) => e.is_retryable(),
+            ModerationError::ScreenUnavailable
+            | ModerationError::HashCorpusUnavailable
+            | ModerationError::ClassifierUnavailable
+            | ModerationError::AccountDirectoryUnavailable
+            | ModerationError::ConcurrentModification => true,
+            _ => false,
+        }
+    }
+
+    fn category(&self) -> &'static str {
+        match self {
+            ModerationError::Records(e) => e.category(),
+            ModerationError::History(e) => e.category(),
+            ModerationError::Cache(e) => e.category(),
+            ModerationError::Validation(e) => e.category(),
+            _ => "MOD",
+        }
+    }
+
+    fn user_facing_message(&self) -> &'static str {
+        match self {
+            ModerationError::Records(e) => e.user_facing_message(),
+            ModerationError::History(e) => e.user_facing_message(),
+            ModerationError::Cache(e) => e.user_facing_message(),
+            ModerationError::Validation(e) => e.user_facing_message(),
+
+            ModerationError::CaseNotFound { .. }
+            | ModerationError::DecisionNotFound { .. }
+            | ModerationError::EnforcementNotFound { .. }
+            | ModerationError::AppealNotFound { .. }
+            | ModerationError::ReportNotFound { .. } => "The requested record does not exist.",
+
+            ModerationError::CaseAlreadyResolved
+            | ModerationError::AppealAlreadyResolved
+            | ModerationError::EnforcementAlreadyReversed => "This item has already been resolved.",
+
+            ModerationError::DecisionImmutable => "This record cannot be changed.",
+
+            ModerationError::AppealWindowClosed => "The window to appeal this decision has closed.",
+            ModerationError::NotAppealable => "This decision cannot be appealed.",
+
+            ModerationError::DuplicateReport => "You have already reported this.",
+            ModerationError::SelfReportRejected => "You cannot report your own content.",
+
+            ModerationError::ContentBlocked { .. } => "This content cannot be published.",
+
+            ModerationError::ScreenUnavailable
+            | ModerationError::HashCorpusUnavailable
+            | ModerationError::ClassifierUnavailable
+            | ModerationError::AccountDirectoryUnavailable => {
+                "Safety checks are temporarily unavailable. Please try again."
+            }
+
+            ModerationError::EventPublishFailed(_) => "We could not complete that action. Please try again.",
+
+            _ => "A domain constraint was violated.",
+        }
+    }
+}

--- a/crates/services/moderation/src/infrastructure/cache/keys.rs
+++ b/crates/services/moderation/src/infrastructure/cache/keys.rs
@@ -1,0 +1,15 @@
+//! Redis key builders. Single-key operations, but every key carries a `{…}` hash
+//! tag on its entity so any future multi-key script stays slot-safe on Redis
+//! Cluster (the mandatory slot-safety rule).
+
+use crate::domain::value_object::ActorId;
+
+/// Hot-path enforcement flag for an actor: `mod:enf:{<actor>}`.
+pub fn enforcement_key(actor: &ActorId) -> String {
+    format!("mod:enf:{{{actor}}}")
+}
+
+/// Known-bad corpus entry for a content hash: `mod:corpus:{<algo>}:<value>`.
+pub fn corpus_key(algorithm: &str, value: &str) -> String {
+    format!("mod:corpus:{{{algorithm}}}:{value}")
+}

--- a/crates/services/moderation/src/infrastructure/cache/mod.rs
+++ b/crates/services/moderation/src/infrastructure/cache/mod.rs
@@ -1,0 +1,9 @@
+//! Redis adapters — the hot-path enforcement projection (Plane B) and the
+//! known-bad screen corpus (Plane C).
+
+pub mod keys;
+pub mod redis_enforcement_projection;
+pub mod redis_screen_corpus;
+
+pub use redis_enforcement_projection::RedisEnforcementProjection;
+pub use redis_screen_corpus::RedisScreenCorpus;

--- a/crates/services/moderation/src/infrastructure/cache/redis_enforcement_projection.rs
+++ b/crates/services/moderation/src/infrastructure/cache/redis_enforcement_projection.rs
@@ -1,0 +1,79 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use fred::interfaces::KeysInterface;
+use fred::types::Expiration;
+use redis_storage::{RedisClient, RedisStorageError};
+
+use crate::application::port::EnforcementProjection;
+use crate::domain::value_object::{ActorId, EnforcementVersion};
+use crate::error::ModerationError;
+
+use super::keys::enforcement_key;
+
+/// Redis Cluster implementation of [`EnforcementProjection`] — the Plane B
+/// hot-path flag the fleet reads to answer "is this actor restricted right now".
+///
+/// The key value is the [`EnforcementVersion`] under which the restriction was
+/// written; a present key means restricted. Writes are version-guarded best-effort
+/// (read-then-act): a lower-versioned write is ignored so a stale reversal cannot
+/// clear a newer restriction. Per-actor event ordering (Kafka keys by `actor_id`)
+/// makes a true race vanishingly unlikely.
+#[derive(Clone)]
+pub struct RedisEnforcementProjection {
+    client: RedisClient,
+}
+
+impl RedisEnforcementProjection {
+    pub fn new(client: RedisClient) -> Self {
+        Self { client }
+    }
+}
+
+fn cache_err(e: fred::error::Error) -> ModerationError {
+    ModerationError::Cache(RedisStorageError::from(e))
+}
+
+#[async_trait]
+impl EnforcementProjection for RedisEnforcementProjection {
+    async fn set_actor_restriction(
+        &self,
+        actor_id: &ActorId,
+        version: EnforcementVersion,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<(), ModerationError> {
+        let key = enforcement_key(actor_id);
+        let current: Option<i64> = self.client.get(&key).await.map_err(cache_err)?;
+        if current.is_some_and(|c| version.value() < c) {
+            return Ok(()); // stale write — a newer restriction already stands.
+        }
+        let expiration = expires_at.map(|exp| {
+            let secs = (exp - Utc::now()).num_seconds().max(1);
+            Expiration::EX(secs)
+        });
+        let _: () = self
+            .client
+            .set(&key, version.value(), expiration, None, false)
+            .await
+            .map_err(cache_err)?;
+        Ok(())
+    }
+
+    async fn clear_actor_restriction(
+        &self,
+        actor_id: &ActorId,
+        version: EnforcementVersion,
+    ) -> Result<(), ModerationError> {
+        let key = enforcement_key(actor_id);
+        let current: Option<i64> = self.client.get(&key).await.map_err(cache_err)?;
+        // Only clear when our version is at least the stored one.
+        if current.is_none_or(|c| version.value() >= c) {
+            let _: i64 = self.client.del(&key).await.map_err(cache_err)?;
+        }
+        Ok(())
+    }
+
+    async fn is_actor_restricted(&self, actor_id: &ActorId) -> Result<bool, ModerationError> {
+        let count: i64 = self.client.exists(enforcement_key(actor_id)).await.map_err(cache_err)?;
+        Ok(count > 0)
+    }
+}

--- a/crates/services/moderation/src/infrastructure/cache/redis_screen_corpus.rs
+++ b/crates/services/moderation/src/infrastructure/cache/redis_screen_corpus.rs
@@ -1,0 +1,76 @@
+use async_trait::async_trait;
+use fred::interfaces::KeysInterface;
+use redis_storage::RedisClient;
+use serde::Deserialize;
+
+use crate::application::port::{ContentHash, CorpusMatch, ScreenCorpus};
+use crate::domain::value_object::PolicyCategory;
+use crate::error::ModerationError;
+
+use super::keys::corpus_key;
+
+/// The on-the-wire shape of a corpus entry: `mod:corpus:{algo}:value` → this JSON.
+/// The corpus is populated out-of-band by the hash-ingestion pipeline; this
+/// adapter only reads it.
+#[derive(Debug, Deserialize)]
+struct StoredMatch {
+    categories: Vec<String>,
+    reference: String,
+}
+
+/// Redis-backed [`ScreenCorpus`] — the bounded-latency, deterministic hash lookup
+/// behind the Plane C gate. A connectivity failure surfaces as
+/// [`ModerationError::HashCorpusUnavailable`], which the caller's per-category fail
+/// policy turns into a hard block for catastrophic categories.
+#[derive(Clone)]
+pub struct RedisScreenCorpus {
+    client: RedisClient,
+}
+
+impl RedisScreenCorpus {
+    pub fn new(client: RedisClient) -> Self {
+        Self { client }
+    }
+}
+
+fn corpus_err(_e: fred::error::Error) -> ModerationError {
+    // A corpus lookup failure is treated as the corpus being unavailable, so the
+    // fail-closed caller blocks rather than admitting unscreened content.
+    ModerationError::HashCorpusUnavailable
+}
+
+fn parse_entry(raw: &str) -> Result<CorpusMatch, ModerationError> {
+    let stored: StoredMatch = serde_json::from_str(raw).map_err(|e| ModerationError::SignalRejected {
+        reason: format!("malformed corpus entry: {e}"),
+    })?;
+    let categories = stored
+        .categories
+        .iter()
+        .map(|c| PolicyCategory::try_from(c.as_str()))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(CorpusMatch { categories, reference: stored.reference })
+}
+
+#[async_trait]
+impl ScreenCorpus for RedisScreenCorpus {
+    async fn screen(
+        &self,
+        hashes: &[ContentHash],
+        _text: Option<&str>,
+        _categories: &[PolicyCategory],
+    ) -> Result<Option<CorpusMatch>, ModerationError> {
+        // Concurrency note: hashes are few (one per algorithm); a sequential set of
+        // single-key GETs keeps each lookup slot-local on the cluster.
+        for h in hashes {
+            let raw: Option<String> = self
+                .client
+                .get(corpus_key(&h.algorithm, &h.value))
+                .await
+                .map_err(corpus_err)?;
+            if let Some(raw) = raw {
+                return Ok(Some(parse_entry(&raw)?));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/crates/services/moderation/src/infrastructure/classifier/log_classifier_gateway.rs
+++ b/crates/services/moderation/src/infrastructure/classifier/log_classifier_gateway.rs
@@ -1,0 +1,24 @@
+use async_trait::async_trait;
+use tracing::debug;
+
+use crate::application::port::ClassifierGateway;
+use crate::domain::value_object::SubjectRef;
+use crate::error::ModerationError;
+
+/// A no-op [`ClassifierGateway`] that traces classification requests instead of
+/// dispatching them. Stands in until the internal classifier services exist; the
+/// graduated engine runs on deterministic rules in the meantime.
+#[derive(Default)]
+pub struct LogClassifierGateway;
+
+#[async_trait]
+impl ClassifierGateway for LogClassifierGateway {
+    async fn request_classification(&self, subject: &SubjectRef) -> Result<(), ModerationError> {
+        debug!(
+            entity_type = %subject.entity_type(),
+            entity_id = subject.entity_id(),
+            "classification requested (log stub)"
+        );
+        Ok(())
+    }
+}

--- a/crates/services/moderation/src/infrastructure/classifier/mod.rs
+++ b/crates/services/moderation/src/infrastructure/classifier/mod.rs
@@ -1,0 +1,7 @@
+//! Classifier-gateway adapters. The real classifier services are a future,
+//! internal dependency; until they exist this is a log stub, and the graduated
+//! engine runs on deterministic rules alone.
+
+pub mod log_classifier_gateway;
+
+pub use log_classifier_gateway::LogClassifierGateway;

--- a/crates/services/moderation/src/infrastructure/consumer/mod.rs
+++ b/crates/services/moderation/src/infrastructure/consumer/mod.rs
@@ -1,0 +1,27 @@
+//! Plane A ingestion consumers — the async, post-hoc path. Each runs on the
+//! shared at-least-once [`run_consumer`](transport::kafka::consumer::run_consumer)
+//! runner (manual commit, bounded retry + jitter, DLQ on poison/exhaustion) and
+//! is self-spawned + supervised in [`crate::service`].
+//!
+//! Two consumers ship here — the moderation-owned topics whose schemas this
+//! service defines: `moderation.reports` (user reports) and `moderation.signals`
+//! (classifier verdicts). Fan-in from the content topics (`post`/`comment`/`chat`)
+//! is a follow-up once a content-screen-on-create handler exists.
+
+pub mod report_consumer;
+pub mod signal_consumer;
+
+pub use report_consumer::run_report_consumer;
+pub use signal_consumer::run_signal_consumer;
+
+use crate::error::ModerationError;
+
+/// Lets the at-least-once runner classify a moderation failure: delegate to the
+/// error's own [`AppError::is_retryable`](error::AppError::is_retryable) verdict
+/// (transient storage/dependency faults retry; domain/validation faults are
+/// poison and dead-letter immediately).
+impl transport::kafka::consumer::ClassifyError for ModerationError {
+    fn is_retryable(&self) -> bool {
+        <Self as error::AppError>::is_retryable(self)
+    }
+}

--- a/crates/services/moderation/src/infrastructure/consumer/report_consumer.rs
+++ b/crates/services/moderation/src/infrastructure/consumer/report_consumer.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use cqrs::Envelope;
+use serde::Deserialize;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use transport::kafka::consumer::{run_consumer, KafkaConsumerHandle, ProcessOutcome, RetryPolicy};
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::command::{IngestReportCommand, IngestReportHandler};
+use crate::domain::value_object::{ActorId, EntityType, PolicyCategory, SubjectRef};
+use crate::error::ModerationError;
+
+/// Payload on `moderation.reports` (a user-submitted abuse report).
+#[derive(Debug, Deserialize)]
+struct ReportEvent {
+    reporter_id: String,
+    entity_type: String,
+    entity_id: String,
+    actor_id: String,
+    #[serde(default)]
+    surface: String,
+    category: String,
+    #[serde(default)]
+    reason: String,
+}
+
+/// Runs the report consumer on the shared at-least-once runner.
+pub async fn run_report_consumer(
+    consumer: KafkaConsumerHandle,
+    handler: Arc<IngestReportHandler>,
+    producer: KafkaProducerHandle,
+) {
+    info!("moderation report consumer started");
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<ReportEvent, _>(&consumer, &producer, &policy, move |event| {
+        let handler = Arc::clone(&handler);
+        Box::pin(async move { process(handler.as_ref(), event).await })
+    })
+    .await;
+    if let Err(e) = result {
+        error!(error = %e, "moderation report consumer stopped");
+    }
+}
+
+async fn process(handler: &IngestReportHandler, event: &ReportEvent) -> ProcessOutcome {
+    let cmd = match build_command(event) {
+        Ok(cmd) => cmd,
+        Err(e) => return ProcessOutcome::from_result(Err::<(), _>(e)),
+    };
+    let result = handler.handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now()).await.map(|_| ());
+    ProcessOutcome::from_result(result)
+}
+
+fn build_command(event: &ReportEvent) -> Result<IngestReportCommand, ModerationError> {
+    let subject = SubjectRef::new(
+        EntityType::try_from(event.entity_type.as_str())?,
+        event.entity_id.clone(),
+        ActorId::try_from(event.actor_id.as_str())?,
+        event.surface.clone(),
+    )?;
+    Ok(IngestReportCommand {
+        reporter_id: ActorId::try_from(event.reporter_id.as_str())?,
+        subject,
+        category: PolicyCategory::try_from(event.category.as_str())?,
+        reason: event.reason.clone(),
+    })
+}

--- a/crates/services/moderation/src/infrastructure/consumer/signal_consumer.rs
+++ b/crates/services/moderation/src/infrastructure/consumer/signal_consumer.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use cqrs::Envelope;
+use serde::Deserialize;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use transport::kafka::consumer::{run_consumer, KafkaConsumerHandle, ProcessOutcome, RetryPolicy};
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::command::{IngestSignalCommand, IngestSignalHandler};
+use crate::domain::value_object::{ActorId, Confidence, EntityType, PolicyCategory, SubjectRef};
+use crate::error::ModerationError;
+
+/// Payload on `moderation.signals` (a classifier verdict).
+#[derive(Debug, Deserialize)]
+struct SignalEvent {
+    entity_type: String,
+    entity_id: String,
+    actor_id: String,
+    #[serde(default)]
+    surface: String,
+    source: String,
+    category: String,
+    confidence: f64,
+}
+
+/// Runs the classifier-signal consumer on the shared at-least-once runner.
+pub async fn run_signal_consumer(
+    consumer: KafkaConsumerHandle,
+    handler: Arc<IngestSignalHandler>,
+    producer: KafkaProducerHandle,
+) {
+    info!("moderation signal consumer started");
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<SignalEvent, _>(&consumer, &producer, &policy, move |event| {
+        let handler = Arc::clone(&handler);
+        Box::pin(async move { process(handler.as_ref(), event).await })
+    })
+    .await;
+    if let Err(e) = result {
+        error!(error = %e, "moderation signal consumer stopped");
+    }
+}
+
+async fn process(handler: &IngestSignalHandler, event: &SignalEvent) -> ProcessOutcome {
+    let cmd = match build_command(event) {
+        Ok(cmd) => cmd,
+        Err(e) => return ProcessOutcome::from_result(Err::<(), _>(e)),
+    };
+    let result = handler.handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now()).await.map(|_| ());
+    ProcessOutcome::from_result(result)
+}
+
+fn build_command(event: &SignalEvent) -> Result<IngestSignalCommand, ModerationError> {
+    let subject = SubjectRef::new(
+        EntityType::try_from(event.entity_type.as_str())?,
+        event.entity_id.clone(),
+        ActorId::try_from(event.actor_id.as_str())?,
+        event.surface.clone(),
+    )?;
+    Ok(IngestSignalCommand {
+        subject,
+        source: event.source.clone(),
+        category: PolicyCategory::try_from(event.category.as_str())?,
+        confidence: Confidence::clamped(event.confidence),
+    })
+}

--- a/crates/services/moderation/src/infrastructure/directory/grpc_account_directory.rs
+++ b/crates/services/moderation/src/infrastructure/directory/grpc_account_directory.rs
@@ -1,0 +1,38 @@
+use account_api::account_service_client::AccountServiceClient;
+use account_api::GetAccountByIdRequest;
+use async_trait::async_trait;
+use tonic::transport::Channel;
+use tonic::Code;
+
+use crate::application::port::AccountDirectory;
+use crate::domain::value_object::ActorId;
+use crate::error::ModerationError;
+
+/// gRPC implementation of [`AccountDirectory`], backed by the `account` service.
+/// The tonic client is cheaply cloneable (the `Channel` is `Arc`-backed), so each
+/// call clones it to satisfy the `&self` port signature.
+#[derive(Clone)]
+pub struct GrpcAccountDirectory {
+    client: AccountServiceClient<Channel>,
+}
+
+impl GrpcAccountDirectory {
+    pub fn new(channel: Channel) -> Self {
+        Self { client: AccountServiceClient::new(channel) }
+    }
+}
+
+#[async_trait]
+impl AccountDirectory for GrpcAccountDirectory {
+    async fn actor_exists(&self, actor_id: &ActorId) -> Result<bool, ModerationError> {
+        let mut client = self.client.clone();
+        match client
+            .get_account_by_id(GetAccountByIdRequest { account_id: actor_id.as_str() })
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(status) if status.code() == Code::NotFound => Ok(false),
+            Err(_) => Err(ModerationError::AccountDirectoryUnavailable),
+        }
+    }
+}

--- a/crates/services/moderation/src/infrastructure/directory/mod.rs
+++ b/crates/services/moderation/src/infrastructure/directory/mod.rs
@@ -1,0 +1,6 @@
+//! Account-directory adapter — the small synchronous slice moderation needs from
+//! `account` (confirming an actor exists before an actor-level enforcement).
+
+pub mod grpc_account_directory;
+
+pub use grpc_account_directory::GrpcAccountDirectory;

--- a/crates/services/moderation/src/infrastructure/event/fanout_event_publisher.rs
+++ b/crates/services/moderation/src/infrastructure/event/fanout_event_publisher.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::warn;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::ModerationError;
+
+/// Fans a domain event out to one **authoritative** sink (Kafka — the Plane B
+/// denormalization notification, whose failure must surface) and zero or more
+/// **best-effort** sinks (the Scylla evidence history — an audit projection whose
+/// transient failure must not fail the moderation operation, only be logged).
+pub struct FanoutEventPublisher {
+    primary: Arc<dyn EventPublisher>,
+    secondaries: Vec<Arc<dyn EventPublisher>>,
+}
+
+impl FanoutEventPublisher {
+    pub fn new(primary: Arc<dyn EventPublisher>, secondaries: Vec<Arc<dyn EventPublisher>>) -> Self {
+        Self { primary, secondaries }
+    }
+}
+
+#[async_trait]
+impl EventPublisher for FanoutEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ModerationError> {
+        for sink in &self.secondaries {
+            if let Err(e) = sink.publish(event).await {
+                warn!(event_type = event.event_type(), error = %e, "best-effort event sink failed");
+            }
+        }
+        self.primary.publish(event).await
+    }
+}

--- a/crates/services/moderation/src/infrastructure/event/kafka_event_publisher.rs
+++ b/crates/services/moderation/src/infrastructure/event/kafka_event_publisher.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+use transport::error::TransportError;
+use transport::kafka::envelope::EventEnvelope;
+use transport::kafka::producer::handle::KafkaProducerHandle;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::ModerationError;
+
+use super::TOPIC_MODERATION_EVENTS;
+
+/// Kafka-backed [`EventPublisher`]. Handlers persist durably first, then publish;
+/// a publish failure surfaces as [`ModerationError::EventPublishFailed`] (the
+/// adapter may itself back an outbox in a later iteration).
+pub struct KafkaEventPublisher {
+    producer: KafkaProducerHandle,
+}
+
+impl KafkaEventPublisher {
+    pub fn new(producer: KafkaProducerHandle) -> Self {
+        Self { producer }
+    }
+}
+
+fn publish_err(e: TransportError) -> ModerationError {
+    ModerationError::EventPublishFailed(e.to_string())
+}
+
+#[async_trait]
+impl EventPublisher for KafkaEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ModerationError> {
+        let key = event.actor_id().as_str();
+        let envelope = EventEnvelope::new(TOPIC_MODERATION_EVENTS, key.clone(), event.clone())
+            .with_header("event_type", event.event_type().to_owned())
+            .with_header("actor_id", key);
+        self.producer.publish(envelope).await.map_err(publish_err)
+    }
+}

--- a/crates/services/moderation/src/infrastructure/event/log_event_publisher.rs
+++ b/crates/services/moderation/src/infrastructure/event/log_event_publisher.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+use tracing::info;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::ModerationError;
+
+/// A no-Kafka [`EventPublisher`] that traces events instead of emitting them.
+/// Used for local development and tests where a broker is not wired.
+#[derive(Default)]
+pub struct LogEventPublisher;
+
+#[async_trait]
+impl EventPublisher for LogEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ModerationError> {
+        info!(
+            event_type = event.event_type(),
+            actor_id = %event.actor_id(),
+            "moderation domain event (log publisher)"
+        );
+        Ok(())
+    }
+}

--- a/crates/services/moderation/src/infrastructure/event/mod.rs
+++ b/crates/services/moderation/src/infrastructure/event/mod.rs
@@ -1,0 +1,16 @@
+//! Event-publication adapters for the `moderation.v1.events` topic.
+//!
+//! Every domain event is keyed by `actor_id` so an actor's moderation events keep
+//! per-partition order — a reversal can never be delivered ahead of the
+//! application it reverses. The `event_type` header carries the dotted routing key.
+
+pub mod fanout_event_publisher;
+pub mod kafka_event_publisher;
+pub mod log_event_publisher;
+
+pub use fanout_event_publisher::FanoutEventPublisher;
+pub use kafka_event_publisher::KafkaEventPublisher;
+pub use log_event_publisher::LogEventPublisher;
+
+/// The single Kafka topic every moderation domain event is published to.
+pub const TOPIC_MODERATION_EVENTS: &str = "moderation.v1.events";

--- a/crates/services/moderation/src/infrastructure/grpc/handler/mod.rs
+++ b/crates/services/moderation/src/infrastructure/grpc/handler/mod.rs
@@ -1,0 +1,4 @@
+pub mod moderation_service_handler;
+
+pub use moderation_service_handler::{proto, ModerationServiceHandler};
+pub use proto::moderation_service_server::ModerationServiceServer;

--- a/crates/services/moderation/src/infrastructure/grpc/handler/moderation_service_handler.rs
+++ b/crates/services/moderation/src/infrastructure/grpc/handler/moderation_service_handler.rs
@@ -1,0 +1,511 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, QueryHandler};
+use error::AppError;
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+use crate::application::command::{
+    AssignCaseCommand, AssignCaseHandler, DecideCaseCommand, DecideCaseHandler, DecideOutcome,
+    FileAppealCommand, FileAppealHandler, OpenCaseCommand, OpenCaseHandler, OpenedCase,
+    ResolveAppealCommand, ResolveAppealHandler, ResolveAppealOutcome, ScreenCommand, ScreenHandler,
+    ScreenVerdict,
+};
+use crate::application::port::ContentHash;
+use crate::application::query::{
+    GetEnforcementStateHandler, GetEnforcementStateQuery, GetStatementOfReasonsHandler,
+    GetStatementOfReasonsQuery, ListQueueHandler, ListQueueQuery, StatementOfReasons,
+};
+use crate::domain::aggregate::{Appeal, Case, Decision, EnforcementAction};
+use crate::domain::value_object::{
+    ActionType, ActorId, AppealId, CaseId, CaseStatus, DecisionId, EnforcementStatus, EntityType,
+    PolicyCategory, Signal, SubjectRef,
+};
+use crate::error::ModerationError;
+
+// ── Proto inclusion ───────────────────────────────────────────────────────────
+pub use moderation_api as proto;
+
+/// gRPC request handler for the `moderation.v1` service. Each method translates an
+/// inbound Protobuf request into an application command/query, runs it with a
+/// fresh correlation id + the wall clock, and maps the result (or
+/// [`ModerationError`]) back to Protobuf / [`Status`].
+#[derive(Clone)]
+pub struct ModerationServiceHandler {
+    screen: Arc<ScreenHandler>,
+    open_case: Arc<OpenCaseHandler>,
+    assign_case: Arc<AssignCaseHandler>,
+    decide_case: Arc<DecideCaseHandler>,
+    list_queue: Arc<ListQueueHandler>,
+    file_appeal: Arc<FileAppealHandler>,
+    resolve_appeal: Arc<ResolveAppealHandler>,
+    statement_of_reasons: Arc<GetStatementOfReasonsHandler>,
+    enforcement_state: Arc<GetEnforcementStateHandler>,
+}
+
+impl ModerationServiceHandler {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        screen: Arc<ScreenHandler>,
+        open_case: Arc<OpenCaseHandler>,
+        assign_case: Arc<AssignCaseHandler>,
+        decide_case: Arc<DecideCaseHandler>,
+        list_queue: Arc<ListQueueHandler>,
+        file_appeal: Arc<FileAppealHandler>,
+        resolve_appeal: Arc<ResolveAppealHandler>,
+        statement_of_reasons: Arc<GetStatementOfReasonsHandler>,
+        enforcement_state: Arc<GetEnforcementStateHandler>,
+    ) -> Self {
+        Self {
+            screen,
+            open_case,
+            assign_case,
+            decide_case,
+            list_queue,
+            file_appeal,
+            resolve_appeal,
+            statement_of_reasons,
+            enforcement_state,
+        }
+    }
+
+    fn envelope<T>(payload: T) -> Envelope<T> {
+        Envelope::new(Uuid::now_v7(), payload)
+    }
+
+    pub async fn screen(
+        &self,
+        request: Request<proto::ScreenRequest>,
+    ) -> Result<Response<proto::ScreenResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = ScreenCommand {
+            subject: subject_from_proto(req.subject)?,
+            hashes: req
+                .hashes
+                .into_iter()
+                .map(|h| ContentHash { algorithm: h.algorithm, value: h.value })
+                .collect(),
+            text: (!req.text.is_empty()).then_some(req.text),
+            categories: req
+                .categories
+                .into_iter()
+                .map(category_from_proto)
+                .collect::<Result<Vec<_>, _>>()?,
+        };
+        let out = self
+            .screen
+            .handle(Self::envelope(cmd), Utc::now())
+            .await
+            .map_err(status)?;
+        Ok(Response::new(proto::ScreenResponse {
+            verdict: verdict_to_proto(out.verdict),
+            matched_categories: out.matched_categories.iter().map(|c| category_to_proto(*c)).collect(),
+            match_reference: out.match_reference.unwrap_or_default(),
+        }))
+    }
+
+    pub async fn open_case(
+        &self,
+        request: Request<proto::OpenCaseRequest>,
+    ) -> Result<Response<proto::OpenCaseResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = OpenCaseCommand {
+            subject: subject_from_proto(req.subject)?,
+            category: category_from_proto(req.category)?,
+            queue: defaulted(req.reason.clone(), "default"),
+            priority: "normal".to_owned(),
+        };
+        let OpenedCase { case, created } = self
+            .open_case
+            .handle(Self::envelope(cmd), Utc::now())
+            .await
+            .map_err(status)?;
+        Ok(Response::new(proto::OpenCaseResponse { case: Some(case_view(&case)), created }))
+    }
+
+    pub async fn assign_case(
+        &self,
+        request: Request<proto::AssignCaseRequest>,
+    ) -> Result<Response<proto::AssignCaseResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = AssignCaseCommand { case_id: parse_case_id(&req.case_id)?, reviewer_id: req.reviewer_id };
+        let case = self.assign_case.handle(Self::envelope(cmd)).await.map_err(status)?;
+        Ok(Response::new(proto::AssignCaseResponse { case: Some(case_view(&case)) }))
+    }
+
+    pub async fn decide_case(
+        &self,
+        request: Request<proto::DecideCaseRequest>,
+    ) -> Result<Response<proto::DecideCaseResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = DecideCaseCommand {
+            case_id: parse_case_id(&req.case_id)?,
+            action: action_from_proto(req.action)?,
+            category: category_from_proto(req.category)?,
+            rationale: req.rationale,
+            reviewer_id: req.reviewer_id,
+            policy_version: req.policy_version,
+        };
+        let DecideOutcome { decision, enforcement } = self
+            .decide_case
+            .handle(Self::envelope(cmd), Utc::now())
+            .await
+            .map_err(status)?;
+        Ok(Response::new(proto::DecideCaseResponse {
+            decision: Some(decision_to_proto(&decision)),
+            enforcement: enforcement.as_ref().map(enforcement_view),
+        }))
+    }
+
+    pub async fn list_queue(
+        &self,
+        request: Request<proto::ListQueueRequest>,
+    ) -> Result<Response<proto::ListQueueResponse>, Status> {
+        let req = request.into_inner();
+        let query = ListQueueQuery {
+            queue: req.queue,
+            status_filter: case_status_filter(req.status_filter),
+            limit: if req.page_size <= 0 { 50 } else { req.page_size as usize },
+        };
+        let cases = self.list_queue.handle(Self::envelope(query)).await.map_err(status)?;
+        Ok(Response::new(proto::ListQueueResponse {
+            cases: cases.iter().map(case_view).collect(),
+            next_page_token: String::new(),
+        }))
+    }
+
+    pub async fn file_appeal(
+        &self,
+        request: Request<proto::FileAppealRequest>,
+    ) -> Result<Response<proto::FileAppealResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = FileAppealCommand {
+            decision_id: DecisionId::try_from(req.decision_id.as_str()).map_err(status)?,
+            actor_id: ActorId::try_from(req.actor_id.as_str()).map_err(status)?,
+            statement: req.statement,
+        };
+        let appeal = self
+            .file_appeal
+            .handle(Self::envelope(cmd), Utc::now())
+            .await
+            .map_err(status)?;
+        Ok(Response::new(proto::FileAppealResponse { appeal: Some(appeal_view(&appeal)) }))
+    }
+
+    pub async fn resolve_appeal(
+        &self,
+        request: Request<proto::ResolveAppealRequest>,
+    ) -> Result<Response<proto::ResolveAppealResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = ResolveAppealCommand {
+            appeal_id: AppealId::try_from(req.appeal_id.as_str()).map_err(status)?,
+            overturn: req.overturn,
+            rationale: req.rationale,
+            reviewer_id: req.reviewer_id,
+        };
+        let ResolveAppealOutcome { appeal, reversal } = self
+            .resolve_appeal
+            .handle(Self::envelope(cmd), Utc::now())
+            .await
+            .map_err(status)?;
+        Ok(Response::new(proto::ResolveAppealResponse {
+            appeal: Some(appeal_view(&appeal)),
+            reversal: reversal.as_ref().map(decision_to_proto),
+        }))
+    }
+
+    pub async fn get_statement_of_reasons(
+        &self,
+        request: Request<proto::GetStatementOfReasonsRequest>,
+    ) -> Result<Response<proto::GetStatementOfReasonsResponse>, Status> {
+        let req = request.into_inner();
+        let query = GetStatementOfReasonsQuery {
+            decision_id: DecisionId::try_from(req.decision_id.as_str()).map_err(status)?,
+        };
+        let sor = self.statement_of_reasons.handle(Self::envelope(query)).await.map_err(status)?;
+        Ok(Response::new(proto::GetStatementOfReasonsResponse {
+            statement: Some(statement_to_proto(&sor)),
+        }))
+    }
+
+    pub async fn get_enforcement_state(
+        &self,
+        request: Request<proto::GetEnforcementStateRequest>,
+    ) -> Result<Response<proto::GetEnforcementStateResponse>, Status> {
+        let req = request.into_inner();
+        let query = GetEnforcementStateQuery {
+            actor_id: ActorId::try_from(req.actor_id.as_str()).map_err(status)?,
+        };
+        let view = self.enforcement_state.handle(Self::envelope(query)).await.map_err(status)?;
+        Ok(Response::new(proto::GetEnforcementStateResponse {
+            actor_restricted: view.actor_restricted,
+            active_enforcements: view.active_enforcements.iter().map(enforcement_view).collect(),
+        }))
+    }
+}
+
+// ── Mapping helpers ─────────────────────────────────────────────────────────
+
+fn defaulted(s: String, fallback: &str) -> String {
+    if s.trim().is_empty() { fallback.to_owned() } else { s }
+}
+
+fn parse_case_id(s: &str) -> Result<CaseId, Status> {
+    Uuid::parse_str(s)
+        .map(CaseId::from_uuid)
+        .map_err(|_| Status::invalid_argument(format!("invalid case_id: '{s}'")))
+}
+
+fn subject_from_proto(s: Option<proto::SubjectRef>) -> Result<SubjectRef, Status> {
+    let s = s.ok_or_else(|| Status::invalid_argument("subject is required"))?;
+    SubjectRef::new(
+        entity_type_from_proto(s.entity_type)?,
+        s.entity_id,
+        ActorId::try_from(s.actor_id.as_str()).map_err(status)?,
+        s.surface,
+    )
+    .map_err(status)
+}
+
+fn subject_to_proto(s: &SubjectRef) -> proto::SubjectRef {
+    proto::SubjectRef {
+        entity_type: entity_type_to_proto(s.entity_type()),
+        entity_id: s.entity_id().to_owned(),
+        actor_id: s.actor_id().as_str(),
+        surface: s.surface().to_owned(),
+    }
+}
+
+fn case_view(case: &Case) -> proto::CaseView {
+    proto::CaseView {
+        case_id: case.id().as_str(),
+        subject: Some(subject_to_proto(case.subject())),
+        status: case_status_to_proto(case.status()),
+        category: category_to_proto(case.category()),
+        queue: case.queue().to_owned(),
+        priority: case.priority().to_owned(),
+        assignee: case.assignee().unwrap_or_default().to_owned(),
+        signals: case.signals().iter().map(signal_summary).collect(),
+        opened_at: Some(to_ts(case.opened_at())),
+    }
+}
+
+fn signal_summary(s: &Signal) -> proto::SignalSummary {
+    proto::SignalSummary {
+        source: s.source().to_owned(),
+        category: category_to_proto(s.category()),
+        confidence: s.confidence().value() as f32,
+        observed_at: Some(to_ts(s.observed_at())),
+    }
+}
+
+fn decision_to_proto(d: &Decision) -> proto::Decision {
+    proto::Decision {
+        decision_id: d.id().as_str(),
+        subject: Some(subject_to_proto(d.subject())),
+        action: action_to_proto(d.action()),
+        category: category_to_proto(d.category()),
+        policy_version: d.policy_version().as_str().to_owned(),
+        rationale: d.rationale().to_owned(),
+        decided_by: d.author().id().to_owned(),
+        automated: d.is_automated(),
+        reverses_decision_id: d.reverses().map(|r| r.as_str()).unwrap_or_default(),
+        decided_at: Some(to_ts(d.decided_at())),
+    }
+}
+
+fn enforcement_view(e: &EnforcementAction) -> proto::EnforcementView {
+    proto::EnforcementView {
+        enforcement_id: e.id().as_str(),
+        subject: Some(subject_to_proto(e.subject())),
+        action: action_to_proto(e.action()),
+        status: enforcement_status_to_proto(e.status()),
+        version: e.version().value(),
+        applied_at: Some(to_ts(e.applied_at())),
+        expires_at: e.expires_at().map(to_ts),
+    }
+}
+
+fn appeal_view(a: &Appeal) -> proto::AppealView {
+    proto::AppealView {
+        appeal_id: a.id().as_str(),
+        decision_id: a.decision_id().as_str(),
+        status: appeal_status_to_proto(a.status()),
+        statement: a.statement().to_owned(),
+        filed_at: Some(to_ts(a.filed_at())),
+        resolved_at: a.resolved_at().map(to_ts),
+    }
+}
+
+fn statement_to_proto(s: &StatementOfReasons) -> proto::StatementOfReasons {
+    proto::StatementOfReasons {
+        decision_id: s.decision_id.as_str(),
+        subject: Some(subject_to_proto(&s.subject)),
+        category: category_to_proto(s.category),
+        action: action_to_proto(s.action),
+        policy_version: s.policy_version.clone(),
+        facts: s.facts.clone(),
+        legal_ground: String::new(),
+        automated: s.automated,
+        territorial_eu: false,
+        decided_at: Some(to_ts(s.decided_at)),
+    }
+}
+
+fn to_ts(dt: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp { seconds: dt.timestamp(), nanos: dt.timestamp_subsec_nanos() as i32 }
+}
+
+// ── Enum conversions ──────────────────────────────────────────────────────────
+
+fn entity_type_to_proto(e: EntityType) -> i32 {
+    let p = match e {
+        EntityType::Post => proto::EntityType::Post,
+        EntityType::Comment => proto::EntityType::Comment,
+        EntityType::ChatMessage => proto::EntityType::ChatMessage,
+        EntityType::Media => proto::EntityType::Media,
+        EntityType::Account => proto::EntityType::Account,
+        EntityType::Profile => proto::EntityType::Profile,
+    };
+    p as i32
+}
+
+fn entity_type_from_proto(v: i32) -> Result<EntityType, Status> {
+    match proto::EntityType::try_from(v) {
+        Ok(proto::EntityType::Post) => Ok(EntityType::Post),
+        Ok(proto::EntityType::Comment) => Ok(EntityType::Comment),
+        Ok(proto::EntityType::ChatMessage) => Ok(EntityType::ChatMessage),
+        Ok(proto::EntityType::Media) => Ok(EntityType::Media),
+        Ok(proto::EntityType::Account) => Ok(EntityType::Account),
+        Ok(proto::EntityType::Profile) => Ok(EntityType::Profile),
+        _ => Err(Status::invalid_argument("entity_type is unspecified or unknown")),
+    }
+}
+
+fn category_to_proto(c: PolicyCategory) -> i32 {
+    let p = match c {
+        PolicyCategory::Spam => proto::PolicyCategory::Spam,
+        PolicyCategory::Harassment => proto::PolicyCategory::Harassment,
+        PolicyCategory::Hate => proto::PolicyCategory::Hate,
+        PolicyCategory::ViolentExtremism => proto::PolicyCategory::ViolentExtremism,
+        PolicyCategory::Csam => proto::PolicyCategory::Csam,
+        PolicyCategory::Ncii => proto::PolicyCategory::Ncii,
+        PolicyCategory::SelfHarm => proto::PolicyCategory::SelfHarm,
+        PolicyCategory::Misinformation => proto::PolicyCategory::Misinformation,
+        PolicyCategory::Other => proto::PolicyCategory::Other,
+    };
+    p as i32
+}
+
+fn category_from_proto(v: i32) -> Result<PolicyCategory, Status> {
+    match proto::PolicyCategory::try_from(v) {
+        Ok(proto::PolicyCategory::Spam) => Ok(PolicyCategory::Spam),
+        Ok(proto::PolicyCategory::Harassment) => Ok(PolicyCategory::Harassment),
+        Ok(proto::PolicyCategory::Hate) => Ok(PolicyCategory::Hate),
+        Ok(proto::PolicyCategory::ViolentExtremism) => Ok(PolicyCategory::ViolentExtremism),
+        Ok(proto::PolicyCategory::Csam) => Ok(PolicyCategory::Csam),
+        Ok(proto::PolicyCategory::Ncii) => Ok(PolicyCategory::Ncii),
+        Ok(proto::PolicyCategory::SelfHarm) => Ok(PolicyCategory::SelfHarm),
+        Ok(proto::PolicyCategory::Misinformation) => Ok(PolicyCategory::Misinformation),
+        Ok(proto::PolicyCategory::Other) => Ok(PolicyCategory::Other),
+        _ => Err(Status::invalid_argument("category is unspecified or unknown")),
+    }
+}
+
+fn action_to_proto(a: ActionType) -> i32 {
+    let p = match a {
+        ActionType::NoAction => proto::ActionType::NoAction,
+        ActionType::Warn => proto::ActionType::Warn,
+        ActionType::VisibilityLimit => proto::ActionType::VisibilityLimit,
+        ActionType::AgeGate => proto::ActionType::AgeGate,
+        ActionType::RemoveContent => proto::ActionType::RemoveContent,
+        ActionType::RestrictActor => proto::ActionType::RestrictActor,
+        ActionType::Suspend => proto::ActionType::Suspend,
+        ActionType::Ban => proto::ActionType::Ban,
+    };
+    p as i32
+}
+
+fn action_from_proto(v: i32) -> Result<ActionType, Status> {
+    match proto::ActionType::try_from(v) {
+        Ok(proto::ActionType::NoAction) => Ok(ActionType::NoAction),
+        Ok(proto::ActionType::Warn) => Ok(ActionType::Warn),
+        Ok(proto::ActionType::VisibilityLimit) => Ok(ActionType::VisibilityLimit),
+        Ok(proto::ActionType::AgeGate) => Ok(ActionType::AgeGate),
+        Ok(proto::ActionType::RemoveContent) => Ok(ActionType::RemoveContent),
+        Ok(proto::ActionType::RestrictActor) => Ok(ActionType::RestrictActor),
+        Ok(proto::ActionType::Suspend) => Ok(ActionType::Suspend),
+        Ok(proto::ActionType::Ban) => Ok(ActionType::Ban),
+        _ => Err(Status::invalid_argument("action is unspecified or unknown")),
+    }
+}
+
+fn case_status_to_proto(s: CaseStatus) -> i32 {
+    let p = match s {
+        CaseStatus::Open => proto::CaseStatus::Open,
+        CaseStatus::Triaged => proto::CaseStatus::Triaged,
+        CaseStatus::Actioned => proto::CaseStatus::Actioned,
+        CaseStatus::Dismissed => proto::CaseStatus::Dismissed,
+        CaseStatus::Appealed => proto::CaseStatus::Appealed,
+    };
+    p as i32
+}
+
+fn case_status_filter(v: i32) -> Option<CaseStatus> {
+    match proto::CaseStatus::try_from(v) {
+        Ok(proto::CaseStatus::Open) => Some(CaseStatus::Open),
+        Ok(proto::CaseStatus::Triaged) => Some(CaseStatus::Triaged),
+        Ok(proto::CaseStatus::Actioned) => Some(CaseStatus::Actioned),
+        Ok(proto::CaseStatus::Dismissed) => Some(CaseStatus::Dismissed),
+        Ok(proto::CaseStatus::Appealed) => Some(CaseStatus::Appealed),
+        _ => None, // UNSPECIFIED ⇒ all open work
+    }
+}
+
+fn enforcement_status_to_proto(s: EnforcementStatus) -> i32 {
+    let p = match s {
+        EnforcementStatus::Active => proto::EnforcementStatus::Active,
+        EnforcementStatus::Expired => proto::EnforcementStatus::Expired,
+        EnforcementStatus::Reversed => proto::EnforcementStatus::Reversed,
+    };
+    p as i32
+}
+
+fn appeal_status_to_proto(s: crate::domain::value_object::AppealStatus) -> i32 {
+    use crate::domain::value_object::AppealStatus;
+    let p = match s {
+        AppealStatus::Filed => proto::AppealStatus::Filed,
+        AppealStatus::UnderReview => proto::AppealStatus::UnderReview,
+        AppealStatus::Upheld => proto::AppealStatus::Upheld,
+        AppealStatus::Overturned => proto::AppealStatus::Overturned,
+    };
+    p as i32
+}
+
+fn verdict_to_proto(v: ScreenVerdict) -> i32 {
+    let p = match v {
+        ScreenVerdict::Allow => proto::ScreenVerdict::Allow,
+        ScreenVerdict::Block => proto::ScreenVerdict::Block,
+        ScreenVerdict::Review => proto::ScreenVerdict::Review,
+    };
+    p as i32
+}
+
+/// Maps a [`ModerationError`] to a gRPC [`Status`] using its [`AppError`]
+/// metadata, so the HTTP semantics defined once in `error.rs` drive the gRPC code.
+pub fn status(err: ModerationError) -> Status {
+    let msg = err.to_string();
+    let retryable = err.is_retryable();
+    match err.http_status().as_u16() {
+        401 => Status::unauthenticated(msg),
+        403 => Status::permission_denied(msg),
+        404 => Status::not_found(msg),
+        409 if retryable => Status::aborted(msg),
+        409 => Status::already_exists(msg),
+        451 => Status::permission_denied(msg), // content blocked for legal reasons
+        400 | 422 => Status::failed_precondition(msg),
+        502 | 503 => Status::unavailable(msg),
+        _ => Status::internal(msg),
+    }
+}

--- a/crates/services/moderation/src/infrastructure/grpc/mod.rs
+++ b/crates/services/moderation/src/infrastructure/grpc/mod.rs
@@ -1,0 +1,7 @@
+//! gRPC ingress for the `moderation.v1` service.
+
+pub mod handler;
+pub mod server;
+
+pub use handler::{proto, ModerationServiceHandler, ModerationServiceServer};
+pub use server::FILE_DESCRIPTOR_SET;

--- a/crates/services/moderation/src/infrastructure/grpc/server.rs
+++ b/crates/services/moderation/src/infrastructure/grpc/server.rs
@@ -1,0 +1,76 @@
+use tonic::{Request, Response, Status};
+
+use super::handler::moderation_service_handler::{proto, ModerationServiceHandler};
+
+// The tonic-generated trait from the bundled proto module.
+use proto::moderation_service_server::ModerationService;
+
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `moderation-api`'s `build.rs`. Registered by the service's runtime adapter.
+pub const FILE_DESCRIPTOR_SET: &[u8] = moderation_api::FILE_DESCRIPTOR_SET;
+
+#[tonic::async_trait]
+impl ModerationService for ModerationServiceHandler {
+    async fn screen(
+        &self,
+        request: Request<proto::ScreenRequest>,
+    ) -> Result<Response<proto::ScreenResponse>, Status> {
+        self.screen(request).await
+    }
+
+    async fn open_case(
+        &self,
+        request: Request<proto::OpenCaseRequest>,
+    ) -> Result<Response<proto::OpenCaseResponse>, Status> {
+        self.open_case(request).await
+    }
+
+    async fn assign_case(
+        &self,
+        request: Request<proto::AssignCaseRequest>,
+    ) -> Result<Response<proto::AssignCaseResponse>, Status> {
+        self.assign_case(request).await
+    }
+
+    async fn decide_case(
+        &self,
+        request: Request<proto::DecideCaseRequest>,
+    ) -> Result<Response<proto::DecideCaseResponse>, Status> {
+        self.decide_case(request).await
+    }
+
+    async fn list_queue(
+        &self,
+        request: Request<proto::ListQueueRequest>,
+    ) -> Result<Response<proto::ListQueueResponse>, Status> {
+        self.list_queue(request).await
+    }
+
+    async fn file_appeal(
+        &self,
+        request: Request<proto::FileAppealRequest>,
+    ) -> Result<Response<proto::FileAppealResponse>, Status> {
+        self.file_appeal(request).await
+    }
+
+    async fn resolve_appeal(
+        &self,
+        request: Request<proto::ResolveAppealRequest>,
+    ) -> Result<Response<proto::ResolveAppealResponse>, Status> {
+        self.resolve_appeal(request).await
+    }
+
+    async fn get_statement_of_reasons(
+        &self,
+        request: Request<proto::GetStatementOfReasonsRequest>,
+    ) -> Result<Response<proto::GetStatementOfReasonsResponse>, Status> {
+        self.get_statement_of_reasons(request).await
+    }
+
+    async fn get_enforcement_state(
+        &self,
+        request: Request<proto::GetEnforcementStateRequest>,
+    ) -> Result<Response<proto::GetEnforcementStateResponse>, Status> {
+        self.get_enforcement_state(request).await
+    }
+}

--- a/crates/services/moderation/src/infrastructure/history/mod.rs
+++ b/crates/services/moderation/src/infrastructure/history/mod.rs
@@ -1,0 +1,6 @@
+//! ScyllaDB evidence-history adapter — the append-only audit feed projected from
+//! the moderation event stream.
+
+pub mod scylla_evidence_history;
+
+pub use scylla_evidence_history::ScyllaEvidenceHistory;

--- a/crates/services/moderation/src/infrastructure/history/scylla_evidence_history.rs
+++ b/crates/services/moderation/src/infrastructure/history/scylla_evidence_history.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use scylla::statement::unprepared::Statement;
+use scylla::value::CqlTimestamp;
+use scylla_storage::{ScyllaClient, ScyllaStorageError};
+use uuid::Uuid;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::domain::value_object::SubjectRef;
+use crate::error::ModerationError;
+
+const INSERT_CQL: &str = r#"
+    INSERT INTO moderation.evidence_history
+        (actor_id, occurred_at, event_id, event_type, entity_type, entity_id, category, action, event)
+    VALUES (?,?,?,?,?,?,?,?,?)
+"#;
+
+/// ScyllaDB append-only **evidence history** — the denormalized, per-actor audit
+/// feed projected from the moderation event stream (Postgres remains the system of
+/// record). It implements [`EventPublisher`] so it composes as a fan-out sink
+/// alongside the Kafka publisher: every event moderation emits is also retained
+/// here for transparency reporting, law-enforcement preservation, and training.
+#[derive(Clone)]
+pub struct ScyllaEvidenceHistory {
+    client: Arc<ScyllaClient>,
+}
+
+impl ScyllaEvidenceHistory {
+    pub fn new(client: Arc<ScyllaClient>) -> Self {
+        Self { client }
+    }
+}
+
+/// The flat projection of an event for the typed history columns.
+struct HistoryRow {
+    occurred_at: i64,
+    entity_type: String,
+    entity_id: String,
+    category: String,
+    action: String,
+}
+
+fn subject_cols(subject: &SubjectRef) -> (String, String) {
+    (subject.entity_type().as_str().to_owned(), subject.entity_id().to_owned())
+}
+
+fn project(event: &DomainEvent) -> HistoryRow {
+    match event {
+        DomainEvent::CaseOpened(e) => {
+            let (et, eid) = subject_cols(&e.subject);
+            HistoryRow {
+                occurred_at: e.occurred_at.timestamp_millis(),
+                entity_type: et,
+                entity_id: eid,
+                category: e.category.as_str().to_owned(),
+                action: String::new(),
+            }
+        }
+        DomainEvent::CaseResolved(e) => HistoryRow {
+            occurred_at: e.occurred_at.timestamp_millis(),
+            entity_type: String::new(),
+            entity_id: String::new(),
+            category: e.category.as_str().to_owned(),
+            action: e.action.as_str().to_owned(),
+        },
+        DomainEvent::EnforcementApplied(e) => {
+            let (et, eid) = subject_cols(&e.subject);
+            HistoryRow {
+                occurred_at: e.occurred_at.timestamp_millis(),
+                entity_type: et,
+                entity_id: eid,
+                category: String::new(),
+                action: e.action.as_str().to_owned(),
+            }
+        }
+        DomainEvent::EnforcementReversed(e) => {
+            let (et, eid) = subject_cols(&e.subject);
+            HistoryRow {
+                occurred_at: e.occurred_at.timestamp_millis(),
+                entity_type: et,
+                entity_id: eid,
+                category: String::new(),
+                action: String::new(),
+            }
+        }
+        DomainEvent::AppealResolved(e) => HistoryRow {
+            occurred_at: e.occurred_at.timestamp_millis(),
+            entity_type: String::new(),
+            entity_id: String::new(),
+            category: String::new(),
+            action: String::new(),
+        },
+    }
+}
+
+#[async_trait]
+impl EventPublisher for ScyllaEvidenceHistory {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ModerationError> {
+        let row = project(event);
+        let payload = serde_json::to_string(event).map_err(|e| ModerationError::EventPublishFailed(e.to_string()))?;
+
+        self.client
+            .session
+            .execute_unpaged(
+                Statement::new(INSERT_CQL),
+                (
+                    event.actor_id().as_uuid(),
+                    CqlTimestamp(row.occurred_at),
+                    Uuid::now_v7(),
+                    event.event_type(),
+                    row.entity_type,
+                    row.entity_id,
+                    row.category,
+                    row.action,
+                    payload,
+                ),
+            )
+            .await
+            .map_err(|e| ModerationError::History(ScyllaStorageError::from(e)))?;
+        Ok(())
+    }
+}

--- a/crates/services/moderation/src/infrastructure/mod.rs
+++ b/crates/services/moderation/src/infrastructure/mod.rs
@@ -1,0 +1,23 @@
+//! The moderation infrastructure layer — concrete adapters implementing the
+//! application ports against real backends.
+//!
+//! The three-store split:
+//! * **`persistence`** — PostgreSQL adapters for the decision/case system of
+//!   record (cases, decisions, enforcements, penalty ledgers, appeals).
+//! * **`history`** — the ScyllaDB append-only evidence feed (an `EventPublisher`
+//!   sink, composed alongside Kafka as fan-out).
+//! * **`cache`** — Redis adapters for the Plane B enforcement projection and the
+//!   Plane C screen corpus.
+//!
+//! Plus the event publisher (`event`), the classifier gateway stub
+//! (`classifier`), and the `account` gRPC client (`directory`). The gRPC service
+//! handler and the ingestion consumers are wired in Phase 5.
+
+pub mod cache;
+pub mod classifier;
+pub mod consumer;
+pub mod directory;
+pub mod event;
+pub mod grpc;
+pub mod history;
+pub mod persistence;

--- a/crates/services/moderation/src/infrastructure/persistence/mod.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,29 @@
+//! PostgreSQL adapters — the decision/case system of record.
+//!
+//! Like `account`/`auth`, writes use a single pool via [`TransactionManager`];
+//! true `account_id` sharding is deferred (every table carries `actor_id` so it
+//! can be added without a schema change). Upserts are last-write-wins on the
+//! aggregate `version`, which is retained for a future optimistic-lock tightening.
+
+pub mod model;
+pub mod pg_appeal_repository;
+pub mod pg_case_repository;
+pub mod pg_decision_repository;
+pub mod pg_enforcement_repository;
+pub mod pg_penalty_repository;
+
+pub use pg_appeal_repository::PgAppealRepository;
+pub use pg_case_repository::PgCaseRepository;
+pub use pg_decision_repository::PgDecisionRepository;
+pub use pg_enforcement_repository::PgEnforcementRepository;
+pub use pg_penalty_repository::PgPenaltyRepository;
+
+use postgres_storage::StorageError;
+
+use crate::error::ModerationError;
+
+/// Maps a raw sqlx error into the moderation error namespace (delegating the code
+/// to the shared `DB-*` storage taxonomy).
+pub(crate) fn storage_err(e: sqlx::Error) -> ModerationError {
+    ModerationError::Records(StorageError::from(e))
+}

--- a/crates/services/moderation/src/infrastructure/persistence/model/appeal_row.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/model/appeal_row.rs
@@ -1,0 +1,34 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::aggregate::Appeal;
+use crate::domain::value_object::{ActorId, AppealId, AppealStatus, DecisionId};
+use crate::error::ModerationError;
+
+/// Flat projection of the `appeals` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct AppealRow {
+    pub id: Uuid,
+    pub decision_id: Uuid,
+    pub actor_id: Uuid,
+    pub statement: String,
+    pub status: String,
+    pub filed_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+impl TryFrom<AppealRow> for Appeal {
+    type Error = ModerationError;
+
+    fn try_from(row: AppealRow) -> Result<Self, Self::Error> {
+        Ok(Appeal::reconstitute(
+            AppealId::from_uuid(row.id),
+            DecisionId::from_uuid(row.decision_id),
+            ActorId::from_uuid(row.actor_id),
+            row.statement,
+            AppealStatus::try_from(row.status.as_str())?,
+            row.filed_at,
+            row.resolved_at,
+        ))
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/model/case_row.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/model/case_row.rs
@@ -1,0 +1,47 @@
+use chrono::{DateTime, Utc};
+use sqlx::types::Json;
+use uuid::Uuid;
+
+use crate::domain::aggregate::Case;
+use crate::domain::value_object::{CaseId, CaseStatus, PolicyCategory, Signal};
+use crate::error::ModerationError;
+
+use super::subject_from;
+
+/// Flat projection of the `cases` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct CaseRow {
+    pub id: Uuid,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub actor_id: Uuid,
+    pub surface: String,
+    pub status: String,
+    pub category: String,
+    pub queue: String,
+    pub priority: String,
+    pub assignee: Option<String>,
+    pub signals: Json<Vec<Signal>>,
+    pub opened_at: DateTime<Utc>,
+    pub version: i64,
+}
+
+impl TryFrom<CaseRow> for Case {
+    type Error = ModerationError;
+
+    fn try_from(row: CaseRow) -> Result<Self, Self::Error> {
+        let subject = subject_from(&row.entity_type, row.entity_id, row.actor_id, row.surface)?;
+        Ok(Case::reconstitute(
+            CaseId::from_uuid(row.id),
+            subject,
+            CaseStatus::try_from(row.status.as_str())?,
+            PolicyCategory::try_from(row.category.as_str())?,
+            row.queue,
+            row.priority,
+            row.assignee,
+            row.signals.0,
+            row.opened_at,
+            row.version,
+        ))
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/model/decision_row.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/model/decision_row.rs
@@ -1,0 +1,55 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::aggregate::{Decision, DecisionAuthor};
+use crate::domain::value_object::{ActionType, DecisionId, PolicyCategory, PolicyVersion};
+use crate::error::ModerationError;
+
+use super::subject_from;
+
+/// Flat projection of the `decisions` table (append-only ledger).
+#[derive(Debug, sqlx::FromRow)]
+pub struct DecisionRow {
+    pub id: Uuid,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub actor_id: Uuid,
+    pub surface: String,
+    pub action: String,
+    pub category: String,
+    pub policy_version: String,
+    pub rationale: String,
+    pub author_kind: String,
+    pub author_id: String,
+    pub reverses: Option<Uuid>,
+    pub decided_at: DateTime<Utc>,
+}
+
+impl TryFrom<DecisionRow> for Decision {
+    type Error = ModerationError;
+
+    fn try_from(row: DecisionRow) -> Result<Self, Self::Error> {
+        let subject = subject_from(&row.entity_type, row.entity_id, row.actor_id, row.surface)?;
+        let author = match row.author_kind.as_str() {
+            "reviewer" => DecisionAuthor::Reviewer(row.author_id),
+            "rule" => DecisionAuthor::Rule(row.author_id),
+            other => {
+                return Err(ModerationError::DomainViolation {
+                    field: "decision.author_kind".into(),
+                    message: format!("unknown author kind: '{other}'"),
+                });
+            }
+        };
+        Ok(Decision::reconstitute(
+            DecisionId::from_uuid(row.id),
+            subject,
+            ActionType::try_from(row.action.as_str())?,
+            PolicyCategory::try_from(row.category.as_str())?,
+            PolicyVersion::new(row.policy_version)?,
+            row.rationale,
+            author,
+            row.reverses.map(DecisionId::from_uuid),
+            row.decided_at,
+        ))
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/model/enforcement_row.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/model/enforcement_row.rs
@@ -1,0 +1,46 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::domain::aggregate::EnforcementAction;
+use crate::domain::value_object::{
+    ActionType, DecisionId, EnforcementId, EnforcementStatus, EnforcementVersion,
+};
+use crate::error::ModerationError;
+
+use super::subject_from;
+
+/// Flat projection of the `enforcements` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct EnforcementRow {
+    pub id: Uuid,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub actor_id: Uuid,
+    pub surface: String,
+    pub action: String,
+    pub status: String,
+    pub version: i64,
+    pub decision_id: Uuid,
+    pub applied_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub reversed_at: Option<DateTime<Utc>>,
+}
+
+impl TryFrom<EnforcementRow> for EnforcementAction {
+    type Error = ModerationError;
+
+    fn try_from(row: EnforcementRow) -> Result<Self, Self::Error> {
+        let subject = subject_from(&row.entity_type, row.entity_id, row.actor_id, row.surface)?;
+        Ok(EnforcementAction::reconstitute(
+            EnforcementId::from_uuid(row.id),
+            subject,
+            ActionType::try_from(row.action.as_str())?,
+            EnforcementStatus::try_from(row.status.as_str())?,
+            EnforcementVersion::from_i64(row.version),
+            DecisionId::from_uuid(row.decision_id),
+            row.applied_at,
+            row.expires_at,
+            row.reversed_at,
+        ))
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/model/mod.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/model/mod.rs
@@ -1,0 +1,35 @@
+//! Flat row projections of the moderation tables. Domain reconstruction
+//! (validation, value-object construction) happens in each `TryFrom`, keeping
+//! persistence free of domain logic.
+
+pub mod appeal_row;
+pub mod case_row;
+pub mod decision_row;
+pub mod enforcement_row;
+pub mod penalty_row;
+
+pub use appeal_row::AppealRow;
+pub use case_row::CaseRow;
+pub use decision_row::DecisionRow;
+pub use enforcement_row::EnforcementRow;
+pub use penalty_row::PenaltyRow;
+
+use uuid::Uuid;
+
+use crate::domain::value_object::{ActorId, EntityType, SubjectRef};
+use crate::error::ModerationError;
+
+/// Reconstructs a [`SubjectRef`] from its four flat columns.
+pub(crate) fn subject_from(
+    entity_type: &str,
+    entity_id: String,
+    actor_id: Uuid,
+    surface: String,
+) -> Result<SubjectRef, ModerationError> {
+    SubjectRef::new(
+        EntityType::try_from(entity_type)?,
+        entity_id,
+        ActorId::from_uuid(actor_id),
+        surface,
+    )
+}

--- a/crates/services/moderation/src/infrastructure/persistence/model/penalty_row.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/model/penalty_row.rs
@@ -1,0 +1,19 @@
+use sqlx::types::Json;
+use uuid::Uuid;
+
+use crate::domain::aggregate::PenaltyLedger;
+use crate::domain::value_object::{ActorId, Strike};
+
+/// Flat projection of the `penalty_ledgers` table.
+#[derive(Debug, sqlx::FromRow)]
+pub struct PenaltyRow {
+    pub actor_id: Uuid,
+    pub strikes: Json<Vec<Strike>>,
+    pub version: i64,
+}
+
+impl From<PenaltyRow> for PenaltyLedger {
+    fn from(row: PenaltyRow) -> Self {
+        PenaltyLedger::reconstitute(ActorId::from_uuid(row.actor_id), row.strikes.0, row.version)
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/pg_appeal_repository.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/pg_appeal_repository.rs
@@ -1,0 +1,58 @@
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+
+use crate::application::port::AppealRepository;
+use crate::domain::aggregate::Appeal;
+use crate::domain::value_object::AppealId;
+use crate::error::ModerationError;
+
+use super::model::AppealRow;
+use super::storage_err;
+
+/// PostgreSQL adapter for [`AppealRepository`].
+#[derive(Clone)]
+pub struct PgAppealRepository {
+    tx: TransactionManager,
+}
+
+impl PgAppealRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl AppealRepository for PgAppealRepository {
+    async fn save(&self, appeal: &Appeal) -> Result<(), ModerationError> {
+        sqlx::query(
+            r#"
+            INSERT INTO appeals (
+                id, decision_id, actor_id, statement, status, filed_at, resolved_at
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7)
+            ON CONFLICT (id) DO UPDATE SET
+                status      = EXCLUDED.status,
+                resolved_at = EXCLUDED.resolved_at
+            "#,
+        )
+        .bind(appeal.id().as_uuid())
+        .bind(appeal.decision_id().as_uuid())
+        .bind(appeal.actor_id().as_uuid())
+        .bind(appeal.statement())
+        .bind(appeal.status().as_str())
+        .bind(appeal.filed_at())
+        .bind(appeal.resolved_at())
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &AppealId) -> Result<Option<Appeal>, ModerationError> {
+        let row = sqlx::query_as::<_, AppealRow>("SELECT * FROM appeals WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(storage_err)?;
+        row.map(Appeal::try_from).transpose()
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/pg_case_repository.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/pg_case_repository.rs
@@ -1,0 +1,96 @@
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+use sqlx::types::Json;
+
+use crate::application::port::CaseRepository;
+use crate::domain::aggregate::Case;
+use crate::domain::value_object::{CaseId, CaseStatus};
+use crate::error::ModerationError;
+
+use super::model::CaseRow;
+use super::storage_err;
+
+/// PostgreSQL adapter for [`CaseRepository`].
+#[derive(Clone)]
+pub struct PgCaseRepository {
+    tx: TransactionManager,
+}
+
+impl PgCaseRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl CaseRepository for PgCaseRepository {
+    async fn save(&self, case: &Case) -> Result<(), ModerationError> {
+        let subject = case.subject();
+        sqlx::query(
+            r#"
+            INSERT INTO cases (
+                id, entity_type, entity_id, actor_id, surface, status, category,
+                queue, priority, assignee, signals, opened_at, version
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+            ON CONFLICT (id) DO UPDATE SET
+                status   = EXCLUDED.status,
+                category = EXCLUDED.category,
+                queue    = EXCLUDED.queue,
+                priority = EXCLUDED.priority,
+                assignee = EXCLUDED.assignee,
+                signals  = EXCLUDED.signals,
+                version  = EXCLUDED.version
+            "#,
+        )
+        .bind(case.id().as_uuid())
+        .bind(subject.entity_type().as_str())
+        .bind(subject.entity_id())
+        .bind(subject.actor_id().as_uuid())
+        .bind(subject.surface())
+        .bind(case.status().as_str())
+        .bind(case.category().as_str())
+        .bind(case.queue())
+        .bind(case.priority())
+        .bind(case.assignee())
+        .bind(Json(case.signals().to_vec()))
+        .bind(case.opened_at())
+        .bind(case.version())
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &CaseId) -> Result<Option<Case>, ModerationError> {
+        let row = sqlx::query_as::<_, CaseRow>("SELECT * FROM cases WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(storage_err)?;
+        row.map(Case::try_from).transpose()
+    }
+
+    async fn list_queue(
+        &self,
+        queue: &str,
+        status: Option<CaseStatus>,
+        limit: usize,
+    ) -> Result<Vec<Case>, ModerationError> {
+        let status_filter = status.map(|s| s.as_str().to_owned());
+        let rows = sqlx::query_as::<_, CaseRow>(
+            r#"
+            SELECT * FROM cases
+            WHERE queue = $1 AND ($2::text IS NULL OR status = $2)
+            ORDER BY opened_at DESC
+            LIMIT $3
+            "#,
+        )
+        .bind(queue)
+        .bind(status_filter)
+        .bind(limit as i64)
+        .fetch_all(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        rows.into_iter().map(Case::try_from).collect()
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/pg_decision_repository.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/pg_decision_repository.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+
+use crate::application::port::DecisionRepository;
+use crate::domain::aggregate::Decision;
+use crate::domain::value_object::DecisionId;
+use crate::error::ModerationError;
+
+use super::model::DecisionRow;
+use super::storage_err;
+
+/// PostgreSQL adapter for the append-only [`DecisionRepository`].
+#[derive(Clone)]
+pub struct PgDecisionRepository {
+    tx: TransactionManager,
+}
+
+impl PgDecisionRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl DecisionRepository for PgDecisionRepository {
+    async fn append(&self, decision: &Decision) -> Result<(), ModerationError> {
+        let subject = decision.subject();
+        let author_kind = if decision.is_automated() { "rule" } else { "reviewer" };
+        // Append-only: a fresh UUIDv7 id never collides; DO NOTHING guards a benign
+        // re-append (e.g. an at-least-once retry) without ever mutating the record.
+        sqlx::query(
+            r#"
+            INSERT INTO decisions (
+                id, entity_type, entity_id, actor_id, surface, action, category,
+                policy_version, rationale, author_kind, author_id, reverses, decided_at
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+            ON CONFLICT (id) DO NOTHING
+            "#,
+        )
+        .bind(decision.id().as_uuid())
+        .bind(subject.entity_type().as_str())
+        .bind(subject.entity_id())
+        .bind(subject.actor_id().as_uuid())
+        .bind(subject.surface())
+        .bind(decision.action().as_str())
+        .bind(decision.category().as_str())
+        .bind(decision.policy_version().as_str())
+        .bind(decision.rationale())
+        .bind(author_kind)
+        .bind(decision.author().id())
+        .bind(decision.reverses().map(|d| d.as_uuid()))
+        .bind(decision.decided_at())
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &DecisionId) -> Result<Option<Decision>, ModerationError> {
+        let row = sqlx::query_as::<_, DecisionRow>("SELECT * FROM decisions WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(storage_err)?;
+        row.map(Decision::try_from).transpose()
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/pg_enforcement_repository.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/pg_enforcement_repository.rs
@@ -1,0 +1,102 @@
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+
+use crate::application::port::EnforcementRepository;
+use crate::domain::aggregate::EnforcementAction;
+use crate::domain::value_object::{ActorId, EnforcementId, EnforcementVersion, SubjectRef};
+use crate::error::ModerationError;
+
+use super::model::EnforcementRow;
+use super::storage_err;
+
+/// PostgreSQL adapter for [`EnforcementRepository`].
+#[derive(Clone)]
+pub struct PgEnforcementRepository {
+    tx: TransactionManager,
+}
+
+impl PgEnforcementRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl EnforcementRepository for PgEnforcementRepository {
+    async fn save(&self, enforcement: &EnforcementAction) -> Result<(), ModerationError> {
+        let subject = enforcement.subject();
+        sqlx::query(
+            r#"
+            INSERT INTO enforcements (
+                id, entity_type, entity_id, actor_id, surface, action, status,
+                version, decision_id, applied_at, expires_at, reversed_at
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+            ON CONFLICT (id) DO UPDATE SET
+                status      = EXCLUDED.status,
+                reversed_at = EXCLUDED.reversed_at
+            "#,
+        )
+        .bind(enforcement.id().as_uuid())
+        .bind(subject.entity_type().as_str())
+        .bind(subject.entity_id())
+        .bind(subject.actor_id().as_uuid())
+        .bind(subject.surface())
+        .bind(enforcement.action().as_str())
+        .bind(enforcement.status().as_str())
+        .bind(enforcement.version().value())
+        .bind(enforcement.decision_id().as_uuid())
+        .bind(enforcement.applied_at())
+        .bind(enforcement.expires_at())
+        .bind(enforcement.reversed_at())
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(())
+    }
+
+    async fn find_by_id(
+        &self,
+        id: &EnforcementId,
+    ) -> Result<Option<EnforcementAction>, ModerationError> {
+        let row = sqlx::query_as::<_, EnforcementRow>("SELECT * FROM enforcements WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(storage_err)?;
+        row.map(EnforcementAction::try_from).transpose()
+    }
+
+    async fn next_version(
+        &self,
+        subject: &SubjectRef,
+    ) -> Result<EnforcementVersion, ModerationError> {
+        // MAX(version) over the subject's enforcements; 0 when none ⇒ next() = INITIAL.
+        let max: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT COALESCE(MAX(version), 0) FROM enforcements
+            WHERE entity_type = $1 AND entity_id = $2 AND surface = $3
+            "#,
+        )
+        .bind(subject.entity_type().as_str())
+        .bind(subject.entity_id())
+        .bind(subject.surface())
+        .fetch_one(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(EnforcementVersion::from_i64(max.unwrap_or(0)).next())
+    }
+
+    async fn list_active_for_actor(
+        &self,
+        actor_id: &ActorId,
+    ) -> Result<Vec<EnforcementAction>, ModerationError> {
+        let rows = sqlx::query_as::<_, EnforcementRow>(
+            "SELECT * FROM enforcements WHERE actor_id = $1 AND status = 'active'",
+        )
+        .bind(actor_id.as_uuid())
+        .fetch_all(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        rows.into_iter().map(EnforcementAction::try_from).collect()
+    }
+}

--- a/crates/services/moderation/src/infrastructure/persistence/pg_penalty_repository.rs
+++ b/crates/services/moderation/src/infrastructure/persistence/pg_penalty_repository.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+use sqlx::types::Json;
+
+use crate::application::port::PenaltyRepository;
+use crate::domain::aggregate::PenaltyLedger;
+use crate::domain::value_object::ActorId;
+use crate::error::ModerationError;
+
+use super::model::PenaltyRow;
+use super::storage_err;
+
+/// PostgreSQL adapter for [`PenaltyRepository`]. One row per actor; the strike
+/// history is stored as JSON and evaluated in-domain.
+#[derive(Clone)]
+pub struct PgPenaltyRepository {
+    tx: TransactionManager,
+}
+
+impl PgPenaltyRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl PenaltyRepository for PgPenaltyRepository {
+    async fn load(&self, actor_id: &ActorId) -> Result<PenaltyLedger, ModerationError> {
+        let row =
+            sqlx::query_as::<_, PenaltyRow>("SELECT * FROM penalty_ledgers WHERE actor_id = $1")
+                .bind(actor_id.as_uuid())
+                .fetch_optional(self.tx.pool())
+                .await
+                .map_err(storage_err)?;
+        Ok(row.map(PenaltyLedger::from).unwrap_or_else(|| PenaltyLedger::empty(*actor_id)))
+    }
+
+    async fn save(&self, ledger: &PenaltyLedger) -> Result<(), ModerationError> {
+        sqlx::query(
+            r#"
+            INSERT INTO penalty_ledgers (actor_id, strikes, version)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (actor_id) DO UPDATE SET
+                strikes = EXCLUDED.strikes,
+                version = EXCLUDED.version
+            "#,
+        )
+        .bind(ledger.actor_id().as_uuid())
+        .bind(Json(ledger.strikes().to_vec()))
+        .bind(ledger.version())
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(())
+    }
+}

--- a/crates/services/moderation/src/lib.rs
+++ b/crates/services/moderation/src/lib.rs
@@ -1,0 +1,40 @@
+//! `moderation` — the platform's integrity **decision-of-record and enforcement
+//! brain** (trust, safety & compliance).
+//!
+//! This service owns the *decision*: what action is taken against what entity,
+//! under which policy version, with what evidence — and it is the authoritative,
+//! auditable source of that fact for the rest of the fleet and for regulators.
+//! It is deliberately distinct from its neighbours:
+//!
+//! * the **content services** (`post` / `comment` / `chat` / `media`) own the
+//!   content bytes and its visibility; they *react* to enforcement, moderation
+//!   never stores a second copy.
+//! * `account` is the identity System of Record and owns suspension/ban
+//!   *execution*; moderation *decides* and emits the enforcement event.
+//! * the **classifier services** own ML inference + hash corpora; moderation
+//!   *consumes* their signals, it never runs inference inline.
+//! * `social-graph` owns personal block/mute (a safety preference, not platform
+//!   integrity).
+//!
+//! The architectural commitment is the separation of the heavy
+//! classification/review path from the hot decision path — three planes:
+//! **(A)** async post-hoc ingestion (the default, ~99% of content),
+//! **(B)** denormalized enforcement state on the hot *read* path (events + a
+//! Redis projection, never a per-item RPC), and **(C)** a narrow, fail-closed
+//! synchronous `Screen` gate for catastrophic-harm categories only. See
+//! `project_moderation_service_blueprint` for the full design.
+//!
+//! ## Module roadmap (built phase by phase)
+//! Phase 0 (now): [`error`] — the canonical `MOD-XXXX` namespace.
+//! Phase 2: `domain` · Phase 3: `application` + ports · Phase 4: `infrastructure`
+//! · Phase 5: `app` (composition root) + `service` (runtime wiring).
+
+pub mod app;
+pub mod application;
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod infrastructure;
+pub mod service;
+
+pub use error::ModerationError;

--- a/crates/services/moderation/src/service.rs
+++ b/crates/services/moderation/src/service.rs
@@ -1,0 +1,139 @@
+//! Adapts the moderation composition root to the fleet [`service_runtime::Service`]
+//! contract. Maps env → config, defers to [`App::build`], self-spawns the Plane A
+//! ingestion consumers (mirroring how profile/chat spawn their workers in
+//! `build`), registers the concrete tonic service, and reports Postgres + Scylla +
+//! Redis liveness via the storage crates' ready-made probes.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use postgres_storage::PostgresConfig;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use service_runtime::{HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
+use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
+use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
+
+use crate::app::{App, Backends};
+use crate::application::command::{IngestReportHandler, IngestSignalHandler};
+use crate::config::ModerationConfig;
+use crate::infrastructure::consumer::{run_report_consumer, run_signal_consumer};
+use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
+use crate::infrastructure::grpc::{ModerationServiceHandler, ModerationServiceServer};
+
+const REPORTS_TOPIC: &str = "moderation.reports";
+const REPORTS_GROUP: &str = "moderation-report-consumer";
+const SIGNALS_TOPIC: &str = "moderation.signals";
+const SIGNALS_GROUP: &str = "moderation-signal-consumer";
+/// Backoff before respawning a consumer after the runner returns.
+const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
+
+/// The concrete tonic server type, named once so the health key and reflection
+/// registration agree.
+type ModerationServer = ModerationServiceServer<ModerationServiceHandler>;
+
+/// The moderation service as hosted by [`service_runtime`].
+pub struct ModerationService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for ModerationService {
+    const NAME: &'static str = "moderation";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str =
+        <ModerationServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let config = ModerationConfig::from_env()?;
+        let backends = Backends {
+            postgres: PostgresConfig::from_env(),
+            scylla: ScyllaConfig::from_env(),
+            redis: RedisConfig::from_env(),
+            kafka: Some(KafkaClientConfig::from_env()),
+        };
+
+        let app = App::build(config, backends)
+            .await
+            .map_err(|e| anyhow::anyhow!("moderation app build: {e}"))?;
+
+        // Plane A inbound integration: user reports + classifier signals.
+        spawn_report_consumer(Arc::clone(&app.ingest_report));
+        spawn_signal_consumer(Arc::clone(&app.ingest_signal));
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        vec![
+            postgres_storage::health::probe(self.app.pool.clone()),
+            scylla_storage::health::probe(Arc::clone(&self.app.scylla)),
+            redis_storage::health::probe(self.app.redis.clone()),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(ModerationServiceServer::new(self.app.handler));
+        Ok(())
+    }
+}
+
+/// Spawns the supervised report consumer, rebuilding its Kafka handles and
+/// restarting after a backoff whenever the runner returns (per its contract).
+fn spawn_report_consumer(handler: Arc<IngestReportHandler>) {
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(REPORTS_TOPIC, REPORTS_GROUP) {
+                Ok((consumer, producer)) => {
+                    run_report_consumer(consumer, Arc::clone(&handler), producer).await;
+                    tracing::warn!("report consumer exited; respawning after backoff");
+                }
+                Err(error) => tracing::error!(%error, "failed to build report consumer; retrying"),
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Spawns the supervised classifier-signal consumer.
+fn spawn_signal_consumer(handler: Arc<IngestSignalHandler>) {
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(SIGNALS_TOPIC, SIGNALS_GROUP) {
+                Ok((consumer, producer)) => {
+                    run_signal_consumer(consumer, Arc::clone(&handler), producer).await;
+                    tracing::warn!("signal consumer exited; respawning after backoff");
+                }
+                Err(error) => tracing::error!(%error, "failed to build signal consumer; retrying"),
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Builds a manual-commit consumer (subscribed to `topic`) and the dead-letter
+/// producer the runner needs.
+fn build_consumer(
+    topic: &str,
+    group: &str,
+) -> anyhow::Result<(KafkaConsumerHandle, KafkaProducerHandle)> {
+    let kafka = KafkaClientConfig::from_env();
+    let consumer = KafkaConsumerBuilder::new(ConsumerConfig::new(kafka.clone(), group))
+        .subscribe(topic)
+        .build()
+        .with_context(|| format!("build consumer for {topic}"))?;
+    let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+        .build()
+        .with_context(|| format!("build dead-letter producer for {topic}"))?;
+    Ok((consumer, producer))
+}

--- a/crates/services/moderation/tests/integration.rs
+++ b/crates/services/moderation/tests/integration.rs
@@ -1,0 +1,27 @@
+//! Live, container-backed integration suite for the moderation service.
+//!
+//! Moderation owns three stores, so this suite boots a real **PostgreSQL** (the
+//! decision/case system of record), a real **ScyllaDB** (the evidence history),
+//! and a real **Redis** (the enforcement projection + screen corpus) via the
+//! shared `test-support` harness, then drives the production composition root
+//! ([`moderation::app::App::compose`]) end-to-end through the gRPC handler. The
+//! only stubbed dependency is the `account` directory (an external boundary).
+//!
+//! Gated behind `integration-moderation` so the default `cargo test -p moderation`
+//! stays hermetic and Docker-free. Run the live suite:
+//!
+//! ```text
+//! cargo test -p moderation --features integration-moderation -- --nocapture
+//! ```
+//!
+//! Coverage:
+//! - **lifecycle** — open → decide(Suspend) → enforcement state restricted →
+//!   appeal → overturn reverses the enforcement, clears the projection, and the
+//!   decision ledger holds both the original and the reversal (append-only).
+//! - **screen** — a seeded known-bad hash blocks at the Plane C gate and records
+//!   automated evidence; clean content allows.
+//! - **ingest** — report ingestion is idempotent (deterministic case dedup), a
+//!   self-report is rejected, and a classifier signal accrues onto the case.
+#![cfg(feature = "integration-moderation")]
+
+mod moderation_it;

--- a/crates/services/moderation/tests/moderation_it/harness/mod.rs
+++ b/crates/services/moderation/tests/moderation_it/harness/mod.rs
@@ -1,0 +1,306 @@
+//! Integration harness: boots ephemeral Postgres + Scylla + Redis containers,
+//! applies the `.sql` + `.cql` migrations, and wires a real moderation graph
+//! against them through the production composition root
+//! ([`moderation::app::App::compose`]). The only external dependency — the
+//! `account` directory — is stubbed at its port boundary.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use fred::interfaces::KeysInterface;
+use sqlx::PgPool;
+use tonic::{Request, Status};
+
+use moderation::app::{App, AppDeps};
+use moderation::application::command::{
+    IngestReportCommand, IngestReportHandler, IngestSignalCommand, IngestSignalHandler,
+};
+use moderation::application::port::AccountDirectory;
+use moderation::application::ModerationPolicy;
+use moderation::domain::value_object::ActorId;
+use moderation::error::ModerationError;
+use moderation::infrastructure::cache::{RedisEnforcementProjection, RedisScreenCorpus};
+use moderation::infrastructure::classifier::LogClassifierGateway;
+use moderation::infrastructure::grpc::{proto, ModerationServiceHandler};
+use moderation::infrastructure::history::ScyllaEvidenceHistory;
+use moderation::infrastructure::persistence::{
+    PgAppealRepository, PgCaseRepository, PgDecisionRepository, PgEnforcementRepository,
+    PgPenaltyRepository,
+};
+
+use postgres_storage::config::StatementLogLevel;
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+
+const MIGRATIONS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations");
+const KEYSPACE: &str = "moderation";
+
+/// `account` stub: every actor exists (so actor-level enforcement is permitted).
+struct StubAccounts;
+
+#[async_trait]
+impl AccountDirectory for StubAccounts {
+    async fn actor_exists(&self, _actor_id: &ActorId) -> Result<bool, ModerationError> {
+        Ok(true)
+    }
+}
+
+pub struct Harness {
+    pub handler: ModerationServiceHandler,
+    pub ingest_report: Arc<IngestReportHandler>,
+    pub ingest_signal: Arc<IngestSignalHandler>,
+    pub pool: PgPool,
+    pub redis: RedisClient,
+}
+
+impl Harness {
+    pub async fn start() -> Self {
+        let pg_url = test_support::containers::postgres_ready(MIGRATIONS_DIR).await;
+        let scylla_cp = test_support::containers::scylla_ready(KEYSPACE, MIGRATIONS_DIR).await;
+        let redis_endpoint = test_support::containers::redis_endpoint().await;
+
+        let pg_config = PostgresConfig {
+            database_url: pg_url,
+            max_connections: 8,
+            min_connections: 1,
+            acquire_timeout: Duration::from_secs(5),
+            idle_timeout: None,
+            max_lifetime: None,
+            statement_log_level: StatementLogLevel::Debug,
+            slow_statement_threshold: Duration::from_millis(500),
+        };
+        let pool = PgPoolBuilder::build(pg_config).await.expect("it: postgres pool");
+        let tx = TransactionManager::new(pool.clone());
+
+        let scylla = Arc::new(
+            ScyllaSessionBuilder::new(ScyllaConfig {
+                contact_points: vec![scylla_cp],
+                keyspace: None,
+                ..ScyllaConfig::default()
+            })
+            .build()
+            .await
+            .expect("it: scylla client"),
+        );
+
+        let redis = RedisClientBuilder::new(RedisConfig {
+            hosts: vec![redis_endpoint],
+            ..RedisConfig::default()
+        })
+        .build()
+        .await
+        .expect("it: redis client");
+
+        // The evidence history (Scylla) is the publisher, so the suite exercises all
+        // three stores: decisions/cases (Postgres), projection/corpus (Redis),
+        // history (Scylla).
+        let publisher = Arc::new(ScyllaEvidenceHistory::new(scylla.clone()));
+        let cases = Arc::new(PgCaseRepository::new(tx.clone()));
+        let classifiers = Arc::new(LogClassifierGateway);
+
+        let ingest_report = Arc::new(IngestReportHandler::new(
+            cases.clone(),
+            publisher.clone(),
+            classifiers.clone(),
+        ));
+        let ingest_signal = Arc::new(IngestSignalHandler::new(cases.clone(), publisher.clone()));
+
+        let deps = AppDeps {
+            cases,
+            decisions: Arc::new(PgDecisionRepository::new(tx.clone())),
+            enforcements: Arc::new(PgEnforcementRepository::new(tx.clone())),
+            penalties: Arc::new(PgPenaltyRepository::new(tx.clone())),
+            appeals: Arc::new(PgAppealRepository::new(tx.clone())),
+            projection: Arc::new(RedisEnforcementProjection::new(redis.clone())),
+            corpus: Arc::new(RedisScreenCorpus::new(redis.clone())),
+            classifiers,
+            accounts: Arc::new(StubAccounts),
+            publisher,
+            policy: ModerationPolicy::standard(),
+        };
+
+        Self {
+            handler: App::compose(deps),
+            ingest_report,
+            ingest_signal,
+            pool,
+            redis,
+        }
+    }
+
+    // ── Corpus seeding ─────────────────────────────────────────────────────────
+
+    /// Seeds a known-bad corpus entry the screen path will match.
+    pub async fn seed_corpus(&self, algorithm: &str, value: &str, categories: &[&str], reference: &str) {
+        let key = format!("mod:corpus:{{{algorithm}}}:{value}");
+        let payload = serde_json::json!({ "categories": categories, "reference": reference }).to_string();
+        let _: () = self.redis.set(key, payload, None, None, false).await.expect("seed corpus");
+    }
+
+    // ── RPC helpers ────────────────────────────────────────────────────────────
+
+    pub async fn screen(
+        &self,
+        subject: proto::SubjectRef,
+        algorithm: &str,
+        value: &str,
+        categories: Vec<i32>,
+    ) -> Result<proto::ScreenResponse, Status> {
+        let request = Request::new(proto::ScreenRequest {
+            subject: Some(subject),
+            hashes: vec![proto::ContentHash { algorithm: algorithm.into(), value: value.into() }],
+            text: String::new(),
+            categories,
+        });
+        self.handler.screen(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn open_case(
+        &self,
+        subject: proto::SubjectRef,
+        category: i32,
+    ) -> Result<proto::OpenCaseResponse, Status> {
+        let request = Request::new(proto::OpenCaseRequest {
+            subject: Some(subject),
+            category,
+            reason: "default".into(),
+        });
+        self.handler.open_case(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn decide_case(
+        &self,
+        case_id: &str,
+        action: i32,
+        category: i32,
+    ) -> Result<proto::DecideCaseResponse, Status> {
+        let request = Request::new(proto::DecideCaseRequest {
+            case_id: case_id.into(),
+            action,
+            category,
+            rationale: "violation".into(),
+            reviewer_id: "rev-1".into(),
+            policy_version: "2026.06.1".into(),
+        });
+        self.handler.decide_case(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn file_appeal(
+        &self,
+        decision_id: &str,
+        actor_id: &str,
+    ) -> Result<proto::FileAppealResponse, Status> {
+        let request = Request::new(proto::FileAppealRequest {
+            decision_id: decision_id.into(),
+            actor_id: actor_id.into(),
+            statement: "I dispute this".into(),
+        });
+        self.handler.file_appeal(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn resolve_appeal(
+        &self,
+        appeal_id: &str,
+        overturn: bool,
+    ) -> Result<proto::ResolveAppealResponse, Status> {
+        let request = Request::new(proto::ResolveAppealRequest {
+            appeal_id: appeal_id.into(),
+            overturn,
+            rationale: "reviewed".into(),
+            reviewer_id: "rev-2".into(),
+        });
+        self.handler.resolve_appeal(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn enforcement_state(
+        &self,
+        actor_id: &str,
+    ) -> Result<proto::GetEnforcementStateResponse, Status> {
+        let request = Request::new(proto::GetEnforcementStateRequest { actor_id: actor_id.into() });
+        self.handler.get_enforcement_state(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn statement_of_reasons(
+        &self,
+        decision_id: &str,
+    ) -> Result<proto::GetStatementOfReasonsResponse, Status> {
+        let request =
+            Request::new(proto::GetStatementOfReasonsRequest { decision_id: decision_id.into() });
+        self.handler.get_statement_of_reasons(request).await.map(|r| r.into_inner())
+    }
+
+    pub async fn ingest_report(
+        &self,
+        cmd: IngestReportCommand,
+    ) -> Result<(), ModerationError> {
+        use cqrs::Envelope;
+        self.ingest_report
+            .handle(Envelope::new(uuid::Uuid::now_v7(), cmd), chrono::Utc::now())
+            .await
+            .map(|_| ())
+    }
+
+    pub async fn ingest_signal(
+        &self,
+        cmd: IngestSignalCommand,
+    ) -> Result<(), ModerationError> {
+        use cqrs::Envelope;
+        self.ingest_signal
+            .handle(Envelope::new(uuid::Uuid::now_v7(), cmd), chrono::Utc::now())
+            .await
+            .map(|_| ())
+    }
+
+    // ── Direct DB assertions ─────────────────────────────────────────────────
+
+    pub async fn count_decisions(&self, actor_id: &str) -> i64 {
+        let id = uuid::Uuid::parse_str(actor_id).unwrap();
+        sqlx::query_scalar("SELECT COUNT(*) FROM decisions WHERE actor_id = $1")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count decisions")
+    }
+
+    pub async fn count_enforcements(&self, actor_id: &str, status: &str) -> i64 {
+        let id = uuid::Uuid::parse_str(actor_id).unwrap();
+        sqlx::query_scalar("SELECT COUNT(*) FROM enforcements WHERE actor_id = $1 AND status = $2")
+            .bind(id)
+            .bind(status)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count enforcements")
+    }
+
+    pub async fn count_cases(&self, actor_id: &str) -> i64 {
+        let id = uuid::Uuid::parse_str(actor_id).unwrap();
+        sqlx::query_scalar("SELECT COUNT(*) FROM cases WHERE actor_id = $1")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count cases")
+    }
+
+    /// Number of accrued evidence signals on an actor's (single) case.
+    pub async fn count_signals(&self, actor_id: &str) -> i64 {
+        let id = uuid::Uuid::parse_str(actor_id).unwrap();
+        sqlx::query_scalar("SELECT COALESCE(jsonb_array_length(signals), 0)::bigint FROM cases WHERE actor_id = $1")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count signals")
+    }
+}
+
+/// A proto subject with a fresh actor — so each scenario is isolated.
+pub fn subject(entity_type: proto::EntityType, surface: &str) -> proto::SubjectRef {
+    proto::SubjectRef {
+        entity_type: entity_type as i32,
+        entity_id: format!("e-{}", uuid::Uuid::now_v7()),
+        actor_id: uuid::Uuid::now_v7().to_string(),
+        surface: surface.into(),
+    }
+}

--- a/crates/services/moderation/tests/moderation_it/mod.rs
+++ b/crates/services/moderation/tests/moderation_it/mod.rs
@@ -1,0 +1,2 @@
+pub mod harness;
+pub mod scenarios;

--- a/crates/services/moderation/tests/moderation_it/scenarios/ingest.rs
+++ b/crates/services/moderation/tests/moderation_it/scenarios/ingest.rs
@@ -1,0 +1,83 @@
+//! Plane A ingestion against the live Postgres store: a redelivered report
+//! deduplicates onto one deterministic case while accruing signals; a self-report
+//! is rejected; a classifier signal accrues onto the case.
+
+use crate::moderation_it::harness::{subject, Harness};
+use moderation::application::command::{IngestReportCommand, IngestSignalCommand};
+use moderation::domain::value_object::{ActorId, Confidence, EntityType, PolicyCategory, SubjectRef};
+use moderation::infrastructure::grpc::proto;
+use uuid::Uuid;
+
+/// Builds a domain `SubjectRef` matching a proto subject's identity.
+fn domain_subject(p: &proto::SubjectRef) -> SubjectRef {
+    SubjectRef::new(
+        EntityType::Comment,
+        p.entity_id.clone(),
+        ActorId::try_from(p.actor_id.as_str()).unwrap(),
+        p.surface.clone(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn redelivered_report_dedups_onto_one_case() {
+    let h = Harness::start().await;
+    let subj = subject(proto::EntityType::Comment, "thread");
+    let actor = subj.actor_id.clone();
+    let domain = domain_subject(&subj);
+
+    // Two different reporters report the same content.
+    for reporter in [Uuid::now_v7(), Uuid::now_v7()] {
+        h.ingest_report(IngestReportCommand {
+            reporter_id: ActorId::from_uuid(reporter),
+            subject: domain.clone(),
+            category: PolicyCategory::Harassment,
+            reason: "abusive".into(),
+        })
+        .await
+        .expect("ingest report");
+    }
+
+    // One deterministic case, two accrued signals.
+    assert_eq!(h.count_cases(&actor).await, 1, "deterministic case dedup");
+    assert_eq!(h.count_signals(&actor).await, 2, "two report signals accrued");
+}
+
+#[tokio::test]
+async fn self_report_is_rejected() {
+    let h = Harness::start().await;
+    let subj = subject(proto::EntityType::Comment, "thread");
+    let domain = domain_subject(&subj);
+
+    let err = h
+        .ingest_report(IngestReportCommand {
+            reporter_id: domain.actor_id(), // reporter == content author
+            subject: domain.clone(),
+            category: PolicyCategory::Spam,
+            reason: "x".into(),
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, moderation::ModerationError::SelfReportRejected));
+    assert_eq!(h.count_cases(&subj.actor_id).await, 0, "no case opened");
+}
+
+#[tokio::test]
+async fn classifier_signal_accrues_onto_a_case() {
+    let h = Harness::start().await;
+    let subj = subject(proto::EntityType::Comment, "thread");
+    let actor = subj.actor_id.clone();
+    let domain = domain_subject(&subj);
+
+    h.ingest_signal(IngestSignalCommand {
+        subject: domain,
+        source: "classifier:text-v2".into(),
+        category: PolicyCategory::Hate,
+        confidence: Confidence::new(0.93).unwrap(),
+    })
+    .await
+    .expect("ingest signal");
+
+    assert_eq!(h.count_cases(&actor).await, 1);
+    assert_eq!(h.count_signals(&actor).await, 1);
+}

--- a/crates/services/moderation/tests/moderation_it/scenarios/lifecycle.rs
+++ b/crates/services/moderation/tests/moderation_it/scenarios/lifecycle.rs
@@ -1,0 +1,86 @@
+//! End-to-end decision lifecycle across all three stores: open a case, suspend
+//! the actor (Postgres ledger + enforcement, Redis projection), then appeal and
+//! overturn — reversing the enforcement, clearing the projection, and leaving the
+//! append-only ledger holding both the original decision and its reversal.
+
+use crate::moderation_it::harness::{subject, Harness};
+use moderation::infrastructure::grpc::proto;
+
+#[tokio::test]
+async fn suspend_then_overturn_on_appeal() {
+    let h = Harness::start().await;
+    let subj = subject(proto::EntityType::Post, "feed");
+    let actor = subj.actor_id.clone();
+
+    // Open a case and suspend the actor.
+    let opened = h
+        .open_case(subj.clone(), proto::PolicyCategory::Harassment as i32)
+        .await
+        .expect("open case");
+    assert!(opened.created);
+    let case_id = opened.case.expect("case view").case_id;
+
+    let decided = h
+        .decide_case(&case_id, proto::ActionType::Suspend as i32, proto::PolicyCategory::Harassment as i32)
+        .await
+        .expect("decide");
+    let decision = decided.decision.expect("decision recorded");
+    assert!(decided.enforcement.is_some(), "suspend creates an enforcement");
+
+    // Durably written: one decision, one active enforcement, one case.
+    assert_eq!(h.count_decisions(&actor).await, 1);
+    assert_eq!(h.count_enforcements(&actor, "active").await, 1);
+    assert_eq!(h.count_cases(&actor).await, 1);
+
+    // The Redis projection reports the actor restricted.
+    let state = h.enforcement_state(&actor).await.expect("enforcement state");
+    assert!(state.actor_restricted, "actor restricted on the hot-path projection");
+    assert_eq!(state.active_enforcements.len(), 1);
+
+    // The DSA statement of reasons echoes the pinned policy version.
+    let sor = h.statement_of_reasons(&decision.decision_id).await.expect("sor");
+    let statement = sor.statement.expect("statement present");
+    assert_eq!(statement.action, proto::ActionType::Suspend as i32);
+    assert_eq!(statement.policy_version, "2026.06.1");
+
+    // File then overturn the appeal.
+    let appeal = h
+        .file_appeal(&decision.decision_id, &actor)
+        .await
+        .expect("file appeal")
+        .appeal
+        .expect("appeal view");
+    let resolved = h.resolve_appeal(&appeal.appeal_id, true).await.expect("resolve appeal");
+    assert!(resolved.reversal.is_some(), "overturn records a reversal decision");
+
+    // Append-only ledger now holds the original + the reversal; the enforcement is
+    // reversed (no longer active) and the projection is cleared.
+    assert_eq!(h.count_decisions(&actor).await, 2, "original + reversal");
+    assert_eq!(h.count_enforcements(&actor, "active").await, 0);
+    assert_eq!(h.count_enforcements(&actor, "reversed").await, 1);
+    assert!(
+        !h.enforcement_state(&actor).await.expect("state").actor_restricted,
+        "projection cleared after overturn"
+    );
+}
+
+#[tokio::test]
+async fn dismissal_records_a_decision_but_no_enforcement() {
+    let h = Harness::start().await;
+    let subj = subject(proto::EntityType::Comment, "thread");
+    let actor = subj.actor_id.clone();
+
+    let opened = h
+        .open_case(subj, proto::PolicyCategory::Spam as i32)
+        .await
+        .expect("open");
+    let case_id = opened.case.unwrap().case_id;
+
+    let decided = h
+        .decide_case(&case_id, proto::ActionType::NoAction as i32, proto::PolicyCategory::Spam as i32)
+        .await
+        .expect("dismiss");
+    assert!(decided.enforcement.is_none(), "no_action creates no enforcement");
+    assert_eq!(h.count_decisions(&actor).await, 1);
+    assert_eq!(h.count_enforcements(&actor, "active").await, 0);
+}

--- a/crates/services/moderation/tests/moderation_it/scenarios/mod.rs
+++ b/crates/services/moderation/tests/moderation_it/scenarios/mod.rs
@@ -1,0 +1,3 @@
+pub mod ingest;
+pub mod lifecycle;
+pub mod screen;

--- a/crates/services/moderation/tests/moderation_it/scenarios/screen.rs
+++ b/crates/services/moderation/tests/moderation_it/scenarios/screen.rs
@@ -1,0 +1,44 @@
+//! Plane C screen gate against the live Redis corpus: a seeded known-bad hash
+//! blocks and records automated evidence (an append-only decision + a content
+//! removal enforcement); clean content allows.
+
+use crate::moderation_it::harness::{subject, Harness};
+use moderation::infrastructure::grpc::proto;
+
+#[tokio::test]
+async fn known_bad_hash_blocks_and_records_evidence() {
+    let h = Harness::start().await;
+    h.seed_corpus("pdq", "badhash", &["csam"], "ncmec:42").await;
+
+    let subj = subject(proto::EntityType::Media, "upload");
+    let actor = subj.actor_id.clone();
+
+    let resp = h
+        .screen(subj, "pdq", "badhash", vec![proto::PolicyCategory::Csam as i32])
+        .await
+        .expect("screen");
+
+    assert_eq!(resp.verdict, proto::ScreenVerdict::Block as i32);
+    assert_eq!(resp.match_reference, "ncmec:42");
+    assert!(resp.matched_categories.contains(&(proto::PolicyCategory::Csam as i32)));
+
+    // Automated evidence is recorded: one decision + one active content removal.
+    assert_eq!(h.count_decisions(&actor).await, 1);
+    assert_eq!(h.count_enforcements(&actor, "active").await, 1);
+}
+
+#[tokio::test]
+async fn clean_content_allows_and_records_nothing() {
+    let h = Harness::start().await;
+    let subj = subject(proto::EntityType::Media, "upload");
+    let actor = subj.actor_id.clone();
+
+    let resp = h
+        .screen(subj, "pdq", "cleanhash", vec![proto::PolicyCategory::Csam as i32])
+        .await
+        .expect("screen");
+
+    assert_eq!(resp.verdict, proto::ScreenVerdict::Allow as i32);
+    assert_eq!(h.count_decisions(&actor).await, 0);
+    assert_eq!(h.count_enforcements(&actor, "active").await, 0);
+}


### PR DESCRIPTION
Lands **`moderation-service`** on `develop`. This is the same work reviewed in #454 (which merged into `feat/auth-service`); it didn't ride along to `develop` because `auth → develop` (#453) merged first. This PR cherry-picks the moderation commit onto `develop`, so the diff is **moderation-only** (auth is already on develop).

See #454 for the full architecture writeup. In brief: the integrity decision-of-record + enforcement brain, three-plane design (async ingestion / hot-read enforcement / fail-closed Screen gate), three stores (Postgres SoR · Scylla evidence history · Redis projection+corpus), 9 `moderation.v1` RPCs + 2 ingestion consumers. 92 unit + 7 live integration tests, all green.

**Follow-up (separate PR after this lands):** register `auth` + `moderation` in the `migrator` (`crates/apps/migrator`) — it's a compile-time `include_dir!` list, so new services need explicit entries; moderation also needs `sorted_migrations` to filter by store extension since it has both `.sql` and `.cql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)