### PR TITLE
feat(profile): publish profile.v1.events lifecycle event stream

### DIFF
--- a/crates/services/profile/README.fr.md
+++ b/crates/services/profile/README.fr.md
@@ -1,8 +1,8 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 18ab5e76420190ced87687f04b6933db1e4a92483d5322732ce3cd7bafd36032
-  translated_at: 2026-06-25
+  source_sha256: 7ed960bb816edbc6d1c8306c6e9d96cc8db2b7a8a8c7e348958b5d81bc12ce75
+  translated_at: 2026-06-26
   status: complete
 ---
 > 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
@@ -20,7 +20,7 @@ i18n:
 > | **Palier (Tier)** | **TIER-0** — chemin de lecture public, résolution d'identité à l'échelle de la flotte |
 > | **Binaire déployable** | `crates/apps/profile-server` (crate bibliothèque : `crates/services/profile`) |
 > | **Bases de données** | ScyllaDB keyspace `profile` · Redis (cache-aside) |
-> | **Asynchrone** | publie `profile.tier_changed` · consomme `account.v1.events` |
+> | **Asynchrone** | publie `profile.v1.events` · consomme `account.v1.events` |
 > | **Appelants amont** | `<TODO: passerelle>`, consommateurs reco/lookup en masse, `geo-discovery` (via événements) |
 > | **Dépendances aval** | ScyllaDB, Redis, Kafka |
 > | **SLO** | lecture cache-hit p99 **< 1 ms** · cache-miss p99 **< 5 ms** |
@@ -169,9 +169,11 @@ réactivement).
 
 **Publie :**
 
-| Topic | Trigger | Key | Consumers |
+| Topic | Déclencheur | Clé | Consommateurs |
 |---|---|---|---|
-| `profile.tier_changed` | author tier change (one event per affected `post_id`) | `post_id` | `geo-discovery` (card tier sync), `timeline` (tier routing, indirect) |
+| `profile.v1.events` | chaque mutation de cycle de vie — `ProfileCreated` / `ProfileUpdated` / `HandleChanged` / `ProfileVerified` / `ProfileHidden` / `ProfileRestored` / `ProfileDeleted` | `profile_id` | `search` (indexation des profils) |
+
+> **Contrat de fil :** un topic versionné unique, tagué en interne sur `type` (convention du service moderation), clé `profile_id` pour l'ordre par-profil. Les événements sont **fins** (ids + horodatages, sans contenu d'affichage) — un consommateur qui a besoin du profil complet l'hydrate via `GetProfileById`. Chaque command handler draine les événements en attente de l'agrégat et les publie **après** l'écriture durable (durable-first ; un publisher no-op couvre la composition sans broker).
 
 **Consomme :**
 

--- a/crates/services/profile/README.md
+++ b/crates/services/profile/README.md
@@ -9,7 +9,7 @@
 > | **Tier** | **TIER-0** — public read path, fleet-wide identity resolution |
 > | **Deployable** | `crates/apps/profile-server` (library crate: `crates/services/profile`) |
 > | **Datastores** | ScyllaDB keyspace `profile` · Redis (cache-aside) |
-> | **Async** | publishes `profile.tier_changed` · consumes `account.v1.events` |
+> | **Async** | publishes `profile.v1.events` · consumes `account.v1.events` |
 > | **Upstream callers** | `<TODO: gateway>`, recommendation/bulk-lookup consumers, `geo-discovery` (via events) |
 > | **Downstream deps** | ScyllaDB, Redis, Kafka |
 > | **SLO** | cache-hit read p99 **< 1 ms** · cache-miss p99 **< 5 ms** |
@@ -157,7 +157,9 @@ pub trait ProfileCache:      Send + Sync + 'static { /* get_by_id, set_by_id, in
 
 | Topic | Trigger | Key | Consumers |
 |---|---|---|---|
-| `profile.tier_changed` | author tier change (one event per affected `post_id`) | `post_id` | `geo-discovery` (card tier sync), `timeline` (tier routing, indirect) |
+| `profile.v1.events` | every profile lifecycle mutation — `ProfileCreated` / `ProfileUpdated` / `HandleChanged` / `ProfileVerified` / `ProfileHidden` / `ProfileRestored` / `ProfileDeleted` | `profile_id` | `search` (profile indexing) |
+
+> **Wire contract:** one versioned topic, internally tagged on `type` (the moderation-service convention), keyed by `profile_id` for per-profile ordering. Events are **thin** (ids + timestamps, no display content) — a consumer that needs the full profile hydrates it via `GetProfileById`. Each command handler drains the aggregate's pending events and publishes them **after** the durable write (durable-first; a no-op publisher backs broker-free composition).
 
 **Consumes:**
 

--- a/crates/services/profile/src/app.rs
+++ b/crates/services/profile/src/app.rs
@@ -4,10 +4,12 @@
 //! graph out. It binds no socket and reads no environment, so a binary entrypoint
 //! and the live integration harness assemble the exact same graph.
 //!
-//! Profile is a downstream service — it publishes no events of its own, and its
-//! one inbound Kafka touchpoint (the account-event consumer) is wired separately
-//! by the serving binary against [`App::command_bus`]; it is intentionally not
-//! part of this composition root, so the graph needs no broker.
+//! Profile publishes its lifecycle events to `profile.v1.events` via an injected
+//! [`EventPublisher`]: each command handler drains the aggregate's pending events
+//! after the durable write and publishes them. The publisher is injected (Kafka in
+//! the binary, a no-op in broker-free composition) so the graph itself needs no
+//! broker. Its one inbound Kafka touchpoint (the account-event consumer) is wired
+//! separately by the serving binary against [`App::command_bus`].
 
 use std::sync::Arc;
 
@@ -24,7 +26,7 @@ use crate::application::command::{
     UpdateAvatarCommand, UpdateAvatarHandler, UpdateBannerCommand, UpdateBannerHandler,
     UpdateProfileCommand, UpdateProfileHandler, VerifyProfileCommand, VerifyProfileHandler,
 };
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::application::query::{
     GetProfileByHandleHandler, GetProfileByHandleQuery, GetProfileByIdHandler, GetProfileByIdQuery,
     ListProfilesByAccountHandler, ListProfilesByAccountQuery,
@@ -64,6 +66,7 @@ impl App {
     pub async fn build(
         backends: Backends,
         cache_registry: Arc<CacheRegistry>,
+        publisher: Arc<dyn EventPublisher>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let Backends { scylla, redis } = backends;
 
@@ -88,42 +91,52 @@ impl App {
                 .register::<CreateProfileCommand, _>(CreateProfileHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<UpdateProfileCommand, _>(UpdateProfileHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<ChangeHandleCommand, _>(ChangeHandleHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<UpdateAvatarCommand, _>(UpdateAvatarHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<UpdateBannerCommand, _>(UpdateBannerHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<SetVisibilityCommand, _>(SetVisibilityHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<VerifyProfileCommand, _>(VerifyProfileHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<HideProfileCommand, _>(HideProfileHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<RestoreProfileCommand, _>(RestoreProfileHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .register::<DeleteProfileCommand, _>(DeleteProfileHandler::new(
                     Arc::clone(&repository),
                     Arc::clone(&cache),
+                    Arc::clone(&publisher),
                 ))?
                 .build(),
         );

--- a/crates/services/profile/src/application/command/change_handle.rs
+++ b/crates/services/profile/src/application/command/change_handle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::{Handle, ProfileId};
 use crate::error::ProfileError;
 
@@ -31,11 +31,12 @@ impl Validate for ChangeHandleCommand {
 pub struct ChangeHandleHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl ChangeHandleHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -74,6 +75,10 @@ impl CommandHandler<ChangeHandleCommand> for ChangeHandleHandler {
 
         self.repo.tombstone_handle(&old_handle).await?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
 
         let _ = self.cache.invalidate_handle(old_handle.as_str()).await;
         let _ = self.cache.invalidate_handle(new_handle.as_str()).await;

--- a/crates/services/profile/src/application/command/create_profile.rs
+++ b/crates/services/profile/src/application/command/create_profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::aggregate::{Profile, ProfileCreateParams};
 use crate::domain::value_object::{AccountId, AvatarUrl, BannerUrl, Bio, DisplayName, Handle, Locale, ProfileKind};
 use crate::error::ProfileError;
@@ -46,11 +46,12 @@ impl Validate for CreateProfileCommand {
 pub struct CreateProfileHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl CreateProfileHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -73,7 +74,7 @@ impl CommandHandler<CreateProfileCommand> for CreateProfileHandler {
             return Err(ProfileError::HandleAlreadyTaken { handle: handle.as_str().to_owned() });
         }
 
-        let profile = Profile::create(ProfileCreateParams {
+        let mut profile = Profile::create(ProfileCreateParams {
             account_id,
             handle: handle.clone(),
             display_name,
@@ -93,6 +94,12 @@ impl CommandHandler<CreateProfileCommand> for CreateProfileHandler {
         let claimed = self.repo.claim_handle(&handle, profile.id(), account_id).await?;
         if !claimed {
             return Err(ProfileError::HandleAlreadyTaken { handle: handle.as_str().to_owned() });
+        }
+
+        // Publish only after the claim succeeds — a lost race must not emit a
+        // phantom ProfileCreated.
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
         }
 
         let _ = self.cache.invalidate_account_profiles(&account_id).await;

--- a/crates/services/profile/src/application/command/delete_profile.rs
+++ b/crates/services/profile/src/application/command/delete_profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::ProfileId;
 use crate::error::ProfileError;
 
@@ -27,11 +27,12 @@ impl Validate for DeleteProfileCommand {
 pub struct DeleteProfileHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl DeleteProfileHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -53,6 +54,10 @@ impl CommandHandler<DeleteProfileCommand> for DeleteProfileHandler {
 
         profile.delete(envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
 
         // Tombstone the handle so it enters the 30-day reservation window.
         self.repo.tombstone_handle(&handle).await?;

--- a/crates/services/profile/src/application/command/hide_profile.rs
+++ b/crates/services/profile/src/application/command/hide_profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::{MaskingReason, ProfileId};
 use crate::error::ProfileError;
 
@@ -36,11 +36,12 @@ impl Validate for HideProfileCommand {
 pub struct HideProfileHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl HideProfileHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -60,6 +61,10 @@ impl CommandHandler<HideProfileCommand> for HideProfileHandler {
 
         profile.hide(reason, cmd.suspension_reason.clone(), envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
         let _ = self.cache.invalidate_account_profiles(&profile.account_id()).await;
 

--- a/crates/services/profile/src/application/command/restore_profile.rs
+++ b/crates/services/profile/src/application/command/restore_profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::ProfileId;
 use crate::error::ProfileError;
 
@@ -27,11 +27,12 @@ impl Validate for RestoreProfileCommand {
 pub struct RestoreProfileHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl RestoreProfileHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -50,6 +51,10 @@ impl CommandHandler<RestoreProfileCommand> for RestoreProfileHandler {
 
         profile.restore(envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
         let _ = self.cache.invalidate_account_profiles(&profile.account_id()).await;
 

--- a/crates/services/profile/src/application/command/set_visibility.rs
+++ b/crates/services/profile/src/application/command/set_visibility.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::{ProfileId, ProfileVisibility};
 use crate::error::ProfileError;
 
@@ -31,11 +31,12 @@ impl Validate for SetVisibilityCommand {
 pub struct SetVisibilityHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl SetVisibilityHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -55,6 +56,10 @@ impl CommandHandler<SetVisibilityCommand> for SetVisibilityHandler {
 
         profile.set_visibility(visibility, envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
         let _ = self.cache.invalidate_account_profiles(&profile.account_id()).await;
 

--- a/crates/services/profile/src/application/command/update_avatar.rs
+++ b/crates/services/profile/src/application/command/update_avatar.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::{AvatarUrl, ProfileId};
 use crate::error::ProfileError;
 
@@ -29,11 +29,12 @@ impl Validate for UpdateAvatarCommand {
 pub struct UpdateAvatarHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl UpdateAvatarHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -57,6 +58,10 @@ impl CommandHandler<UpdateAvatarCommand> for UpdateAvatarHandler {
 
         profile.update_avatar(url, envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
         let _ = self.cache.invalidate_account_profiles(&profile.account_id()).await;
 

--- a/crates/services/profile/src/application/command/update_banner.rs
+++ b/crates/services/profile/src/application/command/update_banner.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::{BannerUrl, ProfileId};
 use crate::error::ProfileError;
 
@@ -29,11 +29,12 @@ impl Validate for UpdateBannerCommand {
 pub struct UpdateBannerHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl UpdateBannerHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -57,6 +58,10 @@ impl CommandHandler<UpdateBannerCommand> for UpdateBannerHandler {
 
         profile.update_banner(url, envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
         let _ = self.cache.invalidate_account_profiles(&profile.account_id()).await;
 

--- a/crates/services/profile/src/application/command/update_profile.rs
+++ b/crates/services/profile/src/application/command/update_profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::entity::ProfileLink;
 use crate::domain::value_object::{Bio, DisplayName, Locale, ProfileId, WebsiteUrl};
 use crate::error::ProfileError;
@@ -37,11 +37,12 @@ impl Validate for UpdateProfileCommand {
 pub struct UpdateProfileHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl UpdateProfileHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -81,6 +82,10 @@ impl CommandHandler<UpdateProfileCommand> for UpdateProfileHandler {
         profile.update(display_name, bio, website_url, locale, custom_links, envelope.correlation_id)?;
 
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
         let _ = self.cache.invalidate_account_profiles(&profile.account_id()).await;
 

--- a/crates/services/profile/src/application/command/verify_profile.rs
+++ b/crates/services/profile/src/application/command/verify_profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
-use crate::application::port::{ProfileCache, ProfileRepository};
+use crate::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use crate::domain::value_object::{ProfileId, VerificationKind};
 use crate::error::ProfileError;
 
@@ -31,11 +31,12 @@ impl Validate for VerifyProfileCommand {
 pub struct VerifyProfileHandler {
     repo: Arc<dyn ProfileRepository>,
     cache: Arc<dyn ProfileCache>,
+    publisher: Arc<dyn EventPublisher>,
 }
 
 impl VerifyProfileHandler {
-    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>) -> Self {
-        Self { repo, cache }
+    pub fn new(repo: Arc<dyn ProfileRepository>, cache: Arc<dyn ProfileCache>, publisher: Arc<dyn EventPublisher>) -> Self {
+        Self { repo, cache, publisher }
     }
 }
 
@@ -55,6 +56,10 @@ impl CommandHandler<VerifyProfileCommand> for VerifyProfileHandler {
 
         profile.verify(kind, envelope.correlation_id)?;
         self.repo.save(&profile).await?;
+
+        for event in profile.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
         let _ = self.cache.invalidate_by_id(&id).await;
 
         Ok(())

--- a/crates/services/profile/src/application/port/event_publisher.rs
+++ b/crates/services/profile/src/application/port/event_publisher.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+use crate::domain::event::DomainEvent;
+use crate::error::ProfileError;
+
+/// Outbound port for publishing profile domain events.
+///
+/// Command handlers persist the aggregate to the system of record first, then
+/// drain its pending events and publish them through this port (durable-first
+/// ordering — the event is a denormalization notification, never the source of
+/// truth). The Kafka adapter emits to `profile.v1.events`; a no-op adapter backs
+/// broker-free composition (tests, no-Kafka deployments).
+#[async_trait]
+pub trait EventPublisher: Send + Sync + 'static {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ProfileError>;
+}

--- a/crates/services/profile/src/application/port/mod.rs
+++ b/crates/services/profile/src/application/port/mod.rs
@@ -1,5 +1,7 @@
+pub mod event_publisher;
 pub mod profile_cache;
 pub mod profile_repository;
 
+pub use event_publisher::EventPublisher;
 pub use profile_cache::{ProfileCache, ProfileLinkView, ProfileView};
 pub use profile_repository::{ProfileRepository, ProfileSummary};

--- a/crates/services/profile/src/infrastructure/mod.rs
+++ b/crates/services/profile/src/infrastructure/mod.rs
@@ -2,3 +2,4 @@ pub mod cache;
 pub mod consumer;
 pub mod grpc;
 pub mod persistence;
+pub mod publisher;

--- a/crates/services/profile/src/infrastructure/publisher/kafka_event_publisher.rs
+++ b/crates/services/profile/src/infrastructure/publisher/kafka_event_publisher.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use transport::error::TransportError;
+use transport::kafka::envelope::EventEnvelope;
+use transport::kafka::producer::handle::KafkaProducerHandle;
+
+use super::wire::ProfileEventWire;
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::ProfileError;
+
+/// The single versioned topic carrying every profile lifecycle event
+/// (moderation-service convention), keyed by `profile_id`.
+const TOPIC: &str = "profile.v1.events";
+
+fn transport_err(e: TransportError) -> ProfileError {
+    ProfileError::DomainViolation {
+        field: "event_publish".to_owned(),
+        message: e.to_string(),
+    }
+}
+
+/// Publishes profile domain events to `profile.v1.events`.
+pub struct KafkaProfileEventPublisher {
+    producer: KafkaProducerHandle,
+}
+
+impl KafkaProfileEventPublisher {
+    pub fn new(producer: KafkaProducerHandle) -> Self {
+        Self { producer }
+    }
+}
+
+#[async_trait]
+impl EventPublisher for KafkaProfileEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ProfileError> {
+        let wire = ProfileEventWire::from(event);
+        let key = wire.profile_id().to_owned();
+        let event_type = wire.event_type();
+        let envelope = EventEnvelope::new(TOPIC, key, wire).with_header("event_type", event_type);
+        self.producer.publish(envelope).await.map_err(transport_err)
+    }
+}

--- a/crates/services/profile/src/infrastructure/publisher/mod.rs
+++ b/crates/services/profile/src/infrastructure/publisher/mod.rs
@@ -1,0 +1,24 @@
+//! Outbound event publishing for `profile.v1.events`.
+
+pub mod kafka_event_publisher;
+pub mod wire;
+
+pub use kafka_event_publisher::KafkaProfileEventPublisher;
+
+use async_trait::async_trait;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::ProfileError;
+
+/// A no-op publisher for broker-free composition (tests, no-Kafka deployments).
+/// Drained events are dropped — the durable write in the system of record is the
+/// source of truth.
+pub struct NoopEventPublisher;
+
+#[async_trait]
+impl EventPublisher for NoopEventPublisher {
+    async fn publish(&self, _event: &DomainEvent) -> Result<(), ProfileError> {
+        Ok(())
+    }
+}

--- a/crates/services/profile/src/infrastructure/publisher/wire.rs
+++ b/crates/services/profile/src/infrastructure/publisher/wire.rs
@@ -1,0 +1,118 @@
+//! Serde wire schema for `profile.v1.events`.
+//!
+//! The wire contract is decoupled from the domain value objects: a thin,
+//! string-typed enum (ids + timestamps, no display content) so a consumer
+//! deserializes a stable shape and a VO refactor never breaks the wire.
+//! Internally tagged on `type` (the moderation-service convention), keyed by
+//! `profile_id`. Events are intentionally **thin** — a consumer that needs the
+//! full profile (e.g. search) hydrates it from `GetProfileById`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::event::DomainEvent;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ProfileEventWire {
+    ProfileCreated {
+        profile_id: String,
+        account_id: String,
+        handle: String,
+        profile_kind: String,
+        occurred_at_ms: i64,
+    },
+    ProfileUpdated {
+        profile_id: String,
+        occurred_at_ms: i64,
+    },
+    HandleChanged {
+        profile_id: String,
+        new_handle: String,
+        occurred_at_ms: i64,
+    },
+    ProfileVerified {
+        profile_id: String,
+        occurred_at_ms: i64,
+    },
+    ProfileHidden {
+        profile_id: String,
+        masking_reason: String,
+        occurred_at_ms: i64,
+    },
+    ProfileRestored {
+        profile_id: String,
+        occurred_at_ms: i64,
+    },
+    ProfileDeleted {
+        profile_id: String,
+        occurred_at_ms: i64,
+    },
+}
+
+impl ProfileEventWire {
+    /// The partition key — guarantees per-profile ordering on the topic.
+    pub fn profile_id(&self) -> &str {
+        match self {
+            ProfileEventWire::ProfileCreated { profile_id, .. }
+            | ProfileEventWire::ProfileUpdated { profile_id, .. }
+            | ProfileEventWire::HandleChanged { profile_id, .. }
+            | ProfileEventWire::ProfileVerified { profile_id, .. }
+            | ProfileEventWire::ProfileHidden { profile_id, .. }
+            | ProfileEventWire::ProfileRestored { profile_id, .. }
+            | ProfileEventWire::ProfileDeleted { profile_id, .. } => profile_id,
+        }
+    }
+
+    /// The `type` tag, also set as the `event_type` Kafka header for routing.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            ProfileEventWire::ProfileCreated { .. } => "ProfileCreated",
+            ProfileEventWire::ProfileUpdated { .. } => "ProfileUpdated",
+            ProfileEventWire::HandleChanged { .. } => "HandleChanged",
+            ProfileEventWire::ProfileVerified { .. } => "ProfileVerified",
+            ProfileEventWire::ProfileHidden { .. } => "ProfileHidden",
+            ProfileEventWire::ProfileRestored { .. } => "ProfileRestored",
+            ProfileEventWire::ProfileDeleted { .. } => "ProfileDeleted",
+        }
+    }
+}
+
+impl From<&DomainEvent> for ProfileEventWire {
+    fn from(event: &DomainEvent) -> Self {
+        match event {
+            DomainEvent::ProfileCreated(e) => ProfileEventWire::ProfileCreated {
+                profile_id: e.profile_id.to_string(),
+                account_id: e.account_id.to_string(),
+                handle: e.handle.to_string(),
+                profile_kind: e.profile_kind.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+            DomainEvent::ProfileUpdated(e) => ProfileEventWire::ProfileUpdated {
+                profile_id: e.profile_id.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+            DomainEvent::HandleChanged(e) => ProfileEventWire::HandleChanged {
+                profile_id: e.profile_id.to_string(),
+                new_handle: e.new_handle.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+            DomainEvent::ProfileVerified(e) => ProfileEventWire::ProfileVerified {
+                profile_id: e.profile_id.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+            DomainEvent::ProfileHidden(e) => ProfileEventWire::ProfileHidden {
+                profile_id: e.profile_id.to_string(),
+                masking_reason: e.masking_reason.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+            DomainEvent::ProfileRestored(e) => ProfileEventWire::ProfileRestored {
+                profile_id: e.profile_id.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+            DomainEvent::ProfileDeleted(e) => ProfileEventWire::ProfileDeleted {
+                profile_id: e.profile_id.to_string(),
+                occurred_at_ms: e.occurred_at.timestamp_millis(),
+            },
+        }
+    }
+}

--- a/crates/services/profile/src/service.rs
+++ b/crates/services/profile/src/service.rs
@@ -26,9 +26,11 @@ use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
 use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
 
 use crate::app::{App, Backends};
+use crate::application::port::EventPublisher;
 use crate::infrastructure::consumer::run_account_event_consumer;
 use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
 use crate::infrastructure::grpc::{ProfileServiceHandler, ProfileServiceServer};
+use crate::infrastructure::publisher::KafkaProfileEventPublisher;
 
 /// Kafka topic carrying the account lifecycle events profile reacts to.
 const ACCOUNT_EVENTS_TOPIC: &str = "account.v1.events";
@@ -65,7 +67,13 @@ impl Service for ProfileService {
             .cache()
             .context("profile requires a [cache] section in infrastructure.toml")?;
 
-        let app = App::build(backends, cache_registry)
+        // Outbound: profile lifecycle events → `profile.v1.events`.
+        let producer = KafkaProducerBuilder::new(ProducerConfig::new(KafkaClientConfig::from_env()))
+            .build()
+            .context("build profile event producer")?;
+        let publisher: Arc<dyn EventPublisher> = Arc::new(KafkaProfileEventPublisher::new(producer));
+
+        let app = App::build(backends, cache_registry, publisher)
             .await
             .map_err(|e| anyhow::anyhow!("profile app build: {e}"))?;
 

--- a/crates/services/profile/tests/profile_it/harness/mod.rs
+++ b/crates/services/profile/tests/profile_it/harness/mod.rs
@@ -3,7 +3,7 @@
 //! the repository and Redis cache handles for assertions.
 #![allow(dead_code)]
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use uuid::Uuid;
@@ -17,8 +17,11 @@ use scylla_storage::ScyllaConfig;
 
 use profile::app::{App, Backends};
 use profile::application::command::{CreateProfileCommand, UpdateProfileCommand};
-use profile::application::port::{ProfileCache, ProfileRepository};
+use profile::application::port::{EventPublisher, ProfileCache, ProfileRepository};
 use profile::application::query::{GetProfileByHandleQuery, GetProfileByIdQuery};
+use profile::domain::event::DomainEvent;
+use profile::error::ProfileError;
+use profile::infrastructure::publisher::wire::ProfileEventWire;
 
 pub use profile::application::port::profile_cache::ProfileView;
 pub use profile::domain::value_object::ProfileId;
@@ -54,12 +57,35 @@ ttl_secs = 600
 "handle-lookup" = "handles"
 "#;
 
+/// Captures the `type` tag of every published profile event, so a scenario can
+/// assert the durable write emitted the right `profile.v1.events` notification.
+#[derive(Default)]
+pub struct CapturingEventPublisher {
+    events: Mutex<Vec<String>>,
+}
+
+#[async_trait::async_trait]
+impl EventPublisher for CapturingEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), ProfileError> {
+        let kind = ProfileEventWire::from(event).event_type();
+        self.events.lock().unwrap().push(kind.to_owned());
+        Ok(())
+    }
+}
+
+impl CapturingEventPublisher {
+    pub fn published(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
 /// A fully-wired profile service bound to ephemeral infra, plus assertion handles.
 pub struct TestHarness {
     pub command_bus: Arc<InMemoryCommandBus>,
     pub query_bus:   Arc<InMemoryQueryBus>,
     pub repository:  Arc<dyn ProfileRepository>,
     pub cache:       Arc<dyn ProfileCache>,
+    pub publisher:   Arc<CapturingEventPublisher>,
 }
 
 impl TestHarness {
@@ -86,15 +112,21 @@ impl TestHarness {
             CacheRegistry::from_section(cache_section).expect("integration: resolve cache registry"),
         );
 
-        let app = App::build(backends, cache_registry)
-            .await
-            .expect("integration: build profile app");
+        let publisher = Arc::new(CapturingEventPublisher::default());
+        let app = App::build(
+            backends,
+            cache_registry,
+            Arc::clone(&publisher) as Arc<dyn EventPublisher>,
+        )
+        .await
+        .expect("integration: build profile app");
 
         Self {
             command_bus: app.command_bus,
             query_bus:   app.query_bus,
             repository:  app.repository,
             cache:       app.cache,
+            publisher,
         }
     }
 

--- a/crates/services/profile/tests/profile_it/scenarios/event_emission.rs
+++ b/crates/services/profile/tests/profile_it/scenarios/event_emission.rs
@@ -1,0 +1,29 @@
+//! Scenario — outbound event emission.
+//!
+//! Every mutating command must publish its lifecycle event to `profile.v1.events`
+//! *after* the durable write, so downstream consumers (notably search) can react.
+//! The harness injects a capturing publisher that records each event's `type` tag.
+
+use crate::profile_it::harness::{self, TestHarness};
+
+#[tokio::test]
+async fn create_then_update_emit_their_lifecycle_events() {
+    let h = TestHarness::start().await;
+    let handle = harness::random_handle();
+    let account = harness::random_account_id();
+
+    h.create(&account, &handle, "Alice").await;
+    assert!(
+        h.publisher.published().contains(&"ProfileCreated".to_owned()),
+        "create must emit ProfileCreated, got {:?}",
+        h.publisher.published()
+    );
+
+    let view = h.get_by_handle(&handle).await.expect("profile exists after create");
+    h.update_display(&view.id, "Alice Updated").await;
+    assert!(
+        h.publisher.published().contains(&"ProfileUpdated".to_owned()),
+        "update must emit ProfileUpdated, got {:?}",
+        h.publisher.published()
+    );
+}

--- a/crates/services/profile/tests/profile_it/scenarios/mod.rs
+++ b/crates/services/profile/tests/profile_it/scenarios/mod.rs
@@ -1,5 +1,7 @@
 //! Scenario groups for the profile live suite, mapping to the testing standard's
-//! axes: concurrency (handle-claim race) and cache invalidation.
+//! axes: concurrency (handle-claim race), cache invalidation, and outbound event
+//! emission.
 
 mod cache_invalidation;
+mod event_emission;
 mod handle_claim_race;


### PR DESCRIPTION
## Summary

Profile accumulated domain events in its aggregate but **never published them** — there was no `EventPublisher` port and `DomainEvent` wasn't serde. This adds the publish side so downstream consumers (notably **search**, for profile indexing) can react to profile lifecycle changes.

This is **PR-1** of the profile-events prerequisite; a follow-up search PR wires the consumer + dual-visibility-flag indexing.

## What changed
- **`EventPublisher` outbound port.** Each of the 10 command handlers drains the aggregate's `pending_events` and publishes them **after** the durable write (durable-first). `create_profile` publishes only **after** the handle-claim LWT succeeds, so a lost race never emits a phantom `ProfileCreated`.
- **`KafkaProfileEventPublisher`** → single versioned topic **`profile.v1.events`**, internally tagged on `type` (moderation-service convention), keyed by `profile_id` for per-profile ordering. **`NoopEventPublisher`** backs broker-free composition.
- **Thin wire DTOs** (ids + timestamps, no display content) decoupled from the domain value objects — a consumer hydrates the full profile via `GetProfileById`, and a VO refactor never breaks the wire.
- **`App::build`** takes the publisher (injected); **`service.rs`** builds the Kafka publisher from env. The query handlers are untouched.
- **Integration harness** gains a capturing publisher + an `event_emission` scenario asserting create/update emit their events.
- **README EN+FR** Events contract updated to the real `profile.v1.events` (replacing the phantom `profile.tier_changed`); i18n drift gate green.

## Event set (`profile.v1.events`, tagged on `type`)
`ProfileCreated` · `ProfileUpdated` · `HandleChanged` · `ProfileVerified` · `ProfileHidden` · `ProfileRestored` · `ProfileDeleted`

## Design notes
- **Thin events + hydrate**, deliberately — consistency with `post`, and no display-PII on the wire.
- **Convention:** single versioned topic (like `moderation.v1.events`), not the older per-event-topic style `post` uses. This is what the search decode expects.
- Publish failure after the durable write surfaces as an error (the SoR write persisted) — a proper outbox is a larger, separate change.

## Testing
- `cargo build -p profile -p profile-server` clean; `cargo test --workspace --no-run` green.
- New `event_emission` integration scenario (gated `integration-profile`) — compiles everywhere, runs where Docker is available.
- Clippy: zero warnings attributed to the changed files (2 pre-existing warnings in untouched files remain).

## Out of scope (follow-ups)
- The **search consumer** + dual-visibility-flag indexing (PR-2).
- An **outbox** for exactly-once publish (current behavior: durable-first, publish error surfaces).
- The stale `profile.tier_changed` mentions in the README blast-radius section (a separate tier-event concern, left consistent across EN/FR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmukNZpRWNHYzkHiCoNAWr