### PR TITLE
feat(post): emit unified post.v1.events alongside legacy per-type topics

### DIFF
--- a/crates/services/post/README.fr.md
+++ b/crates/services/post/README.fr.md
@@ -1,8 +1,8 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 3ed0278a8d7b9a1c0d9afb9e24e790cf7f105e59d9ce6c77a325ca5c4eaa49bf
-  translated_at: 2026-06-25
+  source_sha256: 61e22da790d0aa82a96b28409247cbfec94016b3214f7d644198a6518213722a
+  translated_at: 2026-06-26
   status: complete
 ---
 > 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
@@ -20,7 +20,7 @@ i18n:
 > | **Palier (Tier)** | **TIER-0** — le chemin de publication du contenu ; feeds et découverte dérivent de ses événements |
 > | **Binaire déployable** | `crates/apps/post-server` (crate bibliothèque : `crates/services/post`) |
 > | **Bases de données** | ScyllaDB keyspace `post` (2 tables) |
-> | **Asynchrone** | publie `post.published` / `post.updated` / `post.deleted` · ne consomme rien |
+> | **Asynchrone** | publie `post.v1.events` (unifié) + `post.published` / `post.updated` / `post.deleted` (legacy) · ne consomme rien |
 > | **Appelants amont** | `<TODO: passerelle>` |
 > | **Dépendances aval** | ScyllaDB, Kafka |
 > | **SLO** | `<TODO>` dispo · `GetPost` p99 `<TODO>` · publication p99 `<TODO>` |
@@ -147,11 +147,14 @@ service PostService {
 
 **Publie :**
 
-| Topic | Trigger | Key | Consumers |
+| Topic | Déclencheur | Clé | Consommateurs |
 |---|---|---|---|
+| `post.v1.events` | chaque événement de cycle de vie (`PostPublished` / `PostUpdated` / `PostDeleted`) | `post_id` | `search` (indexation des posts) |
 | `post.published` | `PublishPost` success | `post_id` | `timeline`, `geo-discovery`, `notification` |
 | `post.updated` | `UpdatePost` success | `post_id` | `<TODO>` |
 | `post.deleted` | `DeletePost` success | `post_id` | `timeline`, `geo-discovery` |
+
+> **Deux styles d'émission, par conception.** `post.v1.events` est le flux unifié et versionné (la convention de la flotte, comme `moderation.v1.events` / `profile.v1.events`) : le `DomainEvent` entier tagué en interne, clé `post_id`. Les topics legacy par-type (`post.published` / `.updated` / `.deleted`, charges utiles brutes) sont conservés pour leurs consommateurs existants (`timeline` / `geo-discovery` / `notification`) ; chaque événement est publié sur **les deux**. Migrer ces consommateurs vers `post.v1.events` et retirer les topics legacy est un nettoyage futur.
 
 **Consomme :** rien.
 

--- a/crates/services/post/README.md
+++ b/crates/services/post/README.md
@@ -9,7 +9,7 @@
 > | **Tier** | **TIER-0** — the content publish path; feeds and discovery derive from its events |
 > | **Deployable** | `crates/apps/post-server` (library crate: `crates/services/post`) |
 > | **Datastores** | ScyllaDB keyspace `post` (2 tables) |
-> | **Async** | publishes `post.published` / `post.updated` / `post.deleted` · consumes nothing |
+> | **Async** | publishes `post.v1.events` (unified) + `post.published` / `post.updated` / `post.deleted` (legacy) · consumes nothing |
 > | **Upstream callers** | `<TODO: gateway>` |
 > | **Downstream deps** | ScyllaDB, Kafka |
 > | **SLO** | `<TODO>` avail · `GetPost` p99 `<TODO>` · publish p99 `<TODO>` |
@@ -136,9 +136,12 @@ service PostService {
 
 | Topic | Trigger | Key | Consumers |
 |---|---|---|---|
+| `post.v1.events` | every lifecycle event (`PostPublished` / `PostUpdated` / `PostDeleted`) | `post_id` | `search` (post indexing) |
 | `post.published` | `PublishPost` success | `post_id` | `timeline`, `geo-discovery`, `notification` |
 | `post.updated` | `UpdatePost` success | `post_id` | `<TODO>` |
 | `post.deleted` | `DeletePost` success | `post_id` | `timeline`, `geo-discovery` |
+
+> **Two emission styles, by design.** `post.v1.events` is the unified, versioned stream (the fleet convention, like `moderation.v1.events` / `profile.v1.events`): the whole internally-tagged `DomainEvent`, keyed by `post_id`. The legacy per-type topics (`post.published` / `.updated` / `.deleted`, bare payloads) are retained for their existing consumers (`timeline` / `geo-discovery` / `notification`); every event is published to **both**. Migrating those consumers onto `post.v1.events` and retiring the legacy topics is a future cleanup.
 
 **Consumes:** none.
 

--- a/crates/services/post/src/infrastructure/publisher/kafka_event_publisher.rs
+++ b/crates/services/post/src/infrastructure/publisher/kafka_event_publisher.rs
@@ -8,9 +8,17 @@ use crate::application::port::EventPublisher;
 use crate::domain::event::{DomainEvent, PostDeletedEvent, PostPublishedEvent, PostUpdatedEvent};
 use crate::error::PostError;
 
+// Legacy per-type topics (bare payloads), consumed by notification / geo-discovery
+// / timeline. Retained for backward compatibility.
 const TOPIC_PUBLISHED: &str = "post.published";
 const TOPIC_UPDATED:   &str = "post.updated";
 const TOPIC_DELETED:   &str = "post.deleted";
+
+// The unified, versioned stream (the fleet convention, like `moderation.v1.events`
+// / `profile.v1.events`): the whole internally-tagged `DomainEvent`, keyed by
+// `post_id`. Consumed by `search`. Published ALONGSIDE the legacy topics so the
+// existing per-type consumers keep working.
+const TOPIC_V1: &str = "post.v1.events";
 
 fn transport_err(e: TransportError) -> PostError {
     PostError::DomainViolation {
@@ -32,12 +40,35 @@ impl KafkaEventPublisher {
 #[async_trait]
 impl EventPublisher for KafkaEventPublisher {
     async fn publish(&self, event: &DomainEvent) -> Result<(), PostError> {
+        // 1. Legacy per-type topics (existing consumers).
         match event {
-            DomainEvent::PostPublished(e) => publish_published(&self.producer, e).await,
-            DomainEvent::PostUpdated(e)   => publish_updated(&self.producer, e).await,
-            DomainEvent::PostDeleted(e)   => publish_deleted(&self.producer, e).await,
+            DomainEvent::PostPublished(e) => publish_published(&self.producer, e).await?,
+            DomainEvent::PostUpdated(e)   => publish_updated(&self.producer, e).await?,
+            DomainEvent::PostDeleted(e)   => publish_deleted(&self.producer, e).await?,
         }
+        // 2. Unified `post.v1.events` stream (the fleet convention; consumed by search).
+        publish_v1(&self.producer, event).await
     }
+}
+
+/// Publishes the whole internally-tagged event to `post.v1.events`, keyed by
+/// `post_id`. `DomainEvent` is `#[serde(tag = "type")]`, so the wire payload is
+/// `{"type":"PostPublished", ...}` — the shape `search` deserializes.
+async fn publish_v1(
+    producer: &KafkaProducerHandle,
+    event:    &DomainEvent,
+) -> Result<(), PostError> {
+    let (post_id, profile_id, event_type) = match event {
+        DomainEvent::PostPublished(e) => (&e.post_id, &e.profile_id, "PostPublished"),
+        DomainEvent::PostUpdated(e)   => (&e.post_id, &e.profile_id, "PostUpdated"),
+        DomainEvent::PostDeleted(e)   => (&e.post_id, &e.profile_id, "PostDeleted"),
+    };
+    let envelope = EventEnvelope::new(TOPIC_V1, post_id.clone(), event.clone())
+        .with_header("event_type", event_type)
+        .with_header("post_id",    post_id.clone())
+        .with_header("profile_id", profile_id.clone());
+
+    producer.publish(envelope).await.map_err(transport_err)
 }
 
 async fn publish_published(
@@ -77,4 +108,29 @@ async fn publish_deleted(
         .with_header("profile_id",  event.profile_id.clone());
 
     producer.publish(envelope).await.map_err(transport_err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::event::PostPublishedEvent;
+
+    /// Locks the `post.v1.events` wire shape the `search` decoder depends on:
+    /// internally tagged on `type`, with the fields flattened alongside it.
+    #[test]
+    fn post_v1_payload_is_internally_tagged() {
+        let event = DomainEvent::PostPublished(PostPublishedEvent {
+            post_id:         "post-1".to_owned(),
+            profile_id:      "prof-9".to_owned(),
+            kind:            "text".to_owned(),
+            published_at_ms: 1_700_000_000_000,
+            audio_id:        None,
+            audio_kind:      None,
+        });
+        let value = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(value["type"], "PostPublished");
+        assert_eq!(value["post_id"], "post-1");
+        assert_eq!(value["profile_id"], "prof-9");
+        assert_eq!(value["published_at_ms"], 1_700_000_000_000_i64);
+    }
 }


### PR DESCRIPTION
## Summary

`search` subscribes to **`post.v1.events`**, but `post` only emitted the **legacy per-type topics** (`post.published` / `post.updated` / `post.deleted`, bare payloads) — so search would never receive post events. This was the open finding surfaced while building profile indexing.

Those legacy topics are **actively consumed** by `timeline`, `geo-discovery`, and `notification`, so they can't simply be removed.

## Fix: dual-publish (non-breaking)
`KafkaEventPublisher` now **also** emits the whole internally-tagged `DomainEvent` to **`post.v1.events`**, keyed by `post_id`:
- It's the unified, versioned stream matching the fleet convention (`moderation.v1.events` / `profile.v1.events`).
- `DomainEvent` is `#[serde(tag = "type")]`, so the payload is `{"type":"PostPublished", ...}` — exactly the shape search deserializes.
- The legacy topics are **unchanged**; every event is published to **both**, so existing consumers keep working.

## Testing
- A serde-shape unit test (`post_v1_payload_is_internally_tagged`) locks the `post.v1.events` wire format search depends on.
- `cargo test -p post --lib` green; `cargo check --workspace` green; clippy clean on the changed file (3 pre-existing warnings in `domain/aggregate/post.rs` are unrelated).
- README EN+FR Events contract updated; i18n drift gate green.

## Notes
- This completes the search ingestion picture: with this + the profile-events PR (#457) merged, search's post and profile consumers both receive real events.
- Migrating `timeline` / `geo-discovery` / `notification` onto `post.v1.events` and retiring the legacy topics is a documented **future cleanup**, intentionally out of scope here (it touches three services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmukNZpRWNHYzkHiCoNAWr