### PR TITLE
feat(media): control-plane media service — presigned uploads, async image pipeline, CDN delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +85,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -103,12 +127,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -261,6 +317,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -415,6 +529,12 @@ checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "blurhash"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79769241dcd44edf79a732545e8b5cec84c247ac060f5252cd51885d093a8fc"
 
 [[package]]
 name = "bollard"
@@ -494,16 +614,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -528,6 +666,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -621,6 +761,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "comment"
@@ -804,10 +950,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1204,6 +1378,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,10 +1460,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ferroid"
@@ -1320,6 +1544,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1656,6 +1890,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1976,17 @@ name = "h3o-bit"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b42eb4efef1f96510ae1a33b2682562a677d504641e9903a77bf5c666b9013e"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2140,6 +2395,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2551,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2316,10 +2632,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"
@@ -2394,6 +2726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2788,64 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "media"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "blurhash",
+ "chrono",
+ "cqrs",
+ "error",
+ "fred",
+ "http",
+ "image",
+ "media-api",
+ "moderation-api",
+ "postgres",
+ "prost-types",
+ "redis-storage",
+ "reqwest",
+ "rusty-s3",
+ "serde",
+ "serde_json",
+ "service-runtime",
+ "sha2 0.11.0",
+ "sqlx",
+ "test-support",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-reflection",
+ "tracing",
+ "transport",
+ "url",
+ "uuid",
+ "validation",
+]
+
+[[package]]
+name = "media-api"
+version = "0.1.0"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "media-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "media",
+ "service-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -2469,6 +2878,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2548,6 +2967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +3000,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,10 +3025,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notification"
@@ -2730,6 +3189,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -3021,6 +3491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,6 +3596,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3344,6 +3839,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,6 +3977,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +4004,22 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3616,12 +4161,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3665,7 +4280,7 @@ dependencies = [
  "cookie-factory",
  "crc16",
  "log",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -3819,6 +4434,12 @@ dependencies = [
  "hmac",
  "subtle",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -3976,6 +4597,25 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-s3"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa883f1b986a5249641e574ca0e11ac4fb9970b009c6fbb96fedaf4fa78db8"
+dependencies = [
+ "base64 0.21.7",
+ "hmac",
+ "md-5",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "time",
+ "url",
+ "zeroize",
+]
 
 [[package]]
 name = "ryu"
@@ -4409,6 +5049,21 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
 ]
 
 [[package]]
@@ -4994,6 +5649,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5766,6 +6435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "validate-core"
 version = "0.1.0"
 
@@ -5980,6 +6660,12 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -6428,6 +7114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6549,3 +7241,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/services/auth",
     "crates/services/moderation",
     "crates/services/search",
+    "crates/services/media",
     "crates/apps/chat-server",
     "crates/apps/profile-server",
     "crates/apps/social-graph-server",
@@ -45,6 +46,7 @@ members = [
     "crates/apps/auth-server",
     "crates/apps/moderation-server",
     "crates/apps/search-server",
+    "crates/apps/media-server",
     "crates/apps/migrator",
     "crates/contracts/social-graph-api",
     "crates/contracts/account-api",
@@ -59,6 +61,7 @@ members = [
     "crates/contracts/auth-api",
     "crates/contracts/moderation-api",
     "crates/contracts/search-api",
+    "crates/contracts/media-api",
 ]
 resolver = "2"
 
@@ -109,6 +112,7 @@ timeline-api = { path = "crates/contracts/timeline-api" }
 auth-api = { path = "crates/contracts/auth-api" }
 moderation-api = { path = "crates/contracts/moderation-api" }
 search-api = { path = "crates/contracts/search-api" }
+media-api = { path = "crates/contracts/media-api" }
 account          = { path = "crates/services/account" }
 chat             = { path = "crates/services/chat" }
 profile          = { path = "crates/services/profile" }
@@ -122,6 +126,7 @@ timeline         = { path = "crates/services/timeline" }
 auth             = { path = "crates/services/auth" }
 moderation       = { path = "crates/services/moderation" }
 search           = { path = "crates/services/search" }
+media            = { path = "crates/services/media" }
 
 
 # Communs
@@ -229,3 +234,8 @@ reqwest = { version = "0.12.28", features = ["json", "rustls-tls"] }
 # Tests
 testcontainers = "0.26"
 testcontainers-modules = { version = "0.14" }
+
+# Media — object storage (presigned URLs; bytes go client↔S3 direct) + image pipeline
+rusty-s3 = "0.5"
+image = "0.25"
+blurhash = "0.2"

--- a/crates/apps/media-server/Cargo.toml
+++ b/crates/apps/media-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name                 = "media-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the media service — a thin entrypoint over the shared fleet runtime."
+
+[dependencies]
+media           = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/media-server/src/main.rs
+++ b/crates/apps/media-server/src/main.rs
@@ -1,0 +1,18 @@
+//! `media-server` — the deployable media binary. A one-liner over the shared fleet
+//! runtime: telemetry, externalized config + hot-reload, ingress layers, dynamic
+//! health, and graceful shutdown are all the runtime's job. The Plane B processing
+//! consumer and the moderation takedown consumer self-spawn inside
+//! `MediaService::build`. The control plane carries no bytes (see `media-api`).
+
+use std::net::SocketAddr;
+
+use media::service::MediaService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr: SocketAddr = std::env::var("MEDIA_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50063".to_owned())
+        .parse()?;
+
+    service_runtime::serve::<MediaService>(addr).await
+}

--- a/crates/contracts/media-api/Cargo.toml
+++ b/crates/contracts/media-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name        = "media-api"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Generated gRPC contract for media.v1 — server + client stubs and reflection descriptor."
+
+[dependencies]
+tonic       = { workspace = true }
+tonic-prost = { workspace = true }
+prost       = { workspace = true }
+prost-types = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = { workspace = true }

--- a/crates/contracts/media-api/build.rs
+++ b/crates/contracts/media-api/build.rs
@@ -1,0 +1,20 @@
+//! Compiles the media.v1 contract into server + client stubs plus a reflection
+//! descriptor set, from the shared contracts/proto root (the single IDL source).
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("media_descriptor.bin");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(
+            &[
+                "../proto/media/v1/enums.proto",
+                "../proto/media/v1/messages.proto",
+                "../proto/media/v1/service.proto",
+            ],
+            &["../proto/"],
+        )?;
+    Ok(())
+}

--- a/crates/contracts/media-api/src/lib.rs
+++ b/crates/contracts/media-api/src/lib.rs
@@ -1,0 +1,20 @@
+//! `media-api` — the generated gRPC contract for `media.v1` (server + client
+//! stubs + descriptor), compiled from the shared `contracts/proto` IDL.
+//! Consumers depend on this crate instead of recompiling the `.proto` files.
+//!
+//! Contract rule (the load-bearing one, enforced at proto review): **the media
+//! control plane never carries bytes.** Every `media.v1` message is a small
+//! control message — an upload *ticket*, an asset's *metadata*, a *delivery* URL.
+//! A JPEG or an MP4 must never appear inside a request or response: raw bytes flow
+//! on a separate data plane (client ⇄ object storage ⇄ CDN) that the service
+//! *authorizes and orchestrates* but never *transports*. Pre-signed direct-to-
+//! object-store uploads (Plane A) and CDN/​signed-URL delivery resolution
+//! (Plane C) are the two halves of that guarantee; the async transformation
+//! pipeline (Plane B) is Kafka-driven and off the synchronous path. Events are
+//! serde structs (`media.v1.events`), not proto. See
+//! `project_media_service_blueprint`.
+tonic::include_proto!("media.v1");
+
+/// Encoded protobuf descriptor set for gRPC server reflection.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("media_descriptor");

--- a/crates/contracts/proto/media/v1/enums.proto
+++ b/crates/contracts/proto/media/v1/enums.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package media.v1;
+
+option java_package = "com.coreplatform.media.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/media/v1;mediav1";
+
+// The kind of media an asset holds. `kind` drives the validation policy (MIME
+// allowlist, size ceiling), the rendition ladder generated for it, and the
+// content-addressed storage path. v1 is IMAGES-FIRST; video transcoding is a
+// planned fast-follow phase and will be added as a new, additive enum value
+// (MEDIA_KIND_VIDEO) — never by renumbering these.
+enum MediaKind {
+    MEDIA_KIND_UNSPECIFIED = 0;
+    // A profile/account avatar — square-cropped rendition ladder.
+    MEDIA_KIND_AVATAR      = 1;
+    // An image attached to a post — feed-sized rendition ladder.
+    MEDIA_KIND_POST_IMAGE  = 2;
+}
+
+// The asset lifecycle state machine. An asset is created PENDING at ticket time,
+// advances through UPLOADED → PROCESSING as the pipeline runs, and lands in one of
+// the terminal-ish states READY / FAILED / QUARANTINED / DELETED. The publish path
+// of `post`/`profile` never waits on this — a post may reference a PENDING/
+// PROCESSING asset and render the blurhash placeholder until it reaches READY.
+enum AssetState {
+    MEDIA_ASSET_STATE_UNSPECIFIED = 0;
+    // Ticket issued; awaiting the client's direct-to-object-store upload.
+    MEDIA_ASSET_STATE_PENDING     = 1;
+    // Bytes landed and finalize was accepted; pre-processing.
+    MEDIA_ASSET_STATE_UPLOADED    = 2;
+    // The async transformation pipeline is running (validate → screen → derive).
+    MEDIA_ASSET_STATE_PROCESSING  = 3;
+    // All renditions are available; the asset is deliverable.
+    MEDIA_ASSET_STATE_READY       = 4;
+    // Processing failed terminally (corrupt media, unsupported codec, etc.).
+    MEDIA_ASSET_STATE_FAILED      = 5;
+    // A moderation takedown / compliance hold revoked delivery. Bytes may be
+    // preserved (legal hold) even though the asset is undeliverable.
+    MEDIA_ASSET_STATE_QUARANTINED = 6;
+    // Hard-deleted (bytes purged, honoring the dedup refcount). Absent a legal hold.
+    MEDIA_ASSET_STATE_DELETED     = 7;
+}
+
+// A derivative of an asset. Each rendition is a separately-stored, content-
+// addressed object; the caller receives a URL to it via the delivery plane, never
+// the bytes. v1 renditions are image size buckets; the concrete format (WebP/AVIF/
+// JPEG) is carried per-rendition by its mime_type, not by this enum.
+enum RenditionKind {
+    MEDIA_RENDITION_KIND_UNSPECIFIED = 0;
+    // The validated master (post-probe, pre-derivation source of truth).
+    MEDIA_RENDITION_KIND_ORIGINAL    = 1;
+    MEDIA_RENDITION_KIND_THUMBNAIL   = 2;
+    MEDIA_RENDITION_KIND_SMALL       = 3;
+    MEDIA_RENDITION_KIND_MEDIUM      = 4;
+    MEDIA_RENDITION_KIND_LARGE       = 5;
+}
+
+// How a delivery URL is brokered. PUBLIC media gets a content-addressed, immutable
+// CDN URL (cacheable forever — an edit is a new asset = a new hash = a new URL).
+// SIGNED media gets a short-lived signed URL minted per request, only after the
+// edge has authorized the viewer.
+enum DeliveryVisibility {
+    MEDIA_DELIVERY_VISIBILITY_UNSPECIFIED = 0;
+    MEDIA_DELIVERY_VISIBILITY_PUBLIC      = 1;
+    MEDIA_DELIVERY_VISIBILITY_SIGNED      = 2;
+}

--- a/crates/contracts/proto/media/v1/messages.proto
+++ b/crates/contracts/proto/media/v1/messages.proto
@@ -1,0 +1,209 @@
+syntax = "proto3";
+
+package media.v1;
+
+import "media/v1/enums.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.coreplatform.media.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/media/v1;mediav1";
+
+// ── Core asset projections ────────────────────────────────────────────────────
+
+// The metadata view of an asset. The contract (LOCKED): this carries metadata and
+// content-addressed storage keys ONLY — never bytes. Bytes are uploaded direct to
+// object storage (Plane A) and delivered via CDN / signed URLs (Plane C). `media`
+// is the System-of-Record for everything in this message; object storage is the
+// SoR for the bytes those keys point at.
+message Asset {
+    string                      id           = 1;
+    // The owning actor (edge-authenticated; the asset's authorization principal).
+    string                      owner_id     = 2;
+    MediaKind                   kind         = 3;
+    AssetState                  state        = 4;
+    // The VERIFIED MIME type (from magic-byte probe on finalize), not the
+    // client-declared one.
+    string                      mime_type    = 5;
+    uint64                      byte_size    = 6;
+    uint32                      width        = 7;
+    uint32                      height       = 8;
+    // Lowercase-hex SHA-256 of the original bytes. Drives content-addressing and
+    // (when enabled) cross-owner dedup. Empty until the upload is finalized.
+    string                      content_hash = 9;
+    // A tiny BlurHash placeholder string for progressive render while PROCESSING.
+    // Empty until computed.
+    string                      blurhash     = 10;
+    // The derivative catalog. Empty until the pipeline produces them.
+    repeated Rendition          renditions   = 11;
+    google.protobuf.Timestamp   created_at   = 12;
+    google.protobuf.Timestamp   updated_at   = 13;
+}
+
+// One derivative in an asset's catalog. `storage_key` is an object-store key, not a
+// URL and not bytes — the caller resolves a delivery URL for it via Plane C.
+message Rendition {
+    RenditionKind  kind        = 1;
+    string         mime_type   = 2;
+    // Content-addressed object-store key for this rendition.
+    string         storage_key = 3;
+    uint32         width       = 4;
+    uint32         height      = 5;
+    uint64         byte_size   = 6;
+}
+
+// ── Plane A · Upload brokerage (no bytes — pre-signed direct-to-store) ─────────
+
+message IssueUploadTicketRequest {
+    // The uploading actor (edge-resolved). The service self-authorizes nothing.
+    string     owner_id            = 1;
+    MediaKind  kind                = 2;
+    // The client's claimed content type. VERIFIED server-side on finalize against
+    // the actual magic bytes; a mismatch fails the asset (MED-6001).
+    string     declared_mime_type  = 3;
+    uint64     declared_size_bytes = 4;
+    // Optional lowercase-hex SHA-256 the client intends to upload. When dedup is
+    // enabled this may short-circuit to an existing asset; otherwise it is recorded
+    // for integrity verification on finalize.
+    string     content_sha256      = 5;
+    // Optional caller idempotency key so a retried ticket request returns the same
+    // asset/ticket rather than reserving a new one.
+    string     idempotency_key     = 6;
+}
+
+message IssueUploadTicketResponse {
+    string        asset_id = 1;
+    UploadTicket  ticket   = 2;
+    // True when content-addressed dedup matched existing bytes: `asset_id` already
+    // refers to a READY asset and no upload is needed (the `ticket` is then unset).
+    // Always false when dedup is disabled (the default — it is gated behind a
+    // flag). See the blueprint's open-fork B.
+    bool          deduplicated = 3;
+}
+
+// A pre-signed upload plan. Carries the URL the client PUTs the bytes to and the
+// constraints the signature enforces — never bytes themselves. v1 is a single
+// pre-signed PUT (images); a multipart plan for large video is a fast-follow.
+message UploadTicket {
+    // The pre-signed object-store URL to PUT the bytes to (direct, off-mesh).
+    string                      upload_url       = 1;
+    // The HTTP method the pre-signed URL expects (e.g. "PUT").
+    string                      method           = 2;
+    // Headers the client MUST send with the upload for the signature to validate
+    // (e.g. Content-Type, content-length range, server-side-encryption headers).
+    map<string, string>         required_headers = 3;
+    // The hard byte ceiling the signed policy enforces.
+    uint64                      max_size_bytes   = 4;
+    // After this instant the ticket is dead; request a fresh one (MED-1004).
+    google.protobuf.Timestamp   expires_at       = 5;
+}
+
+message CommitUploadRequest {
+    string  asset_id       = 1;
+    // The object ETag returned by the store on PUT, for an integrity cross-check.
+    string  etag           = 2;
+    // Optional client-computed lowercase-hex SHA-256, verified against the stored
+    // object on finalize.
+    string  content_sha256 = 3;
+}
+
+message CommitUploadResponse {
+    // The asset after finalize — typically UPLOADED or already PROCESSING. The S3
+    // event notification is the authoritative finalize trigger; this RPC is the
+    // low-latency nudge, and the two converge idempotently.
+    Asset  asset = 1;
+}
+
+message AbortUploadRequest {
+    string  asset_id = 1;
+    string  owner_id = 2;
+}
+
+message AbortUploadResponse {}
+
+// ── Asset metadata ────────────────────────────────────────────────────────────
+
+message GetAssetRequest {
+    string  asset_id = 1;
+}
+
+message GetAssetResponse {
+    Asset  asset = 1;
+}
+
+message DeleteAssetRequest {
+    string  asset_id = 1;
+    // The requesting actor (edge-resolved); must own the asset.
+    string  owner_id = 2;
+}
+
+// Hard-delete is refused with PERMISSION_DENIED (MED-7003) while a legal hold is
+// active — compliance preservation overrides owner/GDPR erasure.
+message DeleteAssetResponse {}
+
+// ── Plane C · Delivery resolution (hot read; CDN / signed URLs, no bytes) ─────
+
+message ResolveDeliveryRequest {
+    string              asset_id   = 1;
+    // Preferred rendition; UNSPECIFIED ⇒ a sensible default for the asset's kind.
+    RenditionKind       preferred  = 2;
+    // Requested visibility; UNSPECIFIED ⇒ the asset's default delivery policy.
+    DeliveryVisibility  visibility = 3;
+}
+
+message ResolveDeliveryResponse {
+    DeliveredMedia  media = 1;
+}
+
+// The resolved delivery view for one asset — URLs only, never bytes. Fails OPEN:
+// when the asset is still PROCESSING (or resolution is partial) it carries the
+// blurhash placeholder and `degraded = true` rather than erroring the read path.
+message DeliveredMedia {
+    string                       asset_id   = 1;
+    // So the caller can choose to render a placeholder for a not-yet-READY asset.
+    AssetState                   state      = 2;
+    // Progressive-render placeholder; present even before renditions resolve.
+    string                       blurhash   = 3;
+    repeated DeliveredRendition  renditions = 4;
+    // Fail-open marker: media could not fully resolve (engine/CDN partial); the
+    // caller renders what it can.
+    bool                         degraded   = 5;
+}
+
+message DeliveredRendition {
+    RenditionKind               kind           = 1;
+    // A CDN URL — content-addressed-immutable (PUBLIC) or short-lived signed
+    // (SIGNED). Never bytes.
+    string                      url            = 2;
+    DeliveryVisibility          visibility     = 3;
+    // Set for SIGNED URLs (their expiry); unset for PUBLIC immutable URLs.
+    google.protobuf.Timestamp   url_expires_at = 4;
+    uint32                      width          = 5;
+    uint32                      height         = 6;
+}
+
+message BatchResolveDeliveryRequest {
+    repeated string     asset_ids  = 1;
+    RenditionKind       preferred  = 2;
+    DeliveryVisibility  visibility = 3;
+}
+
+message BatchResolveDeliveryResponse {
+    // One entry per resolvable asset (keyed by `DeliveredMedia.asset_id`). An asset
+    // that cannot be resolved (missing/quarantined) is OMITTED rather than failing
+    // the batch — the boundary fails open for feed hydration.
+    repeated DeliveredMedia  media = 1;
+}
+
+// ── Ops ───────────────────────────────────────────────────────────────────────
+
+message ReprocessRequest {
+    string  asset_id = 1;
+    // Why (e.g. a new rendition-ladder version). Audit-only.
+    string  reason   = 2;
+}
+
+message ReprocessResponse {
+    // The asset, moved back to PROCESSING.
+    Asset  asset = 1;
+}

--- a/crates/contracts/proto/media/v1/service.proto
+++ b/crates/contracts/proto/media/v1/service.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package media.v1;
+
+import "media/v1/messages.proto";
+
+option java_package = "com.coreplatform.media.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/media/v1;mediav1";
+
+// MediaService is the platform's media CONTROL PLANE: the System-of-Record for
+// media assets and their processing lifecycle, and the broker of the byte plane
+// around them.
+//
+// The load-bearing contract (enforced at proto review): NO message on this surface
+// carries a `bytes` payload. Uploads are brokered as pre-signed direct-to-object-
+// store URLs (Plane A: IssueUploadTicket); the async transformation pipeline runs
+// off this synchronous surface, driven by Kafka (Plane B); and delivery is brokered
+// as CDN / short-lived signed URLs (Plane C: ResolveDelivery). Bytes flow client ⇄
+// object storage ⇄ CDN — a path this service authorizes and orchestrates but never
+// transports. If a JPEG ever appears in a request or response here, the design has
+// failed.
+//
+// Failure posture is mixed: the delivery plane is fail-OPEN (a not-yet-ready or
+// unresolvable asset yields a blurhash placeholder + DeliveredMedia.degraded, never
+// an upstream block), while the compliance gate is fail-CLOSED (CSAM-class media is
+// screened before it can go public, and a legal hold blocks deletion). Lifecycle
+// events are published on `media.v1.events` (serde structs, not proto).
+service MediaService {
+
+    // ── Plane A — upload brokerage ────────────────────────────────────────────
+
+    // Reserve an asset (PENDING) and return a pre-signed URL the client PUTs the
+    // bytes to, direct to object storage. The bytes never traverse this RPC.
+    rpc IssueUploadTicket(IssueUploadTicketRequest) returns (IssueUploadTicketResponse);
+
+    // Low-latency finalize nudge after the client's direct upload completes. The
+    // object-store event notification is the authoritative trigger; the two
+    // converge idempotently.
+    rpc CommitUpload(CommitUploadRequest) returns (CommitUploadResponse);
+
+    // Cancel a reserved-but-unfinalized upload, releasing the asset.
+    rpc AbortUpload(AbortUploadRequest) returns (AbortUploadResponse);
+
+    // ── Asset metadata ────────────────────────────────────────────────────────
+
+    // Fetch an asset's metadata + rendition catalog (no bytes, no URLs — use
+    // ResolveDelivery for URLs).
+    rpc GetAsset(GetAssetRequest) returns (GetAssetResponse);
+
+    // Owner-initiated hard delete. Refused (PERMISSION_DENIED, MED-7003) while a
+    // legal hold is active.
+    rpc DeleteAsset(DeleteAssetRequest) returns (DeleteAssetResponse);
+
+    // ── Plane C — delivery resolution (hot read) ──────────────────────────────
+
+    // Resolve one asset to a delivery URL set (CDN immutable or short-lived
+    // signed). Fails open to a placeholder.
+    rpc ResolveDelivery(ResolveDeliveryRequest) returns (ResolveDeliveryResponse);
+
+    // Resolve many assets in one round-trip (feed/timeline hydration); unresolvable
+    // assets are omitted, not errored.
+    rpc BatchResolveDelivery(BatchResolveDeliveryRequest) returns (BatchResolveDeliveryResponse);
+
+    // ── Ops ───────────────────────────────────────────────────────────────────
+
+    // Regenerate an asset's renditions (e.g. after a rendition-ladder change),
+    // moving it back to PROCESSING.
+    rpc Reprocess(ReprocessRequest) returns (ReprocessResponse);
+}

--- a/crates/platform/test-support/Cargo.toml
+++ b/crates/platform/test-support/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 [dependencies]
 # ── Container orchestration ──────────────────────────────────────────────────
 testcontainers         = { workspace = true }
-testcontainers-modules = { workspace = true, features = ["scylladb", "redis", "kafka", "postgres"] }
+testcontainers-modules = { workspace = true, features = ["scylladb", "redis", "kafka", "postgres", "minio"] }
 rdkafka                = { workspace = true }
 
 # ── Async runtime ────────────────────────────────────────────────────────────

--- a/crates/platform/test-support/src/containers.rs
+++ b/crates/platform/test-support/src/containers.rs
@@ -20,6 +20,7 @@ use testcontainers::core::WaitFor;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage, ImageExt};
 use testcontainers_modules::kafka::apache::{Kafka, KAFKA_PORT};
+use testcontainers_modules::minio::MinIO;
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::scylladb::ScyllaDB;
 use tokio::sync::OnceCell;
@@ -34,12 +35,15 @@ const SCYLLA_CQL_PORT: u16 = 9042;
 const POSTGRES_PORT: u16 = 5432;
 /// Internal OpenSearch REST port.
 const OPENSEARCH_PORT: u16 = 9200;
+/// Internal MinIO S3 API port.
+const MINIO_PORT: u16 = 9000;
 
 static SCYLLA: OnceCell<ContainerAsync<ScyllaDB>> = OnceCell::const_new();
 static REDIS: OnceCell<ContainerAsync<GenericImage>> = OnceCell::const_new();
 static KAFKA: OnceCell<ContainerAsync<Kafka>> = OnceCell::const_new();
 static POSTGRES: OnceCell<ContainerAsync<Postgres>> = OnceCell::const_new();
 static OPENSEARCH: OnceCell<ContainerAsync<GenericImage>> = OnceCell::const_new();
+static MINIO: OnceCell<ContainerAsync<MinIO>> = OnceCell::const_new();
 
 static SCYLLA_MIGRATED: OnceCell<()> = OnceCell::const_new();
 static POSTGRES_MIGRATED: OnceCell<()> = OnceCell::const_new();
@@ -138,6 +142,31 @@ pub async fn opensearch_ready() -> String {
         .get_host_port_ipv4(OPENSEARCH_PORT)
         .await
         .expect("failed to resolve the mapped OpenSearch port");
+    format!("http://127.0.0.1:{port}")
+}
+
+// ── MinIO (S3-compatible object storage) ─────────────────────────────────────
+
+/// Boots a single MinIO container (once) and returns its S3 API base URL, e.g.
+/// `http://127.0.0.1:49xxx`. Default credentials are `minioadmin:minioadmin`.
+///
+/// There is no migration step — the media adapter creates its bucket idempotently
+/// (`S3Client::ensure_bucket`) at harness start, the object-storage analogue of how
+/// the OpenSearch adapter self-creates its indices.
+pub async fn minio_ready() -> String {
+    let container = MINIO
+        .get_or_init(|| async {
+            MinIO::default()
+                .start()
+                .await
+                .expect("failed to start the MinIO test container")
+        })
+        .await;
+
+    let port = container
+        .get_host_port_ipv4(MINIO_PORT)
+        .await
+        .expect("failed to resolve the mapped MinIO port");
     format!("http://127.0.0.1:{port}")
 }
 

--- a/crates/services/media/Cargo.toml
+++ b/crates/services/media/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name        = "media"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Media microservice — the platform's media control plane: asset lifecycle SoR, async transformation pipeline, and CDN delivery brokerage (no bytes on the mesh)."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# Only the canonical error namespace (MED-XXXX) lives here today. Subsequent
+# phases add: domain/ (Phase 2: the Asset aggregate + lifecycle state machine,
+# Rendition catalog, UploadTicket, content-addressed VOs + the pure transition
+# logic), application/ + async ports (Phase 3: ObjectStore / AssetRepository /
+# RenditionRepository / DeliveryCache / Transcoder / ModerationScreen / CdnGateway
+# / EventPublisher + in-memory fakes), infrastructure/ adapters (Phase 4: the
+# S3/MinIO object-store adapter speaking pre-signed URLs, Postgres metadata SoR,
+# Redis hot-path delivery cache + ticket reservations, the image/transcode
+# processors, the CloudFront signer + the inbound finalize/moderation consumers),
+# and the composition root + tonic/service-runtime wiring (Phase 5). Dependencies
+# grow per phase — kept minimal here.
+[dependencies]
+# ── Contracts ─────────────────────────────────────────────────────────────────
+media-api = { workspace = true }
+anyhow    = { workspace = true }
+
+# ── Shared platform infrastructure ────────────────────────────────────────────
+error      = { workspace = true }
+validation = { workspace = true }
+
+# ── Domain types (Phase 2): pure, clock-injected asset model ───────────────────
+serde  = { workspace = true }
+uuid   = { workspace = true }
+chrono = { workspace = true }
+
+# ── Application layer (Phase 3): CQRS query bus + async ports ───────────────────
+cqrs        = { workspace = true }
+async-trait = { workspace = true }
+# tokio is a runtime dep: the pipeline wraps the moderation Screen call in a hard
+# timeout (`tokio::time::timeout`) so a slow gate can't wedge processing.
+tokio       = { workspace = true }
+
+# ── Storage delegates (the byte/metadata split: object storage is canonical for
+#    bytes [Phase 4, not a fleet crate]; Postgres is the asset-metadata SoR;
+#    Redis is the hot-path delivery cache + upload-ticket reservations) ─────────
+postgres-storage = { workspace = true }
+redis-storage    = { workspace = true }
+
+# ── Infrastructure adapters (Phase 4) ─────────────────────────────────────────
+# Fleet-standard: Postgres SoR (sqlx), Redis hot cache (fred), Kafka publisher
+# (transport), moderation Screen gRPC client (tonic + moderation-api).
+transport      = { workspace = true }
+moderation-api = { workspace = true }
+sqlx           = { workspace = true }
+fred           = { workspace = true }
+tonic          = { workspace = true }
+tracing        = { workspace = true }
+serde_json     = { workspace = true }
+# Byte plane: presigned S3 URLs (rusty-s3 mints, reqwest executes) + the image
+# pipeline (decode/probe/resize) + content hashing.
+rusty-s3 = { workspace = true }
+reqwest  = { workspace = true }
+image    = { workspace = true }
+blurhash = { workspace = true }
+sha2     = { workspace = true }
+url      = { workspace = true }
+
+# ── Server wiring (Phase 5): runtime, tonic ingress, reflection ────────────────
+service-runtime  = { workspace = true }
+tonic-reflection = { workspace = true }
+prost-types      = { workspace = true }
+
+# ── Error handling ────────────────────────────────────────────────────────────
+thiserror = { workspace = true }
+http      = { workspace = true }
+
+[features]
+# Gates the live, container-backed integration suite (Phase 6, tests/integration.rs).
+# Off by default so `cargo test -p media` stays a fast, infra-free unit run; the
+# live suite boots real MinIO (S3-compatible object storage) + Postgres + Redis
+# and is opt-in via `cargo test -p media --features integration-media`.
+integration-media = []
+
+[dev-dependencies]
+# Live integration suite (Phase 6): shared MinIO + Postgres + Redis containers.
+test-support = { workspace = true }

--- a/crates/services/media/README.fr.md
+++ b/crates/services/media/README.fr.md
@@ -1,0 +1,406 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: bbd88f1e864cedc2e1d7406e05379d9f760ae7a420c6effc6365505a00bc8200
+  translated_at: 2026-06-26
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, variables
+> d'environnement, topics Kafka, identifiants) sont volontairement laissés en anglais.
+
+# `media` — Déplacer pixels et images à l'échelle hyperscale **sans jamais mettre un octet sur le mesh**
+
+> **Fiche service** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Propriétaire** | `<team>` · `<#slack-channel>` |
+> | **Astreinte / escalade** | `<oncall-rotation>` → `<escalation-policy>` |
+> | **Tier** | TIER-1 (posture mixte : plan de diffusion fail-**open** · porte de conformité fail-**closed**) |
+> | **Déployable** | `crates/apps/media-server` (crate bibliothèque : `crates/services/media`) |
+> | **Datastores** | Stockage objet (S3 / MinIO — octets canoniques) · Postgres db `media` (SoR des métadonnées) · Redis Cluster (cache de diffusion + réservations de tickets) |
+> | **Async** | publie `media.v1.events` · consomme les notifications de finalisation du stockage objet, `moderation.v1.events`, `post.v1.events`, `profile.v1.events` (Kafka) |
+> | **Appelants amont** | gateway/BFF, `post`, `profile` |
+> | **Dépendances aval** | Stockage objet, CDN, `moderation` (Screen), Postgres, Redis, Kafka |
+> | **SLO** | `<99.9%>` dispo plan de contrôle · `<p99 ResolveDelivery < N ms>` · latence de traitement suivie, non garantie |
+
+---
+
+## 🎯 Vue d'ensemble & rôle du service
+
+`media` est le **plan de contrôle média** de la plateforme : il détient les *assets
+média et leur cycle de vie de traitement* — la machine à états de l'asset, le
+catalogue des dérivés/renditions, le schéma des clés de stockage, la politique de
+diffusion CDN, et les blocages de conformité qui régissent à la fois la diffusion
+et la suppression.
+
+Le problème difficile qu'il résout est le **déplacement de binaire à l'échelle
+hyperscale sans faire fondre le mesh synchrone** — une conception naïve « POST ta
+vidéo à l'API » fait transiter des téraoctets par gRPC et Kafka, couple chaque
+upload à un transcodage, et bloque `CreatePost` sur le traitement. Le motif qui
+résout cela est une **séparation stricte plan de contrôle / plan de données** : les
+octets circulent client ⇄ stockage objet ⇄ CDN sur un chemin pré-signé et direct
+que le service *autorise* mais ne *transporte* jamais ; le mesh ne transporte que
+des tickets, des métadonnées et des URLs.
+
+**Objectifs essentiels :** (1) **aucun octet sur le mesh** — jamais ; (2) le chemin
+de publication n'attend jamais le traitement (upload d'abord, référence et non
+octets, résolution progressive) ; (3) le contenu de classe CSAM est filtré
+**fail-closed** avant de pouvoir devenir public, et un blocage légal prime sur
+l'effacement RGPD.
+
+| Plan | Interface | Sync ? | Posture |
+|---|---|---|---|
+| **A — Courtage d'upload** | `IssueUploadTicket` → PUT pré-signé (les octets vont direct au stockage) | gRPC, étroit | fail-closed sur la politique |
+| **B — Transformation** | Kafka : finalize → validate → screen → derive → publish | async | la latence est un SLO |
+| **C — Résolution de diffusion** | `ResolveDelivery` / `BatchResolveDelivery` → URLs CDN / signées | gRPC, lecture chaude | fail-**open** (placeholder) |
+
+---
+
+## 📐 Architecture & concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), bus CQRS
+commande/requête, **stockage objet** comme magasin canonique des octets,
+**Postgres** comme SoR des métadonnées d'asset, **Redis** pour le cache de
+diffusion chaud + les réservations de tickets, Kafka pour le pipeline asynchrone et
+les événements de cycle de vie.
+
+```
+            ┌─────────── plan de contrôle (gRPC, sans octets) ─────┐
+ client ───▶│ IssueUploadTicket → asset(Pending) + PUT pré-signé   │
+            └──────────────────────────┬──────────────────────────┘
+                                        │  (les octets ne passent JAMAIS ici)
+   octets ══ PUT ════════════▶ [ Stockage objet ] ◀══ pull origine ══ [ CDN ]
+                                        │                                  ▲
+              finalize (event S3→Kafka  │  ou RPC CommitUpload)            │ URL signée/immuable
+                                        ▼                                  │
+   Plan B :  validate → Screen(moderation, fail-closed) → derive ──▶ renditions
+                                        │  émet media.v1.events (AssetReady …)
+                                        ▼
+   Plan C :  ResolveDelivery(asset_id) ─────────────────────────────▶ URL CDN
+```
+
+**Immutabilité adressée par contenu (le mécanisme clé).** Les clés de dérivés
+publics sont `/{kind}/{content_hash}/{rendition}.{ext}` avec
+`Cache-Control: immutable`. Une modification est un *nouvel asset* = un *nouveau
+hash* = une *nouvelle URL*, donc **l'invalidation de cache est une opération
+réservée aux retraits** — jamais une préoccupation du chemin d'édition. Le média
+privé utilise des URLs signées à courte durée de vie, émises par requête *après*
+que la périphérie a autorisé le spectateur.
+
+> **Invariants** (et où ils sont appliqués) : aucun message ne porte de charge
+> utile `bytes` (revue proto + règle de contrat `media-api`) ; les transitions
+> d'état d'asset sont gardées dans le domaine ; verrou optimiste sur la ligne
+> d'asset (`ConcurrentModification`) ; le stockage objet est canonique pour les
+> octets, Postgres pour la vérité-sur-les-octets ; un blocage légal empêche la
+> suppression définitive même sur un effacement RGPD du propriétaire.
+
+---
+
+## 📊 Objectifs de niveau de service (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objectif | Fenêtre | Mesuré par |
+|---|---|---|---|
+| Dispo plan de contrôle (non-5xx / non-`UNAVAILABLE`) | `<99.9%>` | 30j glissants | `<metric>` |
+| `ResolveDelivery` p99 (Plan C, lecture chaude) | `< <N> ms` | 1h | `<metric>` |
+| `IssueUploadTicket` p99 (Plan A) | `< <N> ms` | 1h | `<metric>` |
+| Latence de traitement (upload → `AssetReady`) | `< <N> s` p99 | live | lag `<consumer-group>` (SLO, non SLA — la publication n'attend jamais) |
+| Durabilité | aucune métadonnée d'asset acquittée perdue | — | commit Postgres ; 11-neuf du stockage objet |
+
+**Budget d'erreur :** `<0.1% / 30j ≈ 43m>`. **À l'épuisement :** `<gel du déploiement | page>`.
+
+---
+
+## 🔗 Dépendances & rayon d'impact &nbsp;·&nbsp; OPS
+
+**Aval — ce dont `media` a besoin pour fonctionner :**
+
+| Dépendance | Rôle | Si indisponible → | Dégradation |
+|---|---|---|---|
+| Stockage objet | octets canoniques ; cible de pré-signature | uploads + origine de diffusion échouent | **Dure** pour l'upload ; la diffusion s'appuie sur le cache CDN |
+| Postgres | SoR des métadonnées d'asset | lectures/écritures de métadonnées échouent | **Dure** — `UNAVAILABLE` sur le plan de contrôle |
+| Redis | cache de diffusion, réservations de tickets | chemin cache-miss | **Souple** — résout depuis Postgres |
+| CDN | diffusion en périphérie | périphérie froide / pression origine | **Souple** — pull origine, plus lent |
+| `moderation` (Screen) | porte CSAM pré-publication | porte indisponible | **Fail-closed** pour la classe CSAM (asset retenu, non publié) |
+| Kafka | finalize + événements de cycle de vie | le pipeline cale | **Souple** — les uploads s'accumulent, le traitement prend du retard |
+
+**Amont — qui dépend de `media` (votre rayon d'impact si VOUS tombez) :**
+
+| Appelant | Utilise | Impact visible si `media` est indisponible |
+|---|---|---|
+| gateway/BFF | `ResolveDelivery` | le média s'affiche en placeholder/blurhash ; le fil charge quand même |
+| `post` / `profile` | référence d'asset + `media.v1.events` | les posts se publient (référence Pending) ; media résout plus tard |
+
+> **Chemin critique ?** **Non pour les écritures cœur** — `post`/`profile`
+> référencent un `asset_id` et ne bloquent jamais sur media. **Oui pour le rendu
+> média** — la résolution de diffusion est sur le chemin de lecture, mais échoue en
+> mode ouvert vers un placeholder.
+
+---
+
+## 🔌 Interfaces publiques & contrat d'API &nbsp;·&nbsp; CORE
+
+### gRPC — `media.v1.MediaService` *(Phase 1 — plan de contrôle, zéro champ d'octets)*
+
+```protobuf
+service MediaService {
+  // Plan A — courtage d'upload (renvoie une URL pré-signée ; les octets vont direct au stockage)
+  rpc IssueUploadTicket (IssueUploadTicketRequest) returns (IssueUploadTicketResponse);
+  rpc CommitUpload      (CommitUploadRequest)      returns (CommitUploadResponse);
+  rpc AbortUpload       (AbortUploadRequest)       returns (AbortUploadResponse);
+  // Métadonnées d'asset
+  rpc GetAsset          (GetAssetRequest)          returns (GetAssetResponse);
+  rpc DeleteAsset       (DeleteAssetRequest)       returns (DeleteAssetResponse);
+  // Plan C — résolution de diffusion (lecture chaude ; URLs CDN / signées)
+  rpc ResolveDelivery      (ResolveDeliveryRequest)      returns (ResolveDeliveryResponse);
+  rpc BatchResolveDelivery (BatchResolveDeliveryRequest) returns (BatchResolveDeliveryResponse);
+  // Ops
+  rpc Reprocess         (ReprocessRequest)         returns (ReprocessResponse);
+}
+```
+
+> **Règle de contrat / wire :** **aucun message `media.v1` ne porte de charge utile
+> `bytes`.** Les uploads sont courtés via des URLs de stockage objet pré-signées ;
+> la diffusion est courtée via des URLs CDN / signées. Les enums sont entièrement
+> préfixés avec une sentinelle `_UNSPECIFIED = 0`.
+
+**Invariants de frontière :** `CommitUpload` sur un objet absent →
+`FAILED_PRECONDITION` (`MED-1005`) ; résolution d'un asset en quarantaine →
+`PERMISSION_DENIED` (`MED-7001`, 451) ; suppression sous blocage légal →
+`PERMISSION_DENIED` (`MED-7003`).
+
+### Contrat d'erreur
+
+Chaque faute implémente `error::AppError` avec un code `MED-XXXX` stable, mappé vers
+`Status` gRPC / HTTP par la crate `error` partagée :
+
+| Plage | Classe |
+|---|---|
+| `MED-1xxx` | courtage d'upload / ticket (Plan A) |
+| `MED-2xxx` | SoR des métadonnées d'asset (+ concurrence) |
+| `MED-3xxx` | pipeline de rendition / transformation (Plan B) |
+| `MED-4xxx` | adaptateur de stockage objet — le plan de données (infra retryable) |
+| `MED-5xxx` | CDN / diffusion / signature (Plan C) |
+| `MED-6xxx` | validation / inspection de contenu (magic-byte, decode-bomb, malware) |
+| `MED-7xxx` | conformité / Screen (Quarantined / LegalHold = 451 ; ScreenUnavailable = 503 fail-closed) |
+| `MED-8xxx` | décodage d'événement entrant / mappage de source |
+| `MED-9xxx` | transverse (domaine/parse, E/S d'événements) |
+
+---
+
+## 📨 Événements & contrat asynchrone &nbsp;·&nbsp; CORE
+
+> Les topics Kafka sont une API. Un changement de schéma ici casse les consommateurs exactement comme un changement proto.
+
+**Publie** (`media.v1.events`, structs serde, clé `asset_id`) :
+
+| Topic | Déclencheur | Clé | Consommateurs |
+|---|---|---|---|
+| `media.v1.events` → `AssetUploaded` | finalize accepté | `asset_id` | `moderation` (screen), pipeline interne |
+| `media.v1.events` → `AssetVariantReady` | une rendition se termine | `asset_id` | BFF (rendu progressif) |
+| `media.v1.events` → `AssetReady` | toutes les renditions faites | `asset_id` | `post`, `profile`, `search`, `timeline` |
+| `media.v1.events` → `AssetFailed` / `AssetQuarantined` / `AssetDeleted` | états terminaux | `asset_id` | appelants, GC |
+
+**Consomme :**
+
+| Topic | Groupe de consommateurs | Rôle | Sur poison/épuisement |
+|---|---|---|---|
+| finalize du stockage objet (bridgé) | `media-finalize-consumer` | finalisation d'upload (source de vérité au-dessus de `CommitUpload`) | DLQ |
+| `moderation.v1.events` | `media-moderation-consumer` | quarantaine / restauration (révoquer / réactiver la diffusion) | DLQ |
+| `post.v1.events` / `profile.v1.events` | `media-binding-consumer` | marquer les assets liés ; GC des uploads abandonnés | DLQ |
+
+> **Contrat d'exécution (obligatoire) :** tous les consommateurs tournent sous
+> `run_consumer` — commit manuel après une issue terminale, retry borné avec
+> backoff + jitter, DLQ sur épuisement/poison. Idempotence : `asset_id`
+> déterministe + clés de rendition adressées par contenu (une rendition re-dérivée
+> écrit la même clé).
+
+---
+
+## 🌩️ Modes de défaillance & dégradation &nbsp;·&nbsp; OPS
+
+| Défaillance | Symptôme | Comportement du service | Action opérateur |
+|---|---|---|---|
+| Stockage objet indispo | uploads + origine échouent | l'upload échoue dur ; la diffusion s'appuie sur le cache CDN | vérifier le stockage / IAM ; les uploads réessaient |
+| Postgres indispo | erreurs plan de contrôle | `UNAVAILABLE` sur les ops de métadonnées | bascule / restauration |
+| Redis froid/évincé | hausse de latence de résolution | reconstruit depuis Postgres, sûr | en général aucune |
+| CDN froid / pression origine | latence du premier octet | pull origine depuis le stockage | réchauffer / vérifier la config edge |
+| Screen `moderation` indispo | classe CSAM retenue | **fail-closed** : asset non publié | vérifier moderation ; le hard timeout borne l'attente |
+| Backlog des workers de transcodage | latence `AssetReady` | publication non impactée ; placeholder affiché | scaler les workers ; vérifier la DLQ |
+
+**Contre-pression & limites :** plafonds de taille par kind + allowlist MIME
+appliqués dans la politique d'upload signée ; plafonds decode-bomb / dimensions à la
+validation ; hard timeout Screen (Phase 7) pour qu'une panne de moderation ne puisse
+pas coincer les uploads ; traitement isolé sur un rôle worker séparé pour que le CPU
+de transcodage ne dégrade pas la latence Plan A/C.
+
+---
+
+## 📦 Intégration & usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+media = { path = "crates/services/media" }
+```
+
+Bibliothèque uniquement. Implémente
+[`service_runtime::Service`](../../platform/service-runtime/README.md) en tant que
+`media::service::MediaService` (Phase 5) — `build` câble les adaptateurs stockage
+objet / Postgres / Redis et lance les consommateurs finalize, moderation et binding ;
+`register` ajoute les services gRPC ; `health_probes` expose la vivacité. La
+télémétrie, la config + rechargement à chaud, la limitation de débit en entrée, la
+santé et l'arrêt gracieux sont gérés par le runtime.
+
+### Amorçage (`crates/apps/media-server`)
+
+```rust
+use media::service::MediaService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("MEDIA_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50063".to_owned()).parse()?;
+    service_runtime::serve::<MediaService>(addr).await
+}
+```
+
+> **Statut de build :** complet jusqu'à la Phase 7 — namespace d'erreur, proto
+> `media.v1` (8 RPCs de plan de contrôle, aucun champ d'octets), domaine +
+> application, adaptateurs S3/Postgres/Redis/CDN/image, serveur + consommateurs
+> worker, et une suite d'intégration live MinIO + Postgres + Redis. Tous les RPCs
+> du plan de contrôle sont sans octets.
+>
+> **Autorisation (exigence de déploiement) :** `media` ne s'auto-autorise en rien.
+> La périphérie/gateway (via `auth-context`) authentifie l'appelant et fournit
+> l'`owner_id` sur `IssueUploadTicket` / `DeleteAsset` / `AbortUpload` ; la
+> propriété est vérifiée en défense dans le handler (une suppression par un
+> non-propriétaire renvoie `NOT_FOUND`, sans rien divulguer). L'autorisation du
+> spectateur pour le média privé se fait à la périphérie **avant** que
+> `ResolveDelivery` n'émette une URL signée. N'exposez les RPCs mutants que derrière
+> cette porte.
+
+---
+
+## ⚙️ Configuration & environnement d'exécution &nbsp;·&nbsp; CORE
+
+### Variables propres à `media`
+
+| Variable | Requis | Défaut | Description |
+|---|---|---|---|
+| `MEDIA_GRPC_ADDR` | Non | `0.0.0.0:50063` | adresse de bind du plan de contrôle gRPC |
+| `MEDIA_OBJECT_STORE_ENDPOINT` | Non | `http://localhost:9000` | URL de l'endpoint S3/MinIO |
+| `MEDIA_OBJECT_STORE_REGION` | Non | `us-east-1` | région S3 |
+| `MEDIA_OBJECT_STORE_BUCKET` | Non | `media` | bucket des octets canoniques |
+| `MEDIA_S3_ACCESS_KEY` / `MEDIA_S3_SECRET_KEY` | **Oui (prod)** | `minioadmin` | identifiants du stockage objet |
+| `MEDIA_PRESIGN_TTL_SECS` | Non | `900` | validité des URLs signées côté serveur |
+| `MEDIA_OBJECT_STORE_TIMEOUT_MS` | Non | `10000` | hard timeout sur chaque appel HTTP au stockage objet |
+| `MEDIA_CDN_BASE_URL` | Non | `…:9000/media` | origine de diffusion publique adressée par contenu |
+| `MEDIA_UPLOAD_TICKET_TTL_SECS` | Non | `900` | fenêtre de validité de l'upload pré-signé |
+| `MEDIA_SIGNED_URL_TTL_SECS` | Non | `300` | validité de l'URL de diffusion privée (signée) |
+| `MEDIA_DEDUP_ENABLED` | Non | `false` | dédup par hash de contenu (off tant que le purge-refcount n'est pas durci) |
+| `MEDIA_SCREEN_GRPC_ENDPOINT` | Non | `http://localhost:50061` | endpoint de la porte Screen de moderation |
+| `MEDIA_SCREEN_TIMEOUT_MS` | Non | `200` | hard timeout fail-closed du Screen |
+
+### Variables d'infrastructure héritées
+
+| Variable | Requis | Défaut | Description |
+|---|---|---|---|
+| `POSTGRES_* / REDIS_HOSTS / KAFKA_BROKERS` | **Oui** | — | SoR des métadonnées, cache chaud, pipeline asynchrone |
+
+> Le réglage complet connexion/timeout/reconnexion vit dans les crates de stockage/transport partagées concernées.
+
+### Features à la compilation
+- `integration-media` — active la suite live MinIO + Postgres + Redis (Phase 6).
+- `build.rs` (Phase 1, dans `media-api`) compile `contracts/proto/media/v1/*` et émet le descriptor set de réflexion.
+
+---
+
+## 🚀 Déploiement, migrations & rollback &nbsp;·&nbsp; OPS
+
+- **Migrations :** `crates/services/media/migrations/*.sql` contre la db Postgres
+  `media` (Phase 4). Appliquer **avant** de déployer le nouveau binaire.
+  Expand-then-contract.
+- **Stockage objet / CDN :** le cycle de vie du bucket (dérivés chauds → masters
+  froids IA/Glacier) et la politique de cache CDN sont de l'infra déclarée, pas un
+  cron applicatif. Bucket object-lock / WORM pour les blocages légaux.
+- **Déploiement :** progressif ; les changements de pipeline risqués sont gardés par
+  config + `Reprocess`.
+- **Rollback :** le binaire est sûr à revenir en arrière (schéma de métadonnées
+  compatible amont avec N-1). **Piège à état :** le schéma de clés adressé par
+  contenu et les slugs de l'échelle de renditions ne doivent **jamais** changer de
+  sens une fois des données existantes — versionnez-les, ne les mutez pas.
+
+**Revue de sécurité (Phase 7, passe manuelle) : propre.** Aucun octet ne traverse
+jamais gRPC/Kafka (vérifié — le `media.v1` généré a zéro champ `bytes`) ; aucun
+octet brut ni PII dans les logs (seulement des champs opérationnels :
+`event_type`, `asset_id`, clés d'objet) ; aucun `unwrap`/`expect`/`panic` sur les
+chemins de requête ou de pipeline ; l'inspection de contenu ne fait jamais
+confiance au type déclaré par le client ; les URLs signées sont à courte durée ;
+un blocage légal empêche la suppression définitive (préservation CSAM/NCMEC primant
+sur l'effacement RGPD). Un constat cohérent avec le reste de la flotte, appliqué au
+gateway (pas un correctif code) : pas d'autorisation par-RPC de l'appelant — voir la
+note Autorisation ci-dessus. Les appels au stockage objet sont bornés par un hard
+timeout (`MEDIA_OBJECT_STORE_TIMEOUT_MS`) et la porte Screen par
+`MEDIA_SCREEN_TIMEOUT_MS`, donc ni un stockage bloqué ni une porte de modération
+bloquée ne peuvent coincer un worker.
+
+**Différé (documenté, non construit) :** transcodage vidéo (v1 images-first — un
+port `Transcoder` frère + échelle ABR en fast-follow) ; un vrai sidecar de scan
+anti-malware (le port `MalwareScanner` livre un stub passe-tout) ; le consommateur
+de GC des orphelins (réclamation des uploads abandonnés non liés après TTL) ;
+l'encodage WebP/AVIF (v1 émet du JPEG) ; un vrai CloudFront `CreateInvalidation`
+(le gateway journalise ; l'immutabilité adressée par contenu fait que
+l'invalidation ne compte qu'au retrait) ; et le purge RGPD conscient du refcount de
+dédup (la dédup est livrée derrière un flag off-par-défaut tant que ce chemin n'a
+pas de couverture live).
+
+---
+
+## 📈 Télémétrie, performance & métriques &nbsp;·&nbsp; CORE
+
+- **Runtime :** Tokio multi-thread. Le serveur d'API (léger, Plan A/C) est déployé
+  comme **rôle séparé** des workers de traitement (lourds, Plan B) pour que la
+  charge de transcodage ne dégrade pas la latence du plan de contrôle. Contexte de
+  trace W3C propagé à travers la frontière Kafka.
+
+| Signal | Pourquoi ça compte | Alerte suggérée |
+|---|---|---|
+| `ResolveDelivery` p99 | lecture chaude sur le chemin de rendu | `> SLO ⇒ investiguer` |
+| latence de traitement (upload→Ready) | UX de rendu progressif | `soutenue > N s ⇒ scaler les workers` |
+| taux de fail-closed Screen | santé de la porte CSAM | `pic ⇒ page` |
+| taux de production DLQ | poison / retry épuisé | tout taux soutenu ⇒ page |
+
+---
+
+## 🛠️ Développement local &nbsp;·&nbsp; CORE
+
+```bash
+cargo build -p media && cargo clippy -p media --all-targets
+cargo test  -p media                                   # run unitaire rapide, sans infra
+cargo test  -p media --features integration-media      # live MinIO + Postgres + Redis (Phase 6)
+```
+
+---
+
+## 🚨 Dépannage & runbook &nbsp;·&nbsp; CORE
+
+> Format : **symptôme → cause racine → mitigation.** Une entrée par classe d'incident réel.
+
+**1. `CommitUpload` renvoie `FAILED_PRECONDITION` (`MED-1005`).**
+Cause racine : le client a appelé commit avant la fin du dépôt des octets dans le
+stockage objet (ou le PUT a échoué). Mitigation : le client réessaie le PUT direct ;
+l'événement de finalisation S3 est le déclencheur faisant autorité et convergera
+quoi qu'il arrive.
+
+**2. Le média s'affiche en placeholder indéfiniment.**
+Cause racine : l'asset est bloqué en `Processing` — backlog des workers de
+transcodage ou message poison dans le pipeline. Mitigation : vérifier le lag de
+`media-finalize-consumer` et la DLQ ; scaler les workers ; `Reprocess` l'asset si une
+rendition a été perdue.
+
+**3. La suppression renvoie 451 (`MED-7003`).**
+Cause racine : un blocage légal est actif (ex. préservation de preuve CSAM) — la
+suppression définitive est intentionnellement bloquée, primant sur l'effacement RGPD.
+Mitigation : ce comportement est correct ; escalader vers trust & safety / legal, ne
+pas forcer la suppression.

--- a/crates/services/media/README.md
+++ b/crates/services/media/README.md
@@ -1,0 +1,369 @@
+# `media` — Move pixels and frames at hyperscale **without ever putting a byte on the mesh**
+
+> **Service Card** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Owner** | `<team>` · `<#slack-channel>` |
+> | **On-call / escalation** | `<oncall-rotation>` → `<escalation-policy>` |
+> | **Tier** | TIER-1 (mixed posture: fail-**open** delivery plane · fail-**closed** compliance gate) |
+> | **Deployable** | `crates/apps/media-server` (library crate: `crates/services/media`) |
+> | **Datastores** | Object storage (S3 / MinIO — canonical bytes) · Postgres db `media` (metadata SoR) · Redis Cluster (delivery cache + ticket reservations) |
+> | **Async** | publishes `media.v1.events` · consumes object-store finalize notifications, `moderation.v1.events`, `post.v1.events`, `profile.v1.events` (Kafka) |
+> | **Upstream callers** | gateway/BFF, `post`, `profile` |
+> | **Downstream deps** | Object storage, CDN, `moderation` (Screen), Postgres, Redis, Kafka |
+> | **SLO** | `<99.9%>` control-plane avail · `<p99 ResolveDelivery < N ms>` · processing lag tracked, not SLA'd |
+
+---
+
+## 🎯 Overview & Service Role
+
+`media` is the **media control plane** for the platform: it owns media *assets and
+their processing lifecycle* — the asset state machine, the derivative/rendition
+catalog, the storage-key scheme, the CDN delivery policy, and the compliance holds
+that gate both delivery and deletion.
+
+The hard problem it solves is **moving binary at hyperscale without melting the
+synchronous mesh** — a naive "POST your video to the API" design routes terabytes
+through gRPC and Kafka, couples every upload to a transcode, and blocks `CreatePost`
+on processing. The resolving pattern is a strict **control-plane / data-plane
+split**: bytes flow client ⇄ object storage ⇄ CDN on a pre-signed, direct path the
+service *authorizes* but never *carries*; the mesh moves only tickets, metadata,
+and URLs.
+
+**Core objectives:** (1) **no bytes on the mesh** — ever; (2) the publish path
+never waits on processing (upload-first, reference-not-bytes, resolve
+progressively); (3) CSAM-class media is gated **fail-closed** before it can go
+public, and a legal hold overrides GDPR erasure.
+
+| Plane | Interface | Sync? | Posture |
+|---|---|---|---|
+| **A — Upload brokerage** | `IssueUploadTicket` → pre-signed PUT (bytes go direct to object store) | gRPC, narrow | fail-closed on policy |
+| **B — Transformation** | Kafka: finalize → validate → screen → derive → publish | async | lag is an SLO |
+| **C — Delivery resolution** | `ResolveDelivery` / `BatchResolveDelivery` → CDN / signed URLs | gRPC, hot read | fail-**open** (placeholder) |
+
+---
+
+## 📐 Architecture & Concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), CQRS command/query
+buses, **object storage** as the canonical byte store, **Postgres** as the asset
+metadata SoR, **Redis** for the hot delivery cache + ticket reservations, Kafka for
+the async pipeline and lifecycle events.
+
+```
+            ┌─────────── control plane (gRPC, no bytes) ───────────┐
+ client ───▶│ IssueUploadTicket → asset(Pending) + pre-signed PUT  │
+            └──────────────────────────┬──────────────────────────┘
+                                        │  (bytes NEVER traverse here)
+   bytes ══ PUT ═════════════▶ [ Object Storage ] ◀═══ origin pull ═══ [ CDN ]
+                                        │                                  ▲
+              finalize (S3 event→Kafka  │  or CommitUpload RPC)            │ signed/immutable URL
+                                        ▼                                  │
+   Plane B:  validate → Screen(moderation, fail-closed) → derive ──▶ renditions
+                                        │  emit media.v1.events (AssetReady …)
+                                        ▼
+   Plane C:  ResolveDelivery(asset_id) ─────────────────────────────▶ CDN URL
+```
+
+**Content-addressed immutability (the key mechanism).** Public derivative keys are
+`/{kind}/{content_hash}/{rendition}.{ext}` with `Cache-Control: immutable`. An edit
+is a *new asset* = a *new hash* = a *new URL*, so **cache invalidation is a
+takedown-only operation** — never an edit-path concern. Private media uses
+short-lived signed URLs minted per-request *after* the edge authorizes the viewer.
+
+> **Invariants** (and where enforced): no message carries a `bytes` payload
+> (proto review + `media-api` contract rule); asset state transitions are guarded
+> in the domain; optimistic lock on the asset row (`ConcurrentModification`);
+> object storage is canonical for bytes, Postgres for truth-about-bytes; a legal
+> hold blocks hard-delete even on owner GDPR erasure.
+
+---
+
+## 📊 Service Level Objectives (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objective | Window | Measured by |
+|---|---|---|---|
+| Control-plane availability (non-5xx / non-`UNAVAILABLE`) | `<99.9%>` | 30d rolling | `<metric>` |
+| `ResolveDelivery` p99 (Plane C, hot read) | `< <N> ms` | 1h | `<metric>` |
+| `IssueUploadTicket` p99 (Plane A) | `< <N> ms` | 1h | `<metric>` |
+| Processing lag (upload → `AssetReady`) | `< <N> s` p99 | live | `<consumer-group> lag` (SLO, not SLA — publish never waits) |
+| Durability | no acked asset metadata lost | — | Postgres commit; object-store 11-nines |
+
+**Error budget:** `<0.1% / 30d ≈ 43m>`. **On burn:** `<freeze rollout | page>`.
+
+---
+
+## 🔗 Dependencies & Blast Radius &nbsp;·&nbsp; OPS
+
+**Downstream — what `media` needs to function:**
+
+| Dependency | Purpose | If down → | Degradation |
+|---|---|---|---|
+| Object storage | canonical bytes; pre-sign target | uploads + delivery-origin fail | **Hard** for upload; delivery rides CDN cache |
+| Postgres | asset metadata SoR | metadata writes/reads fail | **Hard** — `UNAVAILABLE` on control plane |
+| Redis | delivery cache, ticket reservations | cache-miss path | **Soft** — resolves from Postgres |
+| CDN | edge delivery | cold edge / origin pressure | **Soft** — origin pull, slower |
+| `moderation` (Screen) | pre-publish CSAM gate | gate unavailable | **Fail-closed** for CSAM-class (asset held, not published) |
+| Kafka | finalize + lifecycle events | pipeline stalls | **Soft** — uploads queue, processing lags |
+
+**Upstream — who depends on `media` (your blast radius if YOU fail):**
+
+| Caller | Uses | User-visible impact if `media` is down |
+|---|---|---|
+| gateway/BFF | `ResolveDelivery` | media renders as placeholder/blurhash; feed still loads |
+| `post` / `profile` | asset reference + `media.v1.events` | posts publish (reference Pending); media resolves late |
+
+> **Critical path?** **No for core writes** — `post`/`profile` reference an
+> `asset_id` and never block on media. **Yes for media render** — delivery
+> resolution is on the read path, but fails open to a placeholder.
+
+---
+
+## 🔌 Public Interfaces & API Contract &nbsp;·&nbsp; CORE
+
+### gRPC — `media.v1.MediaService` *(Phase 1 — control plane, zero byte fields)*
+
+```protobuf
+service MediaService {
+  // Plane A — upload brokerage (returns a pre-signed URL; bytes go direct to store)
+  rpc IssueUploadTicket (IssueUploadTicketRequest) returns (IssueUploadTicketResponse);
+  rpc CommitUpload      (CommitUploadRequest)      returns (CommitUploadResponse);
+  rpc AbortUpload       (AbortUploadRequest)       returns (AbortUploadResponse);
+  // Asset metadata
+  rpc GetAsset          (GetAssetRequest)          returns (GetAssetResponse);
+  rpc DeleteAsset       (DeleteAssetRequest)       returns (DeleteAssetResponse);
+  // Plane C — delivery resolution (hot read; CDN / signed URLs)
+  rpc ResolveDelivery      (ResolveDeliveryRequest)      returns (ResolveDeliveryResponse);
+  rpc BatchResolveDelivery (BatchResolveDeliveryRequest) returns (BatchResolveDeliveryResponse);
+  // Ops
+  rpc Reprocess         (ReprocessRequest)         returns (ReprocessResponse);
+}
+```
+
+> **Wire / contract rule:** **no `media.v1` message carries a `bytes` payload.**
+> Uploads are brokered via pre-signed object-store URLs; delivery is brokered via
+> CDN / signed URLs. Enums are fully prefixed with an `_UNSPECIFIED = 0` sentinel.
+
+**Boundary invariants:** `CommitUpload` on a missing object → `FAILED_PRECONDITION`
+(`MED-1005`); resolve of a quarantined asset → `PERMISSION_DENIED` (`MED-7001`,
+451); delete under legal hold → `PERMISSION_DENIED` (`MED-7003`).
+
+### Error contract
+
+Every fault implements `error::AppError` with a stable `MED-XXXX` code, mapped to
+gRPC `Status` / HTTP by the shared `error` crate:
+
+| Range | Class |
+|---|---|
+| `MED-1xxx` | upload brokerage / ticket (Plane A) |
+| `MED-2xxx` | asset metadata SoR (+ concurrency) |
+| `MED-3xxx` | rendition / transformation pipeline (Plane B) |
+| `MED-4xxx` | object-store adapter — the byte plane (retryable infra) |
+| `MED-5xxx` | CDN / delivery / signing (Plane C) |
+| `MED-6xxx` | content validation / probe (magic-byte, decode-bomb, malware) |
+| `MED-7xxx` | compliance / Screen (Quarantined / LegalHold = 451; ScreenUnavailable = 503 fail-closed) |
+| `MED-8xxx` | inbound event decode / source mapping |
+| `MED-9xxx` | cross-cutting (domain/parse, event I/O) |
+
+---
+
+## 📨 Events & Async Contract &nbsp;·&nbsp; CORE
+
+> Kafka topics are an API. A schema change here breaks consumers exactly like a proto change.
+
+**Publishes** (`media.v1.events`, serde structs, keyed by `asset_id`):
+
+| Topic | Trigger | Key | Consumers |
+|---|---|---|---|
+| `media.v1.events` → `AssetUploaded` | finalize accepted | `asset_id` | `moderation` (screen), internal pipeline |
+| `media.v1.events` → `AssetVariantReady` | a rendition completes | `asset_id` | BFF (progressive render) |
+| `media.v1.events` → `AssetReady` | all renditions done | `asset_id` | `post`, `profile`, `search`, `timeline` |
+| `media.v1.events` → `AssetFailed` / `AssetQuarantined` / `AssetDeleted` | terminal states | `asset_id` | callers, GC |
+
+**Consumes:**
+
+| Topic | Consumer group | Purpose | On poison/exhaustion |
+|---|---|---|---|
+| object-store finalize (bridged) | `media-finalize-consumer` | upload finalize (source of truth over `CommitUpload`) | DLQ |
+| `moderation.v1.events` | `media-moderation-consumer` | quarantine / restore (revoke / re-enable delivery) | DLQ |
+| `post.v1.events` / `profile.v1.events` | `media-binding-consumer` | mark assets bound; orphan GC of abandoned uploads | DLQ |
+
+> **Runtime contract (mandatory):** all consumers run under `run_consumer` —
+> manual commit after a terminal outcome, bounded retry with backoff + jitter, DLQ
+> on exhaustion/poison. Idempotency: deterministic `asset_id` + content-addressed
+> rendition keys (a re-derived rendition writes the same key).
+
+---
+
+## 🌩️ Failure Modes & Degradation &nbsp;·&nbsp; OPS
+
+| Failure | Symptom | Service behavior | Operator action |
+|---|---|---|---|
+| Object storage down | uploads + origin fail | upload hard-fails; delivery rides CDN cache | check store / IAM; uploads retry |
+| Postgres down | control plane errors | `UNAVAILABLE` on metadata ops | failover / restore |
+| Redis cold/evicted | resolve latency rise | rebuild from Postgres, safe | usually none |
+| CDN cold / origin pressure | first-byte latency | origin pull from store | warm / check edge config |
+| `moderation` Screen unavailable | CSAM-class held | **fail-closed**: asset not published | check moderation; hard timeout bounds wait |
+| Transcode worker backlog | `AssetReady` lag | publish unaffected; placeholder shown | scale workers; check DLQ |
+
+**Backpressure & limits:** per-kind size ceilings + MIME allowlist enforced in the
+signed upload policy; decode-bomb / dimension caps at validate; Screen hard timeout
+(Phase 7) so a moderation outage can't wedge uploads; processing isolated to a
+separate worker role so transcode CPU can't degrade Plane A/C latency.
+
+---
+
+## 📦 Integration & Usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+media = { path = "crates/services/media" }
+```
+
+Library-only. Implements [`service_runtime::Service`](../../platform/service-runtime/README.md)
+as `media::service::MediaService` (Phase 5) — `build` wires the object-store /
+Postgres / Redis adapters and spawns the finalize, moderation, and binding
+consumers; `register` adds the gRPC services; `health_probes` exposes liveness.
+Telemetry, config + hot-reload, ingress rate-limiting, health, and graceful
+shutdown are owned by the runtime.
+
+### Bootstrap (`crates/apps/media-server`)
+
+```rust
+use media::service::MediaService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("MEDIA_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50063".to_owned()).parse()?;
+    service_runtime::serve::<MediaService>(addr).await
+}
+```
+
+> **Build status:** complete through Phase 7 — error namespace, `media.v1` proto
+> (8 control-plane RPCs, no byte fields), domain + application, the S3/Postgres/
+> Redis/CDN/image adapters, the server + worker consumers, and a live MinIO +
+> Postgres + Redis integration suite. All control-plane RPCs are byte-free.
+>
+> **Authorization (deployment requirement):** `media` self-authorizes nothing. The
+> edge/gateway (via `auth-context`) authenticates the caller and supplies the
+> `owner_id` on `IssueUploadTicket` / `DeleteAsset` / `AbortUpload`; ownership is
+> defense-checked in-handler (a non-owner delete returns `NOT_FOUND`, leaking
+> nothing). Viewer authorization for private media happens at the edge **before**
+> `ResolveDelivery` mints a signed URL. Expose mutating RPCs only behind that gate.
+
+---
+
+## ⚙️ Configuration & Runtime Environment &nbsp;·&nbsp; CORE
+
+### `media`-specific variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MEDIA_GRPC_ADDR` | No | `0.0.0.0:50063` | gRPC control-plane bind address |
+| `MEDIA_OBJECT_STORE_ENDPOINT` | No | `http://localhost:9000` | S3/MinIO endpoint URL |
+| `MEDIA_OBJECT_STORE_REGION` | No | `us-east-1` | S3 region |
+| `MEDIA_OBJECT_STORE_BUCKET` | No | `media` | canonical bytes bucket |
+| `MEDIA_S3_ACCESS_KEY` / `MEDIA_S3_SECRET_KEY` | **Yes (prod)** | `minioadmin` | object-store credentials |
+| `MEDIA_PRESIGN_TTL_SECS` | No | `900` | server-side signed-URL validity |
+| `MEDIA_OBJECT_STORE_TIMEOUT_MS` | No | `10000` | hard timeout on every object-store HTTP call |
+| `MEDIA_CDN_BASE_URL` | No | `…:9000/media` | public, content-addressed delivery origin |
+| `MEDIA_UPLOAD_TICKET_TTL_SECS` | No | `900` | pre-signed upload validity window |
+| `MEDIA_SIGNED_URL_TTL_SECS` | No | `300` | private (signed) delivery URL validity |
+| `MEDIA_DEDUP_ENABLED` | No | `false` | content-hash dedup (off until refcount-purge is hardened) |
+| `MEDIA_SCREEN_GRPC_ENDPOINT` | No | `http://localhost:50061` | moderation Screen gate endpoint |
+| `MEDIA_SCREEN_TIMEOUT_MS` | No | `200` | fail-closed Screen hard timeout |
+
+### Inherited infrastructure variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `POSTGRES_* / REDIS_HOSTS / KAFKA_BROKERS` | **Yes** | — | metadata SoR, hot cache, async pipeline |
+
+> Full connection/timeout/reconnect tuning lives in the relevant shared storage/transport crates.
+
+### Compile-time features
+- `integration-media` — gates the live MinIO + Postgres + Redis suite (Phase 6).
+- `build.rs` (Phase 1, in `media-api`) compiles `contracts/proto/media/v1/*` and emits the reflection descriptor set.
+
+---
+
+## 🚀 Deployment, Migrations & Rollback &nbsp;·&nbsp; OPS
+
+- **Migrations:** `crates/services/media/migrations/*.sql` against Postgres db
+  `media` (Phase 4). Apply **before** rolling the new binary. Expand-then-contract.
+- **Object-store / CDN:** bucket lifecycle (hot derivatives → IA/Glacier cold
+  masters) and CDN cache policy are declared infra, not app cron. Object-lock /
+  WORM bucket for legal holds.
+- **Rollout:** rolling; risky pipeline changes gated by config + `Reprocess`.
+- **Rollback:** binary is safe to roll back (metadata schema forward-compatible
+  with N-1). **Stateful gotcha:** the content-addressed key scheme and the
+  rendition-ladder slugs must **never** change meaning after data exists — version
+  them, don't mutate.
+
+**Security review (Phase 7, manual pass): clean.** No bytes ever cross gRPC/Kafka
+(verified — generated `media.v1` has zero `bytes` fields); no raw bytes or PII in
+logs (only operational fields: `event_type`, `asset_id`, object keys); no
+`unwrap`/`expect`/`panic` on request or pipeline paths; the content probe never
+trusts the client's declared type; signed URLs are short-lived; a legal hold blocks
+hard-delete (CSAM/NCMEC preservation overrides GDPR erasure). One fleet-consistent,
+gateway-enforced finding (not a code fix): no per-RPC caller authorization — see the
+Authorization note above. Object-store calls are bounded by a hard timeout
+(`MEDIA_OBJECT_STORE_TIMEOUT_MS`) and the Screen gate by `MEDIA_SCREEN_TIMEOUT_MS`,
+so neither a stuck store nor a stuck moderation gate can wedge a worker.
+
+**Deferred (documented, not built):** video transcoding (images-first v1 — a
+`Transcoder` sibling port + ABR ladder is the fast-follow); a real malware-scan
+sidecar (the `MalwareScanner` port ships a pass-through stub); the orphan-GC
+consumer (unbound-after-TTL reaping of abandoned uploads); WebP/AVIF rendition
+encoding (v1 emits JPEG); a real CloudFront `CreateInvalidation` (the gateway logs;
+content-addressed immutability means invalidation only matters on takedown); and
+the dedup refcount-aware GDPR purge (dedup ships behind a default-off flag until
+that path has live coverage).
+
+---
+
+## 📈 Telemetry, Performance & Metrics &nbsp;·&nbsp; CORE
+
+- **Runtime:** multi-threaded Tokio. API server (light, Plane A/C) is deployed as a
+  **separate role** from the processing workers (heavy, Plane B) so transcode load
+  can't degrade control-plane latency. W3C trace-context propagated across Kafka.
+
+| Signal | Why it matters | Suggested alert |
+|---|---|---|
+| `ResolveDelivery` p99 | hot read on the render path | `> SLO ⇒ investigate` |
+| processing lag (upload→Ready) | progressive-render UX | `sustained > N s ⇒ scale workers` |
+| Screen fail-closed rate | CSAM gate health | `spike ⇒ page` |
+| DLQ produce rate | poison / retry-exhausted | any sustained rate ⇒ page |
+
+---
+
+## 🛠️ Local Development &nbsp;·&nbsp; CORE
+
+```bash
+cargo build -p media && cargo clippy -p media --all-targets
+cargo test  -p media                                   # fast, infra-free unit run
+cargo test  -p media --features integration-media      # live MinIO + Postgres + Redis (Phase 6)
+```
+
+---
+
+## 🚨 Troubleshooting & Runbook &nbsp;·&nbsp; CORE
+
+> Format: **symptom → root cause → mitigation.** One entry per real incident class.
+
+**1. `CommitUpload` returns `FAILED_PRECONDITION` (`MED-1005`).**
+Root cause: the client called commit before the bytes finished landing in the
+object store (or the PUT failed). Mitigation: the client retries the direct PUT;
+the S3 finalize event is the authoritative trigger and will converge regardless.
+
+**2. Media renders as a placeholder forever.**
+Root cause: the asset is stuck in `Processing` — transcode worker backlog or a
+poison message in the pipeline. Mitigation: check `media-finalize-consumer` lag and
+the DLQ; scale workers; `Reprocess` the asset if a rendition was dropped.
+
+**3. Delete returns 451 (`MED-7003`).**
+Root cause: a legal hold is active (e.g. CSAM evidence preservation) — hard-delete
+is intentionally blocked, overriding GDPR erasure. Mitigation: this is correct
+behavior; escalate to trust & safety / legal, do not force-delete.

--- a/crates/services/media/migrations/0001_create_media_tables.sql
+++ b/crates/services/media/migrations/0001_create_media_tables.sql
@@ -1,0 +1,31 @@
+-- media metadata System of Record (Postgres).
+--
+-- The byte *content* lives in object storage; this table holds the canonical
+-- *truth about* each asset: its lifecycle state, owner, verified facts, and its
+-- rendition catalog. The rich aggregate (including renditions) is stored as a
+-- JSONB document so the schema tracks the domain without a wide column list or a
+-- separate renditions table; the few columns that must be queried or indexed
+-- (owner, state, content hash) are projected out alongside.
+
+CREATE TABLE IF NOT EXISTS assets (
+    id            UUID         PRIMARY KEY,
+    owner_id      UUID         NOT NULL,
+    kind          TEXT         NOT NULL,
+    state         TEXT         NOT NULL,
+    -- Lowercase-hex SHA-256 of the original bytes; NULL until finalized. Drives
+    -- content-addressing and (when enabled) cross-owner dedup.
+    content_hash  TEXT,
+    created_at    TIMESTAMPTZ  NOT NULL,
+    updated_at    TIMESTAMPTZ  NOT NULL,
+    -- The full Asset aggregate (serde JSON). Source of truth for reconstruction.
+    doc           JSONB        NOT NULL
+);
+
+-- Owner lookup (orphan GC, per-owner listing).
+CREATE INDEX IF NOT EXISTS idx_assets_owner ON assets (owner_id);
+
+-- Dedup lookup: find a READY asset with these exact bytes. Partial index keeps it
+-- small (only finalized assets carry a hash).
+CREATE INDEX IF NOT EXISTS idx_assets_content_hash
+    ON assets (content_hash)
+    WHERE content_hash IS NOT NULL;

--- a/crates/services/media/src/app.rs
+++ b/crates/services/media/src/app.rs
@@ -1,0 +1,265 @@
+//! The media service's composition root.
+//!
+//! [`App::compose`] is *pure* wiring: the ports in, the assembled gRPC handler out —
+//! no I/O, so the unit graph and the binary build the exact same handler.
+//! [`App::build`] is the I/O variant that constructs the concrete adapters (S3 /
+//! Postgres / Redis / CDN / moderation gRPC / Kafka) from config + backend
+//! connections, then defers to `compose`. It retains the process + moderation
+//! handlers so [`crate::service`] can self-spawn the consumers, and the storage
+//! clients so the runtime builds liveness probes.
+
+use std::sync::Arc;
+
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use sqlx::PgPool;
+use tonic::transport::Channel;
+use transport::kafka::config::client::KafkaClientConfig;
+use transport::kafka::config::producer::ProducerConfig;
+use transport::kafka::producer::KafkaProducerBuilder;
+
+use crate::application::command::{
+    ApplyModerationHandler, CommitUploadHandler, DeleteAssetHandler, IssueUploadTicketHandler,
+    ProcessAssetHandler,
+};
+use crate::application::port::{
+    AssetRepository, CdnGateway, DeliveryCache, EventPublisher, ImageProcessor, MalwareScanner,
+    MediaProbe, ModerationScreen, ObjectStore,
+};
+use crate::application::query::{GetAssetHandler, ResolveDeliveryHandler};
+use crate::application::MediaPolicy;
+use crate::config::MediaConfig;
+use crate::infrastructure::cache::RedisDeliveryCache;
+use crate::infrastructure::cdn::CloudFrontCdnGateway;
+use crate::infrastructure::event::{KafkaEventPublisher, LogEventPublisher};
+use crate::infrastructure::grpc::MediaServiceHandler;
+use crate::infrastructure::persistence::PgAssetRepository;
+use crate::infrastructure::probe::ImageMediaProbe;
+use crate::infrastructure::processor::ImageRenditionProcessor;
+use crate::infrastructure::scanner::LogMalwareScanner;
+use crate::infrastructure::screen::GrpcModerationScreen;
+use crate::infrastructure::store::{S3Client, S3ObjectStore};
+
+/// The nine ports the application layer depends on, plus the policy.
+pub struct AppDeps {
+    pub assets: Arc<dyn AssetRepository>,
+    pub cache: Arc<dyn DeliveryCache>,
+    pub store: Arc<dyn ObjectStore>,
+    pub cdn: Arc<dyn CdnGateway>,
+    pub probe: Arc<dyn MediaProbe>,
+    pub processor: Arc<dyn ImageProcessor>,
+    pub scanner: Arc<dyn MalwareScanner>,
+    pub screen: Arc<dyn ModerationScreen>,
+    pub publisher: Arc<dyn EventPublisher>,
+    pub policy: MediaPolicy,
+}
+
+/// Backend connection configs. `kafka` is optional: absent ⇒ the log publisher.
+pub struct Backends {
+    pub postgres: PostgresConfig,
+    pub redis: RedisConfig,
+    pub kafka: Option<KafkaClientConfig>,
+}
+
+/// A fully-wired media service. Retains the storage clients (for liveness probes)
+/// and the process + moderation handlers (for the self-spawned consumers).
+pub struct App {
+    pub handler: MediaServiceHandler,
+    pub process: Arc<ProcessAssetHandler>,
+    pub apply_moderation: Arc<ApplyModerationHandler>,
+    pub pool: PgPool,
+    pub redis: RedisClient,
+    pub store: Arc<S3Client>,
+}
+
+impl App {
+    /// Pure composition: assemble the gRPC handler from the ports + the shared
+    /// process handler. No I/O — drives the unit graph.
+    pub fn compose(deps: AppDeps, process: Arc<ProcessAssetHandler>) -> MediaServiceHandler {
+        let issue = Arc::new(IssueUploadTicketHandler::new(
+            Arc::clone(&deps.assets),
+            Arc::clone(&deps.store),
+            deps.policy.clone(),
+        ));
+        let commit = Arc::new(CommitUploadHandler::new(
+            Arc::clone(&deps.assets),
+            Arc::clone(&deps.store),
+            Arc::clone(&deps.probe),
+            Arc::clone(&deps.publisher),
+        ));
+        let delete = Arc::new(DeleteAssetHandler::new(
+            Arc::clone(&deps.assets),
+            Arc::clone(&deps.store),
+            Arc::clone(&deps.cdn),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.publisher),
+        ));
+        let get = Arc::new(GetAssetHandler::new(Arc::clone(&deps.assets)));
+        let resolve = Arc::new(ResolveDeliveryHandler::new(
+            Arc::clone(&deps.assets),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.cdn),
+        ));
+        MediaServiceHandler::new(issue, commit, delete, process, get, resolve)
+    }
+
+    /// Builds the process + moderation handlers shared between the gRPC handler and
+    /// the consumers (a single instance of each, over the same ports).
+    fn build_workers(
+        deps: &AppDeps,
+    ) -> (Arc<ProcessAssetHandler>, Arc<ApplyModerationHandler>) {
+        let process = Arc::new(ProcessAssetHandler::new(
+            Arc::clone(&deps.assets),
+            Arc::clone(&deps.scanner),
+            Arc::clone(&deps.screen),
+            Arc::clone(&deps.processor),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.publisher),
+            deps.policy.clone(),
+        ));
+        let apply_moderation = Arc::new(ApplyModerationHandler::new(
+            Arc::clone(&deps.assets),
+            Arc::clone(&deps.cdn),
+            Arc::clone(&deps.cache),
+            Arc::clone(&deps.publisher),
+        ));
+        (process, apply_moderation)
+    }
+
+    /// Builds the concrete adapter graph from config + backend connections.
+    pub async fn build(
+        config: MediaConfig,
+        backends: Backends,
+    ) -> Result<App, Box<dyn std::error::Error>> {
+        let pool = PgPoolBuilder::build(backends.postgres).await?;
+        let tx = TransactionManager::new(pool.clone());
+        let redis = RedisClientBuilder::new(backends.redis).build().await?;
+
+        // Shared S3 client: presigns URLs + does the worker's server-side byte I/O.
+        // Its HTTP client carries the object-store hard timeout.
+        let store = Arc::new(S3Client::new(config.s3)?);
+
+        let publisher: Arc<dyn EventPublisher> = match backends.kafka {
+            Some(cfg) => {
+                let producer = KafkaProducerBuilder::new(ProducerConfig::new(cfg)).build()?;
+                Arc::new(KafkaEventPublisher::new(producer))
+            }
+            None => Arc::new(LogEventPublisher),
+        };
+
+        // Lazy connect: dials `moderation` on first use, so a cold start does not
+        // require the gate to be up at boot.
+        let screen_channel = Channel::from_shared(config.screen_endpoint)?.connect_lazy();
+
+        let deps = AppDeps {
+            assets: Arc::new(PgAssetRepository::new(tx)),
+            cache: Arc::new(RedisDeliveryCache::new(redis.clone())),
+            store: Arc::new(S3ObjectStore::new(Arc::clone(&store))),
+            cdn: Arc::new(CloudFrontCdnGateway::new(
+                config.cdn_base_url,
+                Arc::clone(&store),
+                config.policy.signed_url_ttl,
+            )),
+            probe: Arc::new(ImageMediaProbe::new(Arc::clone(&store))),
+            processor: Arc::new(ImageRenditionProcessor::new(Arc::clone(&store))),
+            scanner: Arc::new(LogMalwareScanner),
+            screen: Arc::new(GrpcModerationScreen::new(screen_channel)),
+            publisher,
+            policy: config.policy,
+        };
+
+        let (process, apply_moderation) = App::build_workers(&deps);
+        let handler = App::compose(deps, Arc::clone(&process));
+        Ok(App { handler, process, apply_moderation, pool, redis, store })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::infrastructure::grpc::proto;
+    use tonic::{Code, Request};
+
+    /// Composes the gRPC handler over the in-memory fakes — the exact graph
+    /// `App::build` produces, minus the real backends.
+    fn handler_from_fakes(fx: &Fixture) -> MediaServiceHandler {
+        let deps = AppDeps {
+            assets: fx.assets.clone(),
+            cache: fx.cache.clone(),
+            store: fx.store.clone(),
+            cdn: fx.cdn.clone(),
+            probe: fx.probe.clone(),
+            processor: fx.processor.clone(),
+            scanner: fx.scanner.clone(),
+            screen: fx.screen.clone(),
+            publisher: fx.publisher.clone(),
+            policy: fx.policy.clone(),
+        };
+        let (process, _apply) = App::build_workers(&deps);
+        App::compose(deps, process)
+    }
+
+    #[tokio::test]
+    async fn issue_ticket_rpc_returns_a_presigned_upload() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::IssueUploadTicketRequest {
+            owner_id: uuid::Uuid::from_u128(7).to_string(),
+            kind: proto::MediaKind::PostImage as i32,
+            declared_mime_type: "image/jpeg".into(),
+            declared_size_bytes: 2_000_000,
+            content_sha256: String::new(),
+            idempotency_key: String::new(),
+        });
+        let resp = handler.issue_upload_ticket(request).await.unwrap().into_inner();
+        assert!(!resp.deduplicated);
+        let ticket = resp.ticket.expect("a presigned ticket");
+        assert_eq!(ticket.method, "PUT");
+        assert!(!resp.asset_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn issue_ticket_rpc_rejects_oversize() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::IssueUploadTicketRequest {
+            owner_id: uuid::Uuid::from_u128(7).to_string(),
+            kind: proto::MediaKind::Avatar as i32,
+            declared_mime_type: "image/png".into(),
+            declared_size_bytes: 999_999_999,
+            content_sha256: String::new(),
+            idempotency_key: String::new(),
+        });
+        let status = handler.issue_upload_ticket(request).await.unwrap_err();
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn resolve_delivery_rpc_returns_public_urls_for_a_ready_asset() {
+        let fx = Fixture::new();
+        let (asset_id, _owner) = fx.ready_asset(crate::domain::value_object::MediaKind::PostImage).await;
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::ResolveDeliveryRequest {
+            asset_id: asset_id.as_str(),
+            preferred: 0,
+            visibility: 0,
+        });
+        let resp = handler.resolve_delivery(request).await.unwrap().into_inner();
+        let media = resp.media.expect("delivered media");
+        assert!(!media.degraded);
+        assert!(!media.renditions.is_empty());
+        assert_eq!(media.state, proto::AssetState::MediaAssetStateReady as i32);
+    }
+
+    #[tokio::test]
+    async fn get_unknown_asset_is_not_found() {
+        let fx = Fixture::new();
+        let handler = handler_from_fakes(&fx);
+        let request = Request::new(proto::GetAssetRequest {
+            asset_id: uuid::Uuid::now_v7().to_string(),
+        });
+        let status = handler.get_asset(request).await.unwrap_err();
+        assert_eq!(status.code(), Code::NotFound);
+    }
+}

--- a/crates/services/media/src/application/command/apply_moderation.rs
+++ b/crates/services/media/src/application/command/apply_moderation.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::port::{AssetRepository, CdnGateway, DeliveryCache, EventPublisher};
+use crate::domain::value_object::{AssetId, AssetState, StorageKey};
+use crate::error::MediaError;
+
+/// The takedown direction, distilled from a consumed `moderation.v1.events`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModerationAction {
+    Quarantine,
+    Restore,
+}
+
+/// Apply a moderation decision to an asset (driven by the moderation consumer,
+/// Phase 5).
+#[derive(Debug, Clone)]
+pub struct ApplyModerationCommand {
+    pub asset_id: AssetId,
+    pub action: ModerationAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyModerationOutcome {
+    /// `false` when the asset is unknown (the event is for media we don't hold) —
+    /// a folded no-op the consumer commits.
+    pub applied: bool,
+    pub state: Option<AssetState>,
+}
+
+/// Reactively enforces a moderation verdict on the byte plane: a quarantine revokes
+/// delivery (state flip + CDN invalidate + cache drop); a restore reinstates it.
+/// This is the content-service side of moderation's enforcement — `media` flips
+/// visibility, it does not decide.
+pub struct ApplyModerationHandler {
+    assets: Arc<dyn AssetRepository>,
+    cdn: Arc<dyn CdnGateway>,
+    cache: Arc<dyn DeliveryCache>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl ApplyModerationHandler {
+    pub fn new(
+        assets: Arc<dyn AssetRepository>,
+        cdn: Arc<dyn CdnGateway>,
+        cache: Arc<dyn DeliveryCache>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { assets, cdn, cache, publisher }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<ApplyModerationCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<ApplyModerationOutcome, MediaError> {
+        let cmd = envelope.payload;
+        let Some(mut asset) = self.assets.find_by_id(&cmd.asset_id).await? else {
+            // Unknown asset — fold to a no-op so the consumer commits.
+            return Ok(ApplyModerationOutcome { applied: false, state: None });
+        };
+
+        match cmd.action {
+            ModerationAction::Quarantine => {
+                asset.quarantine(now)?;
+                // Revoke delivery for every rendition (the takedown path).
+                let keys: Vec<StorageKey> =
+                    asset.renditions().iter().map(|r| r.storage_key().clone()).collect();
+                if !keys.is_empty() {
+                    self.cdn.invalidate(&keys).await?;
+                }
+                self.cache.invalidate(&asset.id()).await?;
+            }
+            ModerationAction::Restore => {
+                asset.restore(now)?;
+                // Drop the (placeholder) cache entry so the next read re-resolves.
+                self.cache.invalidate(&asset.id()).await?;
+            }
+        }
+
+        self.assets.save(&asset).await?;
+        for event in asset.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
+        Ok(ApplyModerationOutcome { applied: true, state: Some(asset.state()) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::MediaKind;
+    use uuid::Uuid;
+
+    fn env(asset_id: AssetId, action: ModerationAction) -> Envelope<ApplyModerationCommand> {
+        Envelope::new(Uuid::now_v7(), ApplyModerationCommand { asset_id, action })
+    }
+
+    #[tokio::test]
+    async fn quarantine_revokes_delivery_then_restore_reinstates() {
+        let fx = Fixture::new();
+        let (asset_id, _owner) = fx.ready_asset(MediaKind::PostImage).await;
+        fx.publisher.clear();
+
+        let out = fx
+            .apply_moderation_handler()
+            .handle(env(asset_id, ModerationAction::Quarantine), t0())
+            .await
+            .unwrap();
+        assert!(out.applied);
+        assert_eq!(out.state, Some(AssetState::Quarantined));
+        assert!(!fx.cdn.invalidated_keys().is_empty(), "delivery revoked at the edge");
+        assert_eq!(fx.publisher.event_types(), vec!["media.asset_quarantined"]);
+
+        fx.publisher.clear();
+        let out = fx
+            .apply_moderation_handler()
+            .handle(env(asset_id, ModerationAction::Restore), t0())
+            .await
+            .unwrap();
+        assert_eq!(out.state, Some(AssetState::Ready));
+        assert_eq!(fx.publisher.event_types(), vec!["media.asset_restored"]);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_asset_is_a_folded_no_op() {
+        let fx = Fixture::new();
+        let out = fx
+            .apply_moderation_handler()
+            .handle(env(AssetId::new(), ModerationAction::Quarantine), t0())
+            .await
+            .unwrap();
+        assert!(!out.applied);
+        assert!(out.state.is_none());
+    }
+}

--- a/crates/services/media/src/application/command/commit_upload.rs
+++ b/crates/services/media/src/application/command/commit_upload.rs
@@ -1,0 +1,171 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::port::{AssetRepository, EventPublisher, MediaProbe, ObjectStore};
+use crate::domain::aggregate::{Asset, FinalizeParams};
+use crate::domain::value_object::{AssetId, AssetState, ContentHash, StorageKey, UploadConstraints};
+use crate::error::MediaError;
+
+/// Plane A — the low-latency finalize nudge after the client's direct upload. The
+/// object-store event is the authoritative trigger; this RPC and that event
+/// converge idempotently on the same finalize.
+#[derive(Debug, Clone)]
+pub struct CommitUploadCommand {
+    pub asset_id: AssetId,
+    pub etag: Option<String>,
+    /// Optional client-computed SHA-256 (hex), cross-checked against the probe.
+    pub content_sha256: Option<String>,
+}
+
+/// Finalizes a pending upload: confirms the bytes landed, probes them for the
+/// verified facts (never trusting the client's declaration), transitions the asset
+/// to `Uploaded`, and emits `AssetUploaded` — the trigger for the async pipeline.
+pub struct CommitUploadHandler {
+    assets: Arc<dyn AssetRepository>,
+    store: Arc<dyn ObjectStore>,
+    probe: Arc<dyn MediaProbe>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl CommitUploadHandler {
+    pub fn new(
+        assets: Arc<dyn AssetRepository>,
+        store: Arc<dyn ObjectStore>,
+        probe: Arc<dyn MediaProbe>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { assets, store, probe, publisher }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<CommitUploadCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<Asset, MediaError> {
+        let cmd = envelope.payload;
+        let mut asset = self
+            .assets
+            .find_by_id(&cmd.asset_id)
+            .await?
+            .ok_or_else(|| MediaError::AssetNotFound { id: cmd.asset_id.as_str() })?;
+
+        // Idempotent: a commit that races the S3 event (or a double-tap) finds the
+        // asset already finalized — return it unchanged.
+        if asset.state() != AssetState::Pending {
+            return Ok(asset);
+        }
+
+        let staging = StorageKey::staging(asset.id());
+        // The bytes must actually be present — a commit ahead of the upload is a
+        // precondition failure, not a finalize.
+        if self.store.head(&staging).await?.is_none() {
+            return Err(MediaError::UploadNotFinalized);
+        }
+
+        // Probe the real bytes for the verified facts (magic-byte type, true size,
+        // dimensions, content hash).
+        let report = self.probe.probe(&staging, asset.declared_mime()).await?;
+
+        // If the client asserted a hash, it must match what we actually stored.
+        if let Some(declared) = cmd.content_sha256.as_deref()
+            && ContentHash::new(declared)? != report.content_hash
+        {
+            return Err(MediaError::CorruptMedia {
+                reason: "client-declared content hash does not match the stored object".into(),
+            });
+        }
+
+        let constraints = UploadConstraints::for_kind(asset.kind());
+        asset.finalize(
+            FinalizeParams {
+                mime_type: report.mime_type,
+                byte_size: report.byte_size,
+                dimensions: report.dimensions,
+                content_hash: report.content_hash,
+            },
+            &constraints,
+            now,
+        )?;
+
+        self.assets.save(&asset).await?;
+        for event in asset.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
+        Ok(asset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture, TEST_HASH};
+    use crate::domain::value_object::MediaKind;
+    use uuid::Uuid;
+
+    fn env(c: CommitUploadCommand) -> Envelope<CommitUploadCommand> {
+        Envelope::new(Uuid::now_v7(), c)
+    }
+
+    #[tokio::test]
+    async fn finalizes_a_present_upload_and_emits_uploaded() {
+        let fx = Fixture::new();
+        let asset_id = fx.reserve_and_upload(MediaKind::PostImage).await;
+
+        let asset = fx
+            .commit_handler()
+            .handle(env(CommitUploadCommand { asset_id, etag: None, content_sha256: None }), t0())
+            .await
+            .unwrap();
+
+        assert_eq!(asset.state(), AssetState::Uploaded);
+        assert_eq!(asset.content_hash().unwrap().as_str(), TEST_HASH);
+        assert_eq!(fx.publisher.event_types(), vec!["media.asset_uploaded"]);
+    }
+
+    #[tokio::test]
+    async fn commit_without_bytes_is_a_precondition_failure() {
+        let fx = Fixture::new();
+        // Reserve but do NOT upload the bytes.
+        let asset_id = fx.reserve_only(MediaKind::Avatar).await;
+        let err = fx
+            .commit_handler()
+            .handle(env(CommitUploadCommand { asset_id, etag: None, content_sha256: None }), t0())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MediaError::UploadNotFinalized));
+    }
+
+    #[tokio::test]
+    async fn commit_is_idempotent_on_an_already_finalized_asset() {
+        let fx = Fixture::new();
+        let asset_id = fx.reserve_and_upload(MediaKind::PostImage).await;
+        let cmd = || CommitUploadCommand { asset_id, etag: None, content_sha256: None };
+        fx.commit_handler().handle(env(cmd()), t0()).await.unwrap();
+        fx.publisher.clear();
+        // Second commit: no state change, no new event.
+        let asset = fx.commit_handler().handle(env(cmd()), t0()).await.unwrap();
+        assert_eq!(asset.state(), AssetState::Uploaded);
+        assert_eq!(fx.publisher.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn a_mismatched_declared_hash_is_rejected_as_corrupt() {
+        let fx = Fixture::new();
+        let asset_id = fx.reserve_and_upload(MediaKind::PostImage).await;
+        let err = fx
+            .commit_handler()
+            .handle(
+                env(CommitUploadCommand {
+                    asset_id,
+                    etag: None,
+                    content_sha256: Some("f".repeat(64)),
+                }),
+                t0(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MediaError::CorruptMedia { .. }));
+    }
+}

--- a/crates/services/media/src/application/command/delete_asset.rs
+++ b/crates/services/media/src/application/command/delete_asset.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::port::{AssetRepository, CdnGateway, DeliveryCache, EventPublisher, ObjectStore};
+use crate::domain::value_object::{AssetId, OwnerId, StorageKey};
+use crate::error::MediaError;
+
+/// Owner-initiated hard delete.
+#[derive(Debug, Clone)]
+pub struct DeleteAssetCommand {
+    pub asset_id: AssetId,
+    /// The requesting actor (edge-resolved); must own the asset.
+    pub owner_id: OwnerId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeleteOutcome {
+    pub deleted: bool,
+}
+
+/// Deletes an asset: the domain `delete` is attempted **first** so a legal hold
+/// (`LegalHoldActive`, MED-7003) blocks erasure before any byte is touched. On a
+/// real delete it purges every object (master + renditions + staging), invalidates
+/// the CDN, drops the cache, tombstones the row, and emits `AssetDeleted`.
+pub struct DeleteAssetHandler {
+    assets: Arc<dyn AssetRepository>,
+    store: Arc<dyn ObjectStore>,
+    cdn: Arc<dyn CdnGateway>,
+    cache: Arc<dyn DeliveryCache>,
+    publisher: Arc<dyn EventPublisher>,
+}
+
+impl DeleteAssetHandler {
+    pub fn new(
+        assets: Arc<dyn AssetRepository>,
+        store: Arc<dyn ObjectStore>,
+        cdn: Arc<dyn CdnGateway>,
+        cache: Arc<dyn DeliveryCache>,
+        publisher: Arc<dyn EventPublisher>,
+    ) -> Self {
+        Self { assets, store, cdn, cache, publisher }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<DeleteAssetCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<DeleteOutcome, MediaError> {
+        let cmd = envelope.payload;
+        let mut asset = self
+            .assets
+            .find_by_id(&cmd.asset_id)
+            .await?
+            .ok_or_else(|| MediaError::AssetNotFound { id: cmd.asset_id.as_str() })?;
+
+        // Don't leak existence to a non-owner — same response as a missing asset.
+        if asset.owner_id() != cmd.owner_id {
+            return Err(MediaError::AssetNotFound { id: cmd.asset_id.as_str() });
+        }
+
+        // Legal-hold guard fires here, before any byte is purged.
+        asset.delete(now)?;
+
+        // Purge bytes: every rendition object + the staging object.
+        let mut keys: Vec<StorageKey> =
+            asset.renditions().iter().map(|r| r.storage_key().clone()).collect();
+        keys.push(StorageKey::staging(asset.id()));
+        for key in &keys {
+            self.store.delete(key).await?;
+        }
+        self.cdn.invalidate(&keys).await?;
+        self.cache.invalidate(&asset.id()).await?;
+
+        self.assets.save(&asset).await?;
+        for event in asset.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
+        Ok(DeleteOutcome { deleted: true })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{AssetState, MediaKind};
+    use uuid::Uuid;
+
+    fn env(asset_id: AssetId, owner_id: OwnerId) -> Envelope<DeleteAssetCommand> {
+        Envelope::new(Uuid::now_v7(), DeleteAssetCommand { asset_id, owner_id })
+    }
+
+    #[tokio::test]
+    async fn deletes_a_ready_asset_and_purges_bytes() {
+        let fx = Fixture::new();
+        let (asset_id, owner) = fx.ready_asset(MediaKind::PostImage).await;
+        fx.publisher.clear();
+
+        let out = fx.delete_handler().handle(env(asset_id, owner), t0()).await.unwrap();
+        assert!(out.deleted);
+
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Deleted);
+        assert_eq!(fx.publisher.event_types(), vec!["media.asset_deleted"]);
+        // The CDN was invalidated for the purged keys.
+        assert!(!fx.cdn.invalidated_keys().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_legal_hold_blocks_deletion_before_any_byte_is_touched() {
+        let fx = Fixture::new();
+        let (asset_id, owner) = fx.ready_asset(MediaKind::PostImage).await;
+        // Quarantine + legal hold via a CSAM screen path would set this; place it directly.
+        {
+            let mut a = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+            a.place_legal_hold(t0());
+            fx.assets.save(&a).await.unwrap();
+        }
+        let err = fx.delete_handler().handle(env(asset_id, owner), t0()).await.unwrap_err();
+        assert!(matches!(err, MediaError::LegalHoldActive));
+        // Nothing purged.
+        assert!(fx.cdn.invalidated_keys().is_empty());
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Ready);
+    }
+
+    #[tokio::test]
+    async fn a_non_owner_cannot_delete_and_sees_not_found() {
+        let fx = Fixture::new();
+        let (asset_id, _owner) = fx.ready_asset(MediaKind::PostImage).await;
+        let stranger = OwnerId::from_uuid(Uuid::from_u128(999));
+        let err = fx.delete_handler().handle(env(asset_id, stranger), t0()).await.unwrap_err();
+        assert!(matches!(err, MediaError::AssetNotFound { .. }));
+    }
+}

--- a/crates/services/media/src/application/command/issue_ticket.rs
+++ b/crates/services/media/src/application/command/issue_ticket.rs
@@ -1,0 +1,192 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::policy::MediaPolicy;
+use crate::application::port::{AssetRepository, ObjectStore, PresignedUpload};
+use crate::domain::aggregate::{Asset, ReserveParams};
+use crate::domain::value_object::{
+    AssetId, ContentHash, MediaKind, MimeType, OwnerId, UploadConstraints, UploadTicket,
+};
+use crate::error::MediaError;
+
+/// Plane A — broker a pre-signed upload. No bytes; the client PUTs them straight to
+/// the object store using the returned URL.
+#[derive(Debug, Clone)]
+pub struct IssueUploadTicketCommand {
+    pub owner_id: OwnerId,
+    pub kind: MediaKind,
+    pub declared_mime: MimeType,
+    pub declared_size: u64,
+    /// Optional client-declared SHA-256 (hex). Used for the dedup short-circuit when
+    /// dedup is enabled; otherwise ignored.
+    pub content_sha256: Option<String>,
+    /// Optional caller idempotency key (honored by the Phase-4 cache adapter).
+    pub idempotency_key: Option<String>,
+}
+
+/// The pre-signed plan returned to the client (absent when the upload deduped onto
+/// existing bytes).
+#[derive(Debug, Clone)]
+pub struct PreparedUpload {
+    pub presigned: PresignedUpload,
+    pub max_size_bytes: u64,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IssueUploadTicketOutcome {
+    pub asset_id: AssetId,
+    /// `None` when `deduplicated` — the asset already exists READY, no upload needed.
+    pub upload: Option<PreparedUpload>,
+    pub deduplicated: bool,
+}
+
+/// Reserves a `Pending` asset (validating the declared MIME/size against the kind's
+/// constraints) and mints a pre-signed upload URL for it.
+pub struct IssueUploadTicketHandler {
+    assets: Arc<dyn AssetRepository>,
+    store: Arc<dyn ObjectStore>,
+    policy: MediaPolicy,
+}
+
+impl IssueUploadTicketHandler {
+    pub fn new(
+        assets: Arc<dyn AssetRepository>,
+        store: Arc<dyn ObjectStore>,
+        policy: MediaPolicy,
+    ) -> Self {
+        Self { assets, store, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<IssueUploadTicketCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<IssueUploadTicketOutcome, MediaError> {
+        let cmd = envelope.payload;
+        let constraints = UploadConstraints::for_kind(cmd.kind);
+
+        // Dedup short-circuit (fork B) — only when enabled and a hash is supplied.
+        if self.policy.dedup_enabled
+            && let Some(sha) = cmd.content_sha256.as_deref()
+        {
+            let hash = ContentHash::new(sha)?;
+            if let Some(existing) = self.assets.find_ready_by_content_hash(&hash).await? {
+                return Ok(IssueUploadTicketOutcome {
+                    asset_id: existing.id(),
+                    upload: None,
+                    deduplicated: true,
+                });
+            }
+        }
+
+        let id = AssetId::new();
+        let asset = Asset::reserve(
+            ReserveParams {
+                id,
+                owner_id: cmd.owner_id,
+                kind: cmd.kind,
+                declared_mime: cmd.declared_mime.clone(),
+                declared_size: cmd.declared_size,
+            },
+            &constraints,
+            now,
+        )?;
+        self.assets.save(&asset).await?;
+
+        let ticket = UploadTicket::issue(id, constraints, self.policy.upload_ticket_ttl, now)?;
+        let presigned = self
+            .store
+            .presign_put(
+                ticket.storage_key(),
+                &cmd.declared_mime,
+                ticket.constraints().max_bytes(),
+                self.policy.upload_ticket_ttl,
+            )
+            .await?;
+
+        Ok(IssueUploadTicketOutcome {
+            asset_id: id,
+            upload: Some(PreparedUpload {
+                presigned,
+                max_size_bytes: ticket.constraints().max_bytes(),
+                expires_at: ticket.expires_at(),
+            }),
+            deduplicated: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture, TEST_HASH};
+    use uuid::Uuid;
+
+    fn cmd() -> IssueUploadTicketCommand {
+        IssueUploadTicketCommand {
+            owner_id: OwnerId::from_uuid(Uuid::from_u128(7)),
+            kind: MediaKind::PostImage,
+            declared_mime: MimeType::new("image/jpeg").unwrap(),
+            declared_size: 2_000_000,
+            content_sha256: None,
+            idempotency_key: None,
+        }
+    }
+
+    fn env(c: IssueUploadTicketCommand) -> Envelope<IssueUploadTicketCommand> {
+        Envelope::new(Uuid::now_v7(), c)
+    }
+
+    #[tokio::test]
+    async fn issues_a_ticket_and_persists_a_pending_asset() {
+        let fx = Fixture::new();
+        let out = fx.issue_ticket_handler().handle(env(cmd()), t0()).await.unwrap();
+
+        assert!(!out.deduplicated);
+        let upload = out.upload.expect("a fresh upload plan");
+        assert_eq!(upload.presigned.method, "PUT");
+        assert!(upload.presigned.url.contains(&out.asset_id.as_str()));
+        // The asset is persisted Pending.
+        let stored = fx.assets.find_by_id(&out.asset_id).await.unwrap().unwrap();
+        assert_eq!(stored.state(), crate::domain::value_object::AssetState::Pending);
+    }
+
+    #[tokio::test]
+    async fn rejects_an_oversize_declaration_before_any_upload() {
+        let fx = Fixture::new();
+        let mut c = cmd();
+        c.declared_size = MediaKind::PostImage.max_bytes() + 1;
+        let err = fx.issue_ticket_handler().handle(env(c), t0()).await.unwrap_err();
+        assert!(matches!(err, MediaError::UploadSizeExceeded { .. }));
+    }
+
+    #[tokio::test]
+    async fn dedup_off_by_default_always_issues_a_fresh_ticket() {
+        let fx = Fixture::new();
+        // Even with a matching READY asset present, dedup is disabled by default.
+        fx.seed_ready_asset(TEST_HASH).await;
+        let mut c = cmd();
+        c.content_sha256 = Some(TEST_HASH.to_owned());
+        let out = fx.issue_ticket_handler().handle(env(c), t0()).await.unwrap();
+        assert!(!out.deduplicated);
+        assert!(out.upload.is_some());
+    }
+
+    #[tokio::test]
+    async fn dedup_when_enabled_short_circuits_onto_existing_bytes() {
+        let mut fx = Fixture::new();
+        fx.policy.dedup_enabled = true;
+        let existing = fx.seed_ready_asset(TEST_HASH).await;
+
+        let mut c = cmd();
+        c.content_sha256 = Some(TEST_HASH.to_owned());
+        let out = fx.issue_ticket_handler().handle(env(c), t0()).await.unwrap();
+
+        assert!(out.deduplicated);
+        assert!(out.upload.is_none(), "no upload needed on a dedup hit");
+        assert_eq!(out.asset_id, existing, "reuses the existing asset");
+    }
+}

--- a/crates/services/media/src/application/command/mod.rs
+++ b/crates/services/media/src/application/command/mod.rs
@@ -1,0 +1,20 @@
+//! Write use-cases — explicit application-service handlers (not `cqrs::Command`),
+//! each taking a [`cqrs::Envelope`] and an injected `now`, returning a rich
+//! outcome. They orchestrate the domain over the outbound ports and publish
+//! lifecycle events durable-first.
+
+pub mod apply_moderation;
+pub mod commit_upload;
+pub mod delete_asset;
+pub mod issue_ticket;
+pub mod process_asset;
+
+pub use apply_moderation::{
+    ApplyModerationCommand, ApplyModerationHandler, ApplyModerationOutcome, ModerationAction,
+};
+pub use commit_upload::{CommitUploadCommand, CommitUploadHandler};
+pub use delete_asset::{DeleteAssetCommand, DeleteAssetHandler, DeleteOutcome};
+pub use issue_ticket::{
+    IssueUploadTicketCommand, IssueUploadTicketHandler, IssueUploadTicketOutcome, PreparedUpload,
+};
+pub use process_asset::{ProcessAssetCommand, ProcessAssetHandler, ProcessOutcome};

--- a/crates/services/media/src/application/command/process_asset.rs
+++ b/crates/services/media/src/application/command/process_asset.rs
@@ -1,0 +1,241 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::Envelope;
+
+use crate::application::policy::MediaPolicy;
+use crate::application::port::{
+    AssetRepository, DeliveryCache, EventPublisher, ImageProcessor, MalwareScanner, ModerationScreen,
+    ScanVerdict,
+};
+use crate::domain::value_object::{AssetId, AssetState, StorageKey};
+use crate::error::MediaError;
+
+/// Plane B — process a finalized (`Uploaded`) asset. Driven off the `AssetUploaded`
+/// event by a worker (Phase 5), not the synchronous RPC path.
+#[derive(Debug, Clone)]
+pub struct ProcessAssetCommand {
+    pub asset_id: AssetId,
+}
+
+/// The terminal outcome of a processing run (all `Ok` at the consumer — the
+/// distinctions drive observability and the worker's commit decision).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessOutcome {
+    Ready,
+    Quarantined,
+    Failed(String),
+    /// The asset was not in `Uploaded` state (already processed / not finalized) —
+    /// a redelivery no-op.
+    Skipped,
+}
+
+/// Runs the transformation pipeline: malware scan → pre-publish moderation screen
+/// (fail-closed) → derive the rendition ladder + BlurHash → mark READY. A screen
+/// block quarantines (and, for CSAM, places a legal hold); a scan hit fails the
+/// asset; a screen outage surfaces `ScreenUnavailable` so the worker retries.
+pub struct ProcessAssetHandler {
+    assets: Arc<dyn AssetRepository>,
+    scanner: Arc<dyn MalwareScanner>,
+    screen: Arc<dyn ModerationScreen>,
+    processor: Arc<dyn ImageProcessor>,
+    cache: Arc<dyn DeliveryCache>,
+    publisher: Arc<dyn EventPublisher>,
+    policy: MediaPolicy,
+}
+
+impl ProcessAssetHandler {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        assets: Arc<dyn AssetRepository>,
+        scanner: Arc<dyn MalwareScanner>,
+        screen: Arc<dyn ModerationScreen>,
+        processor: Arc<dyn ImageProcessor>,
+        cache: Arc<dyn DeliveryCache>,
+        publisher: Arc<dyn EventPublisher>,
+        policy: MediaPolicy,
+    ) -> Self {
+        Self { assets, scanner, screen, processor, cache, publisher, policy }
+    }
+
+    pub async fn handle(
+        &self,
+        envelope: Envelope<ProcessAssetCommand>,
+        now: DateTime<Utc>,
+    ) -> Result<ProcessOutcome, MediaError> {
+        let cmd = envelope.payload;
+        let mut asset = self
+            .assets
+            .find_by_id(&cmd.asset_id)
+            .await?
+            .ok_or_else(|| MediaError::AssetNotFound { id: cmd.asset_id.as_str() })?;
+
+        if asset.state() != AssetState::Uploaded {
+            return Ok(ProcessOutcome::Skipped);
+        }
+
+        let staging = StorageKey::staging(asset.id());
+        // Owned so it doesn't borrow `asset` across the upcoming &mut transitions.
+        let hash = asset.content_hash().cloned().ok_or(MediaError::DomainViolation {
+            field: "content_hash".into(),
+            message: "a finalized asset must carry a content hash".into(),
+        })?;
+
+        // 1. Malware scan — a hit fails the asset terminally.
+        if self.scanner.scan(&staging).await? == ScanVerdict::Infected {
+            asset.mark_failed("malware detected", now)?;
+            self.persist_and_publish(&mut asset).await?;
+            return Ok(ProcessOutcome::Failed("malware detected".into()));
+        }
+
+        // 2. Pre-publish moderation screen (fail-closed, hard timeout).
+        let asset_id = asset.id();
+        let lookup = self.screen.screen(&asset_id, &hash, asset.kind());
+        let decision = match tokio::time::timeout(self.policy.screen_timeout, lookup).await {
+            Ok(result) => result?,
+            Err(_elapsed) => return Err(MediaError::ScreenUnavailable),
+        };
+        if decision.blocked {
+            asset.quarantine(now)?;
+            if decision.csam {
+                // Catastrophic-category match → preserve evidence (blocks deletion).
+                asset.place_legal_hold(now);
+            }
+            self.cache.invalidate(&asset.id()).await?;
+            self.persist_and_publish(&mut asset).await?;
+            return Ok(ProcessOutcome::Quarantined);
+        }
+
+        // 3. Derive the rendition ladder + BlurHash from the validated master.
+        asset.begin_processing(now)?;
+        let derived = self.processor.derive(&staging, asset.kind(), &hash).await?;
+        asset.set_blurhash(derived.blurhash, now)?;
+        for rendition in derived.renditions {
+            asset.attach_rendition(rendition, now)?;
+        }
+
+        // 4. Publish.
+        asset.mark_ready(now)?;
+        self.persist_and_publish(&mut asset).await?;
+        // Warm the delivery cache so the first read is hot.
+        let _ = self.cache.put(&asset).await;
+        Ok(ProcessOutcome::Ready)
+    }
+
+    async fn persist_and_publish(
+        &self,
+        asset: &mut crate::domain::aggregate::Asset,
+    ) -> Result<(), MediaError> {
+        self.assets.save(asset).await?;
+        for event in asset.drain_events() {
+            self.publisher.publish(&event).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::{MediaKind, RenditionKind};
+    use std::time::Duration as StdDuration;
+    use uuid::Uuid;
+
+    fn env(asset_id: AssetId) -> Envelope<ProcessAssetCommand> {
+        Envelope::new(Uuid::now_v7(), ProcessAssetCommand { asset_id })
+    }
+
+    #[tokio::test]
+    async fn clean_asset_processes_to_ready_with_renditions() {
+        let fx = Fixture::new();
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+        fx.publisher.clear();
+
+        let outcome = fx.process_handler().handle(env(asset_id), t0()).await.unwrap();
+        assert_eq!(outcome, ProcessOutcome::Ready);
+
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Ready);
+        assert!(asset.is_deliverable());
+        assert!(asset.rendition(RenditionKind::Original).is_some());
+        assert!(asset.blurhash().is_some());
+        // variant-ready (x2) then ready, in order.
+        let types = fx.publisher.event_types();
+        assert_eq!(*types.last().unwrap(), "media.asset_ready");
+        assert!(types.contains(&"media.asset_variant_ready"));
+    }
+
+    #[tokio::test]
+    async fn a_screen_block_quarantines_and_skips_renditions() {
+        let fx = Fixture::new();
+        fx.screen.set_block(false);
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+        fx.publisher.clear();
+
+        let outcome = fx.process_handler().handle(env(asset_id), t0()).await.unwrap();
+        assert_eq!(outcome, ProcessOutcome::Quarantined);
+
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Quarantined);
+        assert!(!asset.legal_hold(), "a non-CSAM block does not place a legal hold");
+        assert_eq!(fx.publisher.event_types(), vec!["media.asset_quarantined"]);
+    }
+
+    #[tokio::test]
+    async fn a_csam_block_also_places_a_legal_hold() {
+        let fx = Fixture::new();
+        fx.screen.set_block(true); // csam = true
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+
+        fx.process_handler().handle(env(asset_id), t0()).await.unwrap();
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Quarantined);
+        assert!(asset.legal_hold(), "CSAM match preserves evidence via a legal hold");
+    }
+
+    #[tokio::test]
+    async fn malware_fails_the_asset() {
+        let fx = Fixture::new();
+        fx.scanner.set_infected();
+        let asset_id = fx.uploaded_asset(MediaKind::Avatar).await;
+
+        let outcome = fx.process_handler().handle(env(asset_id), t0()).await.unwrap();
+        assert!(matches!(outcome, ProcessOutcome::Failed(_)));
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Failed);
+    }
+
+    #[tokio::test]
+    async fn a_screen_outage_fails_closed_as_unavailable() {
+        let fx = Fixture::new();
+        fx.screen.set_unavailable();
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+
+        let err = fx.process_handler().handle(env(asset_id), t0()).await.unwrap_err();
+        assert!(matches!(err, MediaError::ScreenUnavailable));
+        // Nothing published; the asset stays Uploaded for the worker to retry.
+        let asset = fx.assets.find_by_id(&asset_id).await.unwrap().unwrap();
+        assert_eq!(asset.state(), AssetState::Uploaded);
+    }
+
+    #[tokio::test]
+    async fn a_slow_screen_trips_the_hard_timeout() {
+        let mut fx = Fixture::new();
+        fx.policy.screen_timeout = StdDuration::from_millis(10);
+        fx.screen.set_delay(StdDuration::from_millis(150));
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+
+        let err = fx.process_handler().handle(env(asset_id), t0()).await.unwrap_err();
+        assert!(matches!(err, MediaError::ScreenUnavailable));
+    }
+
+    #[tokio::test]
+    async fn reprocessing_an_already_ready_asset_is_a_no_op() {
+        let fx = Fixture::new();
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+        fx.process_handler().handle(env(asset_id), t0()).await.unwrap();
+        let outcome = fx.process_handler().handle(env(asset_id), t0()).await.unwrap();
+        assert_eq!(outcome, ProcessOutcome::Skipped);
+    }
+}

--- a/crates/services/media/src/application/fakes.rs
+++ b/crates/services/media/src/application/fakes.rs
@@ -1,0 +1,589 @@
+//! In-memory fakes for every outbound port, plus a [`Fixture`] that wires them into
+//! the handlers. Test-only (`#[cfg(test)]`) — they prove the application layer works
+//! against the port contracts with no real backend, which is exactly what makes the
+//! abstraction credible before the Phase 4 adapters exist.
+
+// Fakes are constructed explicitly via `new()` / `Fixture::new()`; a `Default`
+// impl would add noise without a caller.
+#![allow(clippy::new_without_default)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration as StdDuration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use cqrs::Envelope;
+use uuid::Uuid;
+
+use super::command::{
+    CommitUploadCommand, IssueUploadTicketCommand, ProcessAssetCommand,
+};
+use super::policy::MediaPolicy;
+use super::port::{
+    AssetRepository, CdnGateway, DeliveryCache, DerivedRenditions, EventPublisher, ImageProcessor,
+    MalwareScanner, MediaProbe, MediaProbeReport, ModerationScreen, ObjectHead, ObjectStore,
+    PresignedUpload, ResolvedUrl, ScanVerdict, ScreenDecision,
+};
+use crate::domain::aggregate::{Asset, AssetSnapshot, Rendition};
+use crate::domain::event::DomainEvent;
+use crate::domain::value_object::{
+    AssetId, AssetState, Blurhash, ContentHash, DeliveryVisibility, Dimensions, MediaKind, MimeType,
+    OwnerId, RenditionKind, StorageKey,
+};
+use crate::error::MediaError;
+
+/// A fixed reference instant for deterministic tests.
+pub fn t0() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-06-26T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+/// The canonical SHA-256 the [`StubMediaProbe`] reports, so the whole pipeline
+/// shares one content hash.
+pub const TEST_HASH: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+fn owner() -> OwnerId {
+    OwnerId::from_uuid(Uuid::from_u128(7))
+}
+
+fn jpeg() -> MimeType {
+    MimeType::new("image/jpeg").unwrap()
+}
+
+// ─── AssetRepository ─────────────────────────────────────────────────────────────
+
+pub struct InMemoryAssetRepository {
+    assets: Mutex<HashMap<AssetId, Asset>>,
+}
+
+impl InMemoryAssetRepository {
+    pub fn new() -> Self {
+        Self { assets: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl AssetRepository for InMemoryAssetRepository {
+    async fn save(&self, asset: &Asset) -> Result<(), MediaError> {
+        let mut stored = asset.clone();
+        let _ = stored.drain_events(); // events do not survive persistence
+        self.assets.lock().unwrap().insert(stored.id(), stored);
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &AssetId) -> Result<Option<Asset>, MediaError> {
+        Ok(self.assets.lock().unwrap().get(id).cloned())
+    }
+
+    async fn find_ready_by_content_hash(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<Option<Asset>, MediaError> {
+        Ok(self
+            .assets
+            .lock()
+            .unwrap()
+            .values()
+            .find(|a| a.state() == AssetState::Ready && a.content_hash() == Some(hash))
+            .cloned())
+    }
+}
+
+// ─── DeliveryCache ───────────────────────────────────────────────────────────────
+
+pub struct InMemoryDeliveryCache {
+    entries: Mutex<HashMap<AssetId, Asset>>,
+}
+
+impl InMemoryDeliveryCache {
+    pub fn new() -> Self {
+        Self { entries: Mutex::new(HashMap::new()) }
+    }
+}
+
+#[async_trait]
+impl DeliveryCache for InMemoryDeliveryCache {
+    async fn get(&self, id: &AssetId) -> Result<Option<Asset>, MediaError> {
+        Ok(self.entries.lock().unwrap().get(id).cloned())
+    }
+
+    async fn put(&self, asset: &Asset) -> Result<(), MediaError> {
+        let mut stored = asset.clone();
+        let _ = stored.drain_events();
+        self.entries.lock().unwrap().insert(stored.id(), stored);
+        Ok(())
+    }
+
+    async fn invalidate(&self, id: &AssetId) -> Result<(), MediaError> {
+        self.entries.lock().unwrap().remove(id);
+        Ok(())
+    }
+}
+
+// ─── ObjectStore ─────────────────────────────────────────────────────────────────
+
+pub struct StubObjectStore {
+    objects: Mutex<HashMap<String, ObjectHead>>,
+}
+
+impl StubObjectStore {
+    pub fn new() -> Self {
+        Self { objects: Mutex::new(HashMap::new()) }
+    }
+
+    /// Simulates the client's direct-to-store upload landing.
+    pub fn put_object(&self, key: &StorageKey, size_bytes: u64, etag: &str) {
+        self.objects
+            .lock()
+            .unwrap()
+            .insert(key.as_str().to_owned(), ObjectHead { size_bytes, etag: etag.to_owned() });
+    }
+}
+
+#[async_trait]
+impl ObjectStore for StubObjectStore {
+    async fn presign_put(
+        &self,
+        key: &StorageKey,
+        content_type: &MimeType,
+        _max_bytes: u64,
+        _expires_in: Duration,
+    ) -> Result<PresignedUpload, MediaError> {
+        let mut required_headers = HashMap::new();
+        required_headers.insert("Content-Type".to_owned(), content_type.as_str().to_owned());
+        Ok(PresignedUpload {
+            url: format!("https://store.local/{}?X-Sig=fake", key.as_str()),
+            method: "PUT".to_owned(),
+            required_headers,
+        })
+    }
+
+    async fn head(&self, key: &StorageKey) -> Result<Option<ObjectHead>, MediaError> {
+        Ok(self.objects.lock().unwrap().get(key.as_str()).cloned())
+    }
+
+    async fn delete(&self, key: &StorageKey) -> Result<(), MediaError> {
+        self.objects.lock().unwrap().remove(key.as_str());
+        Ok(())
+    }
+}
+
+// ─── CdnGateway ──────────────────────────────────────────────────────────────────
+
+pub struct RecordingCdnGateway {
+    invalidated: Mutex<Vec<String>>,
+}
+
+impl RecordingCdnGateway {
+    pub fn new() -> Self {
+        Self { invalidated: Mutex::new(Vec::new()) }
+    }
+
+    pub fn invalidated_keys(&self) -> Vec<String> {
+        self.invalidated.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl CdnGateway for RecordingCdnGateway {
+    async fn resolve(
+        &self,
+        key: &StorageKey,
+        visibility: DeliveryVisibility,
+        now: DateTime<Utc>,
+    ) -> Result<ResolvedUrl, MediaError> {
+        let expires_at = visibility.is_expiring().then(|| now + Duration::minutes(5));
+        Ok(ResolvedUrl {
+            url: format!("https://cdn.local/{}", key.as_str()),
+            expires_at,
+        })
+    }
+
+    async fn invalidate(&self, keys: &[StorageKey]) -> Result<(), MediaError> {
+        let mut log = self.invalidated.lock().unwrap();
+        for k in keys {
+            log.push(k.as_str().to_owned());
+        }
+        Ok(())
+    }
+}
+
+// ─── MediaProbe ──────────────────────────────────────────────────────────────────
+
+pub struct StubMediaProbe {
+    report: Mutex<MediaProbeReport>,
+}
+
+impl StubMediaProbe {
+    pub fn new() -> Self {
+        Self {
+            report: Mutex::new(MediaProbeReport {
+                mime_type: jpeg(),
+                byte_size: 2_000_000,
+                dimensions: Dimensions::new(1920, 1080).unwrap(),
+                content_hash: ContentHash::new(TEST_HASH).unwrap(),
+            }),
+        }
+    }
+
+    pub fn set_report(&self, report: MediaProbeReport) {
+        *self.report.lock().unwrap() = report;
+    }
+}
+
+#[async_trait]
+impl MediaProbe for StubMediaProbe {
+    async fn probe(
+        &self,
+        _key: &StorageKey,
+        _declared_mime: &MimeType,
+    ) -> Result<MediaProbeReport, MediaError> {
+        Ok(self.report.lock().unwrap().clone())
+    }
+}
+
+// ─── ImageProcessor ──────────────────────────────────────────────────────────────
+
+pub struct StubImageProcessor;
+
+impl StubImageProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ImageProcessor for StubImageProcessor {
+    async fn derive(
+        &self,
+        _source: &StorageKey,
+        kind: MediaKind,
+        hash: &ContentHash,
+    ) -> Result<DerivedRenditions, MediaError> {
+        let original = Rendition::new(
+            RenditionKind::Original,
+            jpeg(),
+            StorageKey::rendition(kind, hash, RenditionKind::Original, "jpg"),
+            Dimensions::new(1920, 1080).unwrap(),
+            2_000_000,
+        );
+        let thumbnail = Rendition::new(
+            RenditionKind::Thumbnail,
+            MimeType::new("image/webp").unwrap(),
+            StorageKey::rendition(kind, hash, RenditionKind::Thumbnail, "webp"),
+            Dimensions::new(320, 180).unwrap(),
+            20_000,
+        );
+        Ok(DerivedRenditions {
+            renditions: vec![original, thumbnail],
+            blurhash: Blurhash::new("LEHV6nWB2yk8pyo0adR*").unwrap(),
+        })
+    }
+}
+
+// ─── MalwareScanner ──────────────────────────────────────────────────────────────
+
+pub struct StubMalwareScanner {
+    infected: Mutex<bool>,
+}
+
+impl StubMalwareScanner {
+    pub fn new() -> Self {
+        Self { infected: Mutex::new(false) }
+    }
+
+    pub fn set_infected(&self) {
+        *self.infected.lock().unwrap() = true;
+    }
+}
+
+#[async_trait]
+impl MalwareScanner for StubMalwareScanner {
+    async fn scan(&self, _key: &StorageKey) -> Result<ScanVerdict, MediaError> {
+        Ok(if *self.infected.lock().unwrap() {
+            ScanVerdict::Infected
+        } else {
+            ScanVerdict::Clean
+        })
+    }
+}
+
+// ─── ModerationScreen ────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum ScreenMode {
+    Allow,
+    Block { csam: bool },
+    Unavailable,
+}
+
+pub struct StubModerationScreen {
+    mode: Mutex<ScreenMode>,
+    delay: Mutex<Option<StdDuration>>,
+}
+
+impl StubModerationScreen {
+    pub fn new() -> Self {
+        Self {
+            mode: Mutex::new(ScreenMode::Allow),
+            delay: Mutex::new(None),
+        }
+    }
+
+    /// `csam = true` flags a catastrophic-category match (warrants a legal hold).
+    pub fn set_block(&self, csam: bool) {
+        *self.mode.lock().unwrap() = ScreenMode::Block { csam };
+    }
+
+    pub fn set_unavailable(&self) {
+        *self.mode.lock().unwrap() = ScreenMode::Unavailable;
+    }
+
+    /// Makes the gate answer after `delay` — to drive the hard-timeout path.
+    pub fn set_delay(&self, delay: StdDuration) {
+        *self.delay.lock().unwrap() = Some(delay);
+    }
+}
+
+#[async_trait]
+impl ModerationScreen for StubModerationScreen {
+    async fn screen(
+        &self,
+        _asset_id: &AssetId,
+        _content_hash: &ContentHash,
+        _kind: MediaKind,
+    ) -> Result<ScreenDecision, MediaError> {
+        let delay = *self.delay.lock().unwrap();
+        if let Some(d) = delay {
+            tokio::time::sleep(d).await;
+        }
+        let mode = *self.mode.lock().unwrap();
+        match mode {
+            ScreenMode::Allow => Ok(ScreenDecision::allow()),
+            ScreenMode::Block { csam } => Ok(ScreenDecision {
+                blocked: true,
+                csam,
+                reference: Some("ncmec:test".to_owned()),
+            }),
+            ScreenMode::Unavailable => Err(MediaError::ScreenUnavailable),
+        }
+    }
+}
+
+// ─── EventPublisher ──────────────────────────────────────────────────────────────
+
+pub struct RecordingEventPublisher {
+    events: Mutex<Vec<DomainEvent>>,
+}
+
+impl RecordingEventPublisher {
+    pub fn new() -> Self {
+        Self { events: Mutex::new(Vec::new()) }
+    }
+
+    pub fn event_types(&self) -> Vec<&'static str> {
+        self.events.lock().unwrap().iter().map(|e| e.event_type()).collect()
+    }
+
+    pub fn count(&self) -> usize {
+        self.events.lock().unwrap().len()
+    }
+
+    pub fn clear(&self) {
+        self.events.lock().unwrap().clear();
+    }
+}
+
+#[async_trait]
+impl EventPublisher for RecordingEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), MediaError> {
+        self.events.lock().unwrap().push(event.clone());
+        Ok(())
+    }
+}
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────────
+
+/// Bundles concrete fakes and builds handlers wired to them. Handlers receive the
+/// fakes as `Arc<dyn Port>`; tests keep the concrete `Arc`s to assert on recorded
+/// state (published events, invalidated keys, stored assets).
+pub struct Fixture {
+    pub assets: Arc<InMemoryAssetRepository>,
+    pub cache: Arc<InMemoryDeliveryCache>,
+    pub store: Arc<StubObjectStore>,
+    pub cdn: Arc<RecordingCdnGateway>,
+    pub probe: Arc<StubMediaProbe>,
+    pub processor: Arc<StubImageProcessor>,
+    pub scanner: Arc<StubMalwareScanner>,
+    pub screen: Arc<StubModerationScreen>,
+    pub publisher: Arc<RecordingEventPublisher>,
+    pub policy: MediaPolicy,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        Self {
+            assets: Arc::new(InMemoryAssetRepository::new()),
+            cache: Arc::new(InMemoryDeliveryCache::new()),
+            store: Arc::new(StubObjectStore::new()),
+            cdn: Arc::new(RecordingCdnGateway::new()),
+            probe: Arc::new(StubMediaProbe::new()),
+            processor: Arc::new(StubImageProcessor::new()),
+            scanner: Arc::new(StubMalwareScanner::new()),
+            screen: Arc::new(StubModerationScreen::new()),
+            publisher: Arc::new(RecordingEventPublisher::new()),
+            policy: MediaPolicy::test_default(),
+        }
+    }
+
+    // ─── Handler builders ────────────────────────────────────────────────────
+
+    pub fn issue_ticket_handler(&self) -> super::command::IssueUploadTicketHandler {
+        super::command::IssueUploadTicketHandler::new(
+            Arc::clone(&self.assets) as _,
+            Arc::clone(&self.store) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn commit_handler(&self) -> super::command::CommitUploadHandler {
+        super::command::CommitUploadHandler::new(
+            Arc::clone(&self.assets) as _,
+            Arc::clone(&self.store) as _,
+            Arc::clone(&self.probe) as _,
+            Arc::clone(&self.publisher) as _,
+        )
+    }
+
+    pub fn process_handler(&self) -> super::command::ProcessAssetHandler {
+        super::command::ProcessAssetHandler::new(
+            Arc::clone(&self.assets) as _,
+            Arc::clone(&self.scanner) as _,
+            Arc::clone(&self.screen) as _,
+            Arc::clone(&self.processor) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.publisher) as _,
+            self.policy.clone(),
+        )
+    }
+
+    pub fn delete_handler(&self) -> super::command::DeleteAssetHandler {
+        super::command::DeleteAssetHandler::new(
+            Arc::clone(&self.assets) as _,
+            Arc::clone(&self.store) as _,
+            Arc::clone(&self.cdn) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.publisher) as _,
+        )
+    }
+
+    pub fn apply_moderation_handler(&self) -> super::command::ApplyModerationHandler {
+        super::command::ApplyModerationHandler::new(
+            Arc::clone(&self.assets) as _,
+            Arc::clone(&self.cdn) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.publisher) as _,
+        )
+    }
+
+    pub fn get_asset_handler(&self) -> super::query::GetAssetHandler {
+        super::query::GetAssetHandler::new(Arc::clone(&self.assets) as _)
+    }
+
+    pub fn resolve_delivery_handler(&self) -> super::query::ResolveDeliveryHandler {
+        super::query::ResolveDeliveryHandler::new(
+            Arc::clone(&self.assets) as _,
+            Arc::clone(&self.cache) as _,
+            Arc::clone(&self.cdn) as _,
+        )
+    }
+
+    // ─── Scenario builders ───────────────────────────────────────────────────
+
+    /// Reserves a `Pending` asset via the real handler; does NOT upload bytes.
+    pub async fn reserve_only(&self, kind: MediaKind) -> AssetId {
+        let cmd = IssueUploadTicketCommand {
+            owner_id: owner(),
+            kind,
+            declared_mime: jpeg(),
+            declared_size: 2_000_000,
+            content_sha256: None,
+            idempotency_key: None,
+        };
+        self.issue_ticket_handler()
+            .handle(Envelope::new(Uuid::now_v7(), cmd), t0())
+            .await
+            .unwrap()
+            .asset_id
+    }
+
+    /// Reserves and lands the bytes in the store (so `commit` finds them).
+    pub async fn reserve_and_upload(&self, kind: MediaKind) -> AssetId {
+        let id = self.reserve_only(kind).await;
+        self.store.put_object(&StorageKey::staging(id), 2_000_000, "etag-1");
+        id
+    }
+
+    /// Drives an asset to `Uploaded` (reserve → upload → commit).
+    pub async fn uploaded_asset(&self, kind: MediaKind) -> AssetId {
+        let id = self.reserve_and_upload(kind).await;
+        self.commit_handler()
+            .handle(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    CommitUploadCommand { asset_id: id, etag: None, content_sha256: None },
+                ),
+                t0(),
+            )
+            .await
+            .unwrap();
+        id
+    }
+
+    /// Drives an asset all the way to `Ready` and returns `(id, owner)`.
+    pub async fn ready_asset(&self, kind: MediaKind) -> (AssetId, OwnerId) {
+        let id = self.uploaded_asset(kind).await;
+        self.process_handler()
+            .handle(Envelope::new(Uuid::now_v7(), ProcessAssetCommand { asset_id: id }), t0())
+            .await
+            .unwrap();
+        (id, owner())
+    }
+
+    /// Seeds a READY asset with a specific content hash directly into the repo
+    /// (for the dedup lookup, independent of the pipeline).
+    pub async fn seed_ready_asset(&self, hash_hex: &str) -> AssetId {
+        let id = AssetId::new();
+        let hash = ContentHash::new(hash_hex).unwrap();
+        let kind = MediaKind::PostImage;
+        let original = Rendition::new(
+            RenditionKind::Original,
+            jpeg(),
+            StorageKey::rendition(kind, &hash, RenditionKind::Original, "jpg"),
+            Dimensions::new(1920, 1080).unwrap(),
+            2_000_000,
+        );
+        let asset = Asset::reconstitute(AssetSnapshot {
+            id,
+            owner_id: owner(),
+            kind,
+            state: AssetState::Ready,
+            declared_mime: jpeg(),
+            declared_size: 2_000_000,
+            mime_type: Some(jpeg()),
+            byte_size: Some(2_000_000),
+            dimensions: Some(Dimensions::new(1920, 1080).unwrap()),
+            content_hash: Some(hash),
+            blurhash: Some(Blurhash::new("LEHV6nWB2yk8pyo0adR*").unwrap()),
+            renditions: vec![original],
+            legal_hold: false,
+            prior_state: None,
+            created_at: t0(),
+            updated_at: t0(),
+        });
+        self.assets.save(&asset).await.unwrap();
+        id
+    }
+}

--- a/crates/services/media/src/application/mod.rs
+++ b/crates/services/media/src/application/mod.rs
@@ -1,0 +1,45 @@
+//! The media application layer — use-case orchestration over the domain and ports.
+//!
+//! ## Handler shape
+//! Like `auth`/`moderation`, the write use-cases are explicit application-service
+//! handlers rather than `cqrs::CommandHandler`: they return rich outcomes (a
+//! prepared upload, a pipeline result) that a `Result<(), E>` command cannot
+//! carry. Each takes a [`cqrs::Envelope`] (so the `correlation_id` threads
+//! through) and an injected `now` for deterministic tests. The genuinely
+//! read-only use-cases — `GetAsset`, `ResolveDelivery` — implement
+//! [`cqrs::QueryHandler`] and ride the query bus.
+//!
+//! ## The two planes, as handlers
+//! * **Plane A (sync, light):** [`IssueUploadTicketHandler`] brokers a pre-signed
+//!   upload; [`CommitUploadHandler`] finalizes it (probe → validate → emit
+//!   `AssetUploaded`). Neither touches a byte of the payload.
+//! * **Plane B (async, heavy):** [`ProcessAssetHandler`] runs the transformation
+//!   pipeline (scan → screen → derive → ready), driven off the finalize event by
+//!   a worker (Phase 5). [`ApplyModerationHandler`] applies takedowns/restores.
+//! * **Compliance:** [`DeleteAssetHandler`] honors the legal hold (erasure is
+//!   refused while held) and purges bytes + CDN on a real delete.
+//!
+//! ## Ports
+//! Every external dependency is an `async_trait` port in [`port`], injected as an
+//! `Arc<dyn …>` at the composition root, so handlers never name a concrete
+//! adapter. In-memory fakes of every port back the unit tests.
+//!
+//! ## Durable-first ordering
+//! Handlers persist to the metadata SoR *first*, then publish the lifecycle event.
+//! The durable write is the source of truth; the event is the decoupling feed.
+//!
+//! [`IssueUploadTicketHandler`]: command::IssueUploadTicketHandler
+//! [`CommitUploadHandler`]: command::CommitUploadHandler
+//! [`ProcessAssetHandler`]: command::ProcessAssetHandler
+//! [`ApplyModerationHandler`]: command::ApplyModerationHandler
+//! [`DeleteAssetHandler`]: command::DeleteAssetHandler
+
+pub mod command;
+pub mod policy;
+pub mod port;
+pub mod query;
+
+#[cfg(test)]
+pub mod fakes;
+
+pub use policy::MediaPolicy;

--- a/crates/services/media/src/application/policy.rs
+++ b/crates/services/media/src/application/policy.rs
@@ -1,0 +1,41 @@
+use std::time::Duration as StdDuration;
+
+use chrono::Duration;
+
+/// Tunable policy the media handlers run under. Injected at the composition root
+/// (`MediaConfig::from_env`, Phase 5); the domain ships sane defaults so behaviour
+/// is well-defined from day one.
+#[derive(Debug, Clone)]
+pub struct MediaPolicy {
+    /// How long an issued pre-signed upload ticket stays valid.
+    pub upload_ticket_ttl: Duration,
+    /// Lifetime of a minted signed (private) delivery URL.
+    pub signed_url_ttl: Duration,
+    /// **Content-hash dedup gate (fork B).** When false (the default), every upload
+    /// gets a fresh asset + ticket; when true, an incoming upload whose declared
+    /// SHA-256 matches an existing READY asset short-circuits to it. Off until the
+    /// refcount-aware purge path has live integration coverage.
+    pub dedup_enabled: bool,
+    /// Hard timeout for the pre-publish moderation Screen call — a slow gate must
+    /// not wedge the pipeline (fail-closed on elapse for CSAM-class).
+    pub screen_timeout: StdDuration,
+}
+
+impl MediaPolicy {
+    /// Production defaults: 15-minute upload window, 5-minute signed URLs, dedup
+    /// OFF, 200 ms screen timeout.
+    pub fn standard() -> Self {
+        Self {
+            upload_ticket_ttl: Duration::minutes(15),
+            signed_url_ttl: Duration::minutes(5),
+            dedup_enabled: false,
+            screen_timeout: StdDuration::from_millis(200),
+        }
+    }
+
+    /// Deterministic defaults for unit tests.
+    #[cfg(test)]
+    pub fn test_default() -> Self {
+        Self::standard()
+    }
+}

--- a/crates/services/media/src/application/port/asset_repository.rs
+++ b/crates/services/media/src/application/port/asset_repository.rs
@@ -1,0 +1,25 @@
+//! Persistence for the [`Asset`] aggregate (its renditions ride with it — there is
+//! no separate rendition repository). The concrete adapter is Postgres (the
+//! metadata SoR), injected as `Arc<dyn …>` at the composition root.
+
+use async_trait::async_trait;
+
+use crate::domain::aggregate::Asset;
+use crate::domain::value_object::{AssetId, ContentHash};
+use crate::error::MediaError;
+
+#[async_trait]
+pub trait AssetRepository: Send + Sync + 'static {
+    /// Upserts the asset (optimistic-lock semantics in the Phase-4 adapter; a
+    /// concurrent writer surfaces `ConcurrentModification`).
+    async fn save(&self, asset: &Asset) -> Result<(), MediaError>;
+
+    async fn find_by_id(&self, id: &AssetId) -> Result<Option<Asset>, MediaError>;
+
+    /// Dedup lookup: an existing **READY** asset with these exact bytes, if any.
+    /// Used only when dedup is enabled (fork B); returns `None` otherwise-unmatched.
+    async fn find_ready_by_content_hash(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<Option<Asset>, MediaError>;
+}

--- a/crates/services/media/src/application/port/cdn_gateway.rs
+++ b/crates/services/media/src/application/port/cdn_gateway.rs
@@ -1,0 +1,33 @@
+//! The delivery-plane port: turn a content-addressed [`StorageKey`] into a CDN URL,
+//! and invalidate the edge on a takedown. The concrete adapter (CloudFront/Fastly
+//! signer, Phase 4) lives in `infrastructure`. Bytes never cross this trait.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::domain::value_object::{DeliveryVisibility, StorageKey};
+use crate::error::MediaError;
+
+/// A resolved delivery URL. `expires_at` is set for signed (private) URLs and
+/// `None` for public, content-addressed-immutable ones.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedUrl {
+    pub url: String,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[async_trait]
+pub trait CdnGateway: Send + Sync + 'static {
+    /// Resolves a delivery URL for `key` under the given visibility. Public ⇒ a
+    /// stable immutable URL; Signed ⇒ a short-lived signed URL minted at `now`.
+    async fn resolve(
+        &self,
+        key: &StorageKey,
+        visibility: DeliveryVisibility,
+        now: DateTime<Utc>,
+    ) -> Result<ResolvedUrl, MediaError>;
+
+    /// Invalidates edge caches for these keys — the takedown-only path (delete /
+    /// quarantine). Content-addressed immutability means this never fires on edit.
+    async fn invalidate(&self, keys: &[StorageKey]) -> Result<(), MediaError>;
+}

--- a/crates/services/media/src/application/port/delivery_cache.rs
+++ b/crates/services/media/src/application/port/delivery_cache.rs
@@ -1,0 +1,21 @@
+//! Hot-path read cache for delivery resolution (Redis adapter, Phase 4). Caches the
+//! asset projection so `ResolveDelivery` does not hit Postgres on every feed
+//! render. Best-effort: a miss falls back to the repository, an error is treated
+//! as a miss (the read path fails open).
+
+use async_trait::async_trait;
+
+use crate::domain::aggregate::Asset;
+use crate::domain::value_object::AssetId;
+use crate::error::MediaError;
+
+#[async_trait]
+pub trait DeliveryCache: Send + Sync + 'static {
+    async fn get(&self, id: &AssetId) -> Result<Option<Asset>, MediaError>;
+
+    async fn put(&self, asset: &Asset) -> Result<(), MediaError>;
+
+    /// Drops the cached entry — called on delete, quarantine, and reprocess so a
+    /// stale deliverable view can't outlive a takedown.
+    async fn invalidate(&self, id: &AssetId) -> Result<(), MediaError>;
+}

--- a/crates/services/media/src/application/port/event_publisher.rs
+++ b/crates/services/media/src/application/port/event_publisher.rs
@@ -1,0 +1,15 @@
+//! Outbound port for publishing lifecycle events to `media.v1.events` (Phase 4
+//! Kafka adapter), keyed by `asset_id` for per-asset ordering.
+//!
+//! Handlers persist durably first, then publish — the durable write is the source
+//! of truth, the event is the decoupling feed `post`/`profile`/`search` react to.
+
+use async_trait::async_trait;
+
+use crate::domain::event::DomainEvent;
+use crate::error::MediaError;
+
+#[async_trait]
+pub trait EventPublisher: Send + Sync + 'static {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), MediaError>;
+}

--- a/crates/services/media/src/application/port/image_processor.rs
+++ b/crates/services/media/src/application/port/image_processor.rs
@@ -1,0 +1,33 @@
+//! The transformation engine (Plane B). For images-first v1 this derives the
+//! resize ladder + a BlurHash from the validated master; the concrete adapter
+//! (in-process image library, Phase 4) reads the source object and writes each
+//! content-addressed derivative to the store, returning their metadata. Video gets
+//! a sibling `Transcoder` port in the fast-follow phase — this trait does not grow
+//! a video arm.
+
+use async_trait::async_trait;
+
+use crate::domain::aggregate::Rendition;
+use crate::domain::value_object::{Blurhash, ContentHash, MediaKind, StorageKey};
+use crate::error::MediaError;
+
+/// The derivatives produced for an asset: the rendition catalog plus the BlurHash
+/// placeholder.
+#[derive(Debug, Clone)]
+pub struct DerivedRenditions {
+    pub renditions: Vec<Rendition>,
+    pub blurhash: Blurhash,
+}
+
+#[async_trait]
+pub trait ImageProcessor: Send + Sync + 'static {
+    /// Derives the rendition ladder for `kind` from the validated master at
+    /// `source`, writing each content-addressed derivative to the store. `hash`
+    /// keys the output objects.
+    async fn derive(
+        &self,
+        source: &StorageKey,
+        kind: MediaKind,
+        hash: &ContentHash,
+    ) -> Result<DerivedRenditions, MediaError>;
+}

--- a/crates/services/media/src/application/port/malware_scanner.rs
+++ b/crates/services/media/src/application/port/malware_scanner.rs
@@ -1,0 +1,19 @@
+//! Anti-malware scan of an uploaded object, early in the pipeline. The concrete
+//! adapter (ClamAV-style sidecar, Phase 4) lives in `infrastructure`.
+
+use async_trait::async_trait;
+
+use crate::domain::value_object::StorageKey;
+use crate::error::MediaError;
+
+/// The verdict of a malware scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanVerdict {
+    Clean,
+    Infected,
+}
+
+#[async_trait]
+pub trait MalwareScanner: Send + Sync + 'static {
+    async fn scan(&self, key: &StorageKey) -> Result<ScanVerdict, MediaError>;
+}

--- a/crates/services/media/src/application/port/media_probe.rs
+++ b/crates/services/media/src/application/port/media_probe.rs
@@ -1,0 +1,30 @@
+//! The finalize-time content probe: inspect the *uploaded bytes* and return the
+//! verified facts. This is the "never trust the client" gate — the adapter reads
+//! the object's magic bytes, real dimensions, true size, and SHA-256, independent
+//! of what the client declared. A type that contradicts the declaration is a
+//! `ContentTypeMismatch`; an undecodable file is `CorruptMedia`.
+
+use async_trait::async_trait;
+
+use crate::domain::value_object::{ContentHash, Dimensions, MimeType, StorageKey};
+use crate::error::MediaError;
+
+/// The server-verified facts about an uploaded object.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MediaProbeReport {
+    pub mime_type: MimeType,
+    pub byte_size: u64,
+    pub dimensions: Dimensions,
+    pub content_hash: ContentHash,
+}
+
+#[async_trait]
+pub trait MediaProbe: Send + Sync + 'static {
+    /// Probes the object at `key`, cross-checking against the client's
+    /// `declared_mime`. Returns the verified report or a content error.
+    async fn probe(
+        &self,
+        key: &StorageKey,
+        declared_mime: &MimeType,
+    ) -> Result<MediaProbeReport, MediaError>;
+}

--- a/crates/services/media/src/application/port/mod.rs
+++ b/crates/services/media/src/application/port/mod.rs
@@ -1,0 +1,31 @@
+//! Outbound ports — the only contracts the application layer holds against the
+//! outside world. Concrete adapters (S3/MinIO object storage, Postgres metadata
+//! SoR, Redis delivery cache, the image processor, the CDN signer, the moderation
+//! gRPC client, the Kafka publisher) live in `infrastructure` (Phase 4) and are
+//! injected at the composition root. Each is an `async_trait` so it can be held as
+//! `Arc<dyn …>`; in-memory fakes back the unit tests.
+//!
+//! The defining boundary: the [`ObjectStore`] and [`CdnGateway`] ports broker the
+//! *byte plane* in URLs and keys — they never pass bytes through the application
+//! layer. A handler asks for a pre-signed URL or a delivery URL; the bytes travel
+//! client ⇄ store ⇄ CDN, out of band.
+
+pub mod asset_repository;
+pub mod cdn_gateway;
+pub mod delivery_cache;
+pub mod event_publisher;
+pub mod image_processor;
+pub mod malware_scanner;
+pub mod media_probe;
+pub mod moderation_screen;
+pub mod object_store;
+
+pub use asset_repository::AssetRepository;
+pub use cdn_gateway::{CdnGateway, ResolvedUrl};
+pub use delivery_cache::DeliveryCache;
+pub use event_publisher::EventPublisher;
+pub use image_processor::{DerivedRenditions, ImageProcessor};
+pub use malware_scanner::{MalwareScanner, ScanVerdict};
+pub use media_probe::{MediaProbe, MediaProbeReport};
+pub use moderation_screen::{ModerationScreen, ScreenDecision};
+pub use object_store::{ObjectHead, ObjectStore, PresignedUpload};

--- a/crates/services/media/src/application/port/moderation_screen.rs
+++ b/crates/services/media/src/application/port/moderation_screen.rs
@@ -1,0 +1,45 @@
+//! The pre-publish moderation Screen gate (Plane C of `moderation`, called from
+//! media's Plane B). media computes the content hash and asks moderation whether
+//! the bytes are known-bad before the asset can go public. The concrete adapter is
+//! a gRPC client to `moderation` (Phase 4).
+//!
+//! **Fail-closed:** a `blocked` decision quarantines the asset (and, for
+//! catastrophic categories, places a legal hold); a `ScreenUnavailable` error must
+//! NOT be folded into an allow — the caller treats an unavailable gate as a block
+//! for CSAM-class media, never an optimistic publish.
+
+use async_trait::async_trait;
+
+use crate::domain::value_object::{AssetId, ContentHash, MediaKind};
+use crate::error::MediaError;
+
+/// The screen result. `blocked` means a known-bad match; `csam` flags a
+/// catastrophic-category match that additionally warrants a legal hold (evidence
+/// preservation). `Allow` is "no known-bad match", never "approved".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenDecision {
+    pub blocked: bool,
+    pub csam: bool,
+    pub reference: Option<String>,
+}
+
+impl ScreenDecision {
+    /// A clean screen — nothing matched.
+    pub fn allow() -> Self {
+        Self {
+            blocked: false,
+            csam: false,
+            reference: None,
+        }
+    }
+}
+
+#[async_trait]
+pub trait ModerationScreen: Send + Sync + 'static {
+    async fn screen(
+        &self,
+        asset_id: &AssetId,
+        content_hash: &ContentHash,
+        kind: MediaKind,
+    ) -> Result<ScreenDecision, MediaError>;
+}

--- a/crates/services/media/src/application/port/object_store.rs
+++ b/crates/services/media/src/application/port/object_store.rs
@@ -1,0 +1,47 @@
+//! The byte-plane port: pre-signed uploads, object inspection, and deletion. The
+//! concrete adapter (S3/MinIO) lives in `infrastructure` (Phase 4). Bytes never
+//! cross this trait — only keys, URLs, and small metadata.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use chrono::Duration;
+
+use crate::domain::value_object::{MimeType, StorageKey};
+use crate::error::MediaError;
+
+/// A pre-signed upload plan the client uses to PUT bytes directly to the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PresignedUpload {
+    pub url: String,
+    pub method: String,
+    /// Headers the client MUST echo for the signature to validate.
+    pub required_headers: HashMap<String, String>,
+}
+
+/// The result of inspecting a stored object (`HEAD`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectHead {
+    pub size_bytes: u64,
+    pub etag: String,
+}
+
+#[async_trait]
+pub trait ObjectStore: Send + Sync + 'static {
+    /// Mints a pre-signed PUT URL scoped to `key`, bounded by `content_type` and
+    /// `max_bytes`, valid for `expires_in`.
+    async fn presign_put(
+        &self,
+        key: &StorageKey,
+        content_type: &MimeType,
+        max_bytes: u64,
+        expires_in: Duration,
+    ) -> Result<PresignedUpload, MediaError>;
+
+    /// Inspects an object; `None` when it does not (yet) exist — the signal a
+    /// commit raced ahead of the upload (`UploadNotFinalized`).
+    async fn head(&self, key: &StorageKey) -> Result<Option<ObjectHead>, MediaError>;
+
+    /// Deletes an object. Idempotent: deleting an absent key is `Ok`.
+    async fn delete(&self, key: &StorageKey) -> Result<(), MediaError>;
+}

--- a/crates/services/media/src/application/query/get_asset.rs
+++ b/crates/services/media/src/application/query/get_asset.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::AssetRepository;
+use crate::domain::aggregate::Asset;
+use crate::domain::value_object::AssetId;
+use crate::error::MediaError;
+
+/// Fetch an asset's metadata + rendition catalog (no URLs — use `ResolveDelivery`).
+#[derive(Debug, Clone)]
+pub struct GetAssetQuery {
+    pub asset_id: AssetId,
+}
+
+impl Query for GetAssetQuery {
+    type Response = Asset;
+}
+
+pub struct GetAssetHandler {
+    assets: Arc<dyn AssetRepository>,
+}
+
+impl GetAssetHandler {
+    pub fn new(assets: Arc<dyn AssetRepository>) -> Self {
+        Self { assets }
+    }
+}
+
+impl QueryHandler<GetAssetQuery> for GetAssetHandler {
+    type Error = MediaError;
+
+    async fn handle(&self, envelope: Envelope<GetAssetQuery>) -> Result<Asset, Self::Error> {
+        let id = envelope.payload.asset_id;
+        self.assets
+            .find_by_id(&id)
+            .await?
+            .ok_or_else(|| MediaError::AssetNotFound { id: id.as_str() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::value_object::MediaKind;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn returns_a_stored_asset() {
+        let fx = Fixture::new();
+        let (asset_id, _owner) = fx.ready_asset(MediaKind::PostImage).await;
+        let env = Envelope::new(Uuid::now_v7(), GetAssetQuery { asset_id });
+        let asset = fx.get_asset_handler().handle(env).await.unwrap();
+        assert_eq!(asset.id(), asset_id);
+    }
+
+    #[tokio::test]
+    async fn missing_asset_is_not_found() {
+        let fx = Fixture::new();
+        let env = Envelope::new(Uuid::now_v7(), GetAssetQuery { asset_id: AssetId::new() });
+        let err = fx.get_asset_handler().handle(env).await.unwrap_err();
+        assert!(matches!(err, MediaError::AssetNotFound { .. }));
+    }
+}

--- a/crates/services/media/src/application/query/mod.rs
+++ b/crates/services/media/src/application/query/mod.rs
@@ -1,0 +1,12 @@
+//! Read use-cases — `cqrs::QueryHandler` implementations that ride the query bus.
+//! `GetAsset` returns the metadata SoR; `ResolveDelivery` brokers CDN/signed URLs
+//! and fails OPEN (a not-ready or partially-resolvable asset yields a placeholder
+//! marked `degraded`, never an error on the read path).
+
+pub mod get_asset;
+pub mod resolve_delivery;
+
+pub use get_asset::{GetAssetHandler, GetAssetQuery};
+pub use resolve_delivery::{
+    DeliveredMediaView, DeliveredRenditionView, ResolveDeliveryHandler, ResolveDeliveryQuery,
+};

--- a/crates/services/media/src/application/query/resolve_delivery.rs
+++ b/crates/services/media/src/application/query/resolve_delivery.rs
@@ -1,0 +1,254 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, Query, QueryHandler};
+
+use crate::application::port::{AssetRepository, CdnGateway, DeliveryCache};
+use crate::domain::aggregate::Asset;
+use crate::domain::value_object::{AssetId, AssetState, DeliveryVisibility, RenditionKind};
+use crate::error::MediaError;
+
+/// Resolve one asset to a delivery URL set (Plane C, hot read).
+#[derive(Debug, Clone)]
+pub struct ResolveDeliveryQuery {
+    pub asset_id: AssetId,
+    /// `None` ⇒ all renditions; `Some(k)` ⇒ just that rendition if present.
+    pub preferred: Option<RenditionKind>,
+    /// `None` ⇒ the asset's default visibility (public).
+    pub visibility: Option<DeliveryVisibility>,
+}
+
+impl Query for ResolveDeliveryQuery {
+    type Response = DeliveredMediaView;
+}
+
+/// The resolved delivery view — URLs only. Fails OPEN: a not-yet-READY or
+/// quarantined asset yields the BlurHash placeholder with `degraded = true`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeliveredMediaView {
+    pub asset_id: AssetId,
+    pub state: AssetState,
+    pub blurhash: Option<String>,
+    pub renditions: Vec<DeliveredRenditionView>,
+    pub degraded: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeliveredRenditionView {
+    pub kind: RenditionKind,
+    pub url: String,
+    pub visibility: DeliveryVisibility,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub width: u32,
+    pub height: u32,
+}
+
+pub struct ResolveDeliveryHandler {
+    assets: Arc<dyn AssetRepository>,
+    cache: Arc<dyn DeliveryCache>,
+    cdn: Arc<dyn CdnGateway>,
+}
+
+impl ResolveDeliveryHandler {
+    pub fn new(
+        assets: Arc<dyn AssetRepository>,
+        cache: Arc<dyn DeliveryCache>,
+        cdn: Arc<dyn CdnGateway>,
+    ) -> Self {
+        Self { assets, cache, cdn }
+    }
+
+    /// Loads via the cache, falling back to the repository (and warming the cache).
+    /// A cache error is treated as a miss — the read path fails open.
+    async fn load(&self, id: &AssetId) -> Result<Option<Asset>, MediaError> {
+        if let Ok(Some(hit)) = self.cache.get(id).await {
+            return Ok(Some(hit));
+        }
+        match self.assets.find_by_id(id).await? {
+            Some(asset) => {
+                let _ = self.cache.put(&asset).await;
+                Ok(Some(asset))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Builds the delivery view for a loaded asset (the shared core of single and
+    /// batch resolution).
+    async fn resolve_asset(
+        &self,
+        asset: &Asset,
+        preferred: Option<RenditionKind>,
+        visibility: Option<DeliveryVisibility>,
+        now: DateTime<Utc>,
+    ) -> DeliveredMediaView {
+        let blurhash = asset.blurhash().map(|b| b.as_str().to_owned());
+
+        // Not deliverable (processing / failed / quarantined) ⇒ placeholder.
+        if !asset.is_deliverable() {
+            return DeliveredMediaView {
+                asset_id: asset.id(),
+                state: asset.state(),
+                blurhash,
+                renditions: Vec::new(),
+                degraded: true,
+            };
+        }
+
+        let visibility = visibility.unwrap_or_default();
+        let mut views = Vec::new();
+        let mut degraded = false;
+
+        for rendition in asset.renditions() {
+            if preferred.is_some_and(|k| k != rendition.kind()) {
+                continue;
+            }
+            // Per-rendition fail-open: a signing/CDN error degrades the result
+            // rather than erroring the whole read.
+            match self.cdn.resolve(rendition.storage_key(), visibility, now).await {
+                Ok(resolved) => views.push(DeliveredRenditionView {
+                    kind: rendition.kind(),
+                    url: resolved.url,
+                    visibility,
+                    expires_at: resolved.expires_at,
+                    width: rendition.dimensions().width(),
+                    height: rendition.dimensions().height(),
+                }),
+                Err(_) => degraded = true,
+            }
+        }
+
+        if preferred.is_some() && views.is_empty() {
+            degraded = true; // the requested rendition was absent
+        }
+
+        DeliveredMediaView {
+            asset_id: asset.id(),
+            state: asset.state(),
+            blurhash,
+            renditions: views,
+            degraded,
+        }
+    }
+
+    /// Clock-injected single resolve.
+    pub async fn handle_at(
+        &self,
+        envelope: Envelope<ResolveDeliveryQuery>,
+        now: DateTime<Utc>,
+    ) -> Result<DeliveredMediaView, MediaError> {
+        let q = envelope.payload;
+        let asset = self
+            .load(&q.asset_id)
+            .await?
+            .ok_or_else(|| MediaError::AssetNotFound { id: q.asset_id.as_str() })?;
+        Ok(self.resolve_asset(&asset, q.preferred, q.visibility, now).await)
+    }
+
+    /// Batch resolution for feed/timeline hydration. Unresolvable assets (missing)
+    /// are OMITTED — the boundary fails open rather than failing the batch.
+    pub async fn resolve_batch(
+        &self,
+        ids: &[AssetId],
+        preferred: Option<RenditionKind>,
+        visibility: Option<DeliveryVisibility>,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<DeliveredMediaView>, MediaError> {
+        let mut out = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(asset) = self.load(id).await? {
+                out.push(self.resolve_asset(&asset, preferred, visibility, now).await);
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl QueryHandler<ResolveDeliveryQuery> for ResolveDeliveryHandler {
+    type Error = MediaError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<ResolveDeliveryQuery>,
+    ) -> Result<DeliveredMediaView, Self::Error> {
+        self.handle_at(envelope, Utc::now()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::{t0, Fixture};
+    use crate::domain::value_object::MediaKind;
+    use uuid::Uuid;
+
+    fn env(q: ResolveDeliveryQuery) -> Envelope<ResolveDeliveryQuery> {
+        Envelope::new(Uuid::now_v7(), q)
+    }
+
+    #[tokio::test]
+    async fn resolves_public_urls_for_a_ready_asset() {
+        let fx = Fixture::new();
+        let (asset_id, _owner) = fx.ready_asset(MediaKind::PostImage).await;
+        let view = fx
+            .resolve_delivery_handler()
+            .handle_at(env(ResolveDeliveryQuery { asset_id, preferred: None, visibility: None }), t0())
+            .await
+            .unwrap();
+
+        assert!(!view.degraded);
+        assert!(!view.renditions.is_empty());
+        // Public URLs are immutable — no expiry.
+        assert!(view.renditions.iter().all(|r| r.expires_at.is_none()));
+        assert!(view.renditions.iter().all(|r| r.url.contains("cdn")));
+    }
+
+    #[tokio::test]
+    async fn signed_visibility_yields_expiring_urls() {
+        let fx = Fixture::new();
+        let (asset_id, _owner) = fx.ready_asset(MediaKind::Avatar).await;
+        let view = fx
+            .resolve_delivery_handler()
+            .handle_at(
+                env(ResolveDeliveryQuery {
+                    asset_id,
+                    preferred: Some(RenditionKind::Original),
+                    visibility: Some(DeliveryVisibility::Signed),
+                }),
+                t0(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(view.renditions.len(), 1);
+        assert!(view.renditions[0].expires_at.is_some(), "signed URLs expire");
+    }
+
+    #[tokio::test]
+    async fn a_processing_asset_fails_open_to_a_placeholder() {
+        let fx = Fixture::new();
+        // Uploaded (not yet READY) asset.
+        let asset_id = fx.uploaded_asset(MediaKind::PostImage).await;
+        let view = fx
+            .resolve_delivery_handler()
+            .handle_at(env(ResolveDeliveryQuery { asset_id, preferred: None, visibility: None }), t0())
+            .await
+            .unwrap();
+        assert!(view.degraded);
+        assert!(view.renditions.is_empty());
+        assert_eq!(view.state, AssetState::Uploaded);
+    }
+
+    #[tokio::test]
+    async fn batch_omits_unresolvable_assets() {
+        let fx = Fixture::new();
+        let (a, _) = fx.ready_asset(MediaKind::PostImage).await;
+        let missing = AssetId::new();
+        let views = fx
+            .resolve_delivery_handler()
+            .resolve_batch(&[a, missing], None, None, t0())
+            .await
+            .unwrap();
+        assert_eq!(views.len(), 1, "the missing asset is omitted, not errored");
+        assert_eq!(views[0].asset_id, a);
+    }
+}

--- a/crates/services/media/src/config.rs
+++ b/crates/services/media/src/config.rs
@@ -1,0 +1,63 @@
+//! Environment-sourced configuration, resolved once at boot and threaded into the
+//! composition root ([`crate::app::App::build`]). The Postgres / Redis / Kafka
+//! backend configs are resolved separately (via their own `from_env`) in
+//! [`crate::service`], mirroring the rest of the fleet.
+
+use std::time::Duration as StdDuration;
+
+use chrono::Duration;
+
+use crate::application::MediaPolicy;
+use crate::infrastructure::store::S3Config;
+
+/// Fully-resolved media configuration (the media-specific knobs; the shared
+/// storage backends are built in `service`).
+pub struct MediaConfig {
+    pub s3: S3Config,
+    /// CDN base URL for public, content-addressed delivery.
+    pub cdn_base_url: String,
+    /// gRPC endpoint of `moderation` (the pre-publish Screen gate).
+    pub screen_endpoint: String,
+    pub policy: MediaPolicy,
+}
+
+impl MediaConfig {
+    pub fn from_env() -> Self {
+        let policy = MediaPolicy {
+            upload_ticket_ttl: Duration::seconds(env_u64("MEDIA_UPLOAD_TICKET_TTL_SECS", 900) as i64),
+            signed_url_ttl: Duration::seconds(env_u64("MEDIA_SIGNED_URL_TTL_SECS", 300) as i64),
+            dedup_enabled: env_bool("MEDIA_DEDUP_ENABLED", false),
+            screen_timeout: StdDuration::from_millis(env_u64("MEDIA_SCREEN_TIMEOUT_MS", 200)),
+        };
+        let s3 = S3Config {
+            endpoint: env_or("MEDIA_OBJECT_STORE_ENDPOINT", "http://localhost:9000"),
+            region: env_or("MEDIA_OBJECT_STORE_REGION", "us-east-1"),
+            bucket: env_or("MEDIA_OBJECT_STORE_BUCKET", "media"),
+            access_key: env_or("MEDIA_S3_ACCESS_KEY", "minioadmin"),
+            secret_key: env_or("MEDIA_S3_SECRET_KEY", "minioadmin"),
+            presign_ttl: StdDuration::from_secs(env_u64("MEDIA_PRESIGN_TTL_SECS", 900)),
+            request_timeout: StdDuration::from_millis(env_u64("MEDIA_OBJECT_STORE_TIMEOUT_MS", 10_000)),
+        };
+        Self {
+            s3,
+            cdn_base_url: env_or("MEDIA_CDN_BASE_URL", "http://localhost:9000/media"),
+            screen_endpoint: env_or("MEDIA_SCREEN_GRPC_ENDPOINT", "http://localhost:50061"),
+            policy,
+        }
+    }
+}
+
+fn env_or(key: &str, default: impl Into<String>) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.into())
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    std::env::var(key)
+        .ok()
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(default)
+}

--- a/crates/services/media/src/domain/aggregate/asset.rs
+++ b/crates/services/media/src/domain/aggregate/asset.rs
@@ -1,0 +1,731 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::event::{
+    AssetDeleted, AssetFailed, AssetQuarantined, AssetReady, AssetRestored, AssetUploaded,
+    AssetVariantReady, DomainEvent,
+};
+use crate::domain::value_object::{
+    AssetId, AssetState, Blurhash, ContentHash, Dimensions, MediaKind, MimeType, OwnerId,
+    RenditionKind, StorageKey, UploadConstraints,
+};
+use crate::error::MediaError;
+
+/// One derivative in an asset's catalog. A content-addressed object in the byte
+/// store; callers receive a delivery URL for its `storage_key`, never the bytes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rendition {
+    kind: RenditionKind,
+    mime_type: MimeType,
+    storage_key: StorageKey,
+    dimensions: Dimensions,
+    byte_size: u64,
+}
+
+impl Rendition {
+    pub fn new(
+        kind: RenditionKind,
+        mime_type: MimeType,
+        storage_key: StorageKey,
+        dimensions: Dimensions,
+        byte_size: u64,
+    ) -> Self {
+        Self {
+            kind,
+            mime_type,
+            storage_key,
+            dimensions,
+            byte_size,
+        }
+    }
+
+    pub fn kind(&self) -> RenditionKind {
+        self.kind
+    }
+    pub fn mime_type(&self) -> &MimeType {
+        &self.mime_type
+    }
+    pub fn storage_key(&self) -> &StorageKey {
+        &self.storage_key
+    }
+    pub fn dimensions(&self) -> Dimensions {
+        self.dimensions
+    }
+    pub fn byte_size(&self) -> u64 {
+        self.byte_size
+    }
+}
+
+/// Inputs to reserve a new asset (issued at upload-ticket time).
+#[derive(Debug, Clone)]
+pub struct ReserveParams {
+    pub id: AssetId,
+    pub owner_id: OwnerId,
+    pub kind: MediaKind,
+    pub declared_mime: MimeType,
+    pub declared_size: u64,
+}
+
+/// The verified facts established when an upload is finalized (from the server-side
+/// probe — never the client's declarations).
+#[derive(Debug, Clone)]
+pub struct FinalizeParams {
+    pub mime_type: MimeType,
+    pub byte_size: u64,
+    pub dimensions: Dimensions,
+    pub content_hash: ContentHash,
+}
+
+/// A full snapshot for reconstructing an asset from storage (no events emitted).
+#[derive(Debug, Clone)]
+pub struct AssetSnapshot {
+    pub id: AssetId,
+    pub owner_id: OwnerId,
+    pub kind: MediaKind,
+    pub state: AssetState,
+    pub declared_mime: MimeType,
+    pub declared_size: u64,
+    pub mime_type: Option<MimeType>,
+    pub byte_size: Option<u64>,
+    pub dimensions: Option<Dimensions>,
+    pub content_hash: Option<ContentHash>,
+    pub blurhash: Option<Blurhash>,
+    pub renditions: Vec<Rendition>,
+    pub legal_hold: bool,
+    pub prior_state: Option<AssetState>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// The **Asset** aggregate — the lifecycle-bearing System-of-Record for one piece
+/// of media. It owns the state machine and the rendition catalog; the bytes live
+/// in object storage, keyed by the content-addressed [`StorageKey`].
+///
+/// # Invariants (enforced here)
+/// 1. Reservation rejects an upload that violates the kind's constraints (MIME
+///    allowlist / size ceiling) before any byte is accepted.
+/// 2. The forward path is `Pending → Uploaded → Processing → Ready`, with
+///    `Uploaded`/`Processing → Failed`; illegal jumps are rejected.
+/// 3. `mark_ready` requires a content hash and the `Original` rendition — a READY
+///    asset is always resolvable.
+/// 4. Quarantine/restore are reversible and cross-state; quarantine remembers the
+///    prior state so restore returns to it.
+/// 5. A legal hold blocks hard-delete (compliance preservation overrides erasure).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Asset {
+    id: AssetId,
+    owner_id: OwnerId,
+    kind: MediaKind,
+    state: AssetState,
+    declared_mime: MimeType,
+    declared_size: u64,
+    mime_type: Option<MimeType>,
+    byte_size: Option<u64>,
+    dimensions: Option<Dimensions>,
+    content_hash: Option<ContentHash>,
+    blurhash: Option<Blurhash>,
+    renditions: Vec<Rendition>,
+    legal_hold: bool,
+    prior_state: Option<AssetState>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+
+    #[serde(skip)]
+    pending_events: Vec<DomainEvent>,
+}
+
+impl Asset {
+    /// Invariant 1: reserves a `Pending` asset after checking the declared MIME and
+    /// size against the kind's constraints. No event — reservation is internal;
+    /// `AssetUploaded` fires on finalize.
+    pub fn reserve(
+        params: ReserveParams,
+        constraints: &UploadConstraints,
+        now: DateTime<Utc>,
+    ) -> Result<Self, MediaError> {
+        constraints.validate(&params.declared_mime, params.declared_size)?;
+        Ok(Self {
+            id: params.id,
+            owner_id: params.owner_id,
+            kind: params.kind,
+            state: AssetState::Pending,
+            declared_mime: params.declared_mime,
+            declared_size: params.declared_size,
+            mime_type: None,
+            byte_size: None,
+            dimensions: None,
+            content_hash: None,
+            blurhash: None,
+            renditions: Vec::new(),
+            legal_hold: false,
+            prior_state: None,
+            created_at: now,
+            updated_at: now,
+            pending_events: Vec::new(),
+        })
+    }
+
+    /// Reconstructs from storage (no events emitted).
+    pub fn reconstitute(s: AssetSnapshot) -> Self {
+        Self {
+            id: s.id,
+            owner_id: s.owner_id,
+            kind: s.kind,
+            state: s.state,
+            declared_mime: s.declared_mime,
+            declared_size: s.declared_size,
+            mime_type: s.mime_type,
+            byte_size: s.byte_size,
+            dimensions: s.dimensions,
+            content_hash: s.content_hash,
+            blurhash: s.blurhash,
+            renditions: s.renditions,
+            legal_hold: s.legal_hold,
+            prior_state: s.prior_state,
+            created_at: s.created_at,
+            updated_at: s.updated_at,
+            pending_events: Vec::new(),
+        }
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    pub fn id(&self) -> AssetId {
+        self.id
+    }
+    pub fn owner_id(&self) -> OwnerId {
+        self.owner_id
+    }
+    pub fn kind(&self) -> MediaKind {
+        self.kind
+    }
+    pub fn state(&self) -> AssetState {
+        self.state
+    }
+    /// The client-declared MIME from reservation (used to cross-check the probe).
+    pub fn declared_mime(&self) -> &MimeType {
+        &self.declared_mime
+    }
+    pub fn mime_type(&self) -> Option<&MimeType> {
+        self.mime_type.as_ref()
+    }
+    pub fn byte_size(&self) -> Option<u64> {
+        self.byte_size
+    }
+    pub fn dimensions(&self) -> Option<Dimensions> {
+        self.dimensions
+    }
+    pub fn content_hash(&self) -> Option<&ContentHash> {
+        self.content_hash.as_ref()
+    }
+    pub fn blurhash(&self) -> Option<&Blurhash> {
+        self.blurhash.as_ref()
+    }
+    pub fn renditions(&self) -> &[Rendition] {
+        &self.renditions
+    }
+    pub fn rendition(&self, kind: RenditionKind) -> Option<&Rendition> {
+        self.renditions.iter().find(|r| r.kind() == kind)
+    }
+    pub fn legal_hold(&self) -> bool {
+        self.legal_hold
+    }
+    pub fn is_deliverable(&self) -> bool {
+        self.state.is_deliverable()
+    }
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
+    }
+
+    // ─── Commands ────────────────────────────────────────────────────────────
+
+    /// Invariant 2: finalizes a pending upload with the server-verified facts,
+    /// re-checking the *actual* MIME/size against the constraints, then transitions
+    /// to `Uploaded` and emits [`AssetUploaded`].
+    pub fn finalize(
+        &mut self,
+        params: FinalizeParams,
+        constraints: &UploadConstraints,
+        now: DateTime<Utc>,
+    ) -> Result<(), MediaError> {
+        self.ensure_state(AssetState::Pending, AssetState::Uploaded)?;
+        constraints.validate(&params.mime_type, params.byte_size)?;
+
+        self.mime_type = Some(params.mime_type);
+        self.byte_size = Some(params.byte_size);
+        self.dimensions = Some(params.dimensions);
+        self.content_hash = Some(params.content_hash.clone());
+        self.transition(AssetState::Uploaded, now);
+
+        self.emit(DomainEvent::AssetUploaded(AssetUploaded {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            kind: self.kind,
+            content_hash: params.content_hash,
+            byte_size: params.byte_size,
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Invariant 2: enters the transformation pipeline. No event — internal.
+    pub fn begin_processing(&mut self, now: DateTime<Utc>) -> Result<(), MediaError> {
+        self.ensure_state(AssetState::Uploaded, AssetState::Processing)?;
+        self.transition(AssetState::Processing, now);
+        Ok(())
+    }
+
+    /// Records the progressive-render placeholder. Allowed while the bytes exist but
+    /// the asset is not yet READY (Uploaded/Processing).
+    pub fn set_blurhash(&mut self, blurhash: Blurhash, now: DateTime<Utc>) -> Result<(), MediaError> {
+        if !matches!(self.state, AssetState::Uploaded | AssetState::Processing) {
+            return Err(MediaError::DomainViolation {
+                field: "blurhash".into(),
+                message: format!("cannot set a blurhash while '{}'", self.state),
+            });
+        }
+        self.blurhash = Some(blurhash);
+        self.updated_at = now;
+        Ok(())
+    }
+
+    /// Adds a derivative to the catalog (during processing) and emits
+    /// [`AssetVariantReady`]. Rejects a duplicate rendition kind.
+    pub fn attach_rendition(&mut self, rendition: Rendition, now: DateTime<Utc>) -> Result<(), MediaError> {
+        if self.state != AssetState::Processing {
+            return Err(MediaError::InvalidStateTransition {
+                from: self.state.to_string(),
+                to: "attach_rendition(processing)".into(),
+            });
+        }
+        if self.rendition(rendition.kind()).is_some() {
+            return Err(MediaError::DomainViolation {
+                field: "rendition".into(),
+                message: format!("a '{}' rendition already exists", rendition.kind()),
+            });
+        }
+        let kind = rendition.kind();
+        self.renditions.push(rendition);
+        self.updated_at = now;
+        self.emit(DomainEvent::AssetVariantReady(AssetVariantReady {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            rendition: kind,
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Invariant 3: completes processing. Requires a content hash and the
+    /// `Original` rendition, then transitions to `Ready` and emits [`AssetReady`].
+    pub fn mark_ready(&mut self, now: DateTime<Utc>) -> Result<(), MediaError> {
+        self.ensure_state(AssetState::Processing, AssetState::Ready)?;
+        if self.content_hash.is_none() {
+            return Err(MediaError::DomainViolation {
+                field: "content_hash".into(),
+                message: "cannot mark ready without a finalized content hash".into(),
+            });
+        }
+        if self.rendition(RenditionKind::Original).is_none() {
+            return Err(MediaError::DomainViolation {
+                field: "renditions".into(),
+                message: "cannot mark ready without the original rendition".into(),
+            });
+        }
+        self.transition(AssetState::Ready, now);
+        self.emit(DomainEvent::AssetReady(AssetReady {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Invariant 2: fails processing terminally and emits [`AssetFailed`].
+    pub fn mark_failed(&mut self, reason: impl Into<String>, now: DateTime<Utc>) -> Result<(), MediaError> {
+        if !matches!(self.state, AssetState::Uploaded | AssetState::Processing) {
+            return Err(MediaError::InvalidStateTransition {
+                from: self.state.to_string(),
+                to: AssetState::Failed.to_string(),
+            });
+        }
+        self.transition(AssetState::Failed, now);
+        self.emit(DomainEvent::AssetFailed(AssetFailed {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            reason: reason.into(),
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Invariant 4: revokes delivery (moderation takedown / compliance hold),
+    /// remembering the prior state for a later restore. Idempotent: re-quarantining
+    /// an already-quarantined asset is a no-op `Ok`. Rejected on a deleted asset.
+    pub fn quarantine(&mut self, now: DateTime<Utc>) -> Result<(), MediaError> {
+        match self.state {
+            AssetState::Quarantined => return Ok(()),
+            AssetState::Deleted => {
+                return Err(MediaError::InvalidStateTransition {
+                    from: self.state.to_string(),
+                    to: AssetState::Quarantined.to_string(),
+                });
+            }
+            _ => {}
+        }
+        self.prior_state = Some(self.state);
+        self.transition(AssetState::Quarantined, now);
+        self.emit(DomainEvent::AssetQuarantined(AssetQuarantined {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Invariant 4: reinstates a quarantined asset to its prior state (defaulting to
+    /// `Ready`) and emits [`AssetRestored`].
+    pub fn restore(&mut self, now: DateTime<Utc>) -> Result<(), MediaError> {
+        if self.state != AssetState::Quarantined {
+            return Err(MediaError::InvalidStateTransition {
+                from: self.state.to_string(),
+                to: "restore".into(),
+            });
+        }
+        let target = self.prior_state.take().unwrap_or(AssetState::Ready);
+        self.transition(target, now);
+        self.emit(DomainEvent::AssetRestored(AssetRestored {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Places a legal hold (e.g. CSAM evidence preservation). Blocks deletion. No
+    /// event — it is an internal compliance flag, not a lifecycle fact.
+    pub fn place_legal_hold(&mut self, now: DateTime<Utc>) {
+        self.legal_hold = true;
+        self.updated_at = now;
+    }
+
+    /// Lifts a legal hold.
+    pub fn lift_legal_hold(&mut self, now: DateTime<Utc>) {
+        self.legal_hold = false;
+        self.updated_at = now;
+    }
+
+    /// Invariant 5: hard-deletes the asset. Refused while a legal hold is active
+    /// (`LegalHoldActive`, MED-7003) — compliance preservation overrides erasure.
+    /// Idempotent: deleting an already-deleted asset is a no-op `Ok`.
+    pub fn delete(&mut self, now: DateTime<Utc>) -> Result<(), MediaError> {
+        if self.legal_hold {
+            return Err(MediaError::LegalHoldActive);
+        }
+        if self.state == AssetState::Deleted {
+            return Ok(());
+        }
+        self.transition(AssetState::Deleted, now);
+        self.emit(DomainEvent::AssetDeleted(AssetDeleted {
+            asset_id: self.id,
+            owner_id: self.owner_id,
+            occurred_at: now,
+        }));
+        Ok(())
+    }
+
+    /// Drains accumulated events for the unit-of-work to publish.
+    pub fn drain_events(&mut self) -> Vec<DomainEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    // ─── Internals ───────────────────────────────────────────────────────────
+
+    /// Guards a forward-path transition (Invariant 2).
+    fn ensure_state(&self, expected: AssetState, target: AssetState) -> Result<(), MediaError> {
+        if self.state != expected {
+            return Err(MediaError::InvalidStateTransition {
+                from: self.state.to_string(),
+                to: target.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn transition(&mut self, next: AssetState, now: DateTime<Utc>) {
+        self.state = next;
+        self.updated_at = now;
+    }
+
+    fn emit(&mut self, event: DomainEvent) {
+        self.pending_events.push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-26T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn constraints() -> UploadConstraints {
+        UploadConstraints::for_kind(MediaKind::PostImage)
+    }
+
+    fn hash() -> ContentHash {
+        ContentHash::new("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").unwrap()
+    }
+
+    fn reserved() -> Asset {
+        Asset::reserve(
+            ReserveParams {
+                id: AssetId::from_uuid(Uuid::from_u128(1)),
+                owner_id: OwnerId::from_uuid(Uuid::from_u128(9)),
+                kind: MediaKind::PostImage,
+                declared_mime: MimeType::new("image/jpeg").unwrap(),
+                declared_size: 2_000_000,
+            },
+            &constraints(),
+            t0(),
+        )
+        .unwrap()
+    }
+
+    fn finalize_params() -> FinalizeParams {
+        FinalizeParams {
+            mime_type: MimeType::new("image/jpeg").unwrap(),
+            byte_size: 2_000_000,
+            dimensions: Dimensions::new(1920, 1080).unwrap(),
+            content_hash: hash(),
+        }
+    }
+
+    fn original_rendition() -> Rendition {
+        Rendition::new(
+            RenditionKind::Original,
+            MimeType::new("image/jpeg").unwrap(),
+            StorageKey::rendition(MediaKind::PostImage, &hash(), RenditionKind::Original, "jpg"),
+            Dimensions::new(1920, 1080).unwrap(),
+            2_000_000,
+        )
+    }
+
+    /// Drives an asset all the way to READY and returns it.
+    fn ready_asset() -> Asset {
+        let mut a = reserved();
+        a.finalize(finalize_params(), &constraints(), t0()).unwrap();
+        a.begin_processing(t0()).unwrap();
+        a.attach_rendition(original_rendition(), t0()).unwrap();
+        a.mark_ready(t0()).unwrap();
+        a.drain_events();
+        a
+    }
+
+    #[test]
+    fn reserve_rejects_oversize_and_off_allowlist() {
+        let oversize = Asset::reserve(
+            ReserveParams {
+                id: AssetId::new(),
+                owner_id: OwnerId::from_uuid(Uuid::nil()),
+                kind: MediaKind::Avatar,
+                declared_mime: MimeType::new("image/png").unwrap(),
+                declared_size: MediaKind::Avatar.max_bytes() + 1,
+            },
+            &UploadConstraints::for_kind(MediaKind::Avatar),
+            t0(),
+        );
+        assert!(matches!(oversize.unwrap_err(), MediaError::UploadSizeExceeded { .. }));
+
+        let bad_mime = Asset::reserve(
+            ReserveParams {
+                id: AssetId::new(),
+                owner_id: OwnerId::from_uuid(Uuid::nil()),
+                kind: MediaKind::Avatar,
+                declared_mime: MimeType::new("application/zip").unwrap(),
+                declared_size: 10,
+            },
+            &UploadConstraints::for_kind(MediaKind::Avatar),
+            t0(),
+        );
+        assert!(matches!(bad_mime.unwrap_err(), MediaError::UnsupportedMimeType { .. }));
+    }
+
+    #[test]
+    fn happy_path_emits_uploaded_variant_and_ready_in_order() {
+        let mut a = reserved();
+        assert_eq!(a.state(), AssetState::Pending);
+
+        a.finalize(finalize_params(), &constraints(), t0()).unwrap();
+        assert_eq!(a.state(), AssetState::Uploaded);
+        assert_eq!(a.content_hash(), Some(&hash()));
+
+        a.begin_processing(t0()).unwrap();
+        a.set_blurhash(Blurhash::new("LEHV6nWB2yk8pyo0adR*").unwrap(), t0()).unwrap();
+        a.attach_rendition(original_rendition(), t0()).unwrap();
+        a.mark_ready(t0()).unwrap();
+        assert!(a.is_deliverable());
+
+        let events = a.drain_events();
+        let kinds: Vec<&str> = events.iter().map(|e| e.event_type()).collect();
+        assert_eq!(
+            kinds,
+            ["media.asset_uploaded", "media.asset_variant_ready", "media.asset_ready"]
+        );
+        assert_eq!(events[0].asset_id(), a.id());
+        assert!(a.drain_events().is_empty(), "events drain once");
+    }
+
+    #[test]
+    fn finalize_is_rejected_from_a_non_pending_state() {
+        let mut a = ready_asset();
+        assert!(matches!(
+            a.finalize(finalize_params(), &constraints(), t0()).unwrap_err(),
+            MediaError::InvalidStateTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn finalize_revalidates_actual_size_against_the_ceiling() {
+        let mut a = reserved();
+        let mut p = finalize_params();
+        p.byte_size = MediaKind::PostImage.max_bytes() + 1; // probe found it bigger than declared
+        assert!(matches!(
+            a.finalize(p, &constraints(), t0()).unwrap_err(),
+            MediaError::UploadSizeExceeded { .. }
+        ));
+        assert_eq!(a.state(), AssetState::Pending, "rejected finalize leaves state untouched");
+    }
+
+    #[test]
+    fn mark_ready_requires_the_original_rendition() {
+        let mut a = reserved();
+        a.finalize(finalize_params(), &constraints(), t0()).unwrap();
+        a.begin_processing(t0()).unwrap();
+        // Only a thumbnail attached — no original.
+        let thumb = Rendition::new(
+            RenditionKind::Thumbnail,
+            MimeType::new("image/webp").unwrap(),
+            StorageKey::rendition(MediaKind::PostImage, &hash(), RenditionKind::Thumbnail, "webp"),
+            Dimensions::new(320, 180).unwrap(),
+            20_000,
+        );
+        a.attach_rendition(thumb, t0()).unwrap();
+        assert!(matches!(
+            a.mark_ready(t0()).unwrap_err(),
+            MediaError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn duplicate_rendition_kind_is_rejected() {
+        let mut a = reserved();
+        a.finalize(finalize_params(), &constraints(), t0()).unwrap();
+        a.begin_processing(t0()).unwrap();
+        a.attach_rendition(original_rendition(), t0()).unwrap();
+        assert!(matches!(
+            a.attach_rendition(original_rendition(), t0()).unwrap_err(),
+            MediaError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn quarantine_remembers_prior_state_and_restore_returns_to_it() {
+        let mut a = ready_asset();
+        a.quarantine(t0()).unwrap();
+        assert_eq!(a.state(), AssetState::Quarantined);
+        assert!(!a.is_deliverable());
+        assert_eq!(a.drain_events().len(), 1, "first quarantine emits one event");
+
+        // Idempotent re-quarantine: no extra event.
+        a.quarantine(t0()).unwrap();
+        assert!(a.drain_events().is_empty());
+
+        a.restore(t0()).unwrap();
+        assert_eq!(a.state(), AssetState::Ready, "restored to the pre-quarantine state");
+        let events = a.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "media.asset_restored");
+    }
+
+    #[test]
+    fn quarantine_then_delete_is_allowed_but_legal_hold_blocks_delete() {
+        let mut a = ready_asset();
+        a.place_legal_hold(t0());
+        a.quarantine(t0()).unwrap();
+        // Legal hold blocks erasure even though it is quarantined.
+        assert!(matches!(a.delete(t0()).unwrap_err(), MediaError::LegalHoldActive));
+
+        // Lift the hold → delete succeeds and is idempotent.
+        a.lift_legal_hold(t0());
+        a.drain_events();
+        a.delete(t0()).unwrap();
+        assert_eq!(a.state(), AssetState::Deleted);
+        let events = a.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type(), "media.asset_deleted");
+        // Idempotent second delete: no event.
+        a.delete(t0()).unwrap();
+        assert!(a.drain_events().is_empty());
+    }
+
+    #[test]
+    fn cannot_quarantine_a_deleted_asset() {
+        let mut a = ready_asset();
+        a.delete(t0()).unwrap();
+        a.drain_events();
+        assert!(matches!(
+            a.quarantine(t0()).unwrap_err(),
+            MediaError::InvalidStateTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn failed_processing_is_terminal_for_the_forward_path() {
+        let mut a = reserved();
+        a.finalize(finalize_params(), &constraints(), t0()).unwrap();
+        a.begin_processing(t0()).unwrap();
+        a.mark_failed("unsupported codec", t0()).unwrap();
+        assert_eq!(a.state(), AssetState::Failed);
+        assert!(matches!(
+            a.mark_ready(t0()).unwrap_err(),
+            MediaError::InvalidStateTransition { .. }
+        ));
+        let events = a.drain_events();
+        assert_eq!(events.last().unwrap().event_type(), "media.asset_failed");
+    }
+
+    #[test]
+    fn snapshot_round_trips_through_reconstitute() {
+        let a = ready_asset();
+        let snapshot = AssetSnapshot {
+            id: a.id(),
+            owner_id: a.owner_id(),
+            kind: a.kind(),
+            state: a.state(),
+            declared_mime: MimeType::new("image/jpeg").unwrap(),
+            declared_size: 2_000_000,
+            mime_type: a.mime_type().cloned(),
+            byte_size: a.byte_size(),
+            dimensions: a.dimensions(),
+            content_hash: a.content_hash().cloned(),
+            blurhash: a.blurhash().cloned(),
+            renditions: a.renditions().to_vec(),
+            legal_hold: a.legal_hold(),
+            prior_state: None,
+            created_at: a.created_at(),
+            updated_at: a.updated_at(),
+        };
+        let mut restored = Asset::reconstitute(snapshot);
+        assert_eq!(restored.state(), AssetState::Ready);
+        assert_eq!(restored.content_hash(), Some(&hash()));
+        assert!(restored.drain_events().is_empty(), "reconstitute emits nothing");
+    }
+}

--- a/crates/services/media/src/domain/aggregate/mod.rs
+++ b/crates/services/media/src/domain/aggregate/mod.rs
@@ -1,0 +1,9 @@
+//! Aggregates for the media domain — the consistency boundary that owns its
+//! invariants and emits domain events.
+//!
+//! * [`Asset`] — the lifecycle-bearing System-of-Record root (state machine +
+//!   rendition catalog + compliance hold). [`Rendition`] is its child entity.
+
+pub mod asset;
+
+pub use asset::{Asset, AssetSnapshot, FinalizeParams, Rendition, ReserveParams};

--- a/crates/services/media/src/domain/event.rs
+++ b/crates/services/media/src/domain/event.rs
@@ -1,0 +1,137 @@
+//! Domain events the media context publishes to the `media.v1.events` Kafka topic.
+//!
+//! Events are serde structs (JSON on the wire), matching the fleet convention —
+//! they are deliberately **not** proto messages (the proto contract is the
+//! synchronous RPC surface only). Every event carries `asset_id`, which the
+//! infrastructure publisher (Phase 4) uses as the partition key so all events for
+//! one asset stay ordered — `AssetReady` can never be delivered ahead of the
+//! `AssetUploaded` it follows, and `AssetDeleted` is always last. `owner_id` rides
+//! along as a secondary routing key.
+//!
+//! This is the decoupling feed that lets the publish path never wait on media:
+//! `post`/`profile` reference a still-processing asset and react to `AssetReady`
+//! (or lazily resolve at read); `moderation` screens off `AssetUploaded`; `search`
+//! and GC consume readiness/lifecycle.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{AssetId, ContentHash, MediaKind, OwnerId, RenditionKind};
+
+/// An upload was finalized and validated; the bytes are in object storage. The
+/// pipeline trigger and the moderation-screen input (carries the content hash).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetUploaded {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub kind: MediaKind,
+    pub content_hash: ContentHash,
+    pub byte_size: u64,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// A single rendition became available — the progressive-render signal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetVariantReady {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub rendition: RenditionKind,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// All renditions are available; the asset is deliverable. The signal `post`/
+/// `profile`/`search` swap a placeholder for the real media on.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetReady {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Processing failed terminally (corrupt / unsupported / pipeline error).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetFailed {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub reason: String,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Delivery was revoked by a moderation takedown / compliance hold.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetQuarantined {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// A quarantined asset was reinstated (moderation reversal / appeal).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetRestored {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// The asset was hard-deleted (bytes purged). Consumers drop their references.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetDeleted {
+    pub asset_id: AssetId,
+    pub owner_id: OwnerId,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Sealed sum type of every domain event media publishes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DomainEvent {
+    AssetUploaded(AssetUploaded),
+    AssetVariantReady(AssetVariantReady),
+    AssetReady(AssetReady),
+    AssetFailed(AssetFailed),
+    AssetQuarantined(AssetQuarantined),
+    AssetRestored(AssetRestored),
+    AssetDeleted(AssetDeleted),
+}
+
+impl DomainEvent {
+    /// Dotted routing key used as the Kafka message type header.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::AssetUploaded(_) => "media.asset_uploaded",
+            Self::AssetVariantReady(_) => "media.asset_variant_ready",
+            Self::AssetReady(_) => "media.asset_ready",
+            Self::AssetFailed(_) => "media.asset_failed",
+            Self::AssetQuarantined(_) => "media.asset_quarantined",
+            Self::AssetRestored(_) => "media.asset_restored",
+            Self::AssetDeleted(_) => "media.asset_deleted",
+        }
+    }
+
+    /// The asset this event concerns — the Kafka partition key, guaranteeing
+    /// per-asset ordering across the whole lifecycle.
+    pub fn asset_id(&self) -> AssetId {
+        match self {
+            Self::AssetUploaded(e) => e.asset_id,
+            Self::AssetVariantReady(e) => e.asset_id,
+            Self::AssetReady(e) => e.asset_id,
+            Self::AssetFailed(e) => e.asset_id,
+            Self::AssetQuarantined(e) => e.asset_id,
+            Self::AssetRestored(e) => e.asset_id,
+            Self::AssetDeleted(e) => e.asset_id,
+        }
+    }
+
+    /// The owning account (secondary routing key).
+    pub fn owner_id(&self) -> OwnerId {
+        match self {
+            Self::AssetUploaded(e) => e.owner_id,
+            Self::AssetVariantReady(e) => e.owner_id,
+            Self::AssetReady(e) => e.owner_id,
+            Self::AssetFailed(e) => e.owner_id,
+            Self::AssetQuarantined(e) => e.owner_id,
+            Self::AssetRestored(e) => e.owner_id,
+            Self::AssetDeleted(e) => e.owner_id,
+        }
+    }
+}

--- a/crates/services/media/src/domain/mod.rs
+++ b/crates/services/media/src/domain/mod.rs
@@ -1,0 +1,23 @@
+//! The media bounded context's domain layer — pure, free of I/O.
+//!
+//! It owns the *asset and its processing lifecycle*: the [`Asset`] aggregate (the
+//! state machine PENDING → UPLOADED → PROCESSING → READY / FAILED / QUARANTINED /
+//! DELETED), its [`Rendition`] catalog, the content-addressed [`StorageKey`]
+//! scheme, the [`UploadTicket`] reservation, and the value objects that make an
+//! invalid asset unrepresentable. The bytes themselves live in object storage; the
+//! CDN owns delivery fan-out; `moderation` owns the integrity decision — none of
+//! those are modelled here. This layer holds only the *truth about* the bytes.
+//!
+//! ## Clock injection
+//! Every time-dependent transition takes `now: DateTime<Utc>` as a parameter
+//! rather than reading the wall clock, so the state machine is deterministically
+//! unit-testable. The application layer supplies the clock.
+//!
+//! [`Asset`]: aggregate::Asset
+//! [`Rendition`]: aggregate::Rendition
+//! [`StorageKey`]: value_object::StorageKey
+//! [`UploadTicket`]: value_object::UploadTicket
+
+pub mod aggregate;
+pub mod event;
+pub mod value_object;

--- a/crates/services/media/src/domain/value_object/asset_state.rs
+++ b/crates/services/media/src/domain/value_object/asset_state.rs
@@ -1,0 +1,156 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// The asset lifecycle state. The legal transitions are:
+///
+/// ```text
+///   Pending ─▶ Uploaded ─▶ Processing ─▶ Ready
+///                 │             │
+///                 └──────┬──────┘
+///                        ▼
+///                      Failed
+///   {any live state} ─▶ Quarantined ─▶ {restored to prior}
+///   {any non-held state} ─▶ Deleted
+/// ```
+///
+/// `Quarantine` and `Delete` are cross-cutting and handled by the aggregate (they
+/// can apply from several states), so they are intentionally NOT in
+/// [`can_transition_to`]; that method governs only the forward processing path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetState {
+    /// Reserved at ticket time; awaiting the client's direct-to-store upload.
+    Pending,
+    /// Bytes landed and finalize accepted; validated, pre-derivation.
+    Uploaded,
+    /// The transformation pipeline is running.
+    Processing,
+    /// All renditions available; deliverable.
+    Ready,
+    /// Terminal processing failure (corrupt / unsupported / pipeline error).
+    Failed,
+    /// Delivery revoked by a moderation takedown / compliance hold (reversible).
+    Quarantined,
+    /// Hard-deleted (bytes purged). Terminal.
+    Deleted,
+}
+
+impl AssetState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Uploaded => "uploaded",
+            Self::Processing => "processing",
+            Self::Ready => "ready",
+            Self::Failed => "failed",
+            Self::Quarantined => "quarantined",
+            Self::Deleted => "deleted",
+        }
+    }
+
+    /// The forward processing path only (Quarantine/Delete are handled separately).
+    pub fn can_transition_to(&self, next: AssetState) -> bool {
+        use AssetState::*;
+        matches!(
+            (self, next),
+            (Pending, Uploaded)
+                | (Uploaded, Processing)
+                | (Uploaded, Failed)
+                | (Processing, Ready)
+                | (Processing, Failed)
+        )
+    }
+
+    /// Deleted is the only fully terminal state; Failed/Quarantined are still
+    /// actionable (reprocess / restore).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Deleted)
+    }
+
+    /// Whether an asset in this state may have a delivery URL resolved for it.
+    /// Only `Ready` is deliverable; everything else resolves to a placeholder
+    /// (Plane C fails open).
+    pub fn is_deliverable(&self) -> bool {
+        matches!(self, Self::Ready)
+    }
+}
+
+impl fmt::Display for AssetState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for AssetState {
+    type Error = MediaError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "uploaded" => Ok(Self::Uploaded),
+            "processing" => Ok(Self::Processing),
+            "ready" => Ok(Self::Ready),
+            "failed" => Ok(Self::Failed),
+            "quarantined" => Ok(Self::Quarantined),
+            "deleted" => Ok(Self::Deleted),
+            other => Err(MediaError::DomainViolation {
+                field: "asset_state".into(),
+                message: format!("unknown asset state: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path_transitions_are_allowed() {
+        assert!(AssetState::Pending.can_transition_to(AssetState::Uploaded));
+        assert!(AssetState::Uploaded.can_transition_to(AssetState::Processing));
+        assert!(AssetState::Processing.can_transition_to(AssetState::Ready));
+    }
+
+    #[test]
+    fn illegal_jumps_are_rejected() {
+        assert!(!AssetState::Pending.can_transition_to(AssetState::Ready));
+        assert!(!AssetState::Ready.can_transition_to(AssetState::Processing));
+        assert!(!AssetState::Deleted.can_transition_to(AssetState::Ready));
+    }
+
+    #[test]
+    fn only_ready_is_deliverable_only_deleted_is_terminal() {
+        assert!(AssetState::Ready.is_deliverable());
+        for s in [
+            AssetState::Pending,
+            AssetState::Uploaded,
+            AssetState::Processing,
+            AssetState::Failed,
+            AssetState::Quarantined,
+        ] {
+            assert!(!s.is_deliverable());
+        }
+        assert!(AssetState::Deleted.is_terminal());
+        assert!(!AssetState::Quarantined.is_terminal());
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for s in [
+            AssetState::Pending,
+            AssetState::Uploaded,
+            AssetState::Processing,
+            AssetState::Ready,
+            AssetState::Failed,
+            AssetState::Quarantined,
+            AssetState::Deleted,
+        ] {
+            assert_eq!(AssetState::try_from(s.as_str()).unwrap(), s);
+        }
+        assert!(AssetState::try_from("bogus").is_err());
+    }
+}

--- a/crates/services/media/src/domain/value_object/blurhash.rs
+++ b/crates/services/media/src/domain/value_object/blurhash.rs
@@ -1,0 +1,67 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// A compact [BlurHash](https://blurha.sh) placeholder string.
+///
+/// It is the tiny representation a client renders *while* an asset is still
+/// processing — the heart of the "publish never waits on media" guarantee: a post
+/// can show a faithful blurred placeholder immediately and swap in the real
+/// rendition once `AssetReady` arrives. The domain stores it opaquely; it only
+/// guards against an empty or absurdly long value (a real BlurHash is on the order
+/// of 20–40 chars).
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Blurhash(String);
+
+impl Blurhash {
+    /// Generous upper bound for a 9×9-component BlurHash.
+    pub const MAX_LEN: usize = 128;
+
+    pub fn new(value: impl Into<String>) -> Result<Self, MediaError> {
+        let raw = value.into();
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.len() > Self::MAX_LEN {
+            return Err(MediaError::DomainViolation {
+                field: "blurhash".into(),
+                message: "blurhash must be non-empty and reasonably short".into(),
+            });
+        }
+        Ok(Self(trimmed.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Blurhash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Blurhash({})", self.0)
+    }
+}
+
+impl fmt::Display for Blurhash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_typical_blurhash() {
+        let b = Blurhash::new("LEHV6nWB2yk8pyo0adR*.7kCMdnj").unwrap();
+        assert_eq!(b.as_str(), "LEHV6nWB2yk8pyo0adR*.7kCMdnj");
+    }
+
+    #[test]
+    fn rejects_empty_and_overlong() {
+        assert!(Blurhash::new("   ").is_err());
+        assert!(Blurhash::new("x".repeat(Blurhash::MAX_LEN + 1)).is_err());
+    }
+}

--- a/crates/services/media/src/domain/value_object/constraints.rs
+++ b/crates/services/media/src/domain/value_object/constraints.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{MediaKind, MimeType};
+use crate::error::MediaError;
+
+/// The policy a [`MediaKind`] imposes on an upload: the MIME allowlist and the
+/// byte ceiling. It is the single place that turns "what the client declared" into
+/// an accept/reject, and it is reused on finalize to re-check the *verified* MIME
+/// and *actual* size against the same rules.
+///
+/// Defaults are derived from the kind ([`UploadConstraints::for_kind`]); the
+/// application may inject overrides in a later phase, but the domain ships sane,
+/// testable defaults so the rules are enforced from day one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UploadConstraints {
+    allowed_mime_types: Vec<String>,
+    max_bytes: u64,
+}
+
+impl UploadConstraints {
+    /// The default constraints for a kind (its allowlist + ceiling).
+    pub fn for_kind(kind: MediaKind) -> Self {
+        Self {
+            allowed_mime_types: kind
+                .allowed_mime_types()
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect(),
+            max_bytes: kind.max_bytes(),
+        }
+    }
+
+    /// Construct explicit constraints (application override).
+    pub fn new(allowed_mime_types: Vec<String>, max_bytes: u64) -> Self {
+        Self {
+            allowed_mime_types,
+            max_bytes,
+        }
+    }
+
+    pub fn max_bytes(&self) -> u64 {
+        self.max_bytes
+    }
+
+    pub fn allows(&self, mime: &MimeType) -> bool {
+        self.allowed_mime_types.iter().any(|m| m == mime.as_str())
+    }
+
+    /// Validates a (mime, size) pair against the policy. Returns the specific,
+    /// caller-actionable error: an off-allowlist type is `UnsupportedMimeType`
+    /// (MED-1002); an oversize upload is `UploadSizeExceeded` (MED-1003).
+    pub fn validate(&self, mime: &MimeType, size_bytes: u64) -> Result<(), MediaError> {
+        if !self.allows(mime) {
+            return Err(MediaError::UnsupportedMimeType {
+                mime: mime.as_str().to_owned(),
+            });
+        }
+        if size_bytes > self.max_bytes {
+            return Err(MediaError::UploadSizeExceeded {
+                limit: self.max_bytes,
+                actual: size_bytes,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn webp() -> MimeType {
+        MimeType::new("image/webp").unwrap()
+    }
+
+    #[test]
+    fn accepts_an_allowed_type_within_the_ceiling() {
+        let c = UploadConstraints::for_kind(MediaKind::PostImage);
+        assert!(c.validate(&webp(), 1_000_000).is_ok());
+    }
+
+    #[test]
+    fn rejects_an_off_allowlist_type() {
+        let c = UploadConstraints::for_kind(MediaKind::Avatar);
+        let mp4 = MimeType::new("video/mp4").unwrap();
+        assert!(matches!(
+            c.validate(&mp4, 10).unwrap_err(),
+            MediaError::UnsupportedMimeType { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_an_oversize_upload_with_the_limit() {
+        let c = UploadConstraints::for_kind(MediaKind::Avatar);
+        let over = MediaKind::Avatar.max_bytes() + 1;
+        assert!(matches!(
+            c.validate(&webp(), over).unwrap_err(),
+            MediaError::UploadSizeExceeded { limit, actual }
+                if limit == MediaKind::Avatar.max_bytes() && actual == over
+        ));
+    }
+}

--- a/crates/services/media/src/domain/value_object/content_hash.rs
+++ b/crates/services/media/src/domain/value_object/content_hash.rs
@@ -1,0 +1,78 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// A lowercase-hex **SHA-256** digest of an asset's original bytes (64 hex chars).
+///
+/// This is the load-bearing value for two of the service's guarantees:
+/// * **content-addressing** — it forms the immutable segment of every rendition's
+///   [`StorageKey`](super::StorageKey), so identical bytes always map to the same
+///   key and an edit (different bytes) lands on a different URL; and
+/// * **dedup** — when enabled, two uploads with the same hash share stored bytes.
+///
+/// Construction normalizes to lowercase and rejects anything that is not exactly
+/// 64 hex characters, so a malformed digest is unrepresentable.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContentHash(String);
+
+impl ContentHash {
+    /// Validates and normalizes a hex SHA-256 string.
+    pub fn new(value: impl Into<String>) -> Result<Self, MediaError> {
+        let raw = value.into();
+        let normalized = raw.trim().to_ascii_lowercase();
+        if normalized.len() != 64 || !normalized.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(MediaError::DomainViolation {
+                field: "content_hash".into(),
+                message: "expected a 64-character hex SHA-256 digest".into(),
+            });
+        }
+        Ok(Self(normalized))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for ContentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ContentHash({})", self.0)
+    }
+}
+
+impl fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn accepts_and_lowercases_a_valid_digest() {
+        let h = ContentHash::new(VALID.to_ascii_uppercase()).unwrap();
+        assert_eq!(h.as_str(), VALID);
+    }
+
+    #[test]
+    fn rejects_wrong_length_and_non_hex() {
+        assert!(ContentHash::new("abc123").is_err());
+        assert!(ContentHash::new("z".repeat(64)).is_err());
+        assert!(matches!(
+            ContentHash::new("").unwrap_err(),
+            MediaError::DomainViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn same_bytes_same_hash_is_eq() {
+        assert_eq!(ContentHash::new(VALID).unwrap(), ContentHash::new(VALID).unwrap());
+    }
+}

--- a/crates/services/media/src/domain/value_object/delivery_visibility.rs
+++ b/crates/services/media/src/domain/value_object/delivery_visibility.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// How a delivery URL is brokered for an asset.
+///
+/// `Public` media gets a content-addressed, immutable CDN URL — cacheable forever,
+/// because an edit produces a new asset (new hash → new URL) rather than mutating
+/// in place. `Signed` media gets a short-lived signed URL minted per request, only
+/// after the edge has authorized the viewer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryVisibility {
+    Public,
+    Signed,
+}
+
+impl DeliveryVisibility {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Signed => "signed",
+        }
+    }
+
+    /// Whether a resolved URL for this visibility carries an expiry (signed URLs
+    /// do; immutable public URLs do not).
+    pub fn is_expiring(&self) -> bool {
+        matches!(self, Self::Signed)
+    }
+}
+
+impl Default for DeliveryVisibility {
+    /// Public is the default: most media (avatars, post images) is world-readable
+    /// and served from immutable content-addressed URLs.
+    fn default() -> Self {
+        Self::Public
+    }
+}
+
+impl fmt::Display for DeliveryVisibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for DeliveryVisibility {
+    type Error = MediaError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "public" => Ok(Self::Public),
+            "signed" => Ok(Self::Signed),
+            other => Err(MediaError::DomainViolation {
+                field: "delivery_visibility".into(),
+                message: format!("unknown delivery visibility: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_public_and_non_expiring() {
+        assert_eq!(DeliveryVisibility::default(), DeliveryVisibility::Public);
+        assert!(!DeliveryVisibility::Public.is_expiring());
+        assert!(DeliveryVisibility::Signed.is_expiring());
+    }
+
+    #[test]
+    fn string_round_trip() {
+        for v in [DeliveryVisibility::Public, DeliveryVisibility::Signed] {
+            assert_eq!(DeliveryVisibility::try_from(v.as_str()).unwrap(), v);
+        }
+        assert!(DeliveryVisibility::try_from("secret").is_err());
+    }
+}

--- a/crates/services/media/src/domain/value_object/dimensions.rs
+++ b/crates/services/media/src/domain/value_object/dimensions.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// Pixel dimensions of an image asset or rendition.
+///
+/// Construction is the **decode-bomb guard**: it rejects zero extents and any
+/// image whose pixel count exceeds [`MAX_PIXELS`](Dimensions::MAX_PIXELS), so a
+/// maliciously tiny file that decodes to a multi-gigapixel canvas can never be
+/// represented (and thus never enters the pipeline). The limit lives in the domain
+/// because it is a safety invariant, not a tunable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Dimensions {
+    width: u32,
+    height: u32,
+}
+
+impl Dimensions {
+    /// ~100 megapixels — comfortably above any legitimate photo, far below a
+    /// decompression-bomb canvas.
+    pub const MAX_PIXELS: u64 = 100_000_000;
+
+    pub fn new(width: u32, height: u32) -> Result<Self, MediaError> {
+        if width == 0 || height == 0 {
+            return Err(MediaError::CorruptMedia {
+                reason: "image has a zero dimension".into(),
+            });
+        }
+        if u64::from(width) * u64::from(height) > Self::MAX_PIXELS {
+            return Err(MediaError::DimensionLimitExceeded);
+        }
+        Ok(Self { width, height })
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    pub fn pixels(&self) -> u64 {
+        u64::from(self.width) * u64::from(self.height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_normal_photo() {
+        let d = Dimensions::new(4032, 3024).unwrap();
+        assert_eq!(d.pixels(), 4032 * 3024);
+    }
+
+    #[test]
+    fn rejects_zero_extent_as_corrupt() {
+        assert!(matches!(
+            Dimensions::new(0, 100).unwrap_err(),
+            MediaError::CorruptMedia { .. }
+        ));
+        assert!(matches!(
+            Dimensions::new(100, 0).unwrap_err(),
+            MediaError::CorruptMedia { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_a_decode_bomb() {
+        assert!(matches!(
+            Dimensions::new(60_000, 60_000).unwrap_err(),
+            MediaError::DimensionLimitExceeded
+        ));
+    }
+}

--- a/crates/services/media/src/domain/value_object/ids.rs
+++ b/crates/services/media/src/domain/value_object/ids.rs
@@ -1,0 +1,143 @@
+//! Identifier value objects for the media domain.
+//!
+//! [`AssetId`] is a freshly-minted **UUIDv7** (time-ordered) — an asset is
+//! reserved exactly once at ticket time, so there is no dedup-by-id requirement
+//! here (content-addressed dedup happens by [`ContentHash`](super::ContentHash),
+//! not by id). [`OwnerId`] wraps the account UUID the asset belongs to and the
+//! events are partitioned alongside.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::MediaError;
+
+/// Opaque asset identifier (UUIDv7, time-ordered). Minted once when the upload
+/// ticket is issued.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AssetId(Uuid);
+
+impl AssetId {
+    /// Generates a fresh UUIDv7 identifier.
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    /// Wraps an existing UUID from a trusted source (storage row).
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl Default for AssetId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for AssetId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AssetId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for AssetId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+impl TryFrom<&str> for AssetId {
+    type Error = MediaError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| MediaError::InvalidIdentifier(s.to_owned()))
+    }
+}
+
+/// The account that owns an asset (its authorization principal and the events'
+/// secondary routing key). Backed by a UUID to match the rest of the fleet.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct OwnerId(Uuid);
+
+impl OwnerId {
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.hyphenated().to_string()
+    }
+}
+
+impl fmt::Debug for OwnerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "OwnerId({})", self.0.hyphenated())
+    }
+}
+
+impl fmt::Display for OwnerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.hyphenated())
+    }
+}
+
+impl TryFrom<&str> for OwnerId {
+    type Error = MediaError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(s)
+            .map(Self)
+            .map_err(|_| MediaError::InvalidIdentifier(s.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_id_is_v7_and_unique() {
+        let a = AssetId::new();
+        let b = AssetId::new();
+        assert_ne!(a, b);
+        assert_eq!(a.as_uuid().get_version_num(), 7);
+    }
+
+    #[test]
+    fn ids_round_trip_through_string() {
+        let a = AssetId::new();
+        assert_eq!(AssetId::try_from(a.as_str().as_str()).unwrap(), a);
+        let o = OwnerId::from_uuid(Uuid::from_u128(42));
+        assert_eq!(OwnerId::try_from(o.as_str().as_str()).unwrap(), o);
+    }
+
+    #[test]
+    fn id_parse_rejects_garbage() {
+        assert!(matches!(
+            AssetId::try_from("not-a-uuid").unwrap_err(),
+            MediaError::InvalidIdentifier(_)
+        ));
+        assert!(matches!(
+            OwnerId::try_from("nope").unwrap_err(),
+            MediaError::InvalidIdentifier(_)
+        ));
+    }
+}

--- a/crates/services/media/src/domain/value_object/media_kind.rs
+++ b/crates/services/media/src/domain/value_object/media_kind.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// What kind of media an asset holds. `kind` is the policy discriminant: it picks
+/// the MIME allowlist, the size ceiling, the rendition ladder, and the leading
+/// segment of the content-addressed storage path.
+///
+/// v1 is **images-first**. Video is a planned fast-follow and will be added as a
+/// new variant (`Video`) — additively, never by re-numbering — at which point the
+/// allowlist/ceiling/ladder methods grow a video arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaKind {
+    /// A profile/account avatar — square-cropped ladder.
+    Avatar,
+    /// An image attached to a post — feed-sized ladder.
+    PostImage,
+}
+
+impl MediaKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Avatar => "avatar",
+            Self::PostImage => "post_image",
+        }
+    }
+
+    /// Leading segment of the content-addressed storage key (`{segment}/{hash}/…`).
+    pub fn path_segment(&self) -> &'static str {
+        match self {
+            Self::Avatar => "avatars",
+            Self::PostImage => "post-images",
+        }
+    }
+
+    /// The MIME types accepted for this kind (canonical, lowercase). v1 is the
+    /// modern still-image set; the concrete rendition output format is chosen by
+    /// the pipeline, independent of what was uploaded.
+    pub fn allowed_mime_types(&self) -> &'static [&'static str] {
+        // Same still-image allowlist for both image kinds today.
+        &["image/jpeg", "image/png", "image/webp", "image/avif"]
+    }
+
+    /// Hard byte ceiling enforced at ticket time and re-checked on finalize.
+    pub fn max_bytes(&self) -> u64 {
+        match self {
+            Self::Avatar => 10 * 1024 * 1024,     // 10 MiB
+            Self::PostImage => 25 * 1024 * 1024,  // 25 MiB
+        }
+    }
+}
+
+impl fmt::Display for MediaKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for MediaKind {
+    type Error = MediaError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "avatar" => Ok(Self::Avatar),
+            "post_image" => Ok(Self::PostImage),
+            other => Err(MediaError::InvalidMediaKind {
+                kind: other.to_owned(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_round_trip() {
+        for k in [MediaKind::Avatar, MediaKind::PostImage] {
+            assert_eq!(MediaKind::try_from(k.as_str()).unwrap(), k);
+        }
+    }
+
+    #[test]
+    fn unknown_kind_is_rejected() {
+        assert!(matches!(
+            MediaKind::try_from("hologram").unwrap_err(),
+            MediaError::InvalidMediaKind { .. }
+        ));
+    }
+
+    #[test]
+    fn post_images_allow_a_larger_ceiling_than_avatars() {
+        assert!(MediaKind::PostImage.max_bytes() > MediaKind::Avatar.max_bytes());
+    }
+
+    #[test]
+    fn allowlist_is_the_modern_still_image_set() {
+        assert!(MediaKind::Avatar.allowed_mime_types().contains(&"image/webp"));
+        assert!(!MediaKind::Avatar.allowed_mime_types().contains(&"video/mp4"));
+    }
+}

--- a/crates/services/media/src/domain/value_object/mime_type.rs
+++ b/crates/services/media/src/domain/value_object/mime_type.rs
@@ -1,0 +1,91 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// A validated, normalized media MIME type (e.g. `image/webp`).
+///
+/// Construction lowercases, trims, and checks the coarse `type/subtype` shape. It
+/// does NOT by itself enforce the per-kind allowlist — that is
+/// [`UploadConstraints`](super::UploadConstraints)' job, since the allowlist is
+/// policy and varies by [`MediaKind`](super::MediaKind). A `MimeType` only
+/// guarantees the value is well-formed.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MimeType(String);
+
+impl MimeType {
+    pub fn new(value: impl Into<String>) -> Result<Self, MediaError> {
+        let normalized = value.into().trim().to_ascii_lowercase();
+        // Coarse RFC-ish shape check: exactly one '/', non-empty type and subtype.
+        let mut parts = normalized.splitn(2, '/');
+        let ok = matches!((parts.next(), parts.next()), (Some(t), Some(s)) if !t.is_empty() && !s.is_empty() && !s.contains('/'));
+        if !ok {
+            return Err(MediaError::UnsupportedMimeType { mime: normalized });
+        }
+        Ok(Self(normalized))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_image(&self) -> bool {
+        self.0.starts_with("image/")
+    }
+
+    /// The conventional file extension for this type, used when building a
+    /// content-addressed rendition key. Falls back to the subtype.
+    pub fn extension(&self) -> &str {
+        match self.0.as_str() {
+            "image/jpeg" => "jpg",
+            "image/png" => "png",
+            "image/webp" => "webp",
+            "image/avif" => "avif",
+            "image/gif" => "gif",
+            // Fall back to the subtype (e.g. "image/svg+xml" → "svg+xml").
+            other => other.split('/').nth(1).unwrap_or("bin"),
+        }
+    }
+}
+
+impl fmt::Debug for MimeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MimeType({})", self.0)
+    }
+}
+
+impl fmt::Display for MimeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_and_classifies() {
+        let m = MimeType::new("  IMAGE/WebP ").unwrap();
+        assert_eq!(m.as_str(), "image/webp");
+        assert!(m.is_image());
+        assert_eq!(m.extension(), "webp");
+    }
+
+    #[test]
+    fn jpeg_extension_is_jpg() {
+        assert_eq!(MimeType::new("image/jpeg").unwrap().extension(), "jpg");
+    }
+
+    #[test]
+    fn rejects_malformed() {
+        for bad in ["", "image", "image/", "/png", "a/b/c"] {
+            assert!(
+                matches!(MimeType::new(bad).unwrap_err(), MediaError::UnsupportedMimeType { .. }),
+                "expected reject for {bad:?}"
+            );
+        }
+    }
+}

--- a/crates/services/media/src/domain/value_object/mod.rs
+++ b/crates/services/media/src/domain/value_object/mod.rs
@@ -1,0 +1,30 @@
+//! Value objects for the media domain — small, validated, immutable types the
+//! [`Asset`](crate::domain::aggregate::Asset) aggregate is built from. Each
+//! enforces its own invariants at construction so an invalid value is
+//! unrepresentable upstream.
+
+pub mod asset_state;
+pub mod blurhash;
+pub mod constraints;
+pub mod content_hash;
+pub mod delivery_visibility;
+pub mod dimensions;
+pub mod ids;
+pub mod media_kind;
+pub mod mime_type;
+pub mod rendition_kind;
+pub mod storage_key;
+pub mod upload_ticket;
+
+pub use asset_state::AssetState;
+pub use blurhash::Blurhash;
+pub use constraints::UploadConstraints;
+pub use content_hash::ContentHash;
+pub use delivery_visibility::DeliveryVisibility;
+pub use dimensions::Dimensions;
+pub use ids::{AssetId, OwnerId};
+pub use media_kind::MediaKind;
+pub use mime_type::MimeType;
+pub use rendition_kind::RenditionKind;
+pub use storage_key::StorageKey;
+pub use upload_ticket::UploadTicket;

--- a/crates/services/media/src/domain/value_object/rendition_kind.rs
+++ b/crates/services/media/src/domain/value_object/rendition_kind.rs
@@ -1,0 +1,91 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::MediaError;
+
+/// A derivative variant in an asset's catalog. v1 variants are image size buckets;
+/// the concrete output format (WebP/AVIF/JPEG) is carried by each rendition's MIME
+/// type, not by this enum. `Original` is the validated master that every other
+/// rendition is derived from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RenditionKind {
+    Original,
+    Thumbnail,
+    Small,
+    Medium,
+    Large,
+}
+
+impl RenditionKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Original => "original",
+            Self::Thumbnail => "thumbnail",
+            Self::Small => "small",
+            Self::Medium => "medium",
+            Self::Large => "large",
+        }
+    }
+
+    /// The slug used in the content-addressed key (`{kind}/{hash}/{slug}.{ext}`).
+    pub fn slug(&self) -> &'static str {
+        self.as_str()
+    }
+
+    /// The master is the source of truth a READY asset must always carry; the
+    /// resized buckets are derived from it.
+    pub fn is_original(&self) -> bool {
+        matches!(self, Self::Original)
+    }
+}
+
+impl fmt::Display for RenditionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&str> for RenditionKind {
+    type Error = MediaError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "original" => Ok(Self::Original),
+            "thumbnail" => Ok(Self::Thumbnail),
+            "small" => Ok(Self::Small),
+            "medium" => Ok(Self::Medium),
+            "large" => Ok(Self::Large),
+            other => Err(MediaError::DomainViolation {
+                field: "rendition_kind".into(),
+                message: format!("unknown rendition kind: '{other}'"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_round_trip() {
+        for k in [
+            RenditionKind::Original,
+            RenditionKind::Thumbnail,
+            RenditionKind::Small,
+            RenditionKind::Medium,
+            RenditionKind::Large,
+        ] {
+            assert_eq!(RenditionKind::try_from(k.as_str()).unwrap(), k);
+        }
+        assert!(RenditionKind::try_from("huge").is_err());
+    }
+
+    #[test]
+    fn only_original_is_the_master() {
+        assert!(RenditionKind::Original.is_original());
+        assert!(!RenditionKind::Thumbnail.is_original());
+    }
+}

--- a/crates/services/media/src/domain/value_object/storage_key.rs
+++ b/crates/services/media/src/domain/value_object/storage_key.rs
@@ -1,0 +1,104 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{AssetId, ContentHash, MediaKind, RenditionKind};
+
+/// An object-storage key — the path of an object in the canonical byte store. It
+/// is never a URL and never bytes; the delivery plane turns a key into a CDN /
+/// signed URL.
+///
+/// Two shapes, by lifecycle:
+/// * **staging** (`uploads/{asset_id}`) — where the client PUTs the raw bytes
+///   before the content hash is known. Keyed by the freshly-minted asset id.
+/// * **rendition** (`{kind}/{content_hash}/{slug}.{ext}`) — the **content-
+///   addressed** key for a derivative. Because the hash segment is derived from
+///   the bytes, the same bytes always map to the same key (cacheable forever) and
+///   an edit (different bytes → different hash) lands on a brand-new key, which is
+///   why public delivery URLs are immutable and never need invalidation on edit.
+///
+/// The scheme is a **stateful contract**: once objects exist, its meaning must
+/// never change (it is load-bearing for cache correctness and dedup) — version it,
+/// don't mutate it.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StorageKey(String);
+
+impl StorageKey {
+    /// The staging key the pre-signed upload PUTs to (pre-hash).
+    pub fn staging(asset_id: AssetId) -> Self {
+        Self(format!("uploads/{asset_id}"))
+    }
+
+    /// The content-addressed key for a finished rendition.
+    pub fn rendition(
+        kind: MediaKind,
+        hash: &ContentHash,
+        rendition: RenditionKind,
+        extension: &str,
+    ) -> Self {
+        Self(format!(
+            "{}/{}/{}.{}",
+            kind.path_segment(),
+            hash.as_str(),
+            rendition.slug(),
+            extension
+        ))
+    }
+
+    /// Wraps a key read back from storage.
+    pub fn from_raw(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for StorageKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StorageKey({})", self.0)
+    }
+}
+
+impl fmt::Display for StorageKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn hash() -> ContentHash {
+        ContentHash::new("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").unwrap()
+    }
+
+    #[test]
+    fn staging_key_is_keyed_by_asset_id() {
+        let id = AssetId::from_uuid(Uuid::from_u128(1));
+        assert_eq!(
+            StorageKey::staging(id).as_str(),
+            format!("uploads/{id}")
+        );
+    }
+
+    #[test]
+    fn rendition_key_is_content_addressed() {
+        let k = StorageKey::rendition(MediaKind::PostImage, &hash(), RenditionKind::Thumbnail, "webp");
+        assert_eq!(
+            k.as_str(),
+            "post-images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/thumbnail.webp"
+        );
+    }
+
+    #[test]
+    fn identical_bytes_yield_identical_keys() {
+        let a = StorageKey::rendition(MediaKind::Avatar, &hash(), RenditionKind::Original, "jpg");
+        let b = StorageKey::rendition(MediaKind::Avatar, &hash(), RenditionKind::Original, "jpg");
+        assert_eq!(a, b, "content-addressing must be deterministic");
+    }
+}

--- a/crates/services/media/src/domain/value_object/upload_ticket.rs
+++ b/crates/services/media/src/domain/value_object/upload_ticket.rs
@@ -1,0 +1,111 @@
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{AssetId, StorageKey, UploadConstraints};
+use crate::error::MediaError;
+
+/// The domain half of a pre-signed upload reservation: *where* the bytes go (the
+/// staging [`StorageKey`]), *what* is allowed (the [`UploadConstraints`]), and
+/// *until when* (`expires_at`). The infrastructure layer turns this into an actual
+/// pre-signed object-store URL — the URL itself is not modelled here because the
+/// domain neither mints nor holds bytes or signed URLs. This keeps the reservation
+/// policy pure and testable while the signing stays at the edge of the system.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UploadTicket {
+    asset_id: AssetId,
+    storage_key: StorageKey,
+    constraints: UploadConstraints,
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+impl UploadTicket {
+    /// Issues a ticket valid for `ttl` from `now`. A non-positive `ttl` is a
+    /// programming error and is rejected.
+    pub fn issue(
+        asset_id: AssetId,
+        constraints: UploadConstraints,
+        ttl: Duration,
+        now: DateTime<Utc>,
+    ) -> Result<Self, MediaError> {
+        if ttl <= Duration::zero() {
+            return Err(MediaError::DomainViolation {
+                field: "upload_ticket.ttl".into(),
+                message: "ticket TTL must be positive".into(),
+            });
+        }
+        Ok(Self {
+            storage_key: StorageKey::staging(asset_id),
+            asset_id,
+            constraints,
+            issued_at: now,
+            expires_at: now + ttl,
+        })
+    }
+
+    pub fn asset_id(&self) -> AssetId {
+        self.asset_id
+    }
+
+    pub fn storage_key(&self) -> &StorageKey {
+        &self.storage_key
+    }
+
+    pub fn constraints(&self) -> &UploadConstraints {
+        &self.constraints
+    }
+
+    pub fn issued_at(&self) -> DateTime<Utc> {
+        self.issued_at
+    }
+
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    /// Whether the ticket is still usable at `now`. A finalize against an expired
+    /// ticket is rejected with `UploadTicketExpired` (MED-1004) by the caller.
+    pub fn is_valid_at(&self, now: DateTime<Utc>) -> bool {
+        now < self.expires_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn t0() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-26T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn ticket(ttl: Duration) -> Result<UploadTicket, MediaError> {
+        UploadTicket::issue(
+            AssetId::from_uuid(Uuid::from_u128(1)),
+            UploadConstraints::for_kind(crate::domain::value_object::MediaKind::Avatar),
+            ttl,
+            t0(),
+        )
+    }
+
+    #[test]
+    fn issued_ticket_is_valid_until_expiry() {
+        let t = ticket(Duration::minutes(15)).unwrap();
+        assert_eq!(t.storage_key().as_str(), format!("uploads/{}", t.asset_id()));
+        assert!(t.is_valid_at(t0()));
+        assert!(t.is_valid_at(t0() + Duration::minutes(14)));
+        assert!(!t.is_valid_at(t0() + Duration::minutes(15)));
+        assert!(!t.is_valid_at(t0() + Duration::minutes(20)));
+    }
+
+    #[test]
+    fn non_positive_ttl_is_rejected() {
+        assert!(matches!(
+            ticket(Duration::zero()).unwrap_err(),
+            MediaError::DomainViolation { .. }
+        ));
+        assert!(ticket(Duration::seconds(-1)).is_err());
+    }
+}

--- a/crates/services/media/src/error.rs
+++ b/crates/services/media/src/error.rs
@@ -1,0 +1,407 @@
+use error::{AppError, Severity};
+use http::StatusCode;
+use thiserror::Error;
+
+/// Canonical domain and application error type for the media microservice.
+///
+/// The `MED-XXXX` namespace is grouped by concern so a code alone localizes the
+/// fault: 1xxx upload brokerage / ticket (Plane A), 2xxx asset metadata SoR,
+/// 3xxx rendition / transformation pipeline (Plane B), 4xxx object-store adapter
+/// (the byte plane — transient infra), 5xxx CDN / delivery / signing (Plane C),
+/// 6xxx content validation / probe (the trust-but-verify gate on finalize), 7xxx
+/// compliance / Screen (the fail-closed sub-plane), 8xxx inbound event decode /
+/// source mapping, 9xxx cross-cutting (domain/parse, concurrency, event I/O).
+///
+/// ## Code catalogue
+///
+/// | Code     | Variant                  | HTTP | Severity | Retryable |
+/// |----------|--------------------------|------|----------|-----------|
+/// | MED-1001 | InvalidMediaKind         | 422  | Low      | No        |
+/// | MED-1002 | UnsupportedMimeType      | 415  | Low      | No        |
+/// | MED-1003 | UploadSizeExceeded       | 413  | Low      | No        |
+/// | MED-1004 | UploadTicketExpired      | 410  | Low      | No        |
+/// | MED-1005 | UploadNotFinalized       | 409  | Low      | No        |
+/// | MED-2001 | AssetNotFound            | 404  | Low      | No        |
+/// | MED-2002 | InvalidStateTransition   | 409  | Medium   | No        |
+/// | MED-2003 | ConcurrentModification   | 409  | **High** | **Yes**   |
+/// | MED-2004 | AssetAlreadyExists       | 409  | Low      | No        |
+/// | MED-3001 | TranscodeFailed          | 500  | Medium   | **Yes**   |
+/// | MED-3002 | UnsupportedCodec         | 422  | Medium   | No        |
+/// | MED-3003 | RenditionNotFound        | 404  | Low      | No        |
+/// | MED-3004 | ProcessingFailed         | 500  | Medium   | **Yes**   |
+/// | MED-4001 | ObjectStoreUnavailable   | 503  | **High** | **Yes**   |
+/// | MED-4002 | ObjectStoreTimeout       | 504  | **High** | **Yes**   |
+/// | MED-4003 | PresignFailed            | 500  | Medium   | **Yes**   |
+/// | MED-4004 | ObjectNotFound           | 404  | Low      | No        |
+/// | MED-5001 | DeliverySigningFailed    | 500  | Medium   | **Yes**   |
+/// | MED-5002 | CdnInvalidationFailed    | 500  | **High** | **Yes**   |
+/// | MED-5003 | ManifestBuildFailed      | 500  | Medium   | No        |
+/// | MED-6001 | ContentTypeMismatch      | 422  | Medium   | No        |
+/// | MED-6002 | CorruptMedia             | 422  | Medium   | No        |
+/// | MED-6003 | DimensionLimitExceeded   | 422  | Low      | No        |
+/// | MED-6004 | MalwareDetected          | 422  | **High** | No        |
+/// | MED-7001 | AssetQuarantined         | 451  | **High** | No        |
+/// | MED-7002 | ScreenUnavailable        | 503  | **High** | **Yes**   |
+/// | MED-7003 | LegalHoldActive          | 451  | **High** | No        |
+/// | MED-8001 | EventDecodeFailed        | 422  | Medium   | No        |
+/// | MED-8002 | UnknownEventType         | 422  | Low      | No        |
+/// | MED-8003 | UnmappedSource           | 422  | Medium   | No        |
+/// | MED-9001 | DomainViolation          | 422  | Medium   | No        |
+/// | MED-9002 | InvalidIdentifier        | 422  | Low      | No        |
+/// | MED-9003 | EventPublishFailed       | 500  | Medium   | No        |
+/// | MED-9004 | EventConsumeFailed       | 500  | Medium   | No        |
+/// | DB-*     | Postgres metadata (deleg.) | var | var      | var       |
+/// | RDS-*    | Redis delivery cache (deleg.) | var | var   | var       |
+/// | VAL-*    | Validation (delegated)   | 422  | Low      | No        |
+///
+/// > **Mixed failure posture.** Media runs two planes with opposite stances. The
+/// > *delivery* plane is **fail-open**: an object-store or CDN fault degrades a
+/// > render (placeholder / blurhash), it never blocks an upstream write or login.
+/// > The *compliance* gate (MED-7xxx) is **fail-closed**: `ScreenUnavailable` is a
+/// > transient fault the *caller* converts into a hard block for CSAM-class media
+/// > — never an optimistic publish — and `AssetQuarantined` / `LegalHoldActive`
+/// > (451) revoke delivery and override deletion. The `is_retryable` flags drive
+/// > the `run_consumer` retry/DLQ classification on the ingestion side: a content
+/// > probe failure (MED-6xxx) is terminal (→ DLQ / Failed), whereas a transient
+/// > object-store or transcode-worker fault is retried then dead-lettered.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MediaError {
+    // ── Storage delegates (the byte/metadata split) ───────────────────────────
+    /// Postgres — the asset metadata System of Record (`assets`, `renditions`,
+    /// `upload_tickets`, compliance flags). Object storage holds the canonical
+    /// *bytes*; this store holds the canonical *truth about* them.
+    #[error(transparent)]
+    Storage(#[from] postgres_storage::StorageError),
+
+    /// Redis — the hot-path delivery-resolution cache + upload-ticket reservations
+    /// + content-hash dedup lookups.
+    #[error(transparent)]
+    Cache(#[from] redis_storage::RedisStorageError),
+
+    #[error(transparent)]
+    Validation(#[from] validation::ValidationError),
+
+    // ── Upload brokerage / ticket · Plane A (MED-1xxx) ────────────────────────
+    #[error("unsupported media kind: '{kind}'")]
+    InvalidMediaKind { kind: String },
+
+    #[error("unsupported MIME type: '{mime}'")]
+    UnsupportedMimeType { mime: String },
+
+    #[error("upload size {actual} bytes exceeds the limit of {limit} bytes")]
+    UploadSizeExceeded { limit: u64, actual: u64 },
+
+    /// The pre-signed upload ticket's validity window has elapsed; the client must
+    /// request a fresh ticket rather than retry against the expired capability.
+    #[error("upload ticket has expired")]
+    UploadTicketExpired,
+
+    /// A commit / finalize was attempted before the bytes actually landed in the
+    /// object store (no object present at the reserved key).
+    #[error("upload has not been finalized: the object is not present in the store")]
+    UploadNotFinalized,
+
+    // ── Asset metadata SoR (MED-2xxx) ─────────────────────────────────────────
+    #[error("asset not found: {id}")]
+    AssetNotFound { id: String },
+
+    #[error("asset state transition from '{from}' to '{to}' is not permitted")]
+    InvalidStateTransition { from: String, to: String },
+
+    /// An optimistic-lock conflict on the asset row; another writer advanced the
+    /// version concurrently. Safe to retry against the fresh row.
+    #[error("concurrent modification: the asset was updated by another writer")]
+    ConcurrentModification,
+
+    #[error("asset already exists: {id}")]
+    AssetAlreadyExists { id: String },
+
+    // ── Rendition / transformation pipeline · Plane B (MED-3xxx) ──────────────
+    #[error("transcode failed: {reason}")]
+    TranscodeFailed { reason: String },
+
+    #[error("unsupported codec: '{codec}'")]
+    UnsupportedCodec { codec: String },
+
+    #[error("rendition not found: '{spec}'")]
+    RenditionNotFound { spec: String },
+
+    #[error("processing pipeline failed: {reason}")]
+    ProcessingFailed { reason: String },
+
+    // ── Object-store adapter · the byte plane (MED-4xxx) ──────────────────────
+    #[error("object storage is unavailable")]
+    ObjectStoreUnavailable,
+
+    #[error("object storage operation timed out")]
+    ObjectStoreTimeout,
+
+    #[error("failed to pre-sign an object-store URL: {reason}")]
+    PresignFailed { reason: String },
+
+    #[error("object not found in store: '{key}'")]
+    ObjectNotFound { key: String },
+
+    // ── CDN / delivery / signing · Plane C (MED-5xxx) ─────────────────────────
+    #[error("failed to mint a signed delivery URL: {reason}")]
+    DeliverySigningFailed { reason: String },
+
+    #[error("CDN cache invalidation failed: {reason}")]
+    CdnInvalidationFailed { reason: String },
+
+    #[error("failed to build the delivery manifest: {reason}")]
+    ManifestBuildFailed { reason: String },
+
+    // ── Content validation / probe (MED-6xxx) ─────────────────────────────────
+    /// The verified magic bytes do not match the client-declared MIME — the upload
+    /// lied about its content type. Never trust the declared type over the bytes.
+    #[error("declared content type '{declared}' does not match the actual content '{actual}'")]
+    ContentTypeMismatch { declared: String, actual: String },
+
+    #[error("media is corrupt or undecodable: {reason}")]
+    CorruptMedia { reason: String },
+
+    /// A decode-bomb guard: declared/actual dimensions exceed the safe ceiling
+    /// (pixel count, frame count, or duration).
+    #[error("media dimensions exceed the permitted limit")]
+    DimensionLimitExceeded,
+
+    #[error("malware detected in the uploaded object")]
+    MalwareDetected,
+
+    // ── Compliance / Screen · the fail-closed sub-plane (MED-7xxx) ────────────
+    /// The asset is under a moderation takedown: delivery is revoked. 451 mirrors
+    /// moderation's `ContentBlocked`.
+    #[error("asset is quarantined and cannot be delivered")]
+    AssetQuarantined,
+
+    /// The pre-publish moderation Screen gate is unavailable. For CSAM-class media
+    /// the *caller* converts this into a hard block (fail-closed) — the asset never
+    /// goes public on uncertainty.
+    #[error("the moderation screen gate is unavailable")]
+    ScreenUnavailable,
+
+    /// A legal hold (e.g. CSAM evidence preservation) is active; the asset's bytes
+    /// cannot be hard-deleted, overriding an owner GDPR-erasure request.
+    #[error("a legal hold is active; the asset cannot be deleted")]
+    LegalHoldActive,
+
+    // ── Inbound event decode / source mapping (MED-8xxx) ──────────────────────
+    #[error("failed to decode event from topic '{topic}': {reason}")]
+    EventDecodeFailed { topic: String, reason: String },
+
+    /// An event type this consumer does not handle; usually folded into an `Ok`
+    /// skip rather than dead-lettered.
+    #[error("unknown event type: '{event_type}'")]
+    UnknownEventType { event_type: String },
+
+    #[error("source event could not be mapped to a media action: {reason}")]
+    UnmappedSource { reason: String },
+
+    // ── Cross-cutting (MED-9xxx) ──────────────────────────────────────────────
+    #[error("domain invariant violated on '{field}': {message}")]
+    DomainViolation { field: String, message: String },
+
+    #[error("invalid identifier: '{0}'")]
+    InvalidIdentifier(String),
+
+    #[error("failed to publish event: {0}")]
+    EventPublishFailed(String),
+
+    #[error("failed to consume event: {0}")]
+    EventConsumeFailed(String),
+}
+
+impl AppError for MediaError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            MediaError::Storage(e) => e.error_code(),
+            MediaError::Cache(e) => e.error_code(),
+            MediaError::Validation(e) => e.error_code(),
+
+            MediaError::InvalidMediaKind { .. } => "MED-1001",
+            MediaError::UnsupportedMimeType { .. } => "MED-1002",
+            MediaError::UploadSizeExceeded { .. } => "MED-1003",
+            MediaError::UploadTicketExpired => "MED-1004",
+            MediaError::UploadNotFinalized => "MED-1005",
+
+            MediaError::AssetNotFound { .. } => "MED-2001",
+            MediaError::InvalidStateTransition { .. } => "MED-2002",
+            MediaError::ConcurrentModification => "MED-2003",
+            MediaError::AssetAlreadyExists { .. } => "MED-2004",
+
+            MediaError::TranscodeFailed { .. } => "MED-3001",
+            MediaError::UnsupportedCodec { .. } => "MED-3002",
+            MediaError::RenditionNotFound { .. } => "MED-3003",
+            MediaError::ProcessingFailed { .. } => "MED-3004",
+
+            MediaError::ObjectStoreUnavailable => "MED-4001",
+            MediaError::ObjectStoreTimeout => "MED-4002",
+            MediaError::PresignFailed { .. } => "MED-4003",
+            MediaError::ObjectNotFound { .. } => "MED-4004",
+
+            MediaError::DeliverySigningFailed { .. } => "MED-5001",
+            MediaError::CdnInvalidationFailed { .. } => "MED-5002",
+            MediaError::ManifestBuildFailed { .. } => "MED-5003",
+
+            MediaError::ContentTypeMismatch { .. } => "MED-6001",
+            MediaError::CorruptMedia { .. } => "MED-6002",
+            MediaError::DimensionLimitExceeded => "MED-6003",
+            MediaError::MalwareDetected => "MED-6004",
+
+            MediaError::AssetQuarantined => "MED-7001",
+            MediaError::ScreenUnavailable => "MED-7002",
+            MediaError::LegalHoldActive => "MED-7003",
+
+            MediaError::EventDecodeFailed { .. } => "MED-8001",
+            MediaError::UnknownEventType { .. } => "MED-8002",
+            MediaError::UnmappedSource { .. } => "MED-8003",
+
+            MediaError::DomainViolation { .. } => "MED-9001",
+            MediaError::InvalidIdentifier(_) => "MED-9002",
+            MediaError::EventPublishFailed(_) => "MED-9003",
+            MediaError::EventConsumeFailed(_) => "MED-9004",
+        }
+    }
+
+    fn http_status(&self) -> StatusCode {
+        match self {
+            MediaError::Storage(e) => e.http_status(),
+            MediaError::Cache(e) => e.http_status(),
+            MediaError::Validation(e) => e.http_status(),
+
+            MediaError::AssetNotFound { .. }
+            | MediaError::RenditionNotFound { .. }
+            | MediaError::ObjectNotFound { .. } => StatusCode::NOT_FOUND,
+
+            MediaError::UploadNotFinalized
+            | MediaError::InvalidStateTransition { .. }
+            | MediaError::ConcurrentModification
+            | MediaError::AssetAlreadyExists { .. } => StatusCode::CONFLICT,
+
+            MediaError::UploadTicketExpired => StatusCode::GONE,
+            MediaError::UploadSizeExceeded { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+            MediaError::UnsupportedMimeType { .. } => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+
+            MediaError::ObjectStoreUnavailable | MediaError::ScreenUnavailable => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            MediaError::ObjectStoreTimeout => StatusCode::GATEWAY_TIMEOUT,
+
+            MediaError::AssetQuarantined | MediaError::LegalHoldActive => {
+                StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS
+            }
+
+            MediaError::TranscodeFailed { .. }
+            | MediaError::ProcessingFailed { .. }
+            | MediaError::PresignFailed { .. }
+            | MediaError::DeliverySigningFailed { .. }
+            | MediaError::CdnInvalidationFailed { .. }
+            | MediaError::ManifestBuildFailed { .. }
+            | MediaError::EventPublishFailed(_)
+            | MediaError::EventConsumeFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+
+            _ => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            MediaError::Storage(e) => e.severity(),
+            MediaError::Cache(e) => e.severity(),
+            MediaError::Validation(e) => e.severity(),
+
+            MediaError::ConcurrentModification
+            | MediaError::ObjectStoreUnavailable
+            | MediaError::ObjectStoreTimeout
+            | MediaError::CdnInvalidationFailed { .. }
+            | MediaError::MalwareDetected
+            | MediaError::AssetQuarantined
+            | MediaError::ScreenUnavailable
+            | MediaError::LegalHoldActive => Severity::High,
+
+            MediaError::InvalidStateTransition { .. }
+            | MediaError::TranscodeFailed { .. }
+            | MediaError::UnsupportedCodec { .. }
+            | MediaError::ProcessingFailed { .. }
+            | MediaError::PresignFailed { .. }
+            | MediaError::DeliverySigningFailed { .. }
+            | MediaError::ManifestBuildFailed { .. }
+            | MediaError::ContentTypeMismatch { .. }
+            | MediaError::CorruptMedia { .. }
+            | MediaError::EventDecodeFailed { .. }
+            | MediaError::UnmappedSource { .. }
+            | MediaError::DomainViolation { .. }
+            | MediaError::EventPublishFailed(_)
+            | MediaError::EventConsumeFailed(_) => Severity::Medium,
+
+            _ => Severity::Low,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            MediaError::Storage(e) => e.is_retryable(),
+            MediaError::Cache(e) => e.is_retryable(),
+            MediaError::Validation(e) => e.is_retryable(),
+
+            MediaError::ConcurrentModification
+            | MediaError::TranscodeFailed { .. }
+            | MediaError::ProcessingFailed { .. }
+            | MediaError::ObjectStoreUnavailable
+            | MediaError::ObjectStoreTimeout
+            | MediaError::PresignFailed { .. }
+            | MediaError::DeliverySigningFailed { .. }
+            | MediaError::CdnInvalidationFailed { .. }
+            | MediaError::ScreenUnavailable => true,
+
+            _ => false,
+        }
+    }
+
+    fn category(&self) -> &'static str {
+        match self {
+            MediaError::Storage(e) => e.category(),
+            MediaError::Cache(e) => e.category(),
+            MediaError::Validation(e) => e.category(),
+            _ => "MED",
+        }
+    }
+
+    fn user_facing_message(&self) -> &'static str {
+        match self {
+            MediaError::Storage(e) => e.user_facing_message(),
+            MediaError::Cache(e) => e.user_facing_message(),
+            MediaError::Validation(e) => e.user_facing_message(),
+
+            MediaError::InvalidMediaKind { .. }
+            | MediaError::UnsupportedMimeType { .. }
+            | MediaError::UploadSizeExceeded { .. }
+            | MediaError::ContentTypeMismatch { .. }
+            | MediaError::CorruptMedia { .. }
+            | MediaError::DimensionLimitExceeded
+            | MediaError::UnsupportedCodec { .. } => "This file could not be accepted.",
+
+            MediaError::UploadTicketExpired | MediaError::UploadNotFinalized => {
+                "Your upload could not be completed. Please try again."
+            }
+
+            MediaError::MalwareDetected
+            | MediaError::AssetQuarantined
+            | MediaError::LegalHoldActive => "This content is not available.",
+
+            MediaError::AssetNotFound { .. }
+            | MediaError::RenditionNotFound { .. }
+            | MediaError::ObjectNotFound { .. } => "The requested media does not exist.",
+
+            MediaError::ObjectStoreUnavailable
+            | MediaError::ObjectStoreTimeout
+            | MediaError::ScreenUnavailable => {
+                "Media is temporarily unavailable. Please try again."
+            }
+
+            _ => "An internal media error occurred.",
+        }
+    }
+}

--- a/crates/services/media/src/infrastructure/cache/keys.rs
+++ b/crates/services/media/src/infrastructure/cache/keys.rs
@@ -1,0 +1,9 @@
+//! Redis key builders. Single-key today, but the asset id is hash-tagged so any
+//! future multi-key script stays slot-safe on Redis Cluster.
+
+use crate::domain::value_object::AssetId;
+
+/// Cached deliverable view of an asset: `media:asset:{<id>}`.
+pub fn asset_key(id: &AssetId) -> String {
+    format!("media:asset:{{{id}}}")
+}

--- a/crates/services/media/src/infrastructure/cache/mod.rs
+++ b/crates/services/media/src/infrastructure/cache/mod.rs
@@ -1,0 +1,9 @@
+//! Redis adapters — the hot-path delivery cache.
+//!
+//! Keys carry a `{…}` hash tag on the asset id so any future multi-key operation
+//! stays slot-safe on Redis Cluster (the mandatory slot-safety rule).
+
+pub mod keys;
+pub mod redis_delivery_cache;
+
+pub use redis_delivery_cache::RedisDeliveryCache;

--- a/crates/services/media/src/infrastructure/cache/redis_delivery_cache.rs
+++ b/crates/services/media/src/infrastructure/cache/redis_delivery_cache.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use fred::interfaces::KeysInterface;
+use fred::types::Expiration;
+use redis_storage::{RedisClient, RedisStorageError};
+
+use crate::application::port::DeliveryCache;
+use crate::domain::aggregate::Asset;
+use crate::domain::value_object::AssetId;
+use crate::error::MediaError;
+
+use super::keys::asset_key;
+
+/// Time-to-live for a cached asset view. The cache is a read accelerator, not the
+/// SoR — a miss simply rebuilds from Postgres.
+const CACHE_TTL_SECS: i64 = 3600;
+
+/// Redis implementation of [`DeliveryCache`]. Stores the asset as JSON; a
+/// deserialize failure on read is treated as a miss (the read path fails open).
+#[derive(Clone)]
+pub struct RedisDeliveryCache {
+    client: RedisClient,
+}
+
+impl RedisDeliveryCache {
+    pub fn new(client: RedisClient) -> Self {
+        Self { client }
+    }
+}
+
+fn cache_err(e: fred::error::Error) -> MediaError {
+    MediaError::Cache(RedisStorageError::from(e))
+}
+
+#[async_trait]
+impl DeliveryCache for RedisDeliveryCache {
+    async fn get(&self, id: &AssetId) -> Result<Option<Asset>, MediaError> {
+        let raw: Option<String> = self.client.get(asset_key(id)).await.map_err(cache_err)?;
+        // A corrupt/forward-incompatible cached value is a miss, not an error.
+        Ok(raw.and_then(|s| serde_json::from_str::<Asset>(&s).ok()))
+    }
+
+    async fn put(&self, asset: &Asset) -> Result<(), MediaError> {
+        let value = serde_json::to_string(asset).map_err(|e| MediaError::DomainViolation {
+            field: "asset".into(),
+            message: format!("failed to serialize asset for cache: {e}"),
+        })?;
+        let _: () = self
+            .client
+            .set(asset_key(&asset.id()), value, Some(Expiration::EX(CACHE_TTL_SECS)), None, false)
+            .await
+            .map_err(cache_err)?;
+        Ok(())
+    }
+
+    async fn invalidate(&self, id: &AssetId) -> Result<(), MediaError> {
+        let _: i64 = self.client.del(asset_key(id)).await.map_err(cache_err)?;
+        Ok(())
+    }
+}

--- a/crates/services/media/src/infrastructure/cdn/cloudfront_cdn_gateway.rs
+++ b/crates/services/media/src/infrastructure/cdn/cloudfront_cdn_gateway.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+
+use crate::application::port::{CdnGateway, ResolvedUrl};
+use crate::domain::value_object::{DeliveryVisibility, StorageKey};
+use crate::error::MediaError;
+
+use crate::infrastructure::store::S3Client;
+
+/// CDN gateway over a content-addressed origin. Public URLs are immutable (no
+/// expiry — an edit is a new asset/hash/URL); signed URLs are minted per request
+/// via the object store.
+pub struct CloudFrontCdnGateway {
+    /// CDN base URL, e.g. `https://cdn.example.com`.
+    base_url: String,
+    store: Arc<S3Client>,
+    signed_ttl: Duration,
+}
+
+impl CloudFrontCdnGateway {
+    pub fn new(base_url: String, store: Arc<S3Client>, signed_ttl: Duration) -> Self {
+        Self { base_url, store, signed_ttl }
+    }
+}
+
+#[async_trait]
+impl CdnGateway for CloudFrontCdnGateway {
+    async fn resolve(
+        &self,
+        key: &StorageKey,
+        visibility: DeliveryVisibility,
+        now: DateTime<Utc>,
+    ) -> Result<ResolvedUrl, MediaError> {
+        match visibility {
+            DeliveryVisibility::Public => Ok(ResolvedUrl {
+                url: format!("{}/{}", self.base_url.trim_end_matches('/'), key.as_str()),
+                expires_at: None,
+            }),
+            DeliveryVisibility::Signed => {
+                let ttl = self.signed_ttl.to_std().unwrap_or(StdDuration::from_secs(300));
+                let url = self.store.presign_get(key.as_str(), ttl);
+                Ok(ResolvedUrl {
+                    url: url.to_string(),
+                    expires_at: Some(now + self.signed_ttl),
+                })
+            }
+        }
+    }
+
+    async fn invalidate(&self, keys: &[StorageKey]) -> Result<(), MediaError> {
+        // Takedown-only path. A real CloudFront CreateInvalidation is a Phase-7
+        // ops follow-up; content-addressed immutability means this never fires on
+        // an edit, only on delete/quarantine.
+        tracing::info!(count = keys.len(), "cdn invalidation requested (log stub)");
+        Ok(())
+    }
+}

--- a/crates/services/media/src/infrastructure/cdn/mod.rs
+++ b/crates/services/media/src/infrastructure/cdn/mod.rs
@@ -1,0 +1,10 @@
+//! The delivery-plane adapter: turn a content-addressed key into a CDN URL.
+//!
+//! Public media gets a stable, immutable URL off the CDN base; private media gets a
+//! short-lived signed URL minted via the object store. Edge invalidation is a
+//! takedown-only path (a real CloudFront `CreateInvalidation` is a Phase-7/ops
+//! follow-up; this logs).
+
+pub mod cloudfront_cdn_gateway;
+
+pub use cloudfront_cdn_gateway::CloudFrontCdnGateway;

--- a/crates/services/media/src/infrastructure/consumer/mod.rs
+++ b/crates/services/media/src/infrastructure/consumer/mod.rs
@@ -1,0 +1,28 @@
+//! Inbound consumers — the async command path. Each runs on the shared
+//! at-least-once [`run_consumer`](transport::kafka::consumer::run_consumer) runner
+//! (manual commit, bounded retry + jitter, DLQ on poison/exhaustion) and is
+//! self-spawned + supervised in [`crate::service`].
+//!
+//! * `process_consumer` — consumes `media.v1.events`, reacting to `AssetUploaded`
+//!   by running the Plane B transformation pipeline. (This is the worker role; it
+//!   can be scaled as a separate deployment of the same image.)
+//! * `moderation_consumer` — consumes `moderation.v1.events`, applying takedowns /
+//!   restores to the byte plane.
+
+pub mod moderation_consumer;
+pub mod process_consumer;
+
+pub use moderation_consumer::run_moderation_consumer;
+pub use process_consumer::run_process_consumer;
+
+use crate::error::MediaError;
+
+/// Lets the at-least-once runner classify a failure: delegate to the error's own
+/// [`AppError::is_retryable`](error::AppError::is_retryable) verdict — a transient
+/// store / screen fault retries (e.g. `ScreenUnavailable` keeps the asset awaiting
+/// processing); a decode / domain fault is poison and dead-letters immediately.
+impl transport::kafka::consumer::ClassifyError for MediaError {
+    fn is_retryable(&self) -> bool {
+        <Self as error::AppError>::is_retryable(self)
+    }
+}

--- a/crates/services/media/src/infrastructure/consumer/moderation_consumer.rs
+++ b/crates/services/media/src/infrastructure/consumer/moderation_consumer.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use cqrs::Envelope;
+use serde::Deserialize;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use transport::kafka::consumer::{run_consumer, KafkaConsumerHandle, ProcessOutcome, RetryPolicy};
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::command::{ApplyModerationCommand, ApplyModerationHandler, ModerationAction};
+use crate::domain::value_object::AssetId;
+use crate::error::MediaError;
+
+/// Lenient wire view of `moderation.v1.events` — media owns its own read schema and
+/// must not depend on the `moderation` crate (a sideways edge). The serde tag is the
+/// snake_case variant name (e.g. `enforcement_applied`).
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ModerationWireEvent {
+    EnforcementApplied { subject: WireSubject, action: String },
+    EnforcementReversed { subject: WireSubject },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireSubject {
+    entity_type: String,
+    entity_id: String,
+}
+
+/// Runs the moderation consumer: maps an enforcement on a *media* subject into a
+/// quarantine (content removal / visibility limit) or a restore (reversal).
+pub async fn run_moderation_consumer(
+    consumer: KafkaConsumerHandle,
+    handler: Arc<ApplyModerationHandler>,
+    producer: KafkaProducerHandle,
+) {
+    info!("media moderation consumer started");
+    let policy = RetryPolicy::default();
+    let result =
+        run_consumer::<ModerationWireEvent, _>(&consumer, &producer, &policy, move |event| {
+            let handler = Arc::clone(&handler);
+            Box::pin(async move { process(handler.as_ref(), event).await })
+        })
+        .await;
+    if let Err(e) = result {
+        error!(error = %e, "media moderation consumer stopped");
+    }
+}
+
+async fn process(handler: &ApplyModerationHandler, event: &ModerationWireEvent) -> ProcessOutcome {
+    let Some((asset_id, action)) = map(event) else {
+        // Not a media enforcement (or unparseable id) — committed no-op.
+        return ProcessOutcome::from_result(Ok::<(), MediaError>(()));
+    };
+    let result = handler
+        .handle(Envelope::new(Uuid::now_v7(), ApplyModerationCommand { asset_id, action }), Utc::now())
+        .await
+        .map(|_| ());
+    ProcessOutcome::from_result(result)
+}
+
+/// Distills a moderation event into a media action, or `None` to skip.
+fn map(event: &ModerationWireEvent) -> Option<(AssetId, ModerationAction)> {
+    match event {
+        ModerationWireEvent::EnforcementApplied { subject, action }
+            if subject.entity_type == "media"
+                && matches!(action.as_str(), "remove_content" | "visibility_limit") =>
+        {
+            AssetId::try_from(subject.entity_id.as_str())
+                .ok()
+                .map(|id| (id, ModerationAction::Quarantine))
+        }
+        ModerationWireEvent::EnforcementReversed { subject } if subject.entity_type == "media" => {
+            AssetId::try_from(subject.entity_id.as_str())
+                .ok()
+                .map(|id| (id, ModerationAction::Restore))
+        }
+        _ => None,
+    }
+}

--- a/crates/services/media/src/infrastructure/consumer/process_consumer.rs
+++ b/crates/services/media/src/infrastructure/consumer/process_consumer.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use cqrs::Envelope;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use transport::kafka::consumer::{run_consumer, KafkaConsumerHandle, ProcessOutcome, RetryPolicy};
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::command::{ProcessAssetCommand, ProcessAssetHandler};
+use crate::domain::event::DomainEvent;
+use crate::error::MediaError;
+
+/// Runs the Plane B processing consumer on the shared at-least-once runner. It
+/// consumes the service's own `media.v1.events` and acts only on `AssetUploaded`
+/// (the finalize trigger); every other lifecycle event is a committed no-op.
+pub async fn run_process_consumer(
+    consumer: KafkaConsumerHandle,
+    handler: Arc<ProcessAssetHandler>,
+    producer: KafkaProducerHandle,
+) {
+    info!("media processing consumer started");
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<DomainEvent, _>(&consumer, &producer, &policy, move |event| {
+        let handler = Arc::clone(&handler);
+        Box::pin(async move { process(handler.as_ref(), event).await })
+    })
+    .await;
+    if let Err(e) = result {
+        error!(error = %e, "media processing consumer stopped");
+    }
+}
+
+async fn process(handler: &ProcessAssetHandler, event: &DomainEvent) -> ProcessOutcome {
+    match event {
+        DomainEvent::AssetUploaded(e) => {
+            let cmd = ProcessAssetCommand { asset_id: e.asset_id };
+            let result = handler
+                .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+                .await
+                .map(|_| ());
+            ProcessOutcome::from_result(result)
+        }
+        // Not a processing trigger — commit and move on.
+        _ => ProcessOutcome::from_result(Ok::<(), MediaError>(())),
+    }
+}

--- a/crates/services/media/src/infrastructure/event/kafka_event_publisher.rs
+++ b/crates/services/media/src/infrastructure/event/kafka_event_publisher.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use transport::error::TransportError;
+use transport::kafka::envelope::EventEnvelope;
+use transport::kafka::producer::handle::KafkaProducerHandle;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::MediaError;
+
+use super::TOPIC_MEDIA_EVENTS;
+
+/// Kafka-backed [`EventPublisher`]. Handlers persist durably first, then publish;
+/// a publish failure surfaces as [`MediaError::EventPublishFailed`].
+pub struct KafkaEventPublisher {
+    producer: KafkaProducerHandle,
+}
+
+impl KafkaEventPublisher {
+    pub fn new(producer: KafkaProducerHandle) -> Self {
+        Self { producer }
+    }
+}
+
+fn publish_err(e: TransportError) -> MediaError {
+    MediaError::EventPublishFailed(e.to_string())
+}
+
+#[async_trait]
+impl EventPublisher for KafkaEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), MediaError> {
+        let key = event.asset_id().as_str();
+        let envelope = EventEnvelope::new(TOPIC_MEDIA_EVENTS, key.clone(), event.clone())
+            .with_header("event_type", event.event_type().to_owned())
+            .with_header("asset_id", key);
+        self.producer.publish(envelope).await.map_err(publish_err)
+    }
+}

--- a/crates/services/media/src/infrastructure/event/log_event_publisher.rs
+++ b/crates/services/media/src/infrastructure/event/log_event_publisher.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+
+use crate::application::port::EventPublisher;
+use crate::domain::event::DomainEvent;
+use crate::error::MediaError;
+
+/// Fallback [`EventPublisher`] that logs instead of producing to Kafka. Used when
+/// no broker is configured (local dev) so the service still boots and runs.
+pub struct LogEventPublisher;
+
+#[async_trait]
+impl EventPublisher for LogEventPublisher {
+    async fn publish(&self, event: &DomainEvent) -> Result<(), MediaError> {
+        tracing::info!(
+            event_type = event.event_type(),
+            asset_id = %event.asset_id(),
+            "media event (log publisher; no Kafka configured)"
+        );
+        Ok(())
+    }
+}

--- a/crates/services/media/src/infrastructure/event/mod.rs
+++ b/crates/services/media/src/infrastructure/event/mod.rs
@@ -1,0 +1,15 @@
+//! Event-publication adapters for the `media.v1.events` topic.
+//!
+//! Every domain event is keyed by `asset_id` so an asset's lifecycle keeps
+//! per-partition order — `AssetReady` can never be delivered ahead of the
+//! `AssetUploaded` it follows, and `AssetDeleted` is always last. The `event_type`
+//! header carries the dotted routing key.
+
+pub mod kafka_event_publisher;
+pub mod log_event_publisher;
+
+pub use kafka_event_publisher::KafkaEventPublisher;
+pub use log_event_publisher::LogEventPublisher;
+
+/// The single Kafka topic every media domain event is published to.
+pub const TOPIC_MEDIA_EVENTS: &str = "media.v1.events";

--- a/crates/services/media/src/infrastructure/grpc/handler.rs
+++ b/crates/services/media/src/infrastructure/grpc/handler.rs
@@ -1,0 +1,365 @@
+//! gRPC request handler for `media.v1`. Each method translates an inbound Protobuf
+//! request into a validated application command/query, runs it with a fresh
+//! correlation id, and maps the outcome (or [`MediaError`]) back to Protobuf /
+//! [`Status`]. No bytes ever cross this surface — only tickets, metadata, and URLs.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, QueryHandler};
+use error::AppError;
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+use crate::application::command::{
+    CommitUploadCommand, CommitUploadHandler, DeleteAssetCommand, DeleteAssetHandler,
+    IssueUploadTicketCommand, IssueUploadTicketHandler, IssueUploadTicketOutcome,
+    ProcessAssetCommand, ProcessAssetHandler,
+};
+use crate::application::query::{
+    DeliveredMediaView, GetAssetHandler, GetAssetQuery, ResolveDeliveryHandler, ResolveDeliveryQuery,
+};
+use crate::domain::aggregate::{Asset, Rendition};
+use crate::domain::value_object::{
+    AssetId, AssetState, DeliveryVisibility, MediaKind, MimeType, OwnerId, RenditionKind,
+};
+use crate::error::MediaError;
+
+pub use media_api as proto;
+
+/// gRPC handler for `media.v1.MediaService`. Holds the application handlers as
+/// `Arc`s (so it is cheaply `Clone`).
+#[derive(Clone)]
+pub struct MediaServiceHandler {
+    issue: Arc<IssueUploadTicketHandler>,
+    commit: Arc<CommitUploadHandler>,
+    delete: Arc<DeleteAssetHandler>,
+    process: Arc<ProcessAssetHandler>,
+    get: Arc<GetAssetHandler>,
+    resolve: Arc<ResolveDeliveryHandler>,
+}
+
+impl MediaServiceHandler {
+    pub fn new(
+        issue: Arc<IssueUploadTicketHandler>,
+        commit: Arc<CommitUploadHandler>,
+        delete: Arc<DeleteAssetHandler>,
+        process: Arc<ProcessAssetHandler>,
+        get: Arc<GetAssetHandler>,
+        resolve: Arc<ResolveDeliveryHandler>,
+    ) -> Self {
+        Self { issue, commit, delete, process, get, resolve }
+    }
+
+    pub async fn issue_upload_ticket(
+        &self,
+        request: Request<proto::IssueUploadTicketRequest>,
+    ) -> Result<Response<proto::IssueUploadTicketResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = IssueUploadTicketCommand {
+            owner_id: OwnerId::try_from(req.owner_id.as_str()).map_err(to_status)?,
+            kind: kind_from_proto(req.kind)?,
+            declared_mime: MimeType::new(req.declared_mime_type).map_err(to_status)?,
+            declared_size: req.declared_size_bytes,
+            content_sha256: optional(req.content_sha256),
+            idempotency_key: optional(req.idempotency_key),
+        };
+        let outcome = self
+            .issue
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(issue_outcome_to_proto(outcome)))
+    }
+
+    pub async fn commit_upload(
+        &self,
+        request: Request<proto::CommitUploadRequest>,
+    ) -> Result<Response<proto::CommitUploadResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = CommitUploadCommand {
+            asset_id: AssetId::try_from(req.asset_id.as_str()).map_err(to_status)?,
+            etag: optional(req.etag),
+            content_sha256: optional(req.content_sha256),
+        };
+        let asset = self
+            .commit
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::CommitUploadResponse { asset: Some(asset_to_proto(&asset)) }))
+    }
+
+    pub async fn abort_upload(
+        &self,
+        request: Request<proto::AbortUploadRequest>,
+    ) -> Result<Response<proto::AbortUploadResponse>, Status> {
+        let req = request.into_inner();
+        // Abort = delete the (still-pending) reservation: purges staging + tombstones.
+        let cmd = DeleteAssetCommand {
+            asset_id: AssetId::try_from(req.asset_id.as_str()).map_err(to_status)?,
+            owner_id: OwnerId::try_from(req.owner_id.as_str()).map_err(to_status)?,
+        };
+        self.delete
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::AbortUploadResponse {}))
+    }
+
+    pub async fn get_asset(
+        &self,
+        request: Request<proto::GetAssetRequest>,
+    ) -> Result<Response<proto::GetAssetResponse>, Status> {
+        let req = request.into_inner();
+        let query = GetAssetQuery {
+            asset_id: AssetId::try_from(req.asset_id.as_str()).map_err(to_status)?,
+        };
+        let asset = self
+            .get
+            .handle(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::GetAssetResponse { asset: Some(asset_to_proto(&asset)) }))
+    }
+
+    pub async fn delete_asset(
+        &self,
+        request: Request<proto::DeleteAssetRequest>,
+    ) -> Result<Response<proto::DeleteAssetResponse>, Status> {
+        let req = request.into_inner();
+        let cmd = DeleteAssetCommand {
+            asset_id: AssetId::try_from(req.asset_id.as_str()).map_err(to_status)?,
+            owner_id: OwnerId::try_from(req.owner_id.as_str()).map_err(to_status)?,
+        };
+        self.delete
+            .handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now())
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::DeleteAssetResponse {}))
+    }
+
+    pub async fn resolve_delivery(
+        &self,
+        request: Request<proto::ResolveDeliveryRequest>,
+    ) -> Result<Response<proto::ResolveDeliveryResponse>, Status> {
+        let req = request.into_inner();
+        let query = ResolveDeliveryQuery {
+            asset_id: AssetId::try_from(req.asset_id.as_str()).map_err(to_status)?,
+            preferred: rendition_from_proto(req.preferred),
+            visibility: visibility_from_proto(req.visibility),
+        };
+        let view = self
+            .resolve
+            .handle(Envelope::new(Uuid::now_v7(), query))
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::ResolveDeliveryResponse {
+            media: Some(delivered_to_proto(view)),
+        }))
+    }
+
+    pub async fn batch_resolve_delivery(
+        &self,
+        request: Request<proto::BatchResolveDeliveryRequest>,
+    ) -> Result<Response<proto::BatchResolveDeliveryResponse>, Status> {
+        let req = request.into_inner();
+        // Unparseable ids are dropped (the batch fails open for feed hydration).
+        let ids: Vec<AssetId> = req
+            .asset_ids
+            .iter()
+            .filter_map(|id| AssetId::try_from(id.as_str()).ok())
+            .collect();
+        let views = self
+            .resolve
+            .resolve_batch(
+                &ids,
+                rendition_from_proto(req.preferred),
+                visibility_from_proto(req.visibility),
+                Utc::now(),
+            )
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::BatchResolveDeliveryResponse {
+            media: views.into_iter().map(delivered_to_proto).collect(),
+        }))
+    }
+
+    pub async fn reprocess(
+        &self,
+        request: Request<proto::ReprocessRequest>,
+    ) -> Result<Response<proto::ReprocessResponse>, Status> {
+        let req = request.into_inner();
+        let asset_id = AssetId::try_from(req.asset_id.as_str()).map_err(to_status)?;
+        // Retrigger the pipeline (a no-op unless the asset is awaiting processing),
+        // then return the current metadata.
+        self.process
+            .handle(Envelope::new(Uuid::now_v7(), ProcessAssetCommand { asset_id }), Utc::now())
+            .await
+            .map_err(to_status)?;
+        let asset = self
+            .get
+            .handle(Envelope::new(Uuid::now_v7(), GetAssetQuery { asset_id }))
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::ReprocessResponse { asset: Some(asset_to_proto(&asset)) }))
+    }
+}
+
+// ── proto → domain ────────────────────────────────────────────────────────────
+
+fn optional(s: String) -> Option<String> {
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn kind_from_proto(value: i32) -> Result<MediaKind, Status> {
+    match value {
+        1 => Ok(MediaKind::Avatar),
+        2 => Ok(MediaKind::PostImage),
+        other => Err(Status::invalid_argument(format!("unsupported media kind: {other}"))),
+    }
+}
+
+/// `UNSPECIFIED`/unknown ⇒ `None` (all renditions); otherwise the specific kind.
+fn rendition_from_proto(value: i32) -> Option<RenditionKind> {
+    match value {
+        1 => Some(RenditionKind::Original),
+        2 => Some(RenditionKind::Thumbnail),
+        3 => Some(RenditionKind::Small),
+        4 => Some(RenditionKind::Medium),
+        5 => Some(RenditionKind::Large),
+        _ => None,
+    }
+}
+
+/// `UNSPECIFIED`/unknown ⇒ `None` (the asset's default visibility).
+fn visibility_from_proto(value: i32) -> Option<DeliveryVisibility> {
+    match value {
+        1 => Some(DeliveryVisibility::Public),
+        2 => Some(DeliveryVisibility::Signed),
+        _ => None,
+    }
+}
+
+// ── domain → proto ────────────────────────────────────────────────────────────
+
+fn kind_to_proto(kind: MediaKind) -> i32 {
+    match kind {
+        MediaKind::Avatar => 1,
+        MediaKind::PostImage => 2,
+    }
+}
+
+fn state_to_proto(state: AssetState) -> i32 {
+    match state {
+        AssetState::Pending => 1,
+        AssetState::Uploaded => 2,
+        AssetState::Processing => 3,
+        AssetState::Ready => 4,
+        AssetState::Failed => 5,
+        AssetState::Quarantined => 6,
+        AssetState::Deleted => 7,
+    }
+}
+
+fn rendition_kind_to_proto(kind: RenditionKind) -> i32 {
+    match kind {
+        RenditionKind::Original => 1,
+        RenditionKind::Thumbnail => 2,
+        RenditionKind::Small => 3,
+        RenditionKind::Medium => 4,
+        RenditionKind::Large => 5,
+    }
+}
+
+fn visibility_to_proto(v: DeliveryVisibility) -> i32 {
+    match v {
+        DeliveryVisibility::Public => 1,
+        DeliveryVisibility::Signed => 2,
+    }
+}
+
+fn issue_outcome_to_proto(outcome: IssueUploadTicketOutcome) -> proto::IssueUploadTicketResponse {
+    proto::IssueUploadTicketResponse {
+        asset_id: outcome.asset_id.as_str(),
+        ticket: outcome.upload.map(|u| proto::UploadTicket {
+            upload_url: u.presigned.url,
+            method: u.presigned.method,
+            required_headers: u.presigned.required_headers,
+            max_size_bytes: u.max_size_bytes,
+            expires_at: Some(to_timestamp(u.expires_at)),
+        }),
+        deduplicated: outcome.deduplicated,
+    }
+}
+
+fn asset_to_proto(a: &Asset) -> proto::Asset {
+    proto::Asset {
+        id: a.id().as_str(),
+        owner_id: a.owner_id().as_str(),
+        kind: kind_to_proto(a.kind()),
+        state: state_to_proto(a.state()),
+        mime_type: a.mime_type().map(|m| m.as_str().to_owned()).unwrap_or_default(),
+        byte_size: a.byte_size().unwrap_or(0),
+        width: a.dimensions().map(|d| d.width()).unwrap_or(0),
+        height: a.dimensions().map(|d| d.height()).unwrap_or(0),
+        content_hash: a.content_hash().map(|h| h.as_str().to_owned()).unwrap_or_default(),
+        blurhash: a.blurhash().map(|b| b.as_str().to_owned()).unwrap_or_default(),
+        renditions: a.renditions().iter().map(rendition_to_proto).collect(),
+        created_at: Some(to_timestamp(a.created_at())),
+        updated_at: Some(to_timestamp(a.updated_at())),
+    }
+}
+
+fn rendition_to_proto(r: &Rendition) -> proto::Rendition {
+    proto::Rendition {
+        kind: rendition_kind_to_proto(r.kind()),
+        mime_type: r.mime_type().as_str().to_owned(),
+        storage_key: r.storage_key().as_str().to_owned(),
+        width: r.dimensions().width(),
+        height: r.dimensions().height(),
+        byte_size: r.byte_size(),
+    }
+}
+
+fn delivered_to_proto(view: DeliveredMediaView) -> proto::DeliveredMedia {
+    proto::DeliveredMedia {
+        asset_id: view.asset_id.as_str(),
+        state: state_to_proto(view.state),
+        blurhash: view.blurhash.unwrap_or_default(),
+        renditions: view
+            .renditions
+            .into_iter()
+            .map(|r| proto::DeliveredRendition {
+                kind: rendition_kind_to_proto(r.kind),
+                url: r.url,
+                visibility: visibility_to_proto(r.visibility),
+                url_expires_at: r.expires_at.map(to_timestamp),
+                width: r.width,
+                height: r.height,
+            })
+            .collect(),
+        degraded: view.degraded,
+    }
+}
+
+fn to_timestamp(dt: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: dt.timestamp(),
+        nanos: dt.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn to_status(err: MediaError) -> Status {
+    let message = err.to_string();
+    match err.http_status().as_u16() {
+        400 | 410 | 413 | 415 | 422 => Status::invalid_argument(message),
+        404 => Status::not_found(message),
+        409 => Status::failed_precondition(message),
+        // 451 — quarantine / legal hold.
+        451 => Status::permission_denied(message),
+        503 => Status::unavailable(message),
+        504 => Status::deadline_exceeded(message),
+        _ => Status::internal(message),
+    }
+}

--- a/crates/services/media/src/infrastructure/grpc/mod.rs
+++ b/crates/services/media/src/infrastructure/grpc/mod.rs
@@ -1,0 +1,9 @@
+//! The `media.v1` gRPC ingress — the request handler (proto ↔ application mapping)
+//! and the generated-trait impl (`server`).
+
+pub mod handler;
+pub mod server;
+
+pub use handler::{proto, MediaServiceHandler};
+pub use proto::media_service_server::MediaServiceServer;
+pub use server::FILE_DESCRIPTOR_SET;

--- a/crates/services/media/src/infrastructure/grpc/server.rs
+++ b/crates/services/media/src/infrastructure/grpc/server.rs
@@ -1,0 +1,67 @@
+use tonic::{Request, Response, Status};
+
+use super::handler::{proto, MediaServiceHandler};
+use proto::media_service_server::MediaService;
+
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `media-api`'s `build.rs`.
+pub const FILE_DESCRIPTOR_SET: &[u8] = media_api::FILE_DESCRIPTOR_SET;
+
+#[tonic::async_trait]
+impl MediaService for MediaServiceHandler {
+    async fn issue_upload_ticket(
+        &self,
+        request: Request<proto::IssueUploadTicketRequest>,
+    ) -> Result<Response<proto::IssueUploadTicketResponse>, Status> {
+        self.issue_upload_ticket(request).await
+    }
+
+    async fn commit_upload(
+        &self,
+        request: Request<proto::CommitUploadRequest>,
+    ) -> Result<Response<proto::CommitUploadResponse>, Status> {
+        self.commit_upload(request).await
+    }
+
+    async fn abort_upload(
+        &self,
+        request: Request<proto::AbortUploadRequest>,
+    ) -> Result<Response<proto::AbortUploadResponse>, Status> {
+        self.abort_upload(request).await
+    }
+
+    async fn get_asset(
+        &self,
+        request: Request<proto::GetAssetRequest>,
+    ) -> Result<Response<proto::GetAssetResponse>, Status> {
+        self.get_asset(request).await
+    }
+
+    async fn delete_asset(
+        &self,
+        request: Request<proto::DeleteAssetRequest>,
+    ) -> Result<Response<proto::DeleteAssetResponse>, Status> {
+        self.delete_asset(request).await
+    }
+
+    async fn resolve_delivery(
+        &self,
+        request: Request<proto::ResolveDeliveryRequest>,
+    ) -> Result<Response<proto::ResolveDeliveryResponse>, Status> {
+        self.resolve_delivery(request).await
+    }
+
+    async fn batch_resolve_delivery(
+        &self,
+        request: Request<proto::BatchResolveDeliveryRequest>,
+    ) -> Result<Response<proto::BatchResolveDeliveryResponse>, Status> {
+        self.batch_resolve_delivery(request).await
+    }
+
+    async fn reprocess(
+        &self,
+        request: Request<proto::ReprocessRequest>,
+    ) -> Result<Response<proto::ReprocessResponse>, Status> {
+        self.reprocess(request).await
+    }
+}

--- a/crates/services/media/src/infrastructure/mod.rs
+++ b/crates/services/media/src/infrastructure/mod.rs
@@ -1,0 +1,28 @@
+//! The media infrastructure layer — concrete adapters implementing the application
+//! ports against real backends.
+//!
+//! * **`persistence`** — the Postgres asset-metadata System of Record.
+//! * **`cache`** — the Redis hot-path delivery cache.
+//! * **`store`** — the S3/MinIO object store (pre-signed uploads + server-side
+//!   byte I/O for the pipeline). The byte plane.
+//! * **`cdn`** — content-addressed public URLs + signed private URLs.
+//! * **`probe`** / **`processor`** — the image pipeline (decode/validate; resize
+//!   ladder + BlurHash).
+//! * **`scanner`** — the malware-scan stub (real sidecar slots in behind the port).
+//! * **`screen`** — the `moderation` Screen gRPC client (fail-closed).
+//! * **`event`** — the Kafka / log event publishers for `media.v1.events`.
+//!
+//! The gRPC service handler/server and the inbound consumers (finalize / moderation
+//! / orphan-GC) are wired in Phase 5.
+
+pub mod cache;
+pub mod cdn;
+pub mod consumer;
+pub mod event;
+pub mod grpc;
+pub mod persistence;
+pub mod probe;
+pub mod processor;
+pub mod scanner;
+pub mod screen;
+pub mod store;

--- a/crates/services/media/src/infrastructure/persistence/mod.rs
+++ b/crates/services/media/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,26 @@
+//! PostgreSQL adapter — the asset metadata System of Record.
+//!
+//! Like `account`/`auth`/`moderation`, writes use a single pool via
+//! [`TransactionManager`]; true `owner_id` sharding is deferred (the column is
+//! present so it can be added without a schema change). The rich [`Asset`]
+//! aggregate is persisted as a JSONB `doc` (it derives `Serialize`/`Deserialize`,
+//! with pending events `#[serde(skip)]`), so a row round-trips straight back to the
+//! aggregate. Upserts are last-write-wins; an optimistic-lock tightening
+//! (`ConcurrentModification`, MED-2003) is a later iteration.
+//!
+//! [`Asset`]: crate::domain::aggregate::Asset
+//! [`TransactionManager`]: postgres_storage::TransactionManager
+
+pub mod pg_asset_repository;
+
+pub use pg_asset_repository::PgAssetRepository;
+
+use postgres_storage::StorageError;
+
+use crate::error::MediaError;
+
+/// Maps a raw sqlx error into the media error namespace (delegating the code to the
+/// shared `DB-*` storage taxonomy).
+pub(crate) fn storage_err(e: sqlx::Error) -> MediaError {
+    MediaError::Storage(StorageError::from(e))
+}

--- a/crates/services/media/src/infrastructure/persistence/pg_asset_repository.rs
+++ b/crates/services/media/src/infrastructure/persistence/pg_asset_repository.rs
@@ -1,0 +1,81 @@
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+use sqlx::types::Json;
+
+use crate::application::port::AssetRepository;
+use crate::domain::aggregate::Asset;
+use crate::domain::value_object::{AssetId, ContentHash};
+use crate::error::MediaError;
+
+use super::storage_err;
+
+/// A row carrying just the stored aggregate document.
+#[derive(Debug, sqlx::FromRow)]
+struct AssetDocRow {
+    doc: Json<Asset>,
+}
+
+/// PostgreSQL adapter for [`AssetRepository`].
+#[derive(Clone)]
+pub struct PgAssetRepository {
+    tx: TransactionManager,
+}
+
+impl PgAssetRepository {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl AssetRepository for PgAssetRepository {
+    async fn save(&self, asset: &Asset) -> Result<(), MediaError> {
+        let content_hash = asset.content_hash().map(|h| h.as_str().to_owned());
+        sqlx::query(
+            r#"
+            INSERT INTO assets (id, owner_id, kind, state, content_hash, created_at, updated_at, doc)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+            ON CONFLICT (id) DO UPDATE SET
+                state        = EXCLUDED.state,
+                content_hash = EXCLUDED.content_hash,
+                updated_at   = EXCLUDED.updated_at,
+                doc          = EXCLUDED.doc
+            "#,
+        )
+        .bind(asset.id().as_uuid())
+        .bind(asset.owner_id().as_uuid())
+        .bind(asset.kind().as_str())
+        .bind(asset.state().as_str())
+        .bind(content_hash)
+        .bind(asset.created_at())
+        .bind(asset.updated_at())
+        .bind(Json(asset))
+        .execute(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: &AssetId) -> Result<Option<Asset>, MediaError> {
+        let row = sqlx::query_as::<_, AssetDocRow>("SELECT doc FROM assets WHERE id = $1")
+            .bind(id.as_uuid())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(storage_err)?;
+        Ok(row.map(|r| r.doc.0))
+    }
+
+    async fn find_ready_by_content_hash(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<Option<Asset>, MediaError> {
+        let row = sqlx::query_as::<_, AssetDocRow>(
+            "SELECT doc FROM assets WHERE content_hash = $1 AND state = 'ready' LIMIT 1",
+        )
+        .bind(hash.as_str())
+        .fetch_optional(self.tx.pool())
+        .await
+        .map_err(storage_err)?;
+        Ok(row.map(|r| r.doc.0))
+    }
+}

--- a/crates/services/media/src/infrastructure/probe/image_media_probe.rs
+++ b/crates/services/media/src/infrastructure/probe/image_media_probe.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::application::port::{MediaProbe, MediaProbeReport};
+use crate::domain::value_object::{ContentHash, Dimensions, MimeType, StorageKey};
+use crate::error::MediaError;
+
+use crate::infrastructure::store::S3Client;
+
+/// Image-backed [`MediaProbe`]: downloads the uploaded object and establishes the
+/// verified facts — the real format (from magic bytes), the true dimensions (with
+/// the decode-bomb guard in [`Dimensions`]), the byte size, and the SHA-256.
+pub struct ImageMediaProbe {
+    store: Arc<S3Client>,
+}
+
+impl ImageMediaProbe {
+    pub fn new(store: Arc<S3Client>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl MediaProbe for ImageMediaProbe {
+    async fn probe(
+        &self,
+        key: &StorageKey,
+        declared_mime: &MimeType,
+    ) -> Result<MediaProbeReport, MediaError> {
+        let bytes = self.store.get_bytes(key.as_str()).await?;
+
+        // SHA-256 of the original bytes (content-addressing + dedup).
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let hex: String = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect();
+        let content_hash = ContentHash::new(hex)?;
+
+        // Real format from magic bytes — never the declared type.
+        let format = image::guess_format(&bytes).map_err(|e| MediaError::CorruptMedia {
+            reason: format!("unrecognized media format: {e}"),
+        })?;
+        let mime_type = MimeType::new(format.to_mime_type())?;
+        if !mime_type.is_image() {
+            return Err(MediaError::ContentTypeMismatch {
+                declared: declared_mime.as_str().to_owned(),
+                actual: mime_type.as_str().to_owned(),
+            });
+        }
+
+        // Decode for true dimensions (the decode-bomb guard lives in Dimensions).
+        let img = image::load_from_memory(&bytes).map_err(|e| MediaError::CorruptMedia {
+            reason: format!("decode failed: {e}"),
+        })?;
+        let dimensions = Dimensions::new(img.width(), img.height())?;
+
+        Ok(MediaProbeReport {
+            mime_type,
+            byte_size: bytes.len() as u64,
+            dimensions,
+            content_hash,
+        })
+    }
+}

--- a/crates/services/media/src/infrastructure/probe/mod.rs
+++ b/crates/services/media/src/infrastructure/probe/mod.rs
@@ -1,0 +1,7 @@
+//! The finalize-time content probe — decode the uploaded bytes for the verified
+//! facts (real format, dimensions, size, SHA-256). Never trusts the client's
+//! declaration.
+
+pub mod image_media_probe;
+
+pub use image_media_probe::ImageMediaProbe;

--- a/crates/services/media/src/infrastructure/processor/image_rendition_processor.rs
+++ b/crates/services/media/src/infrastructure/processor/image_rendition_processor.rs
@@ -1,0 +1,97 @@
+use std::io::Cursor;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use image::{DynamicImage, ImageFormat};
+
+use crate::application::port::{DerivedRenditions, ImageProcessor};
+use crate::domain::aggregate::Rendition;
+use crate::domain::value_object::{
+    Blurhash, ContentHash, Dimensions, MediaKind, MimeType, RenditionKind, StorageKey,
+};
+use crate::error::MediaError;
+
+use crate::infrastructure::store::S3Client;
+
+/// The resize ladder (longest-side caps). The master (`Original`) and `Thumbnail`
+/// are always produced; larger buckets only when the source exceeds them (never
+/// upscale).
+const LADDER: &[(RenditionKind, u32)] = &[
+    (RenditionKind::Thumbnail, 320),
+    (RenditionKind::Small, 640),
+    (RenditionKind::Medium, 1280),
+    (RenditionKind::Large, 1920),
+];
+
+/// `image`-backed [`ImageProcessor`]. v1 encodes every rendition as JPEG (broad
+/// support); WebP/AVIF format optimization is a follow-up. Derivatives are written
+/// to content-addressed keys, so identical bytes always land on identical URLs.
+pub struct ImageRenditionProcessor {
+    store: Arc<S3Client>,
+}
+
+impl ImageRenditionProcessor {
+    pub fn new(store: Arc<S3Client>) -> Self {
+        Self { store }
+    }
+
+    /// Encodes an image as JPEG, uploads it to its content-addressed key, and
+    /// builds the [`Rendition`] record.
+    async fn encode_put(
+        &self,
+        img: &DynamicImage,
+        kind: MediaKind,
+        hash: &ContentHash,
+        rk: RenditionKind,
+    ) -> Result<Rendition, MediaError> {
+        let mut buf = Vec::new();
+        img.write_to(&mut Cursor::new(&mut buf), ImageFormat::Jpeg).map_err(|e| {
+            MediaError::ProcessingFailed { reason: format!("jpeg encode failed: {e}") }
+        })?;
+        let key = StorageKey::rendition(kind, hash, rk, "jpg");
+        let byte_size = buf.len() as u64;
+        self.store.put_bytes(key.as_str(), buf, "image/jpeg").await?;
+        Ok(Rendition::new(
+            rk,
+            MimeType::new("image/jpeg")?,
+            key,
+            Dimensions::new(img.width(), img.height())?,
+            byte_size,
+        ))
+    }
+}
+
+#[async_trait]
+impl ImageProcessor for ImageRenditionProcessor {
+    async fn derive(
+        &self,
+        source: &StorageKey,
+        kind: MediaKind,
+        hash: &ContentHash,
+    ) -> Result<DerivedRenditions, MediaError> {
+        let bytes = self.store.get_bytes(source.as_str()).await?;
+        let img = image::load_from_memory(&bytes).map_err(|e| MediaError::CorruptMedia {
+            reason: format!("decode failed: {e}"),
+        })?;
+        let longest = img.width().max(img.height());
+
+        let mut renditions = Vec::new();
+        // The master, re-encoded at full resolution.
+        renditions.push(self.encode_put(&img, kind, hash, RenditionKind::Original).await?);
+        // The ladder: thumbnail always; larger buckets only if the source exceeds them.
+        for &(rk, target) in LADDER {
+            if rk == RenditionKind::Thumbnail || target < longest {
+                let resized = img.resize(target, target, image::imageops::FilterType::Triangle);
+                renditions.push(self.encode_put(&resized, kind, hash, rk).await?);
+            }
+        }
+
+        // BlurHash from a small RGBA thumbnail (4×3 components is the common choice).
+        let small = img.thumbnail(64, 64).to_rgba8();
+        let blur = blurhash::encode(4, 3, small.width(), small.height(), small.as_raw())
+            .map_err(|e| MediaError::ProcessingFailed { reason: format!("blurhash: {e}") })?;
+        let blurhash = Blurhash::new(blur)?;
+
+        Ok(DerivedRenditions { renditions, blurhash })
+    }
+}

--- a/crates/services/media/src/infrastructure/processor/mod.rs
+++ b/crates/services/media/src/infrastructure/processor/mod.rs
@@ -1,0 +1,7 @@
+//! The transformation engine (Plane B) for images: derive the resize ladder + a
+//! BlurHash from the validated master, writing each content-addressed derivative
+//! back to the object store.
+
+pub mod image_rendition_processor;
+
+pub use image_rendition_processor::ImageRenditionProcessor;

--- a/crates/services/media/src/infrastructure/scanner/log_malware_scanner.rs
+++ b/crates/services/media/src/infrastructure/scanner/log_malware_scanner.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+use crate::application::port::{MalwareScanner, ScanVerdict};
+use crate::domain::value_object::StorageKey;
+use crate::error::MediaError;
+
+/// Stub [`MalwareScanner`] that passes everything (a real ClamAV-style sidecar
+/// replaces it behind the same port). Logs the object it "scanned".
+pub struct LogMalwareScanner;
+
+#[async_trait]
+impl MalwareScanner for LogMalwareScanner {
+    async fn scan(&self, key: &StorageKey) -> Result<ScanVerdict, MediaError> {
+        tracing::debug!(object = key.as_str(), "malware scan (log stub: pass)");
+        Ok(ScanVerdict::Clean)
+    }
+}

--- a/crates/services/media/src/infrastructure/scanner/mod.rs
+++ b/crates/services/media/src/infrastructure/scanner/mod.rs
@@ -1,0 +1,7 @@
+//! Anti-malware scanning. The real scanner is an external sidecar (ClamAV-style);
+//! this ships a log stub that passes everything, mirroring `moderation`'s
+//! `LogClassifierGateway`. A real adapter slots in behind the same port.
+
+pub mod log_malware_scanner;
+
+pub use log_malware_scanner::LogMalwareScanner;

--- a/crates/services/media/src/infrastructure/screen/grpc_moderation_screen.rs
+++ b/crates/services/media/src/infrastructure/screen/grpc_moderation_screen.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use moderation_api::moderation_service_client::ModerationServiceClient;
+use moderation_api::{
+    ContentHash as ModContentHash, EntityType, PolicyCategory, ScreenRequest, ScreenVerdict,
+    SubjectRef,
+};
+use tonic::transport::Channel;
+
+use crate::application::port::{ModerationScreen, ScreenDecision};
+use crate::domain::value_object::{AssetId, ContentHash, MediaKind};
+use crate::error::MediaError;
+
+/// gRPC implementation of [`ModerationScreen`], backed by the `moderation` service's
+/// Plane C Screen RPC. The tonic client is cheaply cloneable (the `Channel` is
+/// `Arc`-backed), so each call clones it to satisfy the `&self` port signature.
+///
+/// **Fail-closed:** any transport/gRPC error maps to
+/// [`MediaError::ScreenUnavailable`] — the caller converts that into a hard block
+/// for CSAM-class media, never an optimistic publish.
+#[derive(Clone)]
+pub struct GrpcModerationScreen {
+    client: ModerationServiceClient<Channel>,
+}
+
+impl GrpcModerationScreen {
+    pub fn new(channel: Channel) -> Self {
+        Self { client: ModerationServiceClient::new(channel) }
+    }
+}
+
+#[async_trait]
+impl ModerationScreen for GrpcModerationScreen {
+    async fn screen(
+        &self,
+        asset_id: &AssetId,
+        content_hash: &ContentHash,
+        _kind: MediaKind,
+    ) -> Result<ScreenDecision, MediaError> {
+        let mut client = self.client.clone();
+        let request = ScreenRequest {
+            subject: Some(SubjectRef {
+                entity_type: EntityType::Media as i32,
+                entity_id: asset_id.as_str(),
+                // A hash match is about content, not the actor; left empty here.
+                actor_id: String::new(),
+                surface: "upload".to_owned(),
+            }),
+            hashes: vec![ModContentHash {
+                algorithm: "sha256".to_owned(),
+                value: content_hash.as_str().to_owned(),
+            }],
+            // No transient text on the media path; empty categories ⇒ all
+            // zero-tolerance categories are screened.
+            text: String::new(),
+            categories: Vec::new(),
+        };
+
+        match client.screen(request).await {
+            Ok(resp) => {
+                let r = resp.into_inner();
+                let verdict =
+                    ScreenVerdict::try_from(r.verdict).unwrap_or(ScreenVerdict::Unspecified);
+                // BLOCK and the ambiguous REVIEW both hold publication (fail-closed).
+                let blocked = matches!(verdict, ScreenVerdict::Block | ScreenVerdict::Review);
+                let csam = r.matched_categories.contains(&(PolicyCategory::Csam as i32));
+                let reference = (!r.match_reference.is_empty()).then_some(r.match_reference);
+                Ok(ScreenDecision { blocked, csam, reference })
+            }
+            // Fail-closed: an unavailable gate is treated as a block upstream.
+            Err(_status) => Err(MediaError::ScreenUnavailable),
+        }
+    }
+}

--- a/crates/services/media/src/infrastructure/screen/mod.rs
+++ b/crates/services/media/src/infrastructure/screen/mod.rs
@@ -1,0 +1,5 @@
+//! The pre-publish moderation Screen gate — a gRPC client to `moderation`.
+
+pub mod grpc_moderation_screen;
+
+pub use grpc_moderation_screen::GrpcModerationScreen;

--- a/crates/services/media/src/infrastructure/store/config.rs
+++ b/crates/services/media/src/infrastructure/store/config.rs
@@ -1,0 +1,19 @@
+use std::time::Duration;
+
+/// Connection settings for the S3-compatible object store. Built from env at the
+/// composition root (Phase 5).
+#[derive(Debug, Clone)]
+pub struct S3Config {
+    /// Endpoint URL (e.g. `https://s3.amazonaws.com` or a MinIO `http://…:9000`).
+    pub endpoint: String,
+    pub region: String,
+    pub bucket: String,
+    pub access_key: String,
+    pub secret_key: String,
+    /// Validity window for the server-side signed URLs this client mints.
+    pub presign_ttl: Duration,
+    /// Hard timeout on every object-store HTTP call (presign execution, GET/PUT,
+    /// HEAD). Bounds the pipeline + delivery paths so a hung store can't wedge a
+    /// worker — the media analogue of the Screen / query timeouts elsewhere.
+    pub request_timeout: Duration,
+}

--- a/crates/services/media/src/infrastructure/store/mod.rs
+++ b/crates/services/media/src/infrastructure/store/mod.rs
@@ -1,0 +1,15 @@
+//! The byte-plane adapter: an S3-compatible object store (S3 / MinIO).
+//!
+//! [`S3Client`] mints pre-signed URLs (the client PUTs bytes straight to the
+//! store, off the mesh) and also performs the server-side GET/PUT the worker needs
+//! to probe and derive renditions. [`S3ObjectStore`] adapts it to the
+//! [`ObjectStore`](crate::application::port::ObjectStore) port. rusty-s3 builds the
+//! signed URLs; reqwest executes the HTTP.
+
+pub mod config;
+pub mod s3_client;
+pub mod s3_object_store;
+
+pub use config::S3Config;
+pub use s3_client::S3Client;
+pub use s3_object_store::S3ObjectStore;

--- a/crates/services/media/src/infrastructure/store/s3_client.rs
+++ b/crates/services/media/src/infrastructure/store/s3_client.rs
@@ -1,0 +1,168 @@
+use std::time::Duration;
+
+use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, RANGE};
+use reqwest::StatusCode;
+use rusty_s3::{Bucket, Credentials, S3Action, UrlStyle};
+use url::Url;
+
+use super::config::S3Config;
+use crate::error::MediaError;
+
+/// A thin S3-compatible client: presigns URLs (for the client's direct upload and
+/// for signed delivery) and performs the server-side byte I/O the pipeline needs.
+/// Bytes only ever flow store ⇄ this worker — never through the gRPC/Kafka mesh.
+pub struct S3Client {
+    bucket: Bucket,
+    credentials: Credentials,
+    http: reqwest::Client,
+    presign_ttl: Duration,
+}
+
+impl S3Client {
+    pub fn new(config: S3Config) -> Result<Self, MediaError> {
+        let endpoint = Url::parse(&config.endpoint).map_err(|e| MediaError::PresignFailed {
+            reason: format!("invalid object-store endpoint: {e}"),
+        })?;
+        let bucket = Bucket::new(endpoint, UrlStyle::Path, config.bucket, config.region).map_err(
+            |e| MediaError::PresignFailed { reason: format!("invalid bucket: {e}") },
+        )?;
+        let credentials = Credentials::new(config.access_key, config.secret_key);
+        // The HTTP client carries the hard request timeout: a stuck object-store
+        // call elapses into `ObjectStoreTimeout` (retryable) rather than hanging.
+        let http = reqwest::Client::builder()
+            .timeout(config.request_timeout)
+            .build()
+            .map_err(|e| MediaError::PresignFailed {
+                reason: format!("failed to build the object-store HTTP client: {e}"),
+            })?;
+        Ok(Self { bucket, credentials, http, presign_ttl: config.presign_ttl })
+    }
+
+    /// Presigned PUT URL the client uploads to directly.
+    pub fn presign_put(&self, key: &str, ttl: Duration) -> Url {
+        self.bucket.put_object(Some(&self.credentials), key).sign(ttl)
+    }
+
+    /// Presigned GET URL (server-side reads + signed delivery).
+    pub fn presign_get(&self, key: &str, ttl: Duration) -> Url {
+        self.bucket.get_object(Some(&self.credentials), key).sign(ttl)
+    }
+
+    fn presign_delete(&self, key: &str, ttl: Duration) -> Url {
+        self.bucket.delete_object(Some(&self.credentials), key).sign(ttl)
+    }
+
+    /// Server-side download of an object's bytes (for probe / derive).
+    pub async fn get_bytes(&self, key: &str) -> Result<Vec<u8>, MediaError> {
+        let url = self.presign_get(key, self.presign_ttl);
+        let resp = self.http.get(url).send().await.map_err(reqwest_err)?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Err(MediaError::ObjectNotFound { key: key.to_owned() });
+        }
+        if !resp.status().is_success() {
+            return Err(MediaError::ObjectStoreUnavailable);
+        }
+        Ok(resp.bytes().await.map_err(reqwest_err)?.to_vec())
+    }
+
+    /// Server-side upload of a derivative object.
+    pub async fn put_bytes(
+        &self,
+        key: &str,
+        bytes: Vec<u8>,
+        content_type: &str,
+    ) -> Result<(), MediaError> {
+        let url = self.presign_put(key, self.presign_ttl);
+        let resp = self
+            .http
+            .put(url)
+            .header(CONTENT_TYPE, content_type)
+            .body(bytes)
+            .send()
+            .await
+            .map_err(reqwest_err)?;
+        if !resp.status().is_success() {
+            return Err(MediaError::ObjectStoreUnavailable);
+        }
+        Ok(())
+    }
+
+    /// Deletes an object. Idempotent: a 404 is treated as success.
+    pub async fn delete(&self, key: &str) -> Result<(), MediaError> {
+        let url = self.presign_delete(key, self.presign_ttl);
+        let resp = self.http.delete(url).send().await.map_err(reqwest_err)?;
+        let status = resp.status();
+        if status.is_success() || status == StatusCode::NOT_FOUND {
+            Ok(())
+        } else {
+            Err(MediaError::ObjectStoreUnavailable)
+        }
+    }
+
+    /// Returns an object's size, or `None` if it does not exist. Implemented as a
+    /// ranged GET (`bytes=0-0`) so it works without a presigned HEAD action.
+    pub async fn object_size(&self, key: &str) -> Result<Option<u64>, MediaError> {
+        let url = self.presign_get(key, self.presign_ttl);
+        let resp = self
+            .http
+            .get(url)
+            .header(RANGE, "bytes=0-0")
+            .send()
+            .await
+            .map_err(reqwest_err)?;
+        let status = resp.status();
+        if status == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !(status.is_success() || status == StatusCode::PARTIAL_CONTENT) {
+            return Err(MediaError::ObjectStoreUnavailable);
+        }
+        // Prefer the total from `Content-Range: bytes 0-0/<total>`, else
+        // `Content-Length`.
+        let size = resp
+            .headers()
+            .get(CONTENT_RANGE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.rsplit('/').next().map(str::to_owned))
+            .and_then(|total| total.parse::<u64>().ok())
+            .or_else(|| {
+                resp.headers()
+                    .get(CONTENT_LENGTH)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok())
+            })
+            .unwrap_or(0);
+        Ok(Some(size))
+    }
+
+    pub fn presign_ttl(&self) -> Duration {
+        self.presign_ttl
+    }
+
+    /// Liveness probe: a cheap reachability check against the bucket. A missing
+    /// sentinel object (404) is healthy; only a transport/5xx fault is unhealthy.
+    pub async fn health(&self) -> Result<(), MediaError> {
+        self.object_size("__healthcheck__").await.map(|_| ())
+    }
+
+    /// Idempotently creates the bucket (for local/test environments where it does
+    /// not pre-exist). A 409 (already owned) is treated as success.
+    pub async fn ensure_bucket(&self) -> Result<(), MediaError> {
+        let url = self.bucket.create_bucket(&self.credentials).sign(self.presign_ttl);
+        let resp = self.http.put(url).send().await.map_err(reqwest_err)?;
+        let status = resp.status();
+        if status.is_success() || status == StatusCode::CONFLICT {
+            Ok(())
+        } else {
+            Err(MediaError::ObjectStoreUnavailable)
+        }
+    }
+}
+
+fn reqwest_err(e: reqwest::Error) -> MediaError {
+    if e.is_timeout() {
+        MediaError::ObjectStoreTimeout
+    } else {
+        MediaError::ObjectStoreUnavailable
+    }
+}

--- a/crates/services/media/src/infrastructure/store/s3_object_store.rs
+++ b/crates/services/media/src/infrastructure/store/s3_object_store.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+
+use async_trait::async_trait;
+use chrono::Duration;
+
+use crate::application::port::{ObjectHead, ObjectStore, PresignedUpload};
+use crate::domain::value_object::{MimeType, StorageKey};
+use crate::error::MediaError;
+
+use super::s3_client::S3Client;
+
+/// Adapts [`S3Client`] to the [`ObjectStore`] port.
+pub struct S3ObjectStore {
+    client: Arc<S3Client>,
+}
+
+impl S3ObjectStore {
+    pub fn new(client: Arc<S3Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for S3ObjectStore {
+    async fn presign_put(
+        &self,
+        key: &StorageKey,
+        content_type: &MimeType,
+        _max_bytes: u64,
+        expires_in: Duration,
+    ) -> Result<PresignedUpload, MediaError> {
+        let ttl = expires_in.to_std().unwrap_or(StdDuration::from_secs(900));
+        let url = self.client.presign_put(key.as_str(), ttl);
+        let mut required_headers = HashMap::new();
+        required_headers.insert("Content-Type".to_owned(), content_type.as_str().to_owned());
+        Ok(PresignedUpload {
+            url: url.to_string(),
+            method: "PUT".to_owned(),
+            required_headers,
+        })
+    }
+
+    async fn head(&self, key: &StorageKey) -> Result<Option<ObjectHead>, MediaError> {
+        Ok(self
+            .client
+            .object_size(key.as_str())
+            .await?
+            .map(|size_bytes| ObjectHead { size_bytes, etag: String::new() }))
+    }
+
+    async fn delete(&self, key: &StorageKey) -> Result<(), MediaError> {
+        self.client.delete(key.as_str()).await
+    }
+}

--- a/crates/services/media/src/lib.rs
+++ b/crates/services/media/src/lib.rs
@@ -1,0 +1,54 @@
+//! `media` — the platform's **media control plane**: the system-of-record for
+//! media *assets and their processing lifecycle*, and the broker of the byte
+//! plane that surrounds them.
+//!
+//! The single framing that sets this service apart from every neighbour: **it is
+//! a control plane, not a data plane.** Bytes never traverse gRPC and never
+//! traverse Kafka. What moves through the mesh is tiny — upload *tickets*, asset
+//! *metadata*, CDN *URLs*; the bytes themselves flow on a separate path (client ⇄
+//! object storage ⇄ CDN) that this service *authorizes and orchestrates* but
+//! never *carries*. If a JPEG or an MP4 ever shows up inside a `tonic` request or
+//! a Kafka record, the design has failed.
+//!
+//! That posture places it next to its neighbours like so:
+//!
+//! * the **content/identity services** (`post` / `profile`) store an `asset_id`
+//!   *reference*, never bytes, and never wait on processing — a post publishes
+//!   referencing a still-processing asset, rendering a blurhash placeholder until
+//!   `AssetReady` lands. Media is upstream of, and decoupled from, the core write
+//!   path.
+//! * `moderation` owns the integrity *decision*; media computes perceptual/crypto
+//!   hashes and calls `Screen` before a CSAM-class asset can go public
+//!   (fail-closed), then *enforces* quarantine on the byte plane — the reactive
+//!   visibility flip moderation delegates to content services.
+//! * the **CDN** owns edge fan-out; media owns the *delivery policy* —
+//!   content-addressed immutable URLs for public media (an edit is a new asset =
+//!   a new hash = a new URL, so cache invalidation is a takedown-only operation)
+//!   and short-lived signed URLs for private media.
+//!
+//! Failure posture is **mixed**, and the README fail matrix splits it: the
+//! *delivery* plane is fail-**open** (a 404 avatar degrades UX, it never blocks a
+//! write or a login), while the narrow *compliance* gate is fail-**closed**
+//! (CSAM-class media must never go public on uncertainty or a Screen outage).
+//! Processing lag is an SLO, not a consistency requirement — the publish path
+//! never waits on a transcode. See `project_media_service_blueprint`.
+//!
+//! ## Module roadmap (built phase by phase)
+//! Phase 0 (now): [`error`] — the canonical `MED-XXXX` namespace.
+//! Phase 2: `domain` (the Asset aggregate + lifecycle state machine, Rendition
+//! catalog, UploadTicket, content-addressed value objects, the pure transition
+//! logic) · Phase 3: `application` + async ports · Phase 4: `infrastructure`
+//! (S3/MinIO object-store adapter, Postgres metadata SoR, Redis delivery cache,
+//! image/transcode processors, CDN signer, inbound finalize/moderation consumers)
+//! · Phase 5: `app` (composition root) + `service` (runtime wiring + the
+//! self-spawned processing & compliance consumers).
+
+pub mod app;
+pub mod application;
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod infrastructure;
+pub mod service;
+
+pub use error::MediaError;

--- a/crates/services/media/src/service.rs
+++ b/crates/services/media/src/service.rs
@@ -1,0 +1,144 @@
+//! Adapts the media composition root to the fleet [`service_runtime::Service`]
+//! contract. Maps env → config, defers to [`App::build`], self-spawns the inbound
+//! consumers (the Plane B processing worker + the moderation takedown consumer),
+//! registers the concrete tonic service, and reports Postgres + Redis + object-store
+//! liveness.
+//!
+//! The processing consumer is the worker role; in production it can be scaled as a
+//! separate deployment of this same image (more replicas absorbing transcode load
+//! without touching the control-plane RPC latency).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use postgres_storage::PostgresConfig;
+use redis_storage::RedisConfig;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
+use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
+use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
+
+use crate::app::{App, Backends};
+use crate::application::command::{ApplyModerationHandler, ProcessAssetHandler};
+use crate::config::MediaConfig;
+use crate::infrastructure::consumer::{run_moderation_consumer, run_process_consumer};
+use crate::infrastructure::grpc::{FILE_DESCRIPTOR_SET, MediaServiceHandler, MediaServiceServer};
+
+const MEDIA_TOPIC: &str = "media.v1.events";
+const PROCESS_GROUP: &str = "media-processor";
+const MODERATION_TOPIC: &str = "moderation.v1.events";
+const MODERATION_GROUP: &str = "media-moderation-consumer";
+/// Backoff before respawning a consumer after the runner returns.
+const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
+
+type MediaServer = MediaServiceServer<MediaServiceHandler>;
+
+/// The media service as hosted by [`service_runtime`].
+pub struct MediaService {
+    app: App,
+}
+
+#[async_trait]
+impl Service for MediaService {
+    const NAME: &'static str = "media";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <MediaServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let config = MediaConfig::from_env();
+        let backends = Backends {
+            postgres: PostgresConfig::from_env(),
+            redis: RedisConfig::from_env(),
+            kafka: Some(KafkaClientConfig::from_env()),
+        };
+
+        let app = App::build(config, backends)
+            .await
+            .map_err(|e| anyhow::anyhow!("media app build: {e}"))?;
+
+        // Plane B pipeline (off media.v1.events) + moderation takedowns.
+        spawn_process_consumer(Arc::clone(&app.process));
+        spawn_moderation_consumer(Arc::clone(&app.apply_moderation));
+
+        Ok(Self { app })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        let store = Arc::clone(&self.app.store);
+        vec![
+            postgres_storage::health::probe(self.app.pool.clone()),
+            redis_storage::health::probe(self.app.redis.clone()),
+            Arc::new(FnProbe::new("object-store", move || {
+                let store = Arc::clone(&store);
+                async move { store.health().await.map_err(anyhow::Error::from) }
+            })),
+        ]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+
+        routes.add_service(reflection);
+        routes.add_service(MediaServiceServer::new(self.app.handler));
+        Ok(())
+    }
+}
+
+/// Spawns the supervised Plane B processing consumer.
+fn spawn_process_consumer(handler: Arc<ProcessAssetHandler>) {
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(MEDIA_TOPIC, PROCESS_GROUP) {
+                Ok((consumer, producer)) => {
+                    run_process_consumer(consumer, Arc::clone(&handler), producer).await;
+                    tracing::warn!("media processing consumer exited; respawning after backoff");
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build processing consumer; retrying")
+                }
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Spawns the supervised moderation takedown consumer.
+fn spawn_moderation_consumer(handler: Arc<ApplyModerationHandler>) {
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(MODERATION_TOPIC, MODERATION_GROUP) {
+                Ok((consumer, producer)) => {
+                    run_moderation_consumer(consumer, Arc::clone(&handler), producer).await;
+                    tracing::warn!("media moderation consumer exited; respawning after backoff");
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build moderation consumer; retrying")
+                }
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Builds a manual-commit consumer (subscribed to `topic`) and the dead-letter
+/// producer the runner needs.
+fn build_consumer(
+    topic: &str,
+    group: &str,
+) -> anyhow::Result<(KafkaConsumerHandle, KafkaProducerHandle)> {
+    let kafka = KafkaClientConfig::from_env();
+    let consumer = KafkaConsumerBuilder::new(ConsumerConfig::new(kafka.clone(), group))
+        .subscribe(topic)
+        .build()
+        .with_context(|| format!("build consumer for {topic}"))?;
+    let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+        .build()
+        .with_context(|| format!("build dead-letter producer for {topic}"))?;
+    Ok((consumer, producer))
+}

--- a/crates/services/media/tests/integration.rs
+++ b/crates/services/media/tests/integration.rs
@@ -1,0 +1,32 @@
+//! Live, container-backed integration suite for the media service.
+//!
+//! Media's whole point is the byte plane, so this suite boots a real **MinIO**
+//! (S3-compatible object storage) alongside **Postgres** (the metadata SoR) and
+//! **Redis** (the delivery cache), and drives the production handlers over the
+//! real adapters — the S3 presign + server-side I/O, the `image`-crate probe and
+//! resize/BlurHash pipeline, and the Postgres/Redis stores. It exercises exactly
+//! what cannot be unit-tested: the client uploading bytes to a pre-signed URL, the
+//! pipeline reading them back, decoding, deriving renditions, and writing them to
+//! content-addressed keys.
+//!
+//! The moderation Screen and the malware scanner are stubbed at their port
+//! boundary (there is no live `moderation` here); everything else is real.
+//!
+//! Gated behind `integration-media` so the default `cargo test -p media` stays
+//! hermetic and Docker-free. Run the live suite:
+//!
+//! ```text
+//! cargo test -p media --features integration-media -- --nocapture
+//! ```
+//!
+//! Coverage:
+//! - **pipeline** — ticket → direct-to-MinIO PUT → commit → process → READY, with
+//!   real renditions present in the store and resolvable public URLs; plus
+//!   content-hash dedup.
+//! - **moderation** — a CSAM screen block quarantines the asset, places a legal
+//!   hold, and that hold blocks deletion; a takedown then restore round-trips.
+//! - **validation** — non-image bytes are rejected by the real probe; an oversize
+//!   declaration is rejected at ticket time.
+#![cfg(feature = "integration-media")]
+
+mod media_it;

--- a/crates/services/media/tests/media_it/harness/mod.rs
+++ b/crates/services/media/tests/media_it/harness/mod.rs
@@ -1,0 +1,335 @@
+//! Integration harness: boots ephemeral MinIO + Postgres + Redis, creates the
+//! bucket + applies the `.sql` migration, and wires the real media handlers against
+//! them. The moderation Screen + malware scanner are stubbed at their ports.
+#![allow(dead_code)]
+
+use std::io::Cursor;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use cqrs::{Envelope, QueryHandler};
+use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use media::application::command::{
+    ApplyModerationCommand, ApplyModerationHandler, CommitUploadCommand, CommitUploadHandler,
+    DeleteAssetCommand, DeleteAssetHandler, DeleteOutcome, IssueUploadTicketCommand,
+    IssueUploadTicketHandler, IssueUploadTicketOutcome, ModerationAction, ProcessAssetCommand,
+    ProcessAssetHandler, ProcessOutcome,
+};
+use media::application::port::{
+    EventPublisher, MalwareScanner, ModerationScreen, ScanVerdict, ScreenDecision,
+};
+use media::application::query::{
+    DeliveredMediaView, GetAssetHandler, GetAssetQuery, ResolveDeliveryHandler, ResolveDeliveryQuery,
+};
+use media::application::MediaPolicy;
+use media::domain::aggregate::Asset;
+use media::domain::value_object::{
+    AssetId, ContentHash, DeliveryVisibility, MediaKind, MimeType, OwnerId, StorageKey,
+};
+use media::error::MediaError;
+use media::infrastructure::cache::RedisDeliveryCache;
+use media::infrastructure::cdn::CloudFrontCdnGateway;
+use media::infrastructure::event::LogEventPublisher;
+use media::infrastructure::persistence::PgAssetRepository;
+use media::infrastructure::probe::ImageMediaProbe;
+use media::infrastructure::processor::ImageRenditionProcessor;
+use media::infrastructure::store::{S3Client, S3Config, S3ObjectStore};
+
+use postgres_storage::config::StatementLogLevel;
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClientBuilder, RedisConfig};
+
+const MIGRATIONS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations");
+
+// ── Stub ports (no live moderation / scanner) ────────────────────────────────
+
+/// A screen whose verdict the scenario controls.
+pub struct ConfigurableScreen {
+    decision: Mutex<ScreenDecision>,
+}
+
+impl ConfigurableScreen {
+    fn new() -> Self {
+        Self { decision: Mutex::new(ScreenDecision::allow()) }
+    }
+
+    pub fn set_block(&self, csam: bool) {
+        *self.decision.lock().unwrap() =
+            ScreenDecision { blocked: true, csam, reference: Some("ncmec:test".into()) };
+    }
+}
+
+#[async_trait]
+impl ModerationScreen for ConfigurableScreen {
+    async fn screen(
+        &self,
+        _asset_id: &AssetId,
+        _content_hash: &ContentHash,
+        _kind: MediaKind,
+    ) -> Result<ScreenDecision, MediaError> {
+        Ok(self.decision.lock().unwrap().clone())
+    }
+}
+
+struct PassScanner;
+
+#[async_trait]
+impl MalwareScanner for PassScanner {
+    async fn scan(&self, _key: &StorageKey) -> Result<ScanVerdict, MediaError> {
+        Ok(ScanVerdict::Clean)
+    }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+pub struct Harness {
+    issue: IssueUploadTicketHandler,
+    issue_dedup: IssueUploadTicketHandler,
+    commit: CommitUploadHandler,
+    process: ProcessAssetHandler,
+    delete: DeleteAssetHandler,
+    moderation: ApplyModerationHandler,
+    get: GetAssetHandler,
+    resolve: ResolveDeliveryHandler,
+    pub store: Arc<S3Client>,
+    pub screen: Arc<ConfigurableScreen>,
+    http: reqwest::Client,
+    owner: OwnerId,
+}
+
+impl Harness {
+    pub async fn start() -> Self {
+        let pg_url = test_support::containers::postgres_ready(MIGRATIONS_DIR).await;
+        let redis_endpoint = test_support::containers::redis_endpoint().await;
+        let minio_endpoint = test_support::containers::minio_ready().await;
+
+        let pg_config = PostgresConfig {
+            database_url: pg_url,
+            max_connections: 8,
+            min_connections: 1,
+            acquire_timeout: Duration::from_secs(5),
+            idle_timeout: None,
+            max_lifetime: None,
+            statement_log_level: StatementLogLevel::Debug,
+            slow_statement_threshold: Duration::from_millis(500),
+        };
+        let pool = PgPoolBuilder::build(pg_config).await.expect("it: postgres pool");
+        let tx = TransactionManager::new(pool.clone());
+
+        let redis = RedisClientBuilder::new(RedisConfig {
+            hosts: vec![redis_endpoint],
+            ..RedisConfig::default()
+        })
+        .build()
+        .await
+        .expect("it: redis client");
+
+        let store = Arc::new(
+            S3Client::new(S3Config {
+                endpoint: minio_endpoint,
+                region: "us-east-1".into(),
+                bucket: "media".into(),
+                access_key: "minioadmin".into(),
+                secret_key: "minioadmin".into(),
+                presign_ttl: Duration::from_secs(900),
+                request_timeout: Duration::from_secs(10),
+            })
+            .expect("it: s3 client"),
+        );
+        store.ensure_bucket().await.expect("it: create bucket");
+
+        let policy = MediaPolicy::standard();
+        let mut dedup_policy = MediaPolicy::standard();
+        dedup_policy.dedup_enabled = true;
+
+        let assets: Arc<PgAssetRepository> = Arc::new(PgAssetRepository::new(tx));
+        let cache = Arc::new(RedisDeliveryCache::new(redis));
+        let object_store = Arc::new(S3ObjectStore::new(Arc::clone(&store)));
+        let cdn = Arc::new(CloudFrontCdnGateway::new(
+            "https://cdn.test".into(),
+            Arc::clone(&store),
+            policy.signed_url_ttl,
+        ));
+        let probe = Arc::new(ImageMediaProbe::new(Arc::clone(&store)));
+        let processor = Arc::new(ImageRenditionProcessor::new(Arc::clone(&store)));
+        let scanner = Arc::new(PassScanner);
+        let screen = Arc::new(ConfigurableScreen::new());
+        let publisher: Arc<dyn EventPublisher> = Arc::new(LogEventPublisher);
+
+        let issue = IssueUploadTicketHandler::new(
+            assets.clone(),
+            object_store.clone(),
+            policy.clone(),
+        );
+        let issue_dedup =
+            IssueUploadTicketHandler::new(assets.clone(), object_store.clone(), dedup_policy);
+        let commit = CommitUploadHandler::new(
+            assets.clone(),
+            object_store.clone(),
+            probe.clone(),
+            publisher.clone(),
+        );
+        let process = ProcessAssetHandler::new(
+            assets.clone(),
+            scanner,
+            Arc::clone(&screen) as Arc<dyn ModerationScreen>,
+            processor,
+            cache.clone(),
+            publisher.clone(),
+            policy,
+        );
+        let delete = DeleteAssetHandler::new(
+            assets.clone(),
+            object_store,
+            cdn.clone(),
+            cache.clone(),
+            publisher.clone(),
+        );
+        let moderation =
+            ApplyModerationHandler::new(assets.clone(), cdn.clone(), cache.clone(), publisher);
+        let get = GetAssetHandler::new(assets.clone());
+        let resolve = ResolveDeliveryHandler::new(assets, cache, cdn);
+
+        Self {
+            issue,
+            issue_dedup,
+            commit,
+            process,
+            delete,
+            moderation,
+            get,
+            resolve,
+            store,
+            screen,
+            http: reqwest::Client::new(),
+            owner: OwnerId::from_uuid(Uuid::from_u128(7)),
+        }
+    }
+
+    pub fn owner(&self) -> OwnerId {
+        self.owner
+    }
+
+    /// A small valid JPEG of the given dimensions (a soft gradient).
+    pub fn sample_jpeg(width: u32, height: u32) -> Vec<u8> {
+        let img = RgbImage::from_fn(width, height, |x, y| {
+            Rgb([(x % 256) as u8, (y % 256) as u8, 128])
+        });
+        let mut buf = Vec::new();
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut buf), ImageFormat::Jpeg)
+            .expect("encode sample jpeg");
+        buf
+    }
+
+    pub fn sha256_hex(bytes: &[u8]) -> String {
+        let mut h = Sha256::new();
+        h.update(bytes);
+        h.finalize().iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    // ── Flow helpers ─────────────────────────────────────────────────────────
+
+    pub async fn issue_ticket(
+        &self,
+        size: u64,
+        sha: Option<String>,
+        dedup: bool,
+    ) -> Result<IssueUploadTicketOutcome, MediaError> {
+        let cmd = IssueUploadTicketCommand {
+            owner_id: self.owner,
+            kind: MediaKind::PostImage,
+            declared_mime: MimeType::new("image/jpeg").unwrap(),
+            declared_size: size,
+            content_sha256: sha,
+            idempotency_key: None,
+        };
+        let handler = if dedup { &self.issue_dedup } else { &self.issue };
+        handler.handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now()).await
+    }
+
+    /// Uploads bytes directly to the pre-signed URL (the client's role).
+    pub async fn put_to_url(&self, url: &str, bytes: Vec<u8>) -> bool {
+        self.http
+            .put(url)
+            .header(reqwest::header::CONTENT_TYPE, "image/jpeg")
+            .body(bytes)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+
+    pub async fn commit(&self, asset_id: AssetId) -> Result<Asset, MediaError> {
+        let cmd = CommitUploadCommand { asset_id, etag: None, content_sha256: None };
+        self.commit.handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now()).await
+    }
+
+    pub async fn process(&self, asset_id: AssetId) -> Result<ProcessOutcome, MediaError> {
+        self.process
+            .handle(Envelope::new(Uuid::now_v7(), ProcessAssetCommand { asset_id }), Utc::now())
+            .await
+    }
+
+    pub async fn get(&self, asset_id: AssetId) -> Result<Asset, MediaError> {
+        self.get.handle(Envelope::new(Uuid::now_v7(), GetAssetQuery { asset_id })).await
+    }
+
+    pub async fn resolve(
+        &self,
+        asset_id: AssetId,
+        visibility: Option<DeliveryVisibility>,
+    ) -> DeliveredMediaView {
+        self.resolve
+            .handle_at(
+                Envelope::new(
+                    Uuid::now_v7(),
+                    ResolveDeliveryQuery { asset_id, preferred: None, visibility },
+                ),
+                Utc::now(),
+            )
+            .await
+            .expect("resolve")
+    }
+
+    pub async fn delete(&self, asset_id: AssetId) -> Result<DeleteOutcome, MediaError> {
+        let cmd = DeleteAssetCommand { asset_id, owner_id: self.owner };
+        self.delete.handle(Envelope::new(Uuid::now_v7(), cmd), Utc::now()).await
+    }
+
+    pub async fn apply_moderation(
+        &self,
+        asset_id: AssetId,
+        action: ModerationAction,
+    ) {
+        self.moderation
+            .handle(
+                Envelope::new(Uuid::now_v7(), ApplyModerationCommand { asset_id, action }),
+                Utc::now(),
+            )
+            .await
+            .expect("apply moderation");
+    }
+
+    /// True if an object exists at `key` in the store.
+    pub async fn object_exists(&self, key: &StorageKey) -> bool {
+        self.store.object_size(key.as_str()).await.expect("object_size").is_some()
+    }
+
+    /// Drives a fresh asset all the way to READY, returning its id.
+    pub async fn upload_and_process(&self) -> AssetId {
+        let bytes = Self::sample_jpeg(1200, 800);
+        let out = self.issue_ticket(bytes.len() as u64, None, false).await.unwrap();
+        let url = out.upload.unwrap().presigned.url;
+        assert!(self.put_to_url(&url, bytes).await, "direct upload to MinIO failed");
+        self.commit(out.asset_id).await.unwrap();
+        let outcome = self.process(out.asset_id).await.unwrap();
+        assert_eq!(outcome, ProcessOutcome::Ready);
+        out.asset_id
+    }
+}

--- a/crates/services/media/tests/media_it/mod.rs
+++ b/crates/services/media/tests/media_it/mod.rs
@@ -1,0 +1,4 @@
+//! Module root for the live media integration suite.
+
+pub mod harness;
+mod scenarios;

--- a/crates/services/media/tests/media_it/scenarios/mod.rs
+++ b/crates/services/media/tests/media_it/scenarios/mod.rs
@@ -1,0 +1,6 @@
+//! Live scenarios, grouped by concern. Each boots (shares) the MinIO + Postgres +
+//! Redis containers via the harness and drives the real adapters end-to-end.
+
+mod moderation;
+mod pipeline;
+mod validation;

--- a/crates/services/media/tests/media_it/scenarios/moderation.rs
+++ b/crates/services/media/tests/media_it/scenarios/moderation.rs
@@ -1,0 +1,52 @@
+//! Compliance over real backends: a CSAM screen block quarantines + legal-holds the
+//! asset (and the hold blocks deletion); a takedown then restore round-trips.
+
+use media::application::command::{ModerationAction, ProcessOutcome};
+use media::domain::value_object::{AssetState, DeliveryVisibility};
+use media::error::MediaError;
+
+use crate::media_it::harness::Harness;
+
+#[tokio::test]
+async fn a_csam_block_quarantines_legal_holds_and_blocks_deletion() {
+    let h = Harness::start().await;
+    h.screen.set_block(true); // blocked + csam
+
+    let bytes = Harness::sample_jpeg(800, 600);
+    let out = h.issue_ticket(bytes.len() as u64, None, false).await.unwrap();
+    assert!(h.put_to_url(&out.upload.unwrap().presigned.url, bytes).await);
+    h.commit(out.asset_id).await.unwrap();
+
+    // The pipeline screens the content, blocks it, and quarantines + legal-holds.
+    assert_eq!(h.process(out.asset_id).await.unwrap(), ProcessOutcome::Quarantined);
+
+    let asset = h.get(out.asset_id).await.unwrap();
+    assert_eq!(asset.state(), AssetState::Quarantined);
+    assert!(asset.legal_hold(), "a CSAM match places a legal hold");
+
+    // Delivery is revoked: resolve fails open to a placeholder.
+    let delivered = h.resolve(out.asset_id, Some(DeliveryVisibility::Public)).await;
+    assert!(delivered.degraded);
+    assert!(delivered.renditions.is_empty());
+
+    // The legal hold blocks erasure (MED-7003).
+    let err = h.delete(out.asset_id).await.unwrap_err();
+    assert!(matches!(err, MediaError::LegalHoldActive));
+}
+
+#[tokio::test]
+async fn a_takedown_then_restore_round_trips_delivery() {
+    let h = Harness::start().await;
+    let asset_id = h.upload_and_process().await;
+
+    // Moderation quarantine revokes delivery.
+    h.apply_moderation(asset_id, ModerationAction::Quarantine).await;
+    assert_eq!(h.get(asset_id).await.unwrap().state(), AssetState::Quarantined);
+    assert!(h.resolve(asset_id, None).await.degraded);
+
+    // Reversal restores it to deliverable.
+    h.apply_moderation(asset_id, ModerationAction::Restore).await;
+    let restored = h.get(asset_id).await.unwrap();
+    assert_eq!(restored.state(), AssetState::Ready);
+    assert!(!h.resolve(asset_id, Some(DeliveryVisibility::Public)).await.degraded);
+}

--- a/crates/services/media/tests/media_it/scenarios/pipeline.rs
+++ b/crates/services/media/tests/media_it/scenarios/pipeline.rs
@@ -1,0 +1,63 @@
+//! The happy path over real backends: ticket → direct-to-MinIO PUT → commit →
+//! process → READY, with renditions actually present in the store and resolvable
+//! public URLs; plus content-hash dedup.
+
+use media::application::command::ProcessOutcome;
+use media::domain::value_object::{AssetState, DeliveryVisibility, RenditionKind};
+
+use crate::media_it::harness::Harness;
+
+#[tokio::test]
+async fn upload_commit_process_yields_a_ready_asset_with_real_renditions() {
+    let h = Harness::start().await;
+
+    let bytes = Harness::sample_jpeg(1200, 800);
+    let out = h.issue_ticket(bytes.len() as u64, None, false).await.unwrap();
+    let ticket = out.upload.expect("a presigned upload plan");
+    assert_eq!(ticket.presigned.method, "PUT");
+
+    // The client uploads the bytes straight to MinIO (off the mesh).
+    assert!(h.put_to_url(&ticket.presigned.url, bytes).await, "direct PUT to MinIO");
+
+    // Finalize: the real probe reads the bytes back from MinIO.
+    let asset = h.commit(out.asset_id).await.unwrap();
+    assert_eq!(asset.state(), AssetState::Uploaded);
+    assert!(asset.content_hash().is_some());
+
+    // Process: the real image pipeline derives the rendition ladder + BlurHash and
+    // writes each derivative to a content-addressed key in MinIO.
+    assert_eq!(h.process(out.asset_id).await.unwrap(), ProcessOutcome::Ready);
+
+    let ready = h.get(out.asset_id).await.unwrap();
+    assert_eq!(ready.state(), AssetState::Ready);
+    assert!(ready.blurhash().is_some(), "a blurhash was computed");
+    let original = ready.rendition(RenditionKind::Original).expect("an original rendition");
+
+    // The derivative object really exists in object storage.
+    assert!(h.object_exists(original.storage_key()).await, "original rendition stored in MinIO");
+
+    // Plane C resolves public, immutable (no-expiry) CDN URLs.
+    let delivered = h.resolve(out.asset_id, Some(DeliveryVisibility::Public)).await;
+    assert!(!delivered.degraded);
+    assert!(!delivered.renditions.is_empty());
+    assert!(delivered.renditions.iter().all(|r| r.expires_at.is_none()));
+}
+
+#[tokio::test]
+async fn identical_bytes_dedup_onto_the_existing_asset() {
+    let h = Harness::start().await;
+
+    // First upload of these exact bytes, processed to READY.
+    let bytes = Harness::sample_jpeg(640, 640);
+    let sha = Harness::sha256_hex(&bytes);
+    let first = h.issue_ticket(bytes.len() as u64, None, false).await.unwrap();
+    assert!(h.put_to_url(&first.upload.unwrap().presigned.url, bytes).await);
+    h.commit(first.asset_id).await.unwrap();
+    assert_eq!(h.process(first.asset_id).await.unwrap(), ProcessOutcome::Ready);
+
+    // A new ticket for the same content hash, with dedup enabled, short-circuits.
+    let second = h.issue_ticket(1, Some(sha), true).await.unwrap();
+    assert!(second.deduplicated, "the second upload deduplicated");
+    assert!(second.upload.is_none(), "no upload needed on a dedup hit");
+    assert_eq!(second.asset_id, first.asset_id, "reuses the existing asset");
+}

--- a/crates/services/media/tests/media_it/scenarios/validation.rs
+++ b/crates/services/media/tests/media_it/scenarios/validation.rs
@@ -1,0 +1,31 @@
+//! Server-side validation over real backends: the real probe rejects non-image
+//! bytes, and an oversize declaration is rejected at ticket time.
+
+use media::error::MediaError;
+
+use crate::media_it::harness::Harness;
+
+#[tokio::test]
+async fn non_image_bytes_are_rejected_by_the_real_probe_on_commit() {
+    let h = Harness::start().await;
+
+    // Issue a ticket, then upload garbage (not a decodable image).
+    let garbage = b"this is definitely not an image".to_vec();
+    let out = h.issue_ticket(garbage.len() as u64, None, false).await.unwrap();
+    assert!(h.put_to_url(&out.upload.unwrap().presigned.url, garbage).await);
+
+    // The probe downloads the bytes, fails to recognize a format, and rejects.
+    let err = h.commit(out.asset_id).await.unwrap_err();
+    assert!(
+        matches!(err, MediaError::CorruptMedia { .. } | MediaError::ContentTypeMismatch { .. }),
+        "expected a content-probe rejection, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_oversize_declaration_is_rejected_at_ticket_time() {
+    let h = Harness::start().await;
+    // PostImage ceiling is 25 MiB; declare more.
+    let err = h.issue_ticket(64 * 1024 * 1024, None, false).await.unwrap_err();
+    assert!(matches!(err, MediaError::UploadSizeExceeded { .. }));
+}


### PR DESCRIPTION
## Summary

New **TIER-1 `media` service** — the system-of-record for media assets and their processing lifecycle, and the broker of the byte plane around them. The defining constraint: **bytes never traverse gRPC or Kafka.** The mesh carries only tickets, metadata, and URLs; bytes flow client ⇄ object storage ⇄ CDN on a pre-signed, direct path the service authorizes but never transports.

Fourth from-scratch service in the auth/moderation/search idiom (port **50063**, `MED-XXXX` errors, crate trio `contracts/media-api` + `services/media` + `apps/media-server`).

## The three planes
- **A — upload brokerage (sync, narrow):** `IssueUploadTicket` mints a pre-signed PUT; `CommitUpload` finalizes — the probe verifies the *real* bytes (magic-byte type, dimensions, SHA-256), never the client's declaration.
- **B — transformation (async, Kafka):** scan → **Screen (fail-closed for CSAM, hard timeout)** → derive the rendition ladder + BlurHash → mark `Ready`. The publish path never waits on it.
- **C — delivery (hot read, fail-open):** `ResolveDelivery` brokers content-addressed-immutable public URLs or short-lived signed URLs; a not-ready/quarantined asset yields a placeholder, never an error.

## Highlights
- **8 byte-free RPCs** (proto-reviewed: zero `bytes` fields in generated `media.v1`).
- Asset lifecycle state machine + content-addressed `StorageKey` + decode-bomb guard; **a legal hold blocks hard-delete** (CSAM/NCMEC preservation overrides GDPR erasure).
- Adapters: S3/MinIO object store (rusty-s3 presign + reqwest), Postgres metadata SoR (Asset stored as JSONB), Redis delivery cache, `image`-crate probe/processor, CloudFront-style CDN gateway, Kafka publisher, moderation Screen gRPC client (fail-closed).
- Server + **two supervised consumers** (processing off `media.v1.events` + moderation takedown); object-store and Screen hard timeouts.
- **Images-first**; content-hash dedup behind a default-off flag.

## Decisions
- Locked: control-plane-only / pre-signed uploads; S3 bytes + Postgres metadata SoR + Redis hot cache; content-addressed immutable public URLs + signed-private; separate worker role with a `Transcoder` port; pre-publish Screen fail-closed + legal-hold/WORM.
- Forks resolved: **images-first** (video is a fast-follow); **dedup behind a flag, default-off**.

## Testing
- **75 unit + 6 live integration tests** (live MinIO + Postgres + Redis) — green. The live suite drives the full byte-plane round trip: presigned PUT → commit → real image pipeline → `Ready` with renditions in MinIO, plus dedup, CSAM-quarantine-legal-hold-blocks-delete, and probe-rejects-garbage.
- `cargo check --workspace` green; media clippy-clean; i18n drift OK.
- Adds `test-support::minio_ready()`; workspace deps `rusty-s3` / `image` / `blurhash`.

## Deferred (documented in README + code)
Video transcoding, a real malware-scan sidecar, the orphan-GC consumer, WebP/AVIF encoding, real CloudFront `CreateInvalidation`, and the dedup refcount-aware GDPR purge.

## Security review
Manual pass — clean: no bytes/PII in logs, no panics on request/pipeline paths, probe never trusts the declared type, signed URLs short-lived, legal hold overrides erasure. One fleet-consistent, gateway-enforced finding (no per-RPC caller authz), documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)