### PR TITLE
feat(counter): reconciliation wiring + migrator registration (follow-up to #462)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "serde",
  "serde_json",
  "service-runtime",
+ "social-graph-api",
  "sqlx",
  "test-support",
  "thiserror 2.0.18",

--- a/crates/apps/migrator/src/main.rs
+++ b/crates/apps/migrator/src/main.rs
@@ -52,7 +52,12 @@ fn services() -> Vec<ServiceMigrations> {
         ServiceMigrations { name: "geo-discovery", store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/geo-discovery/migrations") },
         ServiceMigrations { name: "notification",  store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/notification/migrations") },
         ServiceMigrations { name: "timeline",      store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/timeline/migrations") },
-        ServiceMigrations { name: "account",       store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/account/migrations") },
+        // `counter` is the only dual-store service: its warm ledger is Postgres and
+        // its cold time-series is Scylla, so it registers one entry per backend
+        // (each pointing at the matching `migrations/<store>` subdir).
+        ServiceMigrations { name: "counter-timeseries", store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/counter/migrations/scylla") },
+        ServiceMigrations { name: "account",            store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/account/migrations") },
+        ServiceMigrations { name: "counter",            store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/counter/migrations/postgres") },
     ]
 }
 

--- a/crates/services/counter/Cargo.toml
+++ b/crates/services/counter/Cargo.toml
@@ -19,8 +19,11 @@ description = "Counter-analytics microservice — the platform's real-time count
 # Dependencies grow per phase — kept minimal here.
 [dependencies]
 # ── Contracts ─────────────────────────────────────────────────────────────────
-counter-api = { workspace = true }
-anyhow      = { workspace = true }
+counter-api      = { workspace = true }
+# social-graph is the authoritative SoR for follower/following counts — the
+# reconciliation source queries it over gRPC.
+social-graph-api = { workspace = true }
+anyhow           = { workspace = true }
 
 # ── Shared platform infrastructure ────────────────────────────────────────────
 error      = { workspace = true }

--- a/crates/services/counter/README.fr.md
+++ b/crates/services/counter/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 58970053dfe1f633ebb5943250d8b9325f6ce510115aeee1d0a8cc5c3a5fb9fa
+  source_sha256: f88ba161dbeb9f4f620cb17197ee8933b5375043d899629788f8fb6be2f70dc6
   translated_at: 2026-06-26
   status: complete
 ---
@@ -206,7 +206,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-> **État de build :** complet jusqu'à la Phase 7 (les 8 phases : scaffold → proto → domaine → application+ports → adaptateurs → câblage serveur+worker → IT live → durcissement). La suite d'intégration live est protégée par `integration-counter` et exerce les vrais tiers Redis + Postgres + Scylla. Le `Reconciler` de la boucle de réconciliation + les écritures de guérison sont construits et testés ; câbler une boucle de réconciliation supervisée attend sa `ReconciliationSource` gRPC concrète (vers `engagement` / `social-graph`) — un suivi documenté, avec une cadence de popularité autonome et le producteur concret de fan-out par shard.
+> **État de build :** complet jusqu'à la Phase 7 (les 8 phases : scaffold → proto → domaine → application+ports → adaptateurs → câblage serveur+worker → IT live → durcissement). La suite d'intégration live est protégée par `integration-counter` et exerce les vrais tiers Redis + Postgres + Scylla. **La boucle de réconciliation est câblée :** le worker exécute un balayage supervisé qui pagine les paires réconciliables depuis le registre et guérit la dérive des compteurs exacts contre `social-graph` (le système de référence autoritaire) via `GetRelationStatus`. *Follower/following* sont réconciliés aujourd'hui ; la réconciliation *like/share/comment* reste différée — `engagement` expose des scores de réaction pondérés (pas un compte de réactions), et ses compteurs share/comment sont les approximatifs que ce service supersède. Suivis restants : une cadence de popularité autonome, le producteur concret de fan-out par shard, et un hook de drain à l'arrêt gracieux.
 >
 > **Autorisation (exigence de déploiement) :** `counter` ne s'auto-autorise en rien. Les RPC de lecture sont des magnitudes agrégées exposées à l'appelant ; contrôler l'accès au gateway / `auth-context` avant exposition. Les compteurs ne portent aucune identité par-acteur, donc ne fuitent aucune appartenance.
 
@@ -225,8 +225,9 @@ async fn main() -> anyhow::Result<()> {
 | `COUNTER_SHARD_COUNT` | Non | `16` | shards de clé pour entités chaudes (`entity_id:{0..N}`) |
 | `COUNTER_READ_TIMEOUT_MS` | Non | `50` | timeout dur de lecture chaude par requête ; à expiration la lecture échoue **open** (total ledger périmé) |
 | `COUNTER_POPULARITY_INTERVAL_S` | Non | `60` | cadence du signal de popularité (réservé ; actuellement couplé au flush) |
-| `COUNTER_RECONCILE_INTERVAL_S` | Non | `3600` | cadence de la boucle de réconciliation (réservé ; attend la source concrète) |
+| `COUNTER_RECONCILE_INTERVAL_S` | Non | `3600` | cadence du balayage de réconciliation (correction de dérive follower/following) |
 | `COUNTER_DRIFT_TOLERANCE` | Non | `5` | dérive absolue tolérée avant correction d'un compteur exact par la réconciliation |
+| `COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT` | Non | `http://localhost:50053` | endpoint `social-graph` — comptes follower/following autoritaires pour la réconciliation |
 
 ### Variables d'infrastructure héritées
 

--- a/crates/services/counter/README.md
+++ b/crates/services/counter/README.md
@@ -195,7 +195,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-> **Build status:** complete through Phase 7 (all 8 phases: scaffold → proto → domain → application+ports → adapters → server+worker wiring → live IT → hardening). The live integration suite is gated behind `integration-counter` and exercises the real Redis + Postgres + Scylla tiers. The reconciliation loop's `Reconciler` + heal-writes are built and tested; wiring a supervised reconcile loop awaits its concrete gRPC `ReconciliationSource` (to `engagement` / `social-graph`) — a documented follow-up, along with a standalone popularity cadence and the concrete shard-fan-out producer.
+> **Build status:** complete through Phase 7 (all 8 phases: scaffold → proto → domain → application+ports → adapters → server+worker wiring → live IT → hardening). The live integration suite is gated behind `integration-counter` and exercises the real Redis + Postgres + Scylla tiers. **The reconciliation loop is wired:** the worker runs a supervised sweep that pages reconcilable pairs from the ledger and heals exact-counter drift against `social-graph` (the authoritative SoR) via `GetRelationStatus`. *Follower/following* are reconciled today; *like/share/comment* reconciliation stays deferred — `engagement` exposes weighted reaction scores (not a reaction count), and its share/comment counters are the approximate ones this service supersedes. Remaining follow-ups: a standalone popularity cadence, the concrete shard-fan-out producer, and a graceful-shutdown drain hook.
 >
 > **Authorization (deployment requirement):** `counter` self-authorizes nothing. The read RPCs are caller-facing aggregate magnitudes; gate access at the gateway / `auth-context` before exposure. Counts carry no per-actor identity, so they leak no membership.
 
@@ -214,8 +214,9 @@ async fn main() -> anyhow::Result<()> {
 | `COUNTER_SHARD_COUNT` | No | `16` | hot-entity key shards (`entity_id:{0..N}`) |
 | `COUNTER_READ_TIMEOUT_MS` | No | `50` | hard per-request hot-read timeout; on elapse the read fails **open** (stale ledger total) |
 | `COUNTER_POPULARITY_INTERVAL_S` | No | `60` | slow-loop cadence for the popularity signal (reserved; currently coupled to flush) |
-| `COUNTER_RECONCILE_INTERVAL_S` | No | `3600` | reconciliation-loop cadence (reserved; awaits the concrete source) |
+| `COUNTER_RECONCILE_INTERVAL_S` | No | `3600` | reconciliation sweep cadence (follower/following drift correction) |
 | `COUNTER_DRIFT_TOLERANCE` | No | `5` | absolute drift tolerated before reconciliation corrects an exact counter |
+| `COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT` | No | `http://localhost:50053` | `social-graph` endpoint — authoritative follower/following counts for reconciliation |
 
 ### Inherited infrastructure variables
 

--- a/crates/services/counter/src/application/command/reconcile.rs
+++ b/crates/services/counter/src/application/command/reconcile.rs
@@ -152,4 +152,34 @@ mod tests {
         let outcome = fx.reconciler(5).reconcile(&post("ghost"), Metric::Like).await.unwrap();
         assert_eq!(outcome, ReconcileOutcome::NotApplicable);
     }
+
+    fn profile(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Profile, EntityId::new(id).unwrap())
+    }
+
+    #[tokio::test]
+    async fn candidate_scan_lists_only_reconcilable_metrics_and_pages() {
+        use crate::application::port::{CounterLedger, reconcile_cursor};
+
+        let fx = Fixture::new();
+        fx.ledger.seed_total(&profile("a"), Metric::Follower, 10);
+        fx.ledger.seed_total(&profile("a"), Metric::Following, 5);
+        fx.ledger.seed_total(&profile("b"), Metric::Follower, 20);
+        fx.ledger.seed_total(&post("p"), Metric::View, 999); // approximate → excluded
+        fx.ledger.seed_total(&post("p"), Metric::Like, 7); // no source RPC → excluded
+
+        // Full page: exactly the three follower/following pairs, cursor-ordered.
+        let all = fx.ledger.list_reconcilable(None, 100).await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(all.iter().all(|(e, m)| e.kind == EntityKind::Profile
+            && matches!(m, Metric::Follower | Metric::Following)));
+
+        // Paging: first 2, then the rest after the cursor.
+        let first = fx.ledger.list_reconcilable(None, 2).await.unwrap();
+        assert_eq!(first.len(), 2);
+        let (last_e, last_m) = first.last().unwrap();
+        let cursor = reconcile_cursor(last_e, *last_m);
+        let rest = fx.ledger.list_reconcilable(Some(&cursor), 100).await.unwrap();
+        assert_eq!(rest.len(), 1);
+    }
 }

--- a/crates/services/counter/src/application/fakes.rs
+++ b/crates/services/counter/src/application/fakes.rs
@@ -276,6 +276,37 @@ impl CounterLedger for InMemoryLedger {
             .insert(mkey(entity, metric), value);
         Ok(())
     }
+
+    async fn list_reconcilable(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(EntityRef, Metric)>, CounterError> {
+        self.guard()?;
+        let totals = self.totals.lock().unwrap();
+        let mut pairs: Vec<(String, EntityRef, Metric)> = totals
+            .keys()
+            .filter_map(|(kind, id, metric)| {
+                let metric = Metric::try_from_str(metric).ok()?;
+                if !matches!(metric, Metric::Follower | Metric::Following) {
+                    return None;
+                }
+                let entity = EntityRef::new(
+                    crate::domain::EntityKind::try_from_str(kind).ok()?,
+                    crate::domain::EntityId::new(id.clone()).ok()?,
+                );
+                let cursor = format!("{kind}:{id}:{}", metric.as_str());
+                Some((cursor, entity, metric))
+            })
+            .collect();
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(pairs
+            .into_iter()
+            .filter(|(cursor, _, _)| after.map(|a| cursor.as_str() > a).unwrap_or(true))
+            .take(limit.max(0) as usize)
+            .map(|(_, entity, metric)| (entity, metric))
+            .collect())
+    }
 }
 
 // ── Cold tier (Scylla time-series analogue) ───────────────────────────────────

--- a/crates/services/counter/src/application/port/counter_ledger.rs
+++ b/crates/services/counter/src/application/port/counter_ledger.rs
@@ -47,4 +47,26 @@ pub trait CounterLedger: Send + Sync + 'static {
         metric: Metric,
         value: i64,
     ) -> Result<(), CounterError>;
+
+    /// Page through the `(entity, metric)` pairs the reconciliation loop can correct
+    /// — those whose metric has an authoritative source (today: follower/following).
+    /// `after` is the opaque cursor of the last pair from the previous page
+    /// (`"{kind}:{id}:{metric}"`); `None` starts from the beginning. An empty result
+    /// signals the end of the sweep (the loop wraps back to the start).
+    async fn list_reconcilable(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(EntityRef, Metric)>, CounterError>;
+}
+
+/// The opaque reconciliation cursor for a pair — must match the ordering key the
+/// ledger pages by.
+pub fn reconcile_cursor(entity: &EntityRef, metric: Metric) -> String {
+    format!(
+        "{}:{}:{}",
+        entity.kind.as_str(),
+        entity.id.as_str(),
+        metric.as_str()
+    )
 }

--- a/crates/services/counter/src/application/port/mod.rs
+++ b/crates/services/counter/src/application/port/mod.rs
@@ -16,7 +16,7 @@ pub mod reconciliation_source;
 pub mod signal_publisher;
 pub mod time_series;
 
-pub use counter_ledger::{CounterLedger, FlushOutcome};
+pub use counter_ledger::{CounterLedger, FlushOutcome, reconcile_cursor};
 pub use counter_store::CounterStore;
 pub use reconciliation_source::ReconciliationSource;
 pub use signal_publisher::SignalPublisher;

--- a/crates/services/counter/src/config.rs
+++ b/crates/services/counter/src/config.rs
@@ -33,11 +33,13 @@ pub struct CounterConfig {
     pub popularity_interval: Duration,
     /// Hard per-request hot-read timeout; on elapse the read fails open (stale).
     pub read_timeout: Duration,
-    /// Cadence of the reconciliation loop (reserved — the concrete source that
-    /// drives it is a deferred follow-up).
+    /// Cadence of the reconciliation sweep loop.
     pub reconcile_interval: Duration,
     /// Absolute drift tolerated before reconciliation corrects an exact counter.
     pub drift_tolerance: i64,
+    /// gRPC endpoint of `social-graph` — the authoritative source for
+    /// follower/following counts the reconciliation loop queries.
+    pub social_graph_endpoint: String,
 }
 
 impl CounterConfig {
@@ -72,6 +74,8 @@ impl CounterConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(DEFAULT_DRIFT_TOLERANCE),
+            social_graph_endpoint: std::env::var("COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT")
+                .unwrap_or_else(|_| "http://localhost:50053".to_owned()),
         }
     }
 }

--- a/crates/services/counter/src/infrastructure/mod.rs
+++ b/crates/services/counter/src/infrastructure/mod.rs
@@ -16,6 +16,7 @@ pub mod decode;
 pub mod grpc;
 pub mod kafka_signal_publisher;
 pub mod pg_counter_ledger;
+pub mod reconcile;
 pub mod redis_counter_store;
 pub mod scylla_time_series;
 

--- a/crates/services/counter/src/infrastructure/pg_counter_ledger.rs
+++ b/crates/services/counter/src/infrastructure/pg_counter_ledger.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use postgres_storage::TransactionManager;
 
 use crate::application::port::{CounterLedger, FlushOutcome};
-use crate::domain::{EntityRef, Metric, WindowDelta};
+use crate::domain::{EntityId, EntityKind, EntityRef, Metric, WindowDelta};
 use crate::error::CounterError;
 
 /// Atomically: record the window (idempotent), and advance the total only if the
@@ -51,6 +51,17 @@ const SET_TOTAL_SQL: &str = r#"
 INSERT INTO counter_totals (entity_kind, entity_id, metric, total)
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (entity_kind, entity_id, metric) DO UPDATE SET total = EXCLUDED.total
+"#;
+
+/// Page the reconcilable pairs (metrics with an authoritative source) by a synthetic
+/// `kind:id:metric` cursor, so a pair is never split across pages.
+const LIST_RECONCILABLE_SQL: &str = r#"
+SELECT entity_kind, entity_id, metric
+FROM counter_totals
+WHERE metric IN ('follower', 'following')
+  AND ($1::text IS NULL OR (entity_kind || ':' || entity_id || ':' || metric) > $1)
+ORDER BY (entity_kind || ':' || entity_id || ':' || metric)
+LIMIT $2
 "#;
 
 fn flush_err(e: sqlx::Error) -> CounterError {
@@ -125,5 +136,28 @@ impl CounterLedger for PgCounterLedger {
             .await
             .map_err(flush_err)?;
         Ok(())
+    }
+
+    async fn list_reconcilable(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(EntityRef, Metric)>, CounterError> {
+        let rows: Vec<(String, String, String)> = sqlx::query_as(LIST_RECONCILABLE_SQL)
+            .bind(after)
+            .bind(limit)
+            .fetch_all(self.tx.pool())
+            .await
+            .map_err(read_err)?;
+
+        // A row that fails to parse is a schema/data anomaly, not a reconcilable
+        // pair — skip it rather than abort the sweep.
+        Ok(rows
+            .into_iter()
+            .filter_map(|(kind, id, metric)| {
+                let entity = EntityRef::new(EntityKind::try_from_str(&kind).ok()?, EntityId::new(id).ok()?);
+                Some((entity, Metric::try_from_str(&metric).ok()?))
+            })
+            .collect())
     }
 }

--- a/crates/services/counter/src/infrastructure/reconcile/grpc_source.rs
+++ b/crates/services/counter/src/infrastructure/reconcile/grpc_source.rs
@@ -1,0 +1,77 @@
+//! The concrete reconciliation source: authoritative follower/following counts
+//! from `social-graph` over gRPC.
+//!
+//! Integration reality (mirrors the decode layer's honesty): only the
+//! social-graph-owned profile metrics have a true authoritative count RPC today.
+//! `social-graph` is the transactional system-of-record for the follow graph, so
+//! its counts are correct and worth reconciling against. Like/Share/Comment
+//! reconciliation stays deferred — `engagement` exposes *weighted reaction scores*
+//! (not a reaction count), and its share/comment counters are the approximate ones
+//! this service supersedes; reconciling against them would be circular.
+
+use async_trait::async_trait;
+use social_graph_api::GetRelationStatusRequest;
+use social_graph_api::social_graph_service_client::SocialGraphServiceClient;
+use tonic::Code;
+use tonic::transport::Channel;
+
+use crate::application::port::ReconciliationSource;
+use crate::domain::{EntityKind, EntityRef, Metric};
+use crate::error::CounterError;
+
+/// Resolves authoritative counts from `social-graph`. The channel is cheap to
+/// clone (it is `Arc`-backed), so each call clones the client.
+pub struct GrpcReconciliationSource {
+    social_graph: SocialGraphServiceClient<Channel>,
+}
+
+impl GrpcReconciliationSource {
+    pub fn new(social_graph: Channel) -> Self {
+        Self {
+            social_graph: SocialGraphServiceClient::new(social_graph),
+        }
+    }
+}
+
+#[async_trait]
+impl ReconciliationSource for GrpcReconciliationSource {
+    async fn authoritative_count(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError> {
+        // Pick the field; bail for any metric this source does not own.
+        let want_followers = match metric {
+            Metric::Follower => true,
+            Metric::Following => false,
+            _ => return Ok(None),
+        };
+        if entity.kind != EntityKind::Profile {
+            return Ok(None);
+        }
+
+        // The counts in the view are "for the target profile" regardless of actor;
+        // a self-relation query is the simplest way to read them.
+        let mut client = self.social_graph.clone();
+        let request = GetRelationStatusRequest {
+            actor_id: entity.id.as_str().to_owned(),
+            target_id: entity.id.as_str().to_owned(),
+        };
+        match client.get_relation_status(request).await {
+            Ok(response) => {
+                let view = response.into_inner();
+                Ok(Some(if want_followers {
+                    view.target_followers_count
+                } else {
+                    view.target_following_count
+                }))
+            }
+            // Unknown profile / no relations → nothing to reconcile against.
+            Err(status) if status.code() == Code::NotFound => Ok(None),
+            // Anything else is a transient source fault: the loop logs and moves on.
+            Err(status) => Err(CounterError::SourceReplayFailed {
+                reason: format!("social-graph get_relation_status: {}", status.message()),
+            }),
+        }
+    }
+}

--- a/crates/services/counter/src/infrastructure/reconcile/mod.rs
+++ b/crates/services/counter/src/infrastructure/reconcile/mod.rs
@@ -1,0 +1,57 @@
+//! The concrete reconciliation source (gRPC to `social-graph`) and the supervised
+//! sweep loop that drives the [`Reconciler`](crate::application::command::Reconciler)
+//! over the ledger's reconcilable pairs.
+
+pub mod grpc_source;
+
+pub use grpc_source::GrpcReconciliationSource;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::application::command::Reconciler;
+use crate::application::port::{CounterLedger, reconcile_cursor};
+
+/// Reconcilable pairs fetched per tick. Bounds the sweep's work; the cursor pages
+/// across ticks so the whole reconcilable set is covered over time.
+const RECONCILE_BATCH: i64 = 100;
+
+/// Periodically sweeps the reconcilable `(entity, metric)` pairs, correcting any
+/// exact-counter drift against the authoritative source. Pages by an opaque cursor
+/// and wraps back to the start when the sweep completes. Errors are logged and the
+/// sweep continues — reconciliation is best-effort background healing.
+pub async fn run_reconcile_loop(
+    reconciler: Arc<Reconciler>,
+    ledger: Arc<dyn CounterLedger>,
+    interval: Duration,
+) {
+    tracing::info!("counter reconcile loop started");
+    let mut ticker = tokio::time::interval(interval);
+    let mut cursor: Option<String> = None;
+    loop {
+        ticker.tick().await;
+
+        let batch = match ledger.list_reconcilable(cursor.as_deref(), RECONCILE_BATCH).await {
+            Ok(batch) => batch,
+            Err(error) => {
+                tracing::warn!(%error, "reconcile candidate scan failed");
+                continue;
+            }
+        };
+
+        if batch.is_empty() {
+            cursor = None; // sweep complete — wrap to the start next tick
+            continue;
+        }
+
+        if let Some((entity, metric)) = batch.last() {
+            cursor = Some(reconcile_cursor(entity, *metric));
+        }
+
+        for (entity, metric) in &batch {
+            if let Err(error) = reconciler.reconcile(entity, *metric).await {
+                tracing::warn!(%error, metric = metric.as_str(), "reconcile failed");
+            }
+        }
+    }
+}

--- a/crates/services/counter/src/service.rs
+++ b/crates/services/counter/src/service.rs
@@ -26,13 +26,16 @@ use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig
 use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
 use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
 
+use tonic::transport::Channel;
+
 use crate::app::{Ports, compose_read};
-use crate::application::command::{DeltaFlusher, PopularityPublisher};
-use crate::application::port::SignalPublisher;
+use crate::application::command::{DeltaFlusher, PopularityPublisher, Reconciler};
+use crate::application::port::{ReconciliationSource, SignalPublisher};
 use crate::config::CounterConfig;
 use crate::domain::{Observation, WindowAggregator};
 use crate::error::CounterError;
 use crate::infrastructure::consumer::{run_flush_loop, run_fold_consumer};
+use crate::infrastructure::reconcile::{GrpcReconciliationSource, run_reconcile_loop};
 use crate::infrastructure::decode::{
     FollowWire, HitWire, ReactionWire, map_click, map_follow, map_impression, map_reaction, map_view,
 };
@@ -127,12 +130,6 @@ impl Service for CounterWorkerService {
     const GRPC_SERVICE_NAME: &'static str = <CounterServer as tonic::server::NamedService>::NAME;
 
     async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
-        // `..` ignores the read-path + reconciliation knobs: the read timeout is the
-        // read server's, and the reconciliation loop is wired but not spawned here —
-        // its concrete `ReconciliationSource` (gRPC to engagement / social-graph) is a
-        // deferred follow-up. The `Reconciler` itself is built + unit-tested; once a
-        // source exists, spawn a supervised loop over `drift_tolerance` /
-        // `reconcile_interval` exactly like the consumers below.
         let CounterConfig {
             postgres,
             redis,
@@ -140,6 +137,9 @@ impl Service for CounterWorkerService {
             kafka,
             aggregation_window,
             flush_interval,
+            reconcile_interval,
+            drift_tolerance,
+            social_graph_endpoint,
             ..
         } = CounterConfig::from_env();
 
@@ -192,6 +192,25 @@ impl Service for CounterWorkerService {
             flusher,
             popularity,
             flush_interval,
+        ));
+
+        // The reconciliation sweep: heal exact-counter drift against social-graph.
+        // Lazy connect — a cold start does not require the dependency to be up.
+        let social_graph = Channel::from_shared(social_graph_endpoint)
+            .context("invalid social-graph endpoint")?
+            .connect_lazy();
+        let source: Arc<dyn ReconciliationSource> =
+            Arc::new(GrpcReconciliationSource::new(social_graph));
+        let reconciler = Arc::new(Reconciler::new(
+            Arc::clone(&ports.store),
+            Arc::clone(&ports.ledger),
+            source,
+            drift_tolerance,
+        ));
+        tokio::spawn(run_reconcile_loop(
+            reconciler,
+            Arc::clone(&ports.ledger),
+            reconcile_interval,
         ));
 
         Ok(Self { redis: ports.redis })

--- a/crates/services/counter/tests/counter_it/scenarios/reconcile.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/reconcile.rs
@@ -42,3 +42,31 @@ async fn corrects_exact_counter_drift_on_both_tiers() {
     assert_eq!(h.total(&profile, Metric::Like).await, Some(100));
     assert_eq!(h.read(&profile, &[Metric::Like]).await.get(Metric::Like), Some(100));
 }
+
+#[tokio::test]
+async fn candidate_scan_finds_follower_pairs_on_live_ledger() {
+    use counter::domain::Observation;
+
+    let h = Harness::start().await;
+    let profile = fresh_profile();
+
+    // Accumulate a follower count so a reconcilable row exists in counter_totals.
+    let observations = (0..30)
+        .map(|i| Observation::sum(profile.clone(), Metric::Follower, 1, at(1_000 + i)).unwrap())
+        .collect();
+    h.ingest(observations).await;
+
+    // The real Postgres candidate scan (synthetic-key cursor) must surface this
+    // profile's follower pair; approximate metrics (views) never appear.
+    let pairs = h.ledger.list_reconcilable(None, 1_000).await.unwrap();
+    assert!(
+        pairs
+            .iter()
+            .any(|(e, m)| e.id.as_str() == profile.id.as_str() && *m == Metric::Follower),
+        "live candidate scan should include the seeded follower pair"
+    );
+    assert!(
+        pairs.iter().all(|(_, m)| matches!(m, Metric::Follower | Metric::Following)),
+        "only follower/following are reconcilable"
+    );
+}


### PR DESCRIPTION
Follow-up to **#462** (the base counter-analytics service, already squash-merged into `feat/media-service`). That merge captured the base service; this PR carries the two follow-up commits made afterward, so the net diff here is just the reconciliation + migrator work.

> **Base:** `feat/media-service` (where #462 landed). `develop`/`main` lack the media chain, so those bases would produce a giant wrong-base diff — that's why #464 (→develop) was closed.

## What's in this PR

**1. Concrete gRPC reconciliation source + supervised sweep loop** (`b936c5ae`)
- `GrpcReconciliationSource` — authoritative **follower/following** counts from `social-graph` `GetRelationStatus` (the transactional SoR for the follow graph).
- `CounterLedger::list_reconcilable` — cursor-paged candidate scan over `counter_totals` (synthetic `kind:id:metric` key so a pair is never split across pages).
- `run_reconcile_loop` — ticks on `COUNTER_RECONCILE_INTERVAL_S`, pages candidates, heals drift within `COUNTER_DRIFT_TOLERANCE`, wraps at end of sweep; spawned in `CounterWorkerService::build`. Lazy-connects via `COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT`.
- Integration reality (documented): like/share/comment reconciliation stays deferred — `engagement` exposes weighted reaction scores (not a count), and its share/comment counters are the approximate ones this service supersedes.

**2. Production migration registration** (`736a2b17`)
- Wires counter's schema into the `migrator` app: `counter` (Postgres ledger) + `counter-timeseries` (Scylla time-series). counter is the only dual-store service, so it registers one entry per backend. Same `.sql`/`.cql` files the live IT applies.

## Tests
67 unit + 7 live IT (real Redis/Postgres/Scylla, incl. live reconcile + a live candidate-scan against real Postgres cursor paging) — all green. clippy clean, workspace builds, README EN/FR + i18n updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)