### PR TITLE
feat(counter): land counter-analytics on develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "counter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "counter-api",
+ "cqrs",
+ "error",
+ "fred",
+ "http",
+ "postgres",
+ "prost-types",
+ "redis-storage",
+ "scylla",
+ "scylla-storage",
+ "serde",
+ "serde_json",
+ "service-runtime",
+ "sqlx",
+ "test-support",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-reflection",
+ "tracing",
+ "transport",
+ "uuid",
+ "validation",
+]
+
+[[package]]
+name = "counter-api"
+version = "0.1.0"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "counter-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "counter",
+ "service-runtime",
+ "tokio",
+]
+
+[[package]]
+name = "counter-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "counter",
+ "service-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "serde",
  "serde_json",
  "service-runtime",
+ "social-graph-api",
  "sqlx",
  "test-support",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/services/moderation",
     "crates/services/search",
     "crates/services/media",
+    "crates/services/counter",
     "crates/apps/chat-server",
     "crates/apps/profile-server",
     "crates/apps/social-graph-server",
@@ -47,6 +48,8 @@ members = [
     "crates/apps/moderation-server",
     "crates/apps/search-server",
     "crates/apps/media-server",
+    "crates/apps/counter-server",
+    "crates/apps/counter-worker",
     "crates/apps/migrator",
     "crates/contracts/social-graph-api",
     "crates/contracts/account-api",
@@ -62,6 +65,7 @@ members = [
     "crates/contracts/moderation-api",
     "crates/contracts/search-api",
     "crates/contracts/media-api",
+    "crates/contracts/counter-api",
 ]
 resolver = "2"
 
@@ -113,6 +117,7 @@ auth-api = { path = "crates/contracts/auth-api" }
 moderation-api = { path = "crates/contracts/moderation-api" }
 search-api = { path = "crates/contracts/search-api" }
 media-api = { path = "crates/contracts/media-api" }
+counter-api = { path = "crates/contracts/counter-api" }
 account          = { path = "crates/services/account" }
 chat             = { path = "crates/services/chat" }
 profile          = { path = "crates/services/profile" }
@@ -127,6 +132,7 @@ auth             = { path = "crates/services/auth" }
 moderation       = { path = "crates/services/moderation" }
 search           = { path = "crates/services/search" }
 media            = { path = "crates/services/media" }
+counter          = { path = "crates/services/counter" }
 
 
 # Communs

--- a/crates/apps/counter-server/Cargo.toml
+++ b/crates/apps/counter-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                 = "counter-server"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the counter-analytics READ path — the low-latency, stateless gRPC server over the hot counter tier."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# No-op entrypoint today. Phase 5 wires this over the shared fleet runtime
+# (`service_runtime::serve::<CounterReadService>`), exposing the read-only
+# `counter.v1` surface (BatchGetCounters / GetTrending / GetTimeSeries) on
+# :50064. This binary NEVER consumes the firehose or runs aggregation — that is
+# the separately-deployed `counter-worker`. The split is deliberate: reads scale
+# with fleet QPS, the worker scales with ingest volume, and they share no
+# failure domain.
+[dependencies]
+counter         = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/counter-server/src/main.rs
+++ b/crates/apps/counter-server/src/main.rs
@@ -1,0 +1,16 @@
+//! `counter-server` — the deployable binary for the counter-analytics **read
+//! path**: a low-latency, stateless gRPC server over the hot counter tier.
+//!
+//! gRPC port **50064** (auth 50060 · moderation 50061 · search 50062 · media
+//! 50063 → next free). This process serves reads ONLY; the firehose aggregation
+//! lives in the separate `counter-worker` binary.
+
+use counter::CounterReadService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("COUNTER_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50064".to_owned())
+        .parse()?;
+    service_runtime::serve::<CounterReadService>(addr).await
+}

--- a/crates/apps/counter-worker/Cargo.toml
+++ b/crates/apps/counter-worker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                 = "counter-worker"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the counter-analytics WRITE path — the heavy stream worker: firehose aggregation, durable write-behind, reconciliation, and the popularity-signal publisher."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# No-op entrypoint today. Phase 5 wires this as the stream processor: supervised
+# `run_consumer` loops over the firehose (view/impression/click) + domain topics
+# (engagement.reactions, social-graph follows), the in-process windowed
+# pre-aggregation (N events → 1 delta), the batched idempotent write-behind to
+# the Postgres ledger + Scylla time-series, the reconciliation loop, and the
+# `counter.v1.popularity` publisher. CPU/memory heavy; scaled independently of
+# `counter-server`. This binary exposes NO read RPC.
+[dependencies]
+counter         = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/counter-worker/src/main.rs
+++ b/crates/apps/counter-worker/src/main.rs
@@ -1,0 +1,19 @@
+//! `counter-worker` — the deployable binary for the counter-analytics **write
+//! path**: the heavy stream processor that absorbs the firehose, aggregates it,
+//! flushes it durably, and publishes the popularity signal.
+//!
+//! It runs on the same fleet runtime as the read server but as a consumer-only
+//! service: it serves no domain RPC — only the gRPC health + reflection endpoints
+//! on its own port (default :50065) so Kubernetes can probe readiness — while the
+//! supervised consumers and the drain/flush loop do the work. Scaled independently
+//! of `counter-server`.
+
+use counter::CounterWorkerService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("COUNTER_WORKER_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50065".to_owned())
+        .parse()?;
+    service_runtime::serve::<CounterWorkerService>(addr).await
+}

--- a/crates/apps/migrator/src/main.rs
+++ b/crates/apps/migrator/src/main.rs
@@ -52,7 +52,12 @@ fn services() -> Vec<ServiceMigrations> {
         ServiceMigrations { name: "geo-discovery", store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/geo-discovery/migrations") },
         ServiceMigrations { name: "notification",  store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/notification/migrations") },
         ServiceMigrations { name: "timeline",      store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/timeline/migrations") },
-        ServiceMigrations { name: "account",       store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/account/migrations") },
+        // `counter` is the only dual-store service: its warm ledger is Postgres and
+        // its cold time-series is Scylla, so it registers one entry per backend
+        // (each pointing at the matching `migrations/<store>` subdir).
+        ServiceMigrations { name: "counter-timeseries", store: Store::Scylla,   dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/counter/migrations/scylla") },
+        ServiceMigrations { name: "account",            store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/account/migrations") },
+        ServiceMigrations { name: "counter",            store: Store::Postgres, dir: include_dir!("$CARGO_MANIFEST_DIR/../../services/counter/migrations/postgres") },
     ]
 }
 

--- a/crates/contracts/counter-api/Cargo.toml
+++ b/crates/contracts/counter-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name        = "counter-api"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Generated gRPC contract for counter.v1 — read-only counter/analytics surface (server + client stubs and reflection descriptor)."
+
+[dependencies]
+tonic       = { workspace = true }
+tonic-prost = { workspace = true }
+prost       = { workspace = true }
+prost-types = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = { workspace = true }

--- a/crates/contracts/counter-api/build.rs
+++ b/crates/contracts/counter-api/build.rs
@@ -1,0 +1,20 @@
+//! Compiles the counter.v1 contract into server + client stubs plus a reflection
+//! descriptor set, from the shared contracts/proto root (the single IDL source).
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("counter_descriptor.bin");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(
+            &[
+                "../proto/counter/v1/enums.proto",
+                "../proto/counter/v1/messages.proto",
+                "../proto/counter/v1/service.proto",
+            ],
+            &["../proto/"],
+        )?;
+    Ok(())
+}

--- a/crates/contracts/counter-api/src/lib.rs
+++ b/crates/contracts/counter-api/src/lib.rs
@@ -1,0 +1,20 @@
+//! `counter-api` — the generated gRPC contract for `counter.v1` (server + client
+//! stubs + descriptor), compiled from the shared `contracts/proto` IDL.
+//! Consumers depend on this crate instead of recompiling the `.proto` files.
+//!
+//! Contract rule (the projection guarantee): the surface is **read-only** and
+//! serves *magnitudes*, never identities. `BatchGetCounters` / `GetTrending` /
+//! `GetTimeSeries` answer **"how many?"** for an entity reference — they never
+//! answer **"who?"** or **"which ones?"** (that is the per-actor edge state owned
+//! by `engagement` and `social-graph`). There is **no write/increment RPC**:
+//! ingestion happens entirely off the synchronous path via Kafka consumers, and
+//! the only thing this service publishes is the coarse `counter.v1.popularity`
+//! ranking signal. The read path is fail-open: a degraded tier yields a
+//! stale-but-served snapshot (`degraded = true`), never an upstream block. See
+//! `project_counter_analytics_blueprint`.
+
+tonic::include_proto!("counter.v1");
+
+/// Encoded protobuf descriptor set for gRPC server reflection.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("counter_descriptor");

--- a/crates/contracts/proto/counter/v1/enums.proto
+++ b/crates/contracts/proto/counter/v1/enums.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package counter.v1;
+
+option java_package = "com.coreplatform.counter.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/counter/v1;counterv1";
+
+// The kind of entity a counter is attached to. Counter-analytics owns no entity;
+// it references the authoritative record by (entity_type, id) owned by the
+// originating service (`post` / `profile` / `media` / `comment`). A hashtag is
+// referenced by the tag itself as its id.
+enum CounterEntityType {
+    COUNTER_ENTITY_TYPE_UNSPECIFIED = 0;
+    COUNTER_ENTITY_TYPE_POST        = 1;
+    COUNTER_ENTITY_TYPE_PROFILE     = 2;
+    COUNTER_ENTITY_TYPE_MEDIA       = 3;
+    COUNTER_ENTITY_TYPE_HASHTAG     = 4;
+    COUNTER_ENTITY_TYPE_COMMENT     = 5;
+}
+
+// The metric being counted. The split is load-bearing (see CounterValueKind):
+// VIEW / IMPRESSION / CLICK / UNIQUE_VIEWER / REACH are firehose-volume and
+// served APPROXIMATE (sharded counters + HyperLogLog); LIKE / SHARE / COMMENT /
+// FOLLOWER / FOLLOWING are a window onto a set another service authoritatively
+// owns and are served EXACT (fast, periodically reconciled).
+enum CounterMetric {
+    COUNTER_METRIC_UNSPECIFIED   = 0;
+    COUNTER_METRIC_VIEW          = 1;
+    COUNTER_METRIC_IMPRESSION    = 2;
+    COUNTER_METRIC_CLICK         = 3;
+    COUNTER_METRIC_LIKE          = 4;
+    COUNTER_METRIC_SHARE         = 5;
+    COUNTER_METRIC_COMMENT       = 6;
+    COUNTER_METRIC_FOLLOWER      = 7;
+    COUNTER_METRIC_FOLLOWING     = 8;
+    COUNTER_METRIC_UNIQUE_VIEWER = 9;
+    COUNTER_METRIC_REACH         = 10;
+}
+
+// Provenance of a served value: whether it is an EXACT count (reconcilable
+// against the owning source-of-record) or an APPROXIMATE estimate (sharded
+// counter / HyperLogLog / Count-Min Sketch — accurate within a documented error
+// bound, never reconciled per-unit). Callers may render approximate values with
+// a "~" affordance.
+enum CounterValueKind {
+    COUNTER_VALUE_KIND_UNSPECIFIED = 0;
+    COUNTER_VALUE_KIND_EXACT       = 1;
+    COUNTER_VALUE_KIND_APPROXIMATE = 2;
+}
+
+// The aggregation scope for a trending query. GLOBAL ranks across the whole
+// network; the others rank within a qualifier supplied as `scope_key` (the
+// hashtag tag, a category id, a region code).
+enum TrendingScope {
+    TRENDING_SCOPE_UNSPECIFIED = 0;
+    TRENDING_SCOPE_GLOBAL      = 1;
+    TRENDING_SCOPE_HASHTAG     = 2;
+    TRENDING_SCOPE_CATEGORY    = 3;
+    TRENDING_SCOPE_REGION      = 4;
+}
+
+// Bucket size for a historical time-series query. Coarser granularities read
+// further back; the cold tier (Scylla TWCS) rolls finer buckets up over time.
+enum TimeGranularity {
+    TIME_GRANULARITY_UNSPECIFIED = 0;
+    TIME_GRANULARITY_HOUR        = 1;
+    TIME_GRANULARITY_DAY         = 2;
+    TIME_GRANULARITY_WEEK        = 3;
+}

--- a/crates/contracts/proto/counter/v1/messages.proto
+++ b/crates/contracts/proto/counter/v1/messages.proto
@@ -1,0 +1,117 @@
+syntax = "proto3";
+
+package counter.v1;
+
+import "counter/v1/enums.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.coreplatform.counter.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/counter/v1;counterv1";
+
+// ── Core references & values ──────────────────────────────────────────────────
+
+// A reference to the entity a count is attached to. Counter-analytics stores no
+// entity — only the magnitudes keyed by this reference. The caller hydrates the
+// entity itself (post body, profile, media URL) from its source-of-record.
+message EntityRef {
+    CounterEntityType entity_type = 1;
+    // The authoritative id (post id / profile id / media id / the tag itself for
+    // hashtags), owned by the originating service.
+    string            id          = 2;
+}
+
+// A single metric magnitude for an entity. The contract (LOCKED): this answers
+// "how many?", never "who?". It carries no actor identity and no set membership —
+// that edge state belongs to `engagement` (reactions) and `social-graph`
+// (follows).
+message CounterValue {
+    CounterMetric    metric = 1;
+    int64            value  = 2;
+    // EXACT (reconcilable) vs APPROXIMATE (HLL/sharded/CMS estimate). Lets the
+    // caller render precision honestly.
+    CounterValueKind kind   = 3;
+}
+
+// The set of requested metric magnitudes for one entity.
+message CounterSnapshot {
+    EntityRef             entity = 1;
+    repeated CounterValue values = 2;
+    // True when this snapshot was served from a stale fallback — the hot tier was
+    // partial/unavailable and the read failed OPEN to the last durable total
+    // rather than erroring. The fail-open marker.
+    bool                  degraded = 3;
+}
+
+// ── BatchGetCounters (the feed-hydration hot path) ────────────────────────────
+
+message BatchGetCountersRequest {
+    // The entities to read counts for, in one round-trip (a feed page).
+    repeated EntityRef     entities = 1;
+    // Restrict to these metrics; empty ⇒ all metrics defined for each entity kind.
+    repeated CounterMetric metrics  = 2;
+}
+
+message BatchGetCountersResponse {
+    // Positional, 1:1 with the request's `entities`.
+    repeated CounterSnapshot snapshots = 1;
+    // True when ANY snapshot was served degraded (hot tier partial/unavailable).
+    bool                     degraded  = 2;
+}
+
+// ── GetTrending (top-K from the Count-Min Sketch + bounded heap) ──────────────
+
+message GetTrendingRequest {
+    TrendingScope scope     = 1;
+    // Scope qualifier — the hashtag tag, a category id, or a region code. Empty
+    // for GLOBAL.
+    string        scope_key = 2;
+    // The metric driving the ranking (e.g. VIEW for trending content).
+    CounterMetric metric    = 3;
+    // Max results; the server clamps to a hard ceiling.
+    int32         limit     = 4;
+}
+
+message TrendingEntry {
+    EntityRef entity = 1;
+    // Approximate frequency/score from the Count-Min Sketch — a ranking signal,
+    // not an exact count.
+    int64     score  = 2;
+    // Zero-based rank within this trending response.
+    int32     rank   = 3;
+}
+
+message GetTrendingResponse {
+    repeated TrendingEntry entries  = 1;
+    // True when served from a degraded / partial sketch (fail-open).
+    bool                   degraded = 2;
+}
+
+// ── GetTimeSeries (historical buckets — the cold-tier read) ───────────────────
+
+// NOTE: this is the one RPC permitted to touch the cold time-series tier
+// (Scylla TWCS). It is explicitly NOT sub-millisecond and NOT on the feed-render
+// path; it backs analytics/insight surfaces.
+message GetTimeSeriesRequest {
+    EntityRef                 entity      = 1;
+    CounterMetric             metric      = 2;
+    TimeGranularity           granularity = 3;
+    // Inclusive lower bound of the requested range.
+    google.protobuf.Timestamp start       = 4;
+    // Exclusive upper bound of the requested range.
+    google.protobuf.Timestamp end         = 5;
+}
+
+message TimeSeriesBucket {
+    // Start of the bucket; width is the request's `granularity`.
+    google.protobuf.Timestamp bucket_start = 1;
+    int64                     value        = 2;
+}
+
+message GetTimeSeriesResponse {
+    repeated TimeSeriesBucket buckets  = 1;
+    // Provenance of the series as a whole (EXACT vs APPROXIMATE).
+    CounterValueKind          kind     = 2;
+    // True when the cold tier was partial/unavailable and the read failed OPEN.
+    bool                      degraded = 3;
+}

--- a/crates/contracts/proto/counter/v1/service.proto
+++ b/crates/contracts/proto/counter/v1/service.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package counter.v1;
+
+import "counter/v1/messages.proto";
+
+option java_package = "com.coreplatform.counter.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/counter/v1;counterv1";
+
+// CounterService is the platform's real-time counter aggregator and analytics
+// System-of-Reference: it serves coarse engagement magnitudes (views, likes,
+// shares, followers, reach) for entity references owned by other services.
+//
+// This surface is deliberately READ-ONLY. There is NO write/increment RPC:
+// ingestion happens entirely off the synchronous path via Kafka consumers
+// (`view.v1.events`, `impression.v1.events`, `click.v1.events`,
+// `engagement.reactions`, social-graph follow events). The only thing this
+// service publishes is the coarse `counter.v1.popularity` ranking signal,
+// consumed by `search` and `timeline` — never a synchronous call.
+//
+// Posture is fail-OPEN: a degraded hot tier yields a stale-but-served snapshot
+// (see the `degraded` markers), never an upstream block. A counter outage never
+// blocks a like, a follow, or a publish.
+//
+// Boundary: every response answers "how many?", never "who?" or "which?". Values
+// carry no actor identity and no set membership — that edge state belongs to
+// `engagement` (reactions) and `social-graph` (follows). The caller hydrates the
+// entity itself from its source-of-record.
+service CounterService {
+
+    // Read metric magnitudes for a batch of entity references in a single
+    // round-trip (the feed-hydration hot path). Snapshots are positional, 1:1
+    // with the request's entities; sub-millisecond, Redis-only.
+    rpc BatchGetCounters(BatchGetCountersRequest) returns (BatchGetCountersResponse);
+
+    // Top-K trending entities for a scope, ranked from the Count-Min Sketch +
+    // bounded heap. Approximate by design.
+    rpc GetTrending(GetTrendingRequest) returns (GetTrendingResponse);
+
+    // Historical time-series buckets for one entity+metric. Reads the cold tier
+    // (Scylla TWCS); NOT sub-millisecond and NOT on the feed-render path.
+    rpc GetTimeSeries(GetTimeSeriesRequest) returns (GetTimeSeriesResponse);
+}

--- a/crates/services/counter/Cargo.toml
+++ b/crates/services/counter/Cargo.toml
@@ -1,0 +1,73 @@
+[package]
+name        = "counter"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Counter-analytics microservice — the platform's real-time counter aggregator and analytics System-of-Reference: absorbs the engagement/view firehose, serves coarse magnitudes, owns no entity."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# Only the canonical error namespace (CTR-XXXX) lives here today. Subsequent
+# phases add: domain/ (Phase 2: CounterDelta + MetricKind[exact-vs-approx] + the
+# pure windowed-fold aggregator + HLL/CMS abstractions + popularity derivation),
+# application/ + ports (Phase 3: CounterStore / CounterLedger / TimeSeriesStore /
+# SignalPublisher + ingestion & query handlers + in-memory fakes), infrastructure/
+# adapters (Phase 4: Redis hot / Postgres warm-ledger / Scylla TWCS cold / Kafka
+# popularity publisher + the inbound event-decode layer), and the TWO composition
+# roots — the low-latency read server and the heavy stream worker (Phase 5).
+# Dependencies grow per phase — kept minimal here.
+[dependencies]
+# ── Contracts ─────────────────────────────────────────────────────────────────
+counter-api = { workspace = true }
+anyhow      = { workspace = true }
+
+# ── Shared platform infrastructure ────────────────────────────────────────────
+error      = { workspace = true }
+validation = { workspace = true }
+
+# ── Domain types (Phase 2): pure, clock-injected aggregation model ────────────
+serde  = { workspace = true }
+chrono = { workspace = true }
+
+# ── Application layer (Phase 3): CQRS query bus + async ports ──────────────────
+cqrs        = { workspace = true }
+async-trait = { workspace = true }
+
+# ── Infrastructure adapters (Phase 4): the three storage tiers + Kafka ─────────
+# Hot tier = Redis via fred (HLL/sorted-set ops issued through Lua `eval`, the
+# fleet pattern, so no reliance on fred's typed HLL methods). Warm tier = Postgres
+# via sqlx (idempotent window-keyed UPSERT). Cold tier = Scylla TWCS. Outbound =
+# Kafka via the shared transport producer.
+redis-storage    = { workspace = true }
+postgres-storage = { workspace = true }
+scylla-storage   = { workspace = true }
+transport        = { workspace = true }
+fred             = { workspace = true, features = ["partial-tracing", "i-scripts"] }
+sqlx             = { workspace = true }
+scylla           = { workspace = true }
+serde_json       = { workspace = true }
+tracing          = { workspace = true }
+
+# ── Server + worker wiring (Phase 5): runtime, tonic ingress, consumers ───────
+service-runtime  = { workspace = true }
+tonic            = { workspace = true }
+tonic-reflection = { workspace = true }
+prost-types      = { workspace = true }
+tokio            = { workspace = true }
+uuid             = { workspace = true }
+
+# ── Error handling ────────────────────────────────────────────────────────────
+thiserror = { workspace = true }
+http      = { workspace = true }
+
+[features]
+# Gates the live, container-backed integration suite (Phase 6, tests/integration.rs).
+# Off by default so `cargo test -p counter` stays a fast, infra-free unit run; the
+# live suite boots real Redis + Postgres + Scylla containers (the full hot/warm/cold
+# tiering) and is opt-in via `cargo test -p counter --features integration-counter`.
+integration-counter = []
+
+[dev-dependencies]
+# Live integration suite: shared container orchestration + await_until (Phase 6).
+test-support = { workspace = true }

--- a/crates/services/counter/Cargo.toml
+++ b/crates/services/counter/Cargo.toml
@@ -19,8 +19,11 @@ description = "Counter-analytics microservice — the platform's real-time count
 # Dependencies grow per phase — kept minimal here.
 [dependencies]
 # ── Contracts ─────────────────────────────────────────────────────────────────
-counter-api = { workspace = true }
-anyhow      = { workspace = true }
+counter-api      = { workspace = true }
+# social-graph is the authoritative SoR for follower/following counts — the
+# reconciliation source queries it over gRPC.
+social-graph-api = { workspace = true }
+anyhow           = { workspace = true }
 
 # ── Shared platform infrastructure ────────────────────────────────────────────
 error      = { workspace = true }

--- a/crates/services/counter/README.fr.md
+++ b/crates/services/counter/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 58970053dfe1f633ebb5943250d8b9325f6ce510115aeee1d0a8cc5c3a5fb9fa
+  source_sha256: f88ba161dbeb9f4f620cb17197ee8933b5375043d899629788f8fb6be2f70dc6
   translated_at: 2026-06-26
   status: complete
 ---
@@ -206,7 +206,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-> **État de build :** complet jusqu'à la Phase 7 (les 8 phases : scaffold → proto → domaine → application+ports → adaptateurs → câblage serveur+worker → IT live → durcissement). La suite d'intégration live est protégée par `integration-counter` et exerce les vrais tiers Redis + Postgres + Scylla. Le `Reconciler` de la boucle de réconciliation + les écritures de guérison sont construits et testés ; câbler une boucle de réconciliation supervisée attend sa `ReconciliationSource` gRPC concrète (vers `engagement` / `social-graph`) — un suivi documenté, avec une cadence de popularité autonome et le producteur concret de fan-out par shard.
+> **État de build :** complet jusqu'à la Phase 7 (les 8 phases : scaffold → proto → domaine → application+ports → adaptateurs → câblage serveur+worker → IT live → durcissement). La suite d'intégration live est protégée par `integration-counter` et exerce les vrais tiers Redis + Postgres + Scylla. **La boucle de réconciliation est câblée :** le worker exécute un balayage supervisé qui pagine les paires réconciliables depuis le registre et guérit la dérive des compteurs exacts contre `social-graph` (le système de référence autoritaire) via `GetRelationStatus`. *Follower/following* sont réconciliés aujourd'hui ; la réconciliation *like/share/comment* reste différée — `engagement` expose des scores de réaction pondérés (pas un compte de réactions), et ses compteurs share/comment sont les approximatifs que ce service supersède. Suivis restants : une cadence de popularité autonome, le producteur concret de fan-out par shard, et un hook de drain à l'arrêt gracieux.
 >
 > **Autorisation (exigence de déploiement) :** `counter` ne s'auto-autorise en rien. Les RPC de lecture sont des magnitudes agrégées exposées à l'appelant ; contrôler l'accès au gateway / `auth-context` avant exposition. Les compteurs ne portent aucune identité par-acteur, donc ne fuitent aucune appartenance.
 
@@ -225,8 +225,9 @@ async fn main() -> anyhow::Result<()> {
 | `COUNTER_SHARD_COUNT` | Non | `16` | shards de clé pour entités chaudes (`entity_id:{0..N}`) |
 | `COUNTER_READ_TIMEOUT_MS` | Non | `50` | timeout dur de lecture chaude par requête ; à expiration la lecture échoue **open** (total ledger périmé) |
 | `COUNTER_POPULARITY_INTERVAL_S` | Non | `60` | cadence du signal de popularité (réservé ; actuellement couplé au flush) |
-| `COUNTER_RECONCILE_INTERVAL_S` | Non | `3600` | cadence de la boucle de réconciliation (réservé ; attend la source concrète) |
+| `COUNTER_RECONCILE_INTERVAL_S` | Non | `3600` | cadence du balayage de réconciliation (correction de dérive follower/following) |
 | `COUNTER_DRIFT_TOLERANCE` | Non | `5` | dérive absolue tolérée avant correction d'un compteur exact par la réconciliation |
+| `COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT` | Non | `http://localhost:50053` | endpoint `social-graph` — comptes follower/following autoritaires pour la réconciliation |
 
 ### Variables d'infrastructure héritées
 

--- a/crates/services/counter/README.fr.md
+++ b/crates/services/counter/README.fr.md
@@ -1,0 +1,295 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: 58970053dfe1f633ebb5943250d8b9325f6ce510115aeee1d0a8cc5c3a5fb9fa
+  translated_at: 2026-06-26
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, variables
+> d'environnement, topics Kafka, identifiants) sont volontairement laissés en anglais.
+
+# `counter` — Compter chaque vue, like, partage et abonnement à l'échelle du firehose, servir les totaux en sous-milliseconde, et ne détenir aucune vérité
+
+> **Fiche service** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Équipe** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **Astreinte / escalade** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-1** — surface d'engagement très visible, mais **dérivée et fail-open** : hors de tout chemin d'écriture synchrone ; une panne dégrade les compteurs en « périmé mais servi », elle ne bloque jamais un like/abonnement/publication |
+> | **Déployable** | **deux** binaires — `crates/apps/counter-server` (chemin de lecture) **et** `crates/apps/counter-worker` (agrégateur de flux). Crate bibliothèque : `crates/services/counter` |
+> | **Stockages** | **Redis** (compteurs chauds · HLL · CMS) · **Postgres** (totaux matérialisés tièdes + registre de réconciliation) · **ScyllaDB TWCS** (séries temporelles historiques froides). Ne détient aucune entité |
+> | **Async** | publie `counter.v1.popularity` (signal de classement grossier) · consomme `view.v1.events`, `impression.v1.events`, `click.v1.events`, `engagement.reactions`, les événements d'abonnement de social-graph (Kafka) |
+> | **Appelants amont** | gateway / BFF, `timeline`, `search` (hydratation des compteurs + classement) |
+> | **Dépendances aval** | Redis, Postgres, Scylla, Kafka. Le système de référence reste dans `post` / `profile` / `media` / `engagement` / `social-graph` — counter n'appelle **aucun** service sur le chemin de lecture |
+> | **SLO** | `<TODO>` dispo · `BatchGetCounters` p99 `< <TODO ~5> ms` · latence d'ingestion `< <TODO ~10> s` |
+
+---
+
+## 🎯 Vue d'ensemble & rôle du service
+
+`counter` est l'**agrégateur de compteurs temps réel et le système de référence analytique** de la plateforme : il absorbe le firehose d'engagement/vues, sert des magnitudes grossières au reste de la flotte avec une latence sous-milliseconde, et ne détient **aucune** entité. Chaque compteur est une matérialisation dérivée d'une vérité qui vit dans les services propriétaires — reconstructible, à tout instant, en rejouant leurs flux d'événements. C'est un système de *référence*, jamais un système d'enregistrement.
+
+Le problème difficile qu'il résout est d'**absorber des millions d'engagements concurrents par seconde sans faire fondre une ligne transactionnelle**. Une conception naïve fait un `UPDATE … SET count = count + 1` par événement — transformant un post viral en une seule partition ScyllaDB brûlante ou une seule ligne Postgres verrouillée, où le débit s'effondre à l'inverse de la latence d'un seul verrou. Le motif résolvant est un **entonnoir d'amplification d'écriture** : ingestion Kafka shardée → pré-agrégation fenêtrée en mémoire qui collapse N événements en un seul delta → compteurs chauds Redis pipelinés → write-behind batché et idempotent. **Aucune écriture par-événement ne touche jamais un store durable.**
+
+**Objectifs clés :** (1) l'ingestion est **asynchrone et hors du chemin d'écriture** — liker un post n'attend jamais `counter` ; (2) le chemin de lecture est **autonome et sous-milliseconde** — un simple multi-get Redis, aucun appel inter-service, aucun scan de table analytique en ligne ; (3) les compteurs sont **entièrement reconstructibles** depuis le système de référence + les événements (la réconciliation est de première classe) ; (4) la posture est **fail-open** — une panne de compteur dégrade en « périmé mais servi », jamais un blocage amont.
+
+| Préoccupation | Chemin | Contrat de latence | Notes |
+|---|---|---|---|
+| **Ingestion** | consommateurs Kafka async (`run_consumer`) dans `counter-worker` | aucun (hors chemin d'écriture) | firehose → delta fenêtré → Redis en secondes ; la latence est un SLO, pas une exigence de cohérence |
+| **Lecture** | gRPC synchrone, Redis seul (cache-aside vers Postgres en cas de miss) | p99 sous-ms | renvoie des magnitudes pour des références d'entités ; pas de fan-out |
+| **Signal de classement** | `counter.v1.popularity` async (grossier, boucle lente) | aucun | `search` / `timeline` le consomment ; jamais un appel synchrone |
+
+---
+
+## 📐 Architecture & concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), CQRS là où c'est pertinent, un **store à trois tiers** (Redis chaud / Postgres tiède / Scylla froid), Kafka pour l'ingestion. Le choix structurel déterminant est **deux déployables** : le serveur de lecture et le worker de flux partagent une crate de domaine mais aucun processus, déploiement, ni domaine de panne.
+
+```
+ télémétrie edge/BFF  ── view.v1.events ──┐
+                      ── impression.v1.events ──┤
+                      ── click.v1.events ──┤      ┌─────────────── counter-worker ───────────────┐
+ engagement-service   ── engagement.reactions ──┤  │ [run_consumer · par topic]                    │
+ social-graph         ── événements d'abonnement ──┘  │  → pré-agrégation fenêtrée (N événements → 1 Δ)│
+                                                  ├─►│  → Redis (HINCRBY / PFADD / CMS, ré-agg shard) │
+ (clés shardées étalent les entités chaudes)      │  │  → write-behind idempotent (clé de fenêtre)    │
+                                                  │  │  → boucle de réconciliation → publie popularité│
+                                                  │  └────────┬───────────────┬──────────────┬────────┘
+                                                  │           ▼               ▼              ▼
+                                                  │      Redis (chaud)  Postgres (tiède  Scylla TWCS
+                                                  │                     totaux+registre)  (série froide)
+                                                  │           ▲
+   gateway/BFF/timeline/search ──► counter.v1.CounterService/BatchGetCounters ── lecture Redis seul ─┘
+                                       renvoie des magnitudes pour (entity_type, id) · cache-aside en miss
+   search / timeline ◄── counter.v1.popularity (signal de classement grossier, boucle lente)
+```
+
+**L'amplification d'écriture est éjectée avant la durabilité.** Les millions de `+1` d'un post viral sont étalés sur N partitions par une **clé shardée** (`entity_id:{0..N}`), repliés par chaque worker en un seul delta en mémoire par **fenêtre glissante**, pipelinés dans Redis, et seulement *ensuite* flushés — batchés et idempotents sur `(entity, metric, window_id)` — vers Postgres/Scylla. Un crash de worker et une re-livraison Kafka ré-appliquent la *même* fenêtre sans double comptage.
+
+> **Invariants** (et où ils sont garantis) :
+> - **Counter ne détient aucune source de vérité.** Les lectures renvoient des magnitudes pour une *référence* d'entité ; l'appelant hydrate l'entité depuis son système de référence. Test décisif : chaque compteur doit être reconstructible en rejouant les événements ou en scannant le système de référence — domaine + réconciliation.
+> - **Il répond « combien ? », jamais « qui ? »/« lesquels ? ».** L'état d'arête par-acteur (qui a liké, qui suit) appartient à `engagement` / `social-graph`. Dès qu'une question requiert une identité ou un ensemble, il délègue — contrat de frontière.
+> - **Aucune écriture durable par-événement.** Chaque écriture vers Postgres/Scylla est un agrégat de fenêtre ; le flush durable est idempotent sur `(entity, metric, window_id)` — frontière infrastructure.
+> - **Exact vs probabiliste par classe de métrique.** Likes/partages/abonnés/commentaires sont *exacts-mais-réconciliables* (une fenêtre sur un ensemble qu'un autre système de référence possède) ; vues/impressions/spectateurs-uniques/portée sont *probabilistes par conception* — total via compteurs shardés (double comptage toléré), uniques via **HyperLogLog**, tendances via **Count-Min Sketch** — domaine.
+> - **Lecture et classement sont des mécanismes de livraison séparés.** Le pull sous-ms (`BatchGetCounters`) et le push grossier (`counter.v1.popularity`) ne partagent jamais un chemin, donc le fan-out de classement ne taxe jamais le tier de lecture — application.
+
+---
+
+## 📊 Objectifs de niveau de service (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objectif | Fenêtre | Mesuré par |
+|---|---|---|---|
+| Disponibilité (non-5xx / non-`UNAVAILABLE`) | `<TODO 99.9%>` | 30j glissants | `<metric>` |
+| Latence de lecture p99 (`BatchGetCounters`) | `< <TODO 5> ms` | 1h | `<metric>` |
+| Latence d'ingestion (événement → compté) | `< <TODO 10> s` | live | lag du `<consumer-group>` |
+| Dérive de compteur (approximatif vs réconcilié) | `< <TODO 0.5%>` | par cycle de réconciliation | métrique de réconciliation |
+
+**Budget d'erreur :** `<TODO>`. **En cas de burn :** `<gel des déploiements | page>`. Note : `counter` étant fail-open, l'objectif de *disponibilité* couvre la dégradation du chemin de lecture (périmé mais servi), pas l'exactitude — l'exactitude est couverte par la latence d'ingestion + le SLI de dérive de réconciliation.
+
+---
+
+## 🔗 Dépendances & rayon d'impact &nbsp;·&nbsp; OPS
+
+**Aval — ce dont `counter` a besoin pour fonctionner :**
+
+| Dépendance | Rôle | Si en panne → | Dégradation |
+|---|---|---|---|
+| Redis | compteurs chauds / HLL / CMS (chemin lecture + écriture) | lectures dégradées, écritures chaudes bloquées | **Souple** — les lectures retombent sur le dernier total Postgres flushé (périmé mais servi) ; le worker bufferise/réessaie dans le budget |
+| Postgres | totaux matérialisés tièdes + registre de réconciliation | miss cache-aside + flush bloqué | **Souple** — les lectures chaudes servent toujours depuis Redis ; le flush durable réessaie (aucune perte, offsets non commités) |
+| Scylla (TWCS) | séries temporelles historiques froides | `GetTimeSeries` dégradé | **Souple** — les compteurs live intacts ; seule l'analytique historique est impactée |
+| Kafka | ingestion + publication de popularité | le comptage cesse d'avancer | **Souple** — les compteurs se périment, le lag croît ; aucune perte (commit manuel) |
+
+**Amont — qui dépend de `counter` (votre rayon d'impact si VOUS tombez) :**
+
+| Appelant | Utilise | Impact visible si `counter` est en panne |
+|---|---|---|
+| gateway / BFF | `BatchGetCounters` | les compteurs d'engagement s'affichent périmés ou absents ; **aucune** écriture, like, abonnement ou publication n'est affecté |
+| `timeline` / `search` | `counter.v1.popularity` | le classement retombe sur son dernier snapshot grossier ; la découverte fonctionne toujours |
+
+> **Chemin critique ?** **Non** — dérivé, async, fail-open. `counter` n'est jamais sur le chemin synchrone d'une écriture, d'un like, d'un abonnement, d'une publication ou d'un flux d'auth.
+
+---
+
+## 🔌 Interfaces publiques & contrat d'API &nbsp;·&nbsp; CORE
+
+### gRPC — `counter.v1.CounterService` *(Phase 1)*
+
+La surface synchrone est délibérément **en lecture seule** : `BatchGetCounters` (magnitudes pour un lot de références d'entités + masque de métriques — le chemin chaud d'hydratation de feed), `GetTrending` (top-K pour une portée, servi depuis CMS + un tas borné), et `GetTimeSeries` (buckets historiques — le seul RPC autorisé à toucher le tier froid Scylla, explicitement *non* sous-ms et hors du chemin de feed). **Il n'y a aucun RPC d'écriture/incrément** — l'ingestion est Kafka uniquement.
+
+> **Contrat de fil :** les résultats sont des magnitudes attachées à une référence — `(entity_type, id, metric, value)` plus la provenance approximatif-vs-exact. Les appelants DOIVENT hydrater l'entité elle-même (corps du post, profil, URL média) depuis son système de référence. `counter` ne renvoie aucune entité autoritative ni aucune appartenance par-acteur.
+
+### Ports Rust (contrat hexagonal) *(Phase 3)*
+
+```rust
+#[async_trait] pub trait CounterStore    { /* incr_window · read_batch · pfadd/pfcount · cms_topk — le tier chaud Redis */ }
+#[async_trait] pub trait CounterLedger   { /* upsert_window(idempotent) · read_total · reconcile — le tier tiède Postgres */ }
+#[async_trait] pub trait TimeSeriesStore { /* append_bucket · range — le tier froid Scylla */ }
+#[async_trait] pub trait SignalPublisher { /* publie la popularité grossière — counter.v1.popularity */ }
+```
+
+### Contrat d'erreur
+
+Chaque faute implémente `error::AppError` avec un code `CTR-XXXX` stable, mappé vers gRPC `Status` / HTTP par la crate partagée `error` :
+
+| Plage | Classe |
+|---|---|
+| `CTR-1xxx` | lecture / requête |
+| `CTR-2xxx` | agrégation / fenêtre |
+| `CTR-3xxx` | flush / write-behind (réessayable) |
+| `CTR-4xxx` | disponibilité du store (cœur fail-open ; réessayable) |
+| `CTR-5xxx` | réconciliation / dérive |
+| `CTR-8xxx` | décodage d'événement entrant / mapping de source |
+| `CTR-9xxx` | transverse (domaine/parse, consommation d'événements) |
+
+---
+
+## 📨 Événements & contrat async &nbsp;·&nbsp; CORE
+
+> Les topics Kafka sont une API. Un changement de schéma sur un topic consommé casse le comptage exactement comme un changement de proto.
+
+**Publie :**
+
+| Topic | Clé | Rôle |
+|---|---|---|
+| `counter.v1.popularity` | id d'entité | snapshot grossier et périodique de popularité/tendance pour le classement ; consommé par `search` (`PopularityScore`) et `timeline`. Jamais un compteur par-événement |
+
+**Consomme :**
+
+| Topic | Groupe de consommateurs | Rôle | En cas de poison/épuisement |
+|---|---|---|---|
+| `view.v1.events` | `counter-view-aggregator` | agrège les vues (total via compteur shardé, uniques via HLL) | DLQ `view.v1.events.dlq` |
+| `impression.v1.events` | `counter-impression-aggregator` | agrège impressions / portée | DLQ `impression.v1.events.dlq` |
+| `click.v1.events` | `counter-click-aggregator` | agrège clics / entrées de CTR | DLQ `click.v1.events.dlq` |
+| `engagement.reactions` | `counter-reaction-aggregator` | agrège les magnitudes de like/partage (supersède les compteurs bruts d'engagement) | DLQ `engagement.reactions.dlq` |
+| `<événements d'abonnement social-graph>` | `counter-follow-aggregator` | agrège les compteurs d'abonnés / abonnements | DLQ `<...>.dlq` |
+
+> **Contrat de runtime (obligatoire) :** tous les consommateurs tournent sous `run_consumer` — commit manuel après un résultat terminal, réessai borné avec backoff + jitter, DLQ à l'épuisement/poison, reconstruction depuis le dernier offset commité en cas d'erreur broker. **Idempotence :** le flush durable est clé sur `(entity, metric, window_id)`, donc un événement re-livré ré-applique la même fenêtre sans double comptage ; un événement non-mappé/inconnu (`CTR-8002`) est replié en `Ok` pour que l'offset commite ; les métriques approximatives tolèrent le double comptage at-least-once par conception.
+
+---
+
+## 🌩️ Modes de défaillance & dégradation &nbsp;·&nbsp; OPS
+
+| Défaillance | Symptôme | Comportement du service | Action opérateur |
+|---|---|---|---|
+| Redis indisponible (lecture) | latence / erreurs `BatchGetCounters` | **fail-open** — retombe sur le dernier total Postgres flushé (périmé), ne renvoie jamais 5xx au feed | vérifier la santé de Redis ; les lectures récupèrent quand le tier chaud revient |
+| Redis indisponible (ingestion) | la latence d'ingestion monte | le worker bufferise/réessaie dans le budget, puis DLQ ; offset non commité → aucune perte | restaurer Redis ; les consommateurs reprennent au dernier offset commité |
+| Flush Postgres en échec | le flush réessaie, lag sur le total durable | les compteurs chauds intacts ; le total durable prend du retard | restaurer Postgres ; le re-flush idempotent rattrape |
+| Entité chaude (virale) | une entité domine une partition | la clé shardée (`entity_id:{0..N}`) + ré-agrégation à deux étages étale la charge | aucune (par conception) ; augmenter le nombre de shards si besoin |
+| Dérive de réconciliation > tolérance | `CTR-5002 DriftThresholdExceeded` | le compteur approximatif corrigé contre la vérité rejouée du système de référence | investiguer le flux source ; la boucle de réconciliation auto-guérit les métriques exactes |
+| Kafka indisponible | les compteurs cessent d'avancer | les consommateurs au ralenti ; aucune perte (commit manuel) | restaurer les brokers ; les compteurs rattrapent |
+
+**Contre-pression & limites :** l'agrégation fenêtrée est le délestage primaire (N→1) ; plafonds de taille de lot par requête sur `BatchGetCounters` ; un timeout dur sur le chemin de lecture pour qu'un Redis lent déleste plutôt que de mettre en file ; l'ingestion est naturellement limitée par le débit des consommateurs.
+
+---
+
+## 📦 Intégration & usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+counter = { path = "crates/services/counter" }
+```
+
+Bibliothèque uniquement. Implémentera [`service_runtime::Service`](../../platform/service-runtime/README.md) **deux fois** (Phase 5) : `counter::service::CounterReadService` (le binaire `counter-server` — `build` câble l'adaptateur de lecture Redis, `register` ajoute le service gRPC, `health_probes` ping Redis) et `counter::service::CounterWorkerService` (le binaire `counter-worker` — `build` câble les trois adaptateurs de store + le publieur Kafka et **spawn les consommateurs d'agrégation supervisés**, sans ingress gRPC). La télémétrie, la config + hot-reload, la santé et l'arrêt gracieux sont gérés par le runtime.
+
+### Bootstrap (`crates/apps/counter-server`)
+
+```rust
+use counter::service::CounterReadService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("COUNTER_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50064".to_owned()).parse()?;
+    service_runtime::serve::<CounterReadService>(addr).await
+}
+```
+
+> **État de build :** complet jusqu'à la Phase 7 (les 8 phases : scaffold → proto → domaine → application+ports → adaptateurs → câblage serveur+worker → IT live → durcissement). La suite d'intégration live est protégée par `integration-counter` et exerce les vrais tiers Redis + Postgres + Scylla. Le `Reconciler` de la boucle de réconciliation + les écritures de guérison sont construits et testés ; câbler une boucle de réconciliation supervisée attend sa `ReconciliationSource` gRPC concrète (vers `engagement` / `social-graph`) — un suivi documenté, avec une cadence de popularité autonome et le producteur concret de fan-out par shard.
+>
+> **Autorisation (exigence de déploiement) :** `counter` ne s'auto-autorise en rien. Les RPC de lecture sont des magnitudes agrégées exposées à l'appelant ; contrôler l'accès au gateway / `auth-context` avant exposition. Les compteurs ne portent aucune identité par-acteur, donc ne fuitent aucune appartenance.
+
+---
+
+## ⚙️ Configuration & environnement d'exécution &nbsp;·&nbsp; CORE
+
+### Variables spécifiques à `counter` *(remplies par phase)*
+
+| Variable | Requis | Défaut | Description |
+|---|---|---|---|
+| `COUNTER_GRPC_ADDR` | Non | `0.0.0.0:50064` | adresse d'écoute gRPC du serveur de lecture |
+| `COUNTER_WORKER_GRPC_ADDR` | Non | `0.0.0.0:50065` | adresse santé/réflexion du worker (aucun RPC métier) |
+| `COUNTER_AGGREGATION_WINDOW_MS` | Non | `5000` | fenêtre glissante de pré-agrégation (le collapse N→1) |
+| `COUNTER_FLUSH_INTERVAL_MS` | Non | `=fenêtre` | fréquence de drain+flush des fenêtres fermées par le worker |
+| `COUNTER_SHARD_COUNT` | Non | `16` | shards de clé pour entités chaudes (`entity_id:{0..N}`) |
+| `COUNTER_READ_TIMEOUT_MS` | Non | `50` | timeout dur de lecture chaude par requête ; à expiration la lecture échoue **open** (total ledger périmé) |
+| `COUNTER_POPULARITY_INTERVAL_S` | Non | `60` | cadence du signal de popularité (réservé ; actuellement couplé au flush) |
+| `COUNTER_RECONCILE_INTERVAL_S` | Non | `3600` | cadence de la boucle de réconciliation (réservé ; attend la source concrète) |
+| `COUNTER_DRIFT_TOLERANCE` | Non | `5` | dérive absolue tolérée avant correction d'un compteur exact par la réconciliation |
+
+### Variables d'infrastructure héritées
+
+| Variable | Requis | Défaut | Description |
+|---|---|---|---|
+| `REDIS_URL` | **Oui** | — | tier chaud des compteurs |
+| `DATABASE_URL` | **Oui** | — | registre tiède (Postgres) |
+| `SCYLLA_NODES` | **Oui** | — | séries temporelles froides (Scylla) |
+| `KAFKA_BROKERS` | **Oui** | — | ingestion + publication de popularité |
+
+### Fonctionnalités à la compilation
+- `integration-counter` — active la suite d'intégration live, adossée à des conteneurs (Redis + Postgres + Scylla réels — le tiering chaud/tiède/froid complet).
+- `build.rs` (Phase 1, dans `counter-api`) compile `contracts/proto/counter/v1/*.proto` et émet le descriptor set de réflexion.
+
+---
+
+## 🚀 Déploiement, migrations & rollback &nbsp;·&nbsp; OPS
+
+- **Deux déployables, scalés indépendamment.** `counter-server` scale avec le QPS de lecture de la flotte ; `counter-worker` scale avec le volume du firehose d'ingestion. Ils sont publiés ensemble (même image/tag) mais déployés et autoscalés séparément.
+- **Les migrations de schéma** (tables de registre Postgres + tables de séries temporelles Scylla TWCS) appartiennent à `crates/apps/migrator`, appliquées avant que le nouveau binaire ne serve.
+- **Reconstruire depuis la vérité.** La rétention Kafka étant finie, les compteurs exacts sont réparés par la **boucle de réconciliation** qui scanne/rejoue le système de référence propriétaire (réactions `engagement`, abonnements `social-graph`), pas par un « replay depuis le début ». Les compteurs approximatifs (vues) sont acceptés comme approximatifs.
+- **Rollback :** sûr — les deux binaires sont sans état au-dessus de leurs stores ; le worker reprend aux derniers offsets commités, le serveur est en lecture pure.
+- **Pièges avec état :** changer `COUNTER_AGGREGATION_WINDOW_MS` ou `COUNTER_SHARD_COUNT` en vol affecte les fenêtres en cours — drainer ou accepter un pic de lag transitoire ; les clés d'idempotence durables rendent l'opération sûre, pas transparente.
+
+---
+
+## 📈 Télémétrie, performance & métriques &nbsp;·&nbsp; CORE
+
+- **Runtime :** Tokio multi-thread. `counter-worker` exécute les consommateurs d'agrégation + l'ordonnanceur de flush + la boucle de réconciliation ; `counter-server` exécute les handlers de lecture. Subscriber tracing/OTel global installé avant serve ; trace-context W3C propagé à travers la frontière Kafka.
+
+| Signal | Pourquoi c'est important | Alerte suggérée |
+|---|---|---|
+| Latence d'ingestion (par groupe de consommateurs) | fraîcheur des compteurs live | `> SLO` soutenu ⇒ page |
+| Latence p99 `BatchGetCounters` | réactivité de l'hydratation de feed | `> SLO` ⇒ investiguer Redis |
+| Échec / lag du flush durable | divergence du tier tiède, risque de replay | soutenu ⇒ page |
+| Dérive de réconciliation | divergence approximatif-vs-vérité | `> SLO` ⇒ investiguer le flux source |
+| Taux de production DLQ (`*.dlq`) | ingestion empoisonnée / réessais épuisés | tout taux soutenu ⇒ page |
+
+---
+
+## 🛠️ Développement local &nbsp;·&nbsp; CORE
+
+```bash
+cargo build -p counter && cargo clippy -p counter --all-targets
+cargo test  -p counter                                    # run unitaire rapide, sans infra
+docker compose up -d redis postgres scylla kafka          # compose à la racine (Phase 6)
+cargo test  -p counter --features integration-counter     # suite live (tiers chaud/tiède/froid)
+```
+
+---
+
+## 🚨 Dépannage & runbook &nbsp;·&nbsp; CORE
+
+> Format : **symptôme → cause racine → mitigation.** Une entrée par classe d'incident réel.
+
+**1. Les compteurs s'affichent périmés ou à zéro.**
+Cause racine : Redis dégradé — les lectures échouent **open** vers le dernier total Postgres flushé plutôt que d'erreur le feed. Mitigation : vérifier la santé de Redis ; les compteurs live récupèrent quand le tier chaud revient ; le total durable borne la péremption du fallback.
+
+**2. Un nouvel engagement n'est pas reflété dans les compteurs.**
+Cause racine : lag d'ingestion ou un consommateur bloqué. Mitigation : vérifier le lag du groupe de consommateurs et les topics `*.dlq` ; une erreur broker/store retient l'offset (aucune perte), donc le worker rattrape une fois la dépendance rétablie.
+
+**3. Un compteur semble faux / a dérivé.**
+Cause racine : double comptage at-least-once sur une métrique approximative, ou un événement exact manqué. Mitigation : les métriques approximatives sont acceptées dans la tolérance ; les métriques exactes auto-guérissent au prochain cycle de réconciliation — vérifier la métrique de dérive et, si `CTR-5002` a déclenché, le flux source.
+
+**4. Une entité virale crée un point chaud sur une partition.**
+Cause racine : nombre de shards trop bas pour le débit de l'entité. Mitigation : augmenter `COUNTER_SHARD_COUNT` ; la conception de compteur shardé à deux étages étale l'entité sur plus de partitions/workers et ré-agrège dans Redis.

--- a/crates/services/counter/README.md
+++ b/crates/services/counter/README.md
@@ -195,7 +195,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-> **Build status:** complete through Phase 7 (all 8 phases: scaffold → proto → domain → application+ports → adapters → server+worker wiring → live IT → hardening). The live integration suite is gated behind `integration-counter` and exercises the real Redis + Postgres + Scylla tiers. The reconciliation loop's `Reconciler` + heal-writes are built and tested; wiring a supervised reconcile loop awaits its concrete gRPC `ReconciliationSource` (to `engagement` / `social-graph`) — a documented follow-up, along with a standalone popularity cadence and the concrete shard-fan-out producer.
+> **Build status:** complete through Phase 7 (all 8 phases: scaffold → proto → domain → application+ports → adapters → server+worker wiring → live IT → hardening). The live integration suite is gated behind `integration-counter` and exercises the real Redis + Postgres + Scylla tiers. **The reconciliation loop is wired:** the worker runs a supervised sweep that pages reconcilable pairs from the ledger and heals exact-counter drift against `social-graph` (the authoritative SoR) via `GetRelationStatus`. *Follower/following* are reconciled today; *like/share/comment* reconciliation stays deferred — `engagement` exposes weighted reaction scores (not a reaction count), and its share/comment counters are the approximate ones this service supersedes. Remaining follow-ups: a standalone popularity cadence, the concrete shard-fan-out producer, and a graceful-shutdown drain hook.
 >
 > **Authorization (deployment requirement):** `counter` self-authorizes nothing. The read RPCs are caller-facing aggregate magnitudes; gate access at the gateway / `auth-context` before exposure. Counts carry no per-actor identity, so they leak no membership.
 
@@ -214,8 +214,9 @@ async fn main() -> anyhow::Result<()> {
 | `COUNTER_SHARD_COUNT` | No | `16` | hot-entity key shards (`entity_id:{0..N}`) |
 | `COUNTER_READ_TIMEOUT_MS` | No | `50` | hard per-request hot-read timeout; on elapse the read fails **open** (stale ledger total) |
 | `COUNTER_POPULARITY_INTERVAL_S` | No | `60` | slow-loop cadence for the popularity signal (reserved; currently coupled to flush) |
-| `COUNTER_RECONCILE_INTERVAL_S` | No | `3600` | reconciliation-loop cadence (reserved; awaits the concrete source) |
+| `COUNTER_RECONCILE_INTERVAL_S` | No | `3600` | reconciliation sweep cadence (follower/following drift correction) |
 | `COUNTER_DRIFT_TOLERANCE` | No | `5` | absolute drift tolerated before reconciliation corrects an exact counter |
+| `COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT` | No | `http://localhost:50053` | `social-graph` endpoint — authoritative follower/following counts for reconciliation |
 
 ### Inherited infrastructure variables
 

--- a/crates/services/counter/README.md
+++ b/crates/services/counter/README.md
@@ -1,0 +1,284 @@
+# `counter` — Count every view, like, share, and follow at firehose scale, serve the totals in sub-milliseconds, and own none of the truth
+
+> **Service Card** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Owner** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **On-call / escalation** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-1** — high-visibility engagement surface, but **derived and fail-open**: not in any synchronous write path; an outage degrades counts to stale-but-served, it never blocks a like/follow/publish |
+> | **Deployable** | **two** binaries — `crates/apps/counter-server` (read path) **and** `crates/apps/counter-worker` (stream aggregator). Library crate: `crates/services/counter` |
+> | **Datastores** | **Redis** (hot live counters · HLL · CMS) · **Postgres** (warm materialized totals + reconciliation ledger) · **ScyllaDB TWCS** (cold historical time-series). Owns no entity |
+> | **Async** | publishes `counter.v1.popularity` (coarse ranking signal) · consumes `view.v1.events`, `impression.v1.events`, `click.v1.events`, `engagement.reactions`, social-graph follow events (Kafka) |
+> | **Upstream callers** | gateway / BFF, `timeline`, `search` (count hydration + ranking) |
+> | **Downstream deps** | Redis, Postgres, Scylla, Kafka. Source-of-record stays in `post` / `profile` / `media` / `engagement` / `social-graph` — counter calls **no** service on the read path |
+> | **SLO** | `<TODO>` avail · `BatchGetCounters` p99 `< <TODO ~5> ms` · ingestion lag `< <TODO ~10> s` |
+
+---
+
+## 🎯 Overview & Service Role
+
+`counter` is the platform's **real-time counter aggregator and analytics System-of-Reference**: it absorbs the engagement/view firehose, serves coarse magnitudes back to the fleet at sub-millisecond latency, and owns **no** entity. Every count is a derived materialization of truth that lives in the owning services — reconstructable, at any moment, by replaying their event streams. It is a System-of-*Reference*, never a System-of-Record.
+
+The hard problem it solves is **absorbing millions of concurrent engagements per second without melting a transactional row**. A naive design does `UPDATE … SET count = count + 1` per event — turning a viral post into a single hot ScyllaDB partition or a single locked Postgres row, where throughput collapses to the reciprocal of one lock's latency. The resolving pattern is a **write-amplification funnel**: sharded Kafka ingestion → in-process windowed pre-aggregation that collapses N events into one delta → pipelined Redis hot counters → batched, idempotent write-behind. **No per-event write ever touches a durable store.**
+
+**Core objectives:** (1) ingestion is **async and off the write path** — liking a post never waits on `counter`; (2) the read path is **self-contained and sub-millisecond** — a thin Redis multi-get, no inter-service call, no analytics-table scan inline; (3) counts are **fully reconstructable** from source-of-record + events (reconciliation is first-class); (4) posture is **fail-open** — a counter outage degrades to stale-but-served, never an upstream block.
+
+| Concern | Path | Latency contract | Notes |
+|---|---|---|---|
+| **Ingestion** | async Kafka consumers (`run_consumer`) in `counter-worker` | none (off the write path) | firehose → windowed delta → Redis in seconds; lag is an SLO, not a consistency requirement |
+| **Read** | synchronous gRPC, Redis-only (cache-aside to Postgres on miss) | sub-ms p99 | returns magnitudes for entity references; no fan-out |
+| **Ranking signal** | async `counter.v1.popularity` (coarse, slow-loop) | none | `search` / `timeline` consume it; never a synchronous call |
+
+---
+
+## 📐 Architecture & Concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), CQRS where it fits, a **three-tier store** (Redis hot / Postgres warm / Scylla cold), Kafka for ingestion. The defining structural choice is **two deployables**: the read server and the stream worker share a domain crate but no process, deployment, or failure domain.
+
+```
+ edge/BFF telemetry  ── view.v1.events ──┐
+                     ── impression.v1.events ──┤
+                     ── click.v1.events ──┤      ┌─────────────── counter-worker ───────────────┐
+ engagement-service  ── engagement.reactions ──┤  │ [run_consumer · per topic]                    │
+ social-graph        ── follow events ──┘      ├─►│  → windowed pre-aggregation (N events → 1 Δ)   │
+                                               │  │  → Redis (HINCRBY / PFADD / CMS, shard re-agg) │
+ (sharded keys spread hot entities)            │  │  → idempotent write-behind (window-keyed)      │
+                                               │  │  → reconciliation loop → publish popularity    │
+                                               │  └────────┬───────────────┬──────────────┬────────┘
+                                               │           ▼               ▼              ▼
+                                               │      Redis (hot)    Postgres (warm   Scylla TWCS
+                                               │                     totals+ledger)   (cold series)
+                                               │           ▲                                 
+   gateway/BFF/timeline/search ──► counter.v1.CounterService/BatchGetCounters ── Redis-only read ─┘
+                                       returns magnitudes for (entity_type, id) · cache-aside on miss
+   search / timeline ◄── counter.v1.popularity (coarse, slow-loop ranking signal)
+```
+
+**Write-amplification is pushed out before durability.** A viral post's millions of `+1`s are spread across N partitions by a **sharded key** (`entity_id:{0..N}`), folded by each worker into one in-memory delta per **tumbling window**, pipelined into Redis, and only *then* flushed — batched and idempotent on `(entity, metric, window_id)` — into Postgres/Scylla. A worker crash and Kafka redelivery re-applies the *same* window without double-counting.
+
+> **Invariants** (and where enforced):
+> - **Counter holds no source of truth.** Reads return magnitudes for an entity *reference*; the caller hydrates the entity from its SoR. Litmus: every count must be rebuildable by replaying events or scanning the SoR — domain + reconciliation.
+> - **It answers "how many?", never "who?"/"which?".** Per-actor edge state (who liked, who follows) belongs to `engagement` / `social-graph`. The moment a question needs an identity or a set, it delegates — boundary contract.
+> - **No per-event durable write.** Every write to Postgres/Scylla is a window aggregate; the durable flush is idempotent on `(entity, metric, window_id)` — infrastructure boundary.
+> - **Exact vs probabilistic by metric class.** Likes/shares/followers/comments are *exact-but-reconcilable* (a window onto a set another SoR owns); views/impressions/unique-viewers/reach are *probabilistic by design* — total via sharded counters (double-count tolerated), uniques via **HyperLogLog**, trending via **Count-Min Sketch** — domain.
+> - **Read and ranking are separate delivery mechanisms.** The sub-ms pull (`BatchGetCounters`) and the coarse push (`counter.v1.popularity`) never share a path, so ranking fan-out never taxes the read tier — application.
+
+---
+
+## 📊 Service Level Objectives (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objective | Window | Measured by |
+|---|---|---|---|
+| Availability (non-5xx / non-`UNAVAILABLE`) | `<TODO 99.9%>` | 30d rolling | `<metric>` |
+| Read latency p99 (`BatchGetCounters`) | `< <TODO 5> ms` | 1h | `<metric>` |
+| Ingestion lag (event → counted) | `< <TODO 10> s` | live | `<consumer-group> lag` |
+| Counter drift (approximate vs reconciled) | `< <TODO 0.5%>` | per reconciliation cycle | reconciliation metric |
+
+**Error budget:** `<TODO>`. **On burn:** `<freeze rollout | page>`. Note: because `counter` is fail-open, the *availability* objective covers read-path degradation (stale-but-served), not exactness — exactness is covered by ingestion lag + the reconciliation drift SLI.
+
+---
+
+## 🔗 Dependencies & Blast Radius &nbsp;·&nbsp; OPS
+
+**Downstream — what `counter` needs to function:**
+
+| Dependency | Purpose | If down → | Degradation |
+|---|---|---|---|
+| Redis | hot counters / HLL / CMS (read + write path) | reads degrade, hot writes stall | **Soft** — reads fall back to last-flushed Postgres total (stale-but-served); the worker buffers/retries within budget |
+| Postgres | warm materialized totals + reconciliation ledger | cache-aside misses + flush stall | **Soft** — hot reads still serve from Redis; durable flush retries (no loss, offsets uncommitted) |
+| Scylla (TWCS) | cold historical time-series | `GetTimeSeries` degrades | **Soft** — live counters unaffected; only historical analytics is impacted |
+| Kafka | ingestion + popularity publish | counting stops advancing | **Soft** — counts go stale, lag grows; no data lost (manual commit) |
+
+**Upstream — who depends on `counter` (your blast radius if YOU fail):**
+
+| Caller | Uses | User-visible impact if `counter` is down |
+|---|---|---|
+| gateway / BFF | `BatchGetCounters` | engagement counts render stale or absent; **no** write, like, follow, or publish is affected |
+| `timeline` / `search` | `counter.v1.popularity` | ranking falls back to its last coarse snapshot; discovery still works |
+
+> **Critical path?** **No** — derived, async, fail-open. `counter` is never in the synchronous path of a write, like, follow, publish, or auth flow.
+
+---
+
+## 🔌 Public Interfaces & API Contract &nbsp;·&nbsp; CORE
+
+### gRPC — `counter.v1.CounterService` *(Phase 1)*
+
+The synchronous surface is deliberately **read-only**: `BatchGetCounters` (magnitudes for a batch of entity references + metric mask — the feed-hydration hot path), `GetTrending` (top-K for a scope, served from CMS + a bounded heap), and `GetTimeSeries` (historical buckets — the one RPC allowed to touch the cold Scylla tier, explicitly *not* sub-ms and off the feed path). **There is no write/increment RPC** — ingestion is Kafka-only.
+
+> **Wire contract:** results are magnitudes attached to a reference — `(entity_type, id, metric, value)` plus approximate-vs-exact provenance. Callers MUST hydrate the entity itself (post body, profile, media URL) from its SoR. `counter` returns no authoritative entity and no per-actor membership.
+
+### Rust ports (hexagonal contract) *(Phase 3)*
+
+```rust
+#[async_trait] pub trait CounterStore    { /* incr_window · read_batch · pfadd/pfcount · cms_topk — the hot Redis tier */ }
+#[async_trait] pub trait CounterLedger   { /* upsert_window(idempotent) · read_total · reconcile — the warm Postgres tier */ }
+#[async_trait] pub trait TimeSeriesStore { /* append_bucket · range — the cold Scylla tier */ }
+#[async_trait] pub trait SignalPublisher { /* publish coarse popularity — counter.v1.popularity */ }
+```
+
+### Error contract
+
+Every fault implements `error::AppError` with a stable `CTR-XXXX` code, mapped to gRPC `Status` / HTTP by the shared `error` crate:
+
+| Range | Class |
+|---|---|
+| `CTR-1xxx` | read / query |
+| `CTR-2xxx` | aggregation / window |
+| `CTR-3xxx` | flush / write-behind (retryable) |
+| `CTR-4xxx` | store availability (fail-open core; retryable) |
+| `CTR-5xxx` | reconciliation / drift |
+| `CTR-8xxx` | inbound event decode / source mapping |
+| `CTR-9xxx` | cross-cutting (domain/parse, event consumption) |
+
+---
+
+## 📨 Events & Async Contract &nbsp;·&nbsp; CORE
+
+> Kafka topics are an API. A schema change in a consumed topic breaks counting exactly like a proto change.
+
+**Publishes:**
+
+| Topic | Key | Purpose |
+|---|---|---|
+| `counter.v1.popularity` | entity id | coarse, periodic popularity/trending snapshot for ranking; consumed by `search` (`PopularityScore`) and `timeline`. Never a per-event count |
+
+**Consumes:**
+
+| Topic | Consumer group | Purpose | On poison/exhaustion |
+|---|---|---|---|
+| `view.v1.events` | `counter-view-aggregator` | aggregate views (total via sharded counter, uniques via HLL) | DLQ `view.v1.events.dlq` |
+| `impression.v1.events` | `counter-impression-aggregator` | aggregate impressions / reach | DLQ `impression.v1.events.dlq` |
+| `click.v1.events` | `counter-click-aggregator` | aggregate clicks / CTR inputs | DLQ `click.v1.events.dlq` |
+| `engagement.reactions` | `counter-reaction-aggregator` | aggregate like/share magnitudes (supersedes engagement's raw counters) | DLQ `engagement.reactions.dlq` |
+| `<social-graph follow events>` | `counter-follow-aggregator` | aggregate follower / following counts | DLQ `<...>.dlq` |
+
+> **Runtime contract (mandatory):** all consumers run under `run_consumer` — manual commit after a terminal outcome, bounded retry with backoff + jitter, DLQ on exhaustion/poison, rebuild-from-last-committed-offset on broker error. **Idempotency:** the durable flush is keyed by `(entity, metric, window_id)`, so a redelivered event re-applies the same window without double-counting; an unmapped/unknown event (`CTR-8002`) is folded into `Ok` so the offset still commits; approximate metrics tolerate at-least-once double-counting by design.
+
+---
+
+## 🌩️ Failure Modes & Degradation &nbsp;·&nbsp; OPS
+
+| Failure | Symptom | Service behavior | Operator action |
+|---|---|---|---|
+| Redis unavailable (read) | `BatchGetCounters` latency / errors | **fail-open** — fall back to last-flushed Postgres total (stale), never 5xx the feed | check Redis health; reads recover when the hot tier does |
+| Redis unavailable (ingest) | ingestion lag rises | worker buffers/retries within budget, then DLQ; offset uncommitted → no loss | restore Redis; consumers resume from last committed offset |
+| Postgres flush failing | flush retries, lag on durable total | hot counts unaffected; durable total lags | restore Postgres; idempotent re-flush catches up |
+| Hot entity (viral) | one entity dominates a partition | sharded key (`entity_id:{0..N}`) + two-stage re-aggregation spreads load | none (by design); raise shard count if needed |
+| Reconciliation drift > tolerance | `CTR-5002 DriftThresholdExceeded` | approximate count corrected against replayed SoR truth | investigate the source stream; the reconciliation loop self-heals exact metrics |
+| Kafka unavailable | counts stop advancing | consumers idle; no loss (manual commit) | restore brokers; counters catch up |
+
+**Backpressure & limits:** windowed aggregation is the primary shed (N→1); per-request batch-size caps on `BatchGetCounters`; a read-path hard timeout so a slow Redis sheds load rather than queueing; ingestion is naturally rate-limited by consumer throughput.
+
+---
+
+## 📦 Integration & Usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+counter = { path = "crates/services/counter" }
+```
+
+Library-only. Will implement [`service_runtime::Service`](../../platform/service-runtime/README.md) **twice** (Phase 5): `counter::service::CounterReadService` (the `counter-server` binary — `build` wires the Redis read adapter, `register` adds the gRPC service, `health_probes` pings Redis) and `counter::service::CounterWorkerService` (the `counter-worker` binary — `build` wires all three store adapters + the Kafka publisher and **spawns the supervised aggregation consumers**, no gRPC ingress). Telemetry, config + hot-reload, health, and graceful shutdown are owned by the runtime.
+
+### Bootstrap (`crates/apps/counter-server`)
+
+```rust
+use counter::service::CounterReadService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("COUNTER_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50064".to_owned()).parse()?;
+    service_runtime::serve::<CounterReadService>(addr).await
+}
+```
+
+> **Build status:** complete through Phase 7 (all 8 phases: scaffold → proto → domain → application+ports → adapters → server+worker wiring → live IT → hardening). The live integration suite is gated behind `integration-counter` and exercises the real Redis + Postgres + Scylla tiers. The reconciliation loop's `Reconciler` + heal-writes are built and tested; wiring a supervised reconcile loop awaits its concrete gRPC `ReconciliationSource` (to `engagement` / `social-graph`) — a documented follow-up, along with a standalone popularity cadence and the concrete shard-fan-out producer.
+>
+> **Authorization (deployment requirement):** `counter` self-authorizes nothing. The read RPCs are caller-facing aggregate magnitudes; gate access at the gateway / `auth-context` before exposure. Counts carry no per-actor identity, so they leak no membership.
+
+---
+
+## ⚙️ Configuration & Runtime Environment &nbsp;·&nbsp; CORE
+
+### `counter`-specific variables *(filled per phase)*
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `COUNTER_GRPC_ADDR` | No | `0.0.0.0:50064` | read-server gRPC listen address |
+| `COUNTER_WORKER_GRPC_ADDR` | No | `0.0.0.0:50065` | worker health/reflection listen address (no domain RPC) |
+| `COUNTER_AGGREGATION_WINDOW_MS` | No | `5000` | tumbling pre-aggregation window (the N→1 collapse) |
+| `COUNTER_FLUSH_INTERVAL_MS` | No | `=window` | how often the worker drains closed windows and flushes |
+| `COUNTER_SHARD_COUNT` | No | `16` | hot-entity key shards (`entity_id:{0..N}`) |
+| `COUNTER_READ_TIMEOUT_MS` | No | `50` | hard per-request hot-read timeout; on elapse the read fails **open** (stale ledger total) |
+| `COUNTER_POPULARITY_INTERVAL_S` | No | `60` | slow-loop cadence for the popularity signal (reserved; currently coupled to flush) |
+| `COUNTER_RECONCILE_INTERVAL_S` | No | `3600` | reconciliation-loop cadence (reserved; awaits the concrete source) |
+| `COUNTER_DRIFT_TOLERANCE` | No | `5` | absolute drift tolerated before reconciliation corrects an exact counter |
+
+### Inherited infrastructure variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `REDIS_URL` | **Yes** | — | hot counter tier |
+| `DATABASE_URL` | **Yes** | — | warm ledger (Postgres) |
+| `SCYLLA_NODES` | **Yes** | — | cold time-series (Scylla) |
+| `KAFKA_BROKERS` | **Yes** | — | ingestion + popularity publish |
+
+### Compile-time features
+- `integration-counter` — gates the live, container-backed integration suite (real Redis + Postgres + Scylla — the full hot/warm/cold tiering).
+- `build.rs` (Phase 1, in `counter-api`) compiles `contracts/proto/counter/v1/*.proto` and emits the reflection descriptor set.
+
+---
+
+## 🚀 Deployment, Migrations & Rollback &nbsp;·&nbsp; OPS
+
+- **Two deployables, scaled independently.** `counter-server` scales with fleet read QPS; `counter-worker` scales with ingest firehose volume. They are released together (same image/tag) but rolled and autoscaled separately.
+- **Schema migrations** (Postgres ledger tables + Scylla TWCS time-series tables) are owned by `crates/apps/migrator`, applied before the new binary serves.
+- **Rebuild from truth.** Because Kafka retention is finite, exact counts are repaired by the **reconciliation loop** scanning/replaying the owning SoR (`engagement` reactions, `social-graph` follows), not by "replay from earliest". Approximate counts (views) are accepted as approximate.
+- **Rollback:** safe — both binaries are stateless over their stores; the worker resumes from last committed offsets, the server is pure read.
+- **Stateful gotchas:** changing `COUNTER_AGGREGATION_WINDOW_MS` or `COUNTER_SHARD_COUNT` mid-flight affects in-flight windows — drain or accept a transient lag blip; durable idempotency keys make it safe, not seamless.
+
+---
+
+## 📈 Telemetry, Performance & Metrics &nbsp;·&nbsp; CORE
+
+- **Runtime:** multi-threaded Tokio. `counter-worker` runs the aggregation consumers + flush scheduler + reconciliation loop; `counter-server` runs the read handlers. Global tracing/OTel subscriber installed before serve; W3C trace-context propagated across the Kafka boundary.
+
+| Signal | Why it matters | Suggested alert |
+|---|---|---|
+| Ingestion lag (per consumer group) | staleness of live counts | sustained `> SLO` ⇒ page |
+| `BatchGetCounters` p99 latency | feed-hydration responsiveness | `> SLO` ⇒ investigate Redis |
+| Durable-flush failure / lag | warm-tier divergence, replay risk | sustained ⇒ page |
+| Reconciliation drift | approximate-vs-truth divergence | `> SLO` ⇒ investigate source stream |
+| DLQ produce rate (`*.dlq`) | poison / retry-exhausted ingestion | any sustained rate ⇒ page |
+
+---
+
+## 🛠️ Local Development &nbsp;·&nbsp; CORE
+
+```bash
+cargo build -p counter && cargo clippy -p counter --all-targets
+cargo test  -p counter                                    # fast, infra-free unit run
+docker compose up -d redis postgres scylla kafka          # repo-root compose (Phase 6)
+cargo test  -p counter --features integration-counter     # live suite (hot/warm/cold tiers)
+```
+
+---
+
+## 🚨 Troubleshooting & Runbook &nbsp;·&nbsp; CORE
+
+> Format: **symptom → root cause → mitigation.** One entry per real incident class.
+
+**1. Counts render stale or zero.**
+Root cause: Redis degraded — reads fail **open** to the last-flushed Postgres total rather than erroring the feed. Mitigation: check Redis health; live counts recover when the hot tier does; the durable total bounds how stale the fallback can be.
+
+**2. New engagement isn't reflected in counts.**
+Root cause: ingestion lag or a stuck consumer. Mitigation: check consumer-group lag and the `*.dlq` topics; a broker/store error holds the offset (no loss), so the worker catches up once the dependency recovers.
+
+**3. A count looks wrong / has drifted.**
+Root cause: at-least-once double-count on an approximate metric, or a missed exact event. Mitigation: approximate metrics are accepted within tolerance; exact metrics self-heal on the next reconciliation cycle — check the reconciliation drift metric and, if `CTR-5002` fired, the source stream.
+
+**4. One viral entity is hot-spotting a partition.**
+Root cause: shard count too low for the entity's rate. Mitigation: raise `COUNTER_SHARD_COUNT`; the two-stage sharded-counter design spreads the entity across more partitions/workers and re-aggregates in Redis.

--- a/crates/services/counter/migrations/postgres/0001_counter_tables.sql
+++ b/crates/services/counter/migrations/postgres/0001_counter_tables.sql
@@ -1,0 +1,24 @@
+-- Warm counter tier (Postgres): the auditable durable totals + the idempotency
+-- ledger. Written only by the worker's batched window flushes; read on a
+-- cache-aside miss and by reconciliation.
+
+-- One row per flushed window. Its existence is the idempotency token: a
+-- redelivered (entity, metric, window_id) hits the PK and is skipped, so the
+-- total is never double-advanced.
+CREATE TABLE IF NOT EXISTS counter_windows (
+    entity_kind TEXT   NOT NULL,
+    entity_id   TEXT   NOT NULL,
+    metric      TEXT   NOT NULL,
+    window_id   BIGINT NOT NULL,
+    PRIMARY KEY (entity_kind, entity_id, metric, window_id)
+);
+
+-- The materialized durable total per (entity, metric) — the auditable
+-- "how many", and the cache-aside fallback when the hot tier is cold.
+CREATE TABLE IF NOT EXISTS counter_totals (
+    entity_kind TEXT   NOT NULL,
+    entity_id   TEXT   NOT NULL,
+    metric      TEXT   NOT NULL,
+    total       BIGINT NOT NULL,
+    PRIMARY KEY (entity_kind, entity_id, metric)
+);

--- a/crates/services/counter/migrations/scylla/0001_counter_keyspace.cql
+++ b/crates/services/counter/migrations/scylla/0001_counter_keyspace.cql
@@ -1,0 +1,6 @@
+-- Cold time-series tier keyspace. The test harness rewrites this to
+-- SimpleStrategy RF=1 for a single-node container; production runs the
+-- NetworkTopologyStrategy below.
+CREATE KEYSPACE IF NOT EXISTS counter
+    WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3}
+    AND durable_writes = true;

--- a/crates/services/counter/migrations/scylla/0002_counter_timeseries.cql
+++ b/crates/services/counter/migrations/scylla/0002_counter_timeseries.cql
@@ -1,0 +1,11 @@
+-- Historical per-bucket rollups. A `counter` column accumulates each window's
+-- scalar contribution into its hour bucket; TWCS keeps time-ordered SSTables
+-- cheap to expire. Read only by GetTimeSeries (off the hot path).
+CREATE TABLE IF NOT EXISTS counter.timeseries (
+    entity_kind  text,
+    entity_id    text,
+    metric       text,
+    bucket_start timestamp,
+    value        counter,
+    PRIMARY KEY ((entity_kind, entity_id, metric), bucket_start)
+) WITH compaction = {'class': 'TimeWindowCompactionStrategy'};

--- a/crates/services/counter/src/app.rs
+++ b/crates/services/counter/src/app.rs
@@ -1,0 +1,162 @@
+//! The counter-analytics composition roots.
+//!
+//! [`compose_read`] is *pure* wiring (the storage ports in, the gRPC read handler
+//! out — no I/O), so the unit/integration graph and the binary build the exact same
+//! handler over the fakes or the real adapters. [`Ports::build`] is the I/O variant
+//! that constructs the three storage adapters from config; both binaries build from
+//! it (the read server uses the ports for the query handlers, the worker additionally
+//! builds the Kafka producer + the write-side handlers).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+
+use crate::application::port::{CounterLedger, CounterStore, TimeSeriesStore};
+use crate::application::query::{BatchGetHandler, TimeSeriesHandler, TrendingHandler};
+use crate::domain::WindowSize;
+use crate::infrastructure::grpc::CounterServiceHandler;
+use crate::infrastructure::pg_counter_ledger::PgCounterLedger;
+use crate::infrastructure::redis_counter_store::RedisCounterStore;
+use crate::infrastructure::scylla_time_series::ScyllaTimeSeriesStore;
+
+/// The shared storage adapter set both binaries build from. Retains the concrete
+/// [`RedisClient`] so the runtime can build a hot-tier liveness probe.
+pub struct Ports {
+    pub store: Arc<dyn CounterStore>,
+    pub ledger: Arc<dyn CounterLedger>,
+    pub series: Arc<dyn TimeSeriesStore>,
+    pub redis: RedisClient,
+}
+
+impl Ports {
+    /// Connects the three storage tiers and wraps them as ports. Connections are
+    /// established eagerly; a tier being briefly down at boot surfaces as an error
+    /// the runtime supervises.
+    pub async fn build(
+        postgres: PostgresConfig,
+        redis: RedisConfig,
+        scylla: ScyllaConfig,
+        window: WindowSize,
+    ) -> Result<Ports, Box<dyn std::error::Error>> {
+        let pool = PgPoolBuilder::build(postgres).await?;
+        let tx = TransactionManager::new(pool);
+        let redis = RedisClientBuilder::new(redis).build().await?;
+        let scylla = Arc::new(ScyllaSessionBuilder::new(scylla).build().await?);
+
+        let store: Arc<dyn CounterStore> = Arc::new(RedisCounterStore::new(redis.clone()));
+        let ledger: Arc<dyn CounterLedger> = Arc::new(PgCounterLedger::new(tx));
+        let series: Arc<dyn TimeSeriesStore> =
+            Arc::new(ScyllaTimeSeriesStore::new(scylla, window));
+
+        Ok(Ports {
+            store,
+            ledger,
+            series,
+            redis,
+        })
+    }
+}
+
+/// Pure read composition: the three query handlers wrapped in the gRPC handler.
+/// Drives the unit/integration graph over the fakes; the binary calls it over the
+/// real adapters.
+pub fn compose_read(
+    store: Arc<dyn CounterStore>,
+    ledger: Arc<dyn CounterLedger>,
+    series: Arc<dyn TimeSeriesStore>,
+    read_timeout: Duration,
+) -> CounterServiceHandler {
+    let batch = Arc::new(BatchGetHandler::new(
+        Arc::clone(&store),
+        Arc::clone(&ledger),
+        read_timeout,
+    ));
+    let trending = Arc::new(TrendingHandler::new(Arc::clone(&store)));
+    let timeseries = Arc::new(TimeSeriesHandler::new(series));
+    CounterServiceHandler::new(batch, trending, timeseries)
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Request;
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{EntityId, EntityKind, EntityRef, Metric};
+    use crate::infrastructure::grpc::proto;
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    #[tokio::test]
+    async fn batch_get_rpc_returns_counts() {
+        let fx = Fixture::new();
+        fx.hot.seed(&post("p1"), Metric::View, 99);
+
+        let handler = compose_read(
+            fx.hot.clone(),
+            fx.ledger.clone(),
+            fx.series.clone(),
+            std::time::Duration::from_secs(5),
+        );
+        let request = Request::new(proto::BatchGetCountersRequest {
+            entities: vec![proto::EntityRef {
+                entity_type: proto::CounterEntityType::Post as i32,
+                id: "p1".into(),
+            }],
+            metrics: vec![proto::CounterMetric::View as i32],
+        });
+        let resp = handler.batch_get_counters(request).await.unwrap().into_inner();
+
+        assert!(!resp.degraded);
+        assert_eq!(resp.snapshots.len(), 1);
+        assert_eq!(resp.snapshots[0].values[0].value, 99);
+        assert_eq!(
+            resp.snapshots[0].values[0].metric,
+            proto::CounterMetric::View as i32
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_get_rpc_rejects_empty_entities() {
+        let fx = Fixture::new();
+        let handler = compose_read(
+            fx.hot.clone(),
+            fx.ledger.clone(),
+            fx.series.clone(),
+            std::time::Duration::from_secs(5),
+        );
+        let request = Request::new(proto::BatchGetCountersRequest {
+            entities: vec![],
+            metrics: vec![],
+        });
+        let status = handler.batch_get_counters(request).await.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    // Ensures the query handler is reachable through the trait impl (used by tonic).
+    #[tokio::test]
+    async fn trending_rpc_through_handler() {
+        let fx = Fixture::new();
+        fx.hot.seed_trending(Metric::View, &post("hot"), 500);
+        let handler = compose_read(
+            fx.hot.clone(),
+            fx.ledger.clone(),
+            fx.series.clone(),
+            std::time::Duration::from_secs(5),
+        );
+        let request = Request::new(proto::GetTrendingRequest {
+            scope: proto::TrendingScope::Global as i32,
+            scope_key: String::new(),
+            metric: proto::CounterMetric::View as i32,
+            limit: 10,
+        });
+        let resp = handler.get_trending(request).await.unwrap().into_inner();
+        assert_eq!(resp.entries.len(), 1);
+        assert_eq!(resp.entries[0].entity.as_ref().unwrap().id, "hot");
+    }
+}

--- a/crates/services/counter/src/application/command/flush.rs
+++ b/crates/services/counter/src/application/command/flush.rs
@@ -1,0 +1,138 @@
+//! The write-side use case: flush closed window deltas across the three storage
+//! tiers. This is the application service the worker drives after draining the
+//! domain [`WindowAggregator`](crate::domain::WindowAggregator); the windowing
+//! itself is stateful and lives in the worker (Phase 5), not here.
+//!
+//! Like `search`/`moderation`, this is a plain application-service struct (not a
+//! `cqrs::CommandHandler`): it returns a rich [`FlushReport`] for metrics rather
+//! than a bare `Result<()>`.
+
+use std::sync::Arc;
+
+use crate::application::port::{CounterLedger, CounterStore, FlushOutcome, TimeSeriesStore};
+use crate::domain::WindowDelta;
+use crate::error::CounterError;
+
+/// What a flush batch did, for observability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FlushReport {
+    /// Windows applied for the first time (durable total advanced).
+    pub applied: usize,
+    /// Windows that were redeliveries — already durably flushed, so skipped across
+    /// all tiers (no double-add).
+    pub already_applied: usize,
+}
+
+impl FlushReport {
+    pub fn total(&self) -> usize {
+        self.applied + self.already_applied
+    }
+}
+
+/// Fans a closed window delta out to the hot tier, the durable ledger, and the
+/// cold time-series.
+///
+/// **The durable ledger's idempotency gates every side effect.** `flush_window`
+/// is keyed by `(entity, metric, window_id)`; only when it reports
+/// [`FlushOutcome::Applied`] (a first-time flush) does the delta also land in the
+/// hot tier and the time-series. A Kafka redelivery therefore re-runs the whole
+/// fan-out as a true no-op — no double-counted view, no double-incremented HLL.
+///
+/// Ingestion **fails closed**: any tier error propagates so the consumer retries
+/// then dead-letters, rather than silently dropping a window.
+pub struct DeltaFlusher {
+    hot: Arc<dyn CounterStore>,
+    ledger: Arc<dyn CounterLedger>,
+    series: Arc<dyn TimeSeriesStore>,
+}
+
+impl DeltaFlusher {
+    pub fn new(
+        hot: Arc<dyn CounterStore>,
+        ledger: Arc<dyn CounterLedger>,
+        series: Arc<dyn TimeSeriesStore>,
+    ) -> Self {
+        Self {
+            hot,
+            ledger,
+            series,
+        }
+    }
+
+    /// Flush a batch of closed window deltas. Returns once every delta has reached
+    /// a terminal tier outcome, or on the first propagating error.
+    pub async fn flush(&self, deltas: &[WindowDelta]) -> Result<FlushReport, CounterError> {
+        let mut report = FlushReport::default();
+        for delta in deltas {
+            match self.ledger.flush_window(delta).await? {
+                FlushOutcome::Applied => {
+                    self.hot.apply_delta(delta).await?;
+                    self.series.append(delta).await?;
+                    report.applied += 1;
+                }
+                FlushOutcome::AlreadyApplied => {
+                    report.already_applied += 1;
+                }
+            }
+        }
+        Ok(report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{
+        EntityId, EntityKind, EntityRef, Metric, Observation, WindowAggregator, WindowSize,
+    };
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    fn one_view_window(id: &str, views: i64) -> Vec<WindowDelta> {
+        let mut agg = WindowAggregator::new(WindowSize::from_millis(5_000).unwrap());
+        let at = Utc.timestamp_millis_opt(1_000).unwrap();
+        for _ in 0..views {
+            agg.fold(Observation::sum(post(id), Metric::View, 1, at).unwrap())
+                .unwrap();
+        }
+        agg.drain_all()
+    }
+
+    #[tokio::test]
+    async fn first_flush_lands_in_all_tiers() {
+        let fx = Fixture::new();
+        let flusher = fx.delta_flusher();
+        let deltas = one_view_window("p1", 1000);
+
+        let report = flusher.flush(&deltas).await.unwrap();
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.already_applied, 0);
+
+        assert_eq!(fx.ledger.total(&post("p1"), Metric::View), Some(1000));
+        assert_eq!(fx.hot.value(&post("p1"), Metric::View), 1000);
+        assert_eq!(fx.series.bucket_count(&post("p1"), Metric::View), 1);
+    }
+
+    #[tokio::test]
+    async fn redelivered_window_is_a_no_op_across_all_tiers() {
+        let fx = Fixture::new();
+        let flusher = fx.delta_flusher();
+        let deltas = one_view_window("p1", 1000);
+
+        flusher.flush(&deltas).await.unwrap();
+        // Exact same window (same window_id) redelivered.
+        let report = flusher.flush(&deltas).await.unwrap();
+
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.already_applied, 1);
+        // Hot counter did NOT double — idempotency gated the side effects.
+        assert_eq!(fx.hot.value(&post("p1"), Metric::View), 1000);
+        assert_eq!(fx.ledger.total(&post("p1"), Metric::View), Some(1000));
+        assert_eq!(fx.series.bucket_count(&post("p1"), Metric::View), 1);
+    }
+}

--- a/crates/services/counter/src/application/command/mod.rs
+++ b/crates/services/counter/src/application/command/mod.rs
@@ -1,0 +1,12 @@
+//! Write-side use cases. Both are plain application-service structs (not
+//! `cqrs::CommandHandler`s): the ingestion path returns a rich [`FlushReport`], and
+//! the popularity path is a slow-loop side effect — neither fits the
+//! command-bus request/response shape.
+
+pub mod flush;
+pub mod popularity;
+pub mod reconcile;
+
+pub use flush::{DeltaFlusher, FlushReport};
+pub use popularity::PopularityPublisher;
+pub use reconcile::{ReconcileOutcome, Reconciler};

--- a/crates/services/counter/src/application/command/popularity.rs
+++ b/crates/services/counter/src/application/command/popularity.rs
@@ -1,0 +1,85 @@
+//! The slow-loop popularity publisher: read an entity's coarse magnitudes, derive
+//! the popularity score, and emit it on `counter.v1.popularity`.
+//!
+//! This is what unblocks `search`'s `PopularityScore` ranking input. It is
+//! deliberately decoupled from ingestion — driven on a slow cadence by the worker
+//! (Phase 5), never per-event — so updating a ranking signal never amplifies the
+//! firehose.
+
+use std::sync::Arc;
+
+use crate::application::port::{CounterStore, SignalPublisher};
+use crate::domain::{EntityRef, Metric, PopularityWeights};
+use crate::error::CounterError;
+
+/// The metrics that feed the coarse popularity score. Reading only these keeps the
+/// slow-loop read cheap.
+const POPULARITY_METRICS: [Metric; 4] =
+    [Metric::View, Metric::Like, Metric::Share, Metric::Comment];
+
+/// Derives and publishes the coarse popularity signal for an entity.
+pub struct PopularityPublisher {
+    hot: Arc<dyn CounterStore>,
+    publisher: Arc<dyn SignalPublisher>,
+    weights: PopularityWeights,
+}
+
+impl PopularityPublisher {
+    pub fn new(hot: Arc<dyn CounterStore>, publisher: Arc<dyn SignalPublisher>) -> Self {
+        Self {
+            hot,
+            publisher,
+            weights: PopularityWeights::default(),
+        }
+    }
+
+    pub fn with_weights(mut self, weights: PopularityWeights) -> Self {
+        self.weights = weights;
+        self
+    }
+
+    /// Read the entity's popularity-relevant magnitudes, blend them, and publish.
+    pub async fn publish(&self, entity: &EntityRef) -> Result<(), CounterError> {
+        let snapshots = self
+            .hot
+            .read(std::slice::from_ref(entity), &POPULARITY_METRICS)
+            .await?;
+        let score = snapshots
+            .first()
+            .map(|snap| snap.popularity(&self.weights))
+            .unwrap_or_default();
+        self.publisher.publish_popularity(entity, score).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{EntityId, EntityKind};
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    #[tokio::test]
+    async fn derives_and_publishes_weighted_score() {
+        let fx = Fixture::new();
+        // 100 views (*0.1=10) + 5 shares (*3.0=15) = 25
+        fx.hot.seed(&post("p1"), Metric::View, 100);
+        fx.hot.seed(&post("p1"), Metric::Share, 5);
+
+        let pp = fx.popularity_publisher();
+        pp.publish(&post("p1")).await.unwrap();
+
+        assert_eq!(fx.publisher.last_score(&post("p1")), Some(25.0));
+    }
+
+    #[tokio::test]
+    async fn unknown_entity_publishes_zero() {
+        let fx = Fixture::new();
+        let pp = fx.popularity_publisher();
+        pp.publish(&post("ghost")).await.unwrap();
+        assert_eq!(fx.publisher.last_score(&post("ghost")), Some(0.0));
+    }
+}

--- a/crates/services/counter/src/application/command/reconcile.rs
+++ b/crates/services/counter/src/application/command/reconcile.rs
@@ -1,0 +1,155 @@
+//! The reconciliation use case — the self-heal that makes an *exact* metric
+//! trustworthy despite at-least-once delivery.
+//!
+//! The hot counter for a like/follow drifts: a redelivered window that the ledger
+//! gated still applied to the HLL-free sum on a partial failure, a lost window
+//! under-counts, etc. Periodically the reconciler asks the owning service for the
+//! true magnitude and, if the durable total has drifted beyond tolerance, heals
+//! both the durable total and the hot counter to the authoritative value. Approximate
+//! metrics (views) are never reconciled — they are accepted within their error bound.
+
+use std::sync::Arc;
+
+use crate::application::port::{CounterLedger, CounterStore, ReconciliationSource};
+use crate::domain::{EntityRef, Metric, MetricKind};
+use crate::error::CounterError;
+
+/// What a single reconciliation did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconcileOutcome {
+    /// The durable total already matched the authoritative count.
+    InSync,
+    /// Drift existed but stayed within tolerance — left untouched to avoid churn.
+    WithinTolerance { drift: i64 },
+    /// Drift exceeded tolerance; the total + hot counter were healed.
+    Corrected { from: i64, to: i64 },
+    /// Not reconcilable: an approximate metric, or the source does not own this
+    /// `(entity, metric)`.
+    NotApplicable,
+}
+
+/// Reconciles exact counters against the owning source-of-record.
+pub struct Reconciler {
+    store: Arc<dyn CounterStore>,
+    ledger: Arc<dyn CounterLedger>,
+    source: Arc<dyn ReconciliationSource>,
+    /// Absolute drift tolerated before a correction is applied.
+    tolerance: i64,
+}
+
+impl Reconciler {
+    pub fn new(
+        store: Arc<dyn CounterStore>,
+        ledger: Arc<dyn CounterLedger>,
+        source: Arc<dyn ReconciliationSource>,
+        tolerance: i64,
+    ) -> Self {
+        Self {
+            store,
+            ledger,
+            source,
+            tolerance,
+        }
+    }
+
+    /// Reconcile one `(entity, metric)`. Only exact metrics are reconcilable.
+    pub async fn reconcile(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<ReconcileOutcome, CounterError> {
+        if metric.kind() != MetricKind::Exact {
+            return Ok(ReconcileOutcome::NotApplicable);
+        }
+
+        let authoritative = match self.source.authoritative_count(entity, metric).await? {
+            Some(value) => value,
+            None => return Ok(ReconcileOutcome::NotApplicable),
+        };
+
+        let current = self.ledger.read_total(entity, metric).await?.unwrap_or(0);
+        let drift = authoritative - current;
+
+        if drift == 0 {
+            return Ok(ReconcileOutcome::InSync);
+        }
+        if drift.abs() <= self.tolerance {
+            return Ok(ReconcileOutcome::WithinTolerance { drift });
+        }
+
+        // Heal both tiers to truth. The hot overwrite is a set, not a delta.
+        self.ledger.set_total(entity, metric, authoritative).await?;
+        self.store.overwrite(entity, metric, authoritative).await?;
+
+        // CTR-5002 is the drift alarm; emitted as an operational signal (the
+        // correction itself succeeded, so this is a warning, not a returned error).
+        tracing::warn!(
+            code = "CTR-5002",
+            entity_kind = entity.kind.as_str(),
+            entity_id = entity.id.as_str(),
+            metric = metric.as_str(),
+            from = current,
+            to = authoritative,
+            "counter drift exceeded tolerance; corrected against source-of-record"
+        );
+
+        Ok(ReconcileOutcome::Corrected {
+            from: current,
+            to: authoritative,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{EntityId, EntityKind};
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    #[tokio::test]
+    async fn corrects_drift_beyond_tolerance() {
+        let fx = Fixture::new();
+        // Durable total drifted low; SoR says 1000.
+        fx.ledger.seed_total(&post("p1"), Metric::Like, 940);
+        fx.source.set_authoritative(&post("p1"), Metric::Like, 1000);
+
+        let reconciler = fx.reconciler(5);
+        let outcome = reconciler.reconcile(&post("p1"), Metric::Like).await.unwrap();
+
+        assert_eq!(outcome, ReconcileOutcome::Corrected { from: 940, to: 1000 });
+        assert_eq!(fx.ledger.total(&post("p1"), Metric::Like), Some(1000));
+        assert_eq!(fx.hot.value(&post("p1"), Metric::Like), 1000);
+    }
+
+    #[tokio::test]
+    async fn leaves_small_drift_untouched() {
+        let fx = Fixture::new();
+        fx.ledger.seed_total(&post("p1"), Metric::Like, 998);
+        fx.source.set_authoritative(&post("p1"), Metric::Like, 1000);
+
+        let outcome = fx.reconciler(5).reconcile(&post("p1"), Metric::Like).await.unwrap();
+        assert_eq!(outcome, ReconcileOutcome::WithinTolerance { drift: 2 });
+        // Unchanged.
+        assert_eq!(fx.ledger.total(&post("p1"), Metric::Like), Some(998));
+    }
+
+    #[tokio::test]
+    async fn approximate_metrics_are_not_reconciled() {
+        let fx = Fixture::new();
+        fx.source.set_authoritative(&post("p1"), Metric::View, 1000);
+        let outcome = fx.reconciler(5).reconcile(&post("p1"), Metric::View).await.unwrap();
+        assert_eq!(outcome, ReconcileOutcome::NotApplicable);
+    }
+
+    #[tokio::test]
+    async fn unknown_to_source_is_not_applicable() {
+        let fx = Fixture::new();
+        // No authoritative value seeded.
+        let outcome = fx.reconciler(5).reconcile(&post("ghost"), Metric::Like).await.unwrap();
+        assert_eq!(outcome, ReconcileOutcome::NotApplicable);
+    }
+}

--- a/crates/services/counter/src/application/command/reconcile.rs
+++ b/crates/services/counter/src/application/command/reconcile.rs
@@ -152,4 +152,34 @@ mod tests {
         let outcome = fx.reconciler(5).reconcile(&post("ghost"), Metric::Like).await.unwrap();
         assert_eq!(outcome, ReconcileOutcome::NotApplicable);
     }
+
+    fn profile(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Profile, EntityId::new(id).unwrap())
+    }
+
+    #[tokio::test]
+    async fn candidate_scan_lists_only_reconcilable_metrics_and_pages() {
+        use crate::application::port::{CounterLedger, reconcile_cursor};
+
+        let fx = Fixture::new();
+        fx.ledger.seed_total(&profile("a"), Metric::Follower, 10);
+        fx.ledger.seed_total(&profile("a"), Metric::Following, 5);
+        fx.ledger.seed_total(&profile("b"), Metric::Follower, 20);
+        fx.ledger.seed_total(&post("p"), Metric::View, 999); // approximate → excluded
+        fx.ledger.seed_total(&post("p"), Metric::Like, 7); // no source RPC → excluded
+
+        // Full page: exactly the three follower/following pairs, cursor-ordered.
+        let all = fx.ledger.list_reconcilable(None, 100).await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(all.iter().all(|(e, m)| e.kind == EntityKind::Profile
+            && matches!(m, Metric::Follower | Metric::Following)));
+
+        // Paging: first 2, then the rest after the cursor.
+        let first = fx.ledger.list_reconcilable(None, 2).await.unwrap();
+        assert_eq!(first.len(), 2);
+        let (last_e, last_m) = first.last().unwrap();
+        let cursor = reconcile_cursor(last_e, *last_m);
+        let rest = fx.ledger.list_reconcilable(Some(&cursor), 100).await.unwrap();
+        assert_eq!(rest.len(), 1);
+    }
 }

--- a/crates/services/counter/src/application/fakes.rs
+++ b/crates/services/counter/src/application/fakes.rs
@@ -1,0 +1,473 @@
+//! In-memory fakes for the four ports, plus a [`Fixture`] composition root, for
+//! the application unit tests. They model the semantics that matter — the durable
+//! ledger's `(entity, metric, window_id)` idempotency, the hot tier's sum/HLL
+//! split, the fail-open `unavailable` toggle — without any container.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+
+use crate::application::command::{DeltaFlusher, PopularityPublisher, Reconciler};
+use crate::application::port::{
+    CounterLedger, CounterStore, FlushOutcome, ReconciliationSource, SignalPublisher,
+    TimeSeriesStore,
+};
+use crate::application::query::{BatchGetHandler, TimeSeriesHandler, TrendingHandler};
+use crate::domain::{
+    Aggregation, CountSnapshot, CounterValue, EntityRef, Metric, PopularityScore, TimeSeriesBucket,
+    TimeSeriesQuery, TrendingItem, TrendingScope, WindowDelta,
+};
+use crate::error::CounterError;
+
+type MetricKey = (String, String, String);
+type EntityKey = (String, String);
+/// Per-metric trending board: entity key → (entity, accumulated score).
+type TrendingBoard = HashMap<String, HashMap<EntityKey, (EntityRef, i64)>>;
+/// Per-`(entity, metric)` time-series: a list of `(bucket_start, value)` points.
+type SeriesStore = HashMap<MetricKey, Vec<(DateTime<Utc>, i64)>>;
+
+fn mkey(entity: &EntityRef, metric: Metric) -> MetricKey {
+    (
+        entity.kind.as_str().to_owned(),
+        entity.id.as_str().to_owned(),
+        metric.as_str().to_owned(),
+    )
+}
+
+fn ekey(entity: &EntityRef) -> EntityKey {
+    (
+        entity.kind.as_str().to_owned(),
+        entity.id.as_str().to_owned(),
+    )
+}
+
+// ── Hot tier (Redis analogue) ─────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct InMemoryHotStore {
+    sums: Mutex<HashMap<MetricKey, i64>>,
+    hll: Mutex<HashMap<MetricKey, BTreeSet<String>>>,
+    trending: Mutex<TrendingBoard>,
+    unavailable: AtomicBool,
+    /// Artificial read latency, in millis, to exercise the read-path timeout.
+    read_delay_ms: AtomicU64,
+}
+
+impl InMemoryHotStore {
+    pub fn set_unavailable(&self, down: bool) {
+        self.unavailable.store(down, Ordering::SeqCst);
+    }
+
+    /// Make `read` sleep this long, to trip the handler's hard timeout.
+    pub fn set_read_delay(&self, delay: Duration) {
+        self.read_delay_ms
+            .store(delay.as_millis() as u64, Ordering::SeqCst);
+    }
+
+    fn guard(&self) -> Result<(), CounterError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(CounterError::HotStoreUnavailable);
+        }
+        Ok(())
+    }
+
+    pub fn seed(&self, entity: &EntityRef, metric: Metric, value: i64) {
+        self.sums.lock().unwrap().insert(mkey(entity, metric), value);
+    }
+
+    pub fn seed_trending(&self, metric: Metric, entity: &EntityRef, score: i64) {
+        self.trending
+            .lock()
+            .unwrap()
+            .entry(metric.as_str().to_owned())
+            .or_default()
+            .insert(ekey(entity), (entity.clone(), score));
+    }
+
+    /// The current value of a metric (sum counter or HLL cardinality), for asserts.
+    pub fn value(&self, entity: &EntityRef, metric: Metric) -> i64 {
+        match metric.aggregation() {
+            Aggregation::Sum => self
+                .sums
+                .lock()
+                .unwrap()
+                .get(&mkey(entity, metric))
+                .copied()
+                .unwrap_or(0),
+            Aggregation::Cardinality => self
+                .hll
+                .lock()
+                .unwrap()
+                .get(&mkey(entity, metric))
+                .map(|s| s.len() as i64)
+                .unwrap_or(0),
+        }
+    }
+}
+
+#[async_trait]
+impl CounterStore for InMemoryHotStore {
+    async fn apply_delta(&self, delta: &WindowDelta) -> Result<(), CounterError> {
+        self.guard()?;
+        let metric = delta.metric();
+        let key = mkey(delta.entity(), metric);
+        match metric.aggregation() {
+            Aggregation::Sum => {
+                *self.sums.lock().unwrap().entry(key).or_insert(0) += delta.sum;
+                let mut t = self.trending.lock().unwrap();
+                let bucket = t.entry(metric.as_str().to_owned()).or_default();
+                let entry = bucket
+                    .entry(ekey(delta.entity()))
+                    .or_insert_with(|| (delta.entity().clone(), 0));
+                entry.1 += delta.sum;
+            }
+            Aggregation::Cardinality => {
+                let mut hll = self.hll.lock().unwrap();
+                let set = hll.entry(key).or_default();
+                for m in &delta.unique_members {
+                    set.insert(m.as_str().to_owned());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn read(
+        &self,
+        entities: &[EntityRef],
+        metrics: &[Metric],
+    ) -> Result<Vec<CountSnapshot>, CounterError> {
+        let delay = self.read_delay_ms.load(Ordering::SeqCst);
+        if delay > 0 {
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+        }
+        self.guard()?;
+        let sums = self.sums.lock().unwrap();
+        let hll = self.hll.lock().unwrap();
+        let mut out = Vec::with_capacity(entities.len());
+        for entity in entities {
+            let mut values = Vec::new();
+            for &metric in metrics {
+                let key = mkey(entity, metric);
+                let v = match metric.aggregation() {
+                    Aggregation::Sum => sums.get(&key).copied(),
+                    Aggregation::Cardinality => hll.get(&key).map(|s| s.len() as i64),
+                };
+                if let Some(v) = v {
+                    values.push(CounterValue::new(metric, v));
+                }
+            }
+            out.push(CountSnapshot::new(entity.clone(), values));
+        }
+        Ok(out)
+    }
+
+    async fn top_k(
+        &self,
+        scope: TrendingScope,
+        _scope_key: Option<&str>,
+        metric: Metric,
+        limit: usize,
+    ) -> Result<Vec<TrendingItem>, CounterError> {
+        self.guard()?;
+        if scope != TrendingScope::Global {
+            return Ok(Vec::new()); // scoped trending not modeled in the fake
+        }
+        let trending = self.trending.lock().unwrap();
+        let mut ranked: Vec<(EntityRef, i64)> = trending
+            .get(metric.as_str())
+            .map(|b| b.values().cloned().collect())
+            .unwrap_or_default();
+        ranked.sort_by(|a, b| b.1.cmp(&a.1));
+        Ok(ranked
+            .into_iter()
+            .take(limit)
+            .enumerate()
+            .map(|(i, (entity, score))| TrendingItem {
+                entity,
+                score,
+                rank: i as u32,
+            })
+            .collect())
+    }
+
+    async fn overwrite(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+        value: i64,
+    ) -> Result<(), CounterError> {
+        self.guard()?;
+        self.sums.lock().unwrap().insert(mkey(entity, metric), value);
+        Ok(())
+    }
+}
+
+// ── Warm tier (Postgres ledger analogue) ──────────────────────────────────────
+
+#[derive(Default)]
+pub struct InMemoryLedger {
+    totals: Mutex<HashMap<MetricKey, i64>>,
+    applied: Mutex<HashSet<(String, String, String, u64)>>,
+    unavailable: AtomicBool,
+}
+
+impl InMemoryLedger {
+    pub fn set_unavailable(&self, down: bool) {
+        self.unavailable.store(down, Ordering::SeqCst);
+    }
+
+    fn guard(&self) -> Result<(), CounterError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(CounterError::LedgerUnavailable);
+        }
+        Ok(())
+    }
+
+    pub fn seed_total(&self, entity: &EntityRef, metric: Metric, value: i64) {
+        self.totals
+            .lock()
+            .unwrap()
+            .insert(mkey(entity, metric), value);
+    }
+
+    pub fn total(&self, entity: &EntityRef, metric: Metric) -> Option<i64> {
+        self.totals.lock().unwrap().get(&mkey(entity, metric)).copied()
+    }
+}
+
+#[async_trait]
+impl CounterLedger for InMemoryLedger {
+    async fn flush_window(&self, delta: &WindowDelta) -> Result<FlushOutcome, CounterError> {
+        self.guard()?;
+        let (k0, k1, k2) = mkey(delta.entity(), delta.metric());
+        let window_key = (k0.clone(), k1.clone(), k2.clone(), delta.window().index());
+        let mut applied = self.applied.lock().unwrap();
+        if !applied.insert(window_key) {
+            return Ok(FlushOutcome::AlreadyApplied);
+        }
+        *self.totals.lock().unwrap().entry((k0, k1, k2)).or_insert(0) += delta.scalar();
+        Ok(FlushOutcome::Applied)
+    }
+
+    async fn read_total(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError> {
+        self.guard()?;
+        Ok(self.total(entity, metric))
+    }
+
+    async fn set_total(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+        value: i64,
+    ) -> Result<(), CounterError> {
+        self.guard()?;
+        self.totals
+            .lock()
+            .unwrap()
+            .insert(mkey(entity, metric), value);
+        Ok(())
+    }
+}
+
+// ── Cold tier (Scylla time-series analogue) ───────────────────────────────────
+
+#[derive(Default)]
+pub struct InMemoryTimeSeries {
+    buckets: Mutex<SeriesStore>,
+    unavailable: AtomicBool,
+}
+
+impl InMemoryTimeSeries {
+    pub fn set_unavailable(&self, down: bool) {
+        self.unavailable.store(down, Ordering::SeqCst);
+    }
+
+    fn guard(&self) -> Result<(), CounterError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(CounterError::TimeSeriesUnavailable);
+        }
+        Ok(())
+    }
+
+    pub fn seed_bucket(&self, entity: &EntityRef, metric: Metric, start: DateTime<Utc>, value: i64) {
+        self.buckets
+            .lock()
+            .unwrap()
+            .entry(mkey(entity, metric))
+            .or_default()
+            .push((start, value));
+    }
+
+    pub fn bucket_count(&self, entity: &EntityRef, metric: Metric) -> usize {
+        self.buckets
+            .lock()
+            .unwrap()
+            .get(&mkey(entity, metric))
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+}
+
+#[async_trait]
+impl TimeSeriesStore for InMemoryTimeSeries {
+    async fn append(&self, delta: &WindowDelta) -> Result<(), CounterError> {
+        self.guard()?;
+        // Synthesize a deterministic bucket instant from the window index.
+        let start = Utc.timestamp_millis_opt(delta.window().index() as i64).unwrap();
+        self.seed_bucket(delta.entity(), delta.metric(), start, delta.scalar());
+        Ok(())
+    }
+
+    async fn range(&self, query: &TimeSeriesQuery) -> Result<Vec<TimeSeriesBucket>, CounterError> {
+        self.guard()?;
+        let buckets = self.buckets.lock().unwrap();
+        let mut out: Vec<TimeSeriesBucket> = buckets
+            .get(&mkey(&query.entity, query.metric))
+            .map(|series| {
+                series
+                    .iter()
+                    .filter(|(ts, _)| *ts >= query.start && *ts < query.end)
+                    .map(|(ts, v)| TimeSeriesBucket {
+                        bucket_start: *ts,
+                        value: *v,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        out.sort_by_key(|b| b.bucket_start);
+        Ok(out)
+    }
+}
+
+// ── Signal publisher (Kafka analogue) ─────────────────────────────────────────
+
+#[derive(Default)]
+pub struct InMemorySignalPublisher {
+    scores: Mutex<HashMap<EntityKey, f64>>,
+}
+
+impl InMemorySignalPublisher {
+    pub fn last_score(&self, entity: &EntityRef) -> Option<f64> {
+        self.scores.lock().unwrap().get(&ekey(entity)).copied()
+    }
+}
+
+#[async_trait]
+impl SignalPublisher for InMemorySignalPublisher {
+    async fn publish_popularity(
+        &self,
+        entity: &EntityRef,
+        score: PopularityScore,
+    ) -> Result<(), CounterError> {
+        self.scores
+            .lock()
+            .unwrap()
+            .insert(ekey(entity), score.value());
+        Ok(())
+    }
+}
+
+// ── Reconciliation source (engagement / social-graph analogue) ────────────────
+
+#[derive(Default)]
+pub struct InMemoryReconciliationSource {
+    authoritative: Mutex<HashMap<MetricKey, i64>>,
+}
+
+impl InMemoryReconciliationSource {
+    pub fn set_authoritative(&self, entity: &EntityRef, metric: Metric, value: i64) {
+        self.authoritative
+            .lock()
+            .unwrap()
+            .insert(mkey(entity, metric), value);
+    }
+}
+
+#[async_trait]
+impl ReconciliationSource for InMemoryReconciliationSource {
+    async fn authoritative_count(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError> {
+        Ok(self
+            .authoritative
+            .lock()
+            .unwrap()
+            .get(&mkey(entity, metric))
+            .copied())
+    }
+}
+
+// ── Composition root ──────────────────────────────────────────────────────────
+
+/// Holds the concrete fakes (so tests can seed + assert) and builds the
+/// application services over them as `Arc<dyn …>`.
+pub struct Fixture {
+    pub hot: std::sync::Arc<InMemoryHotStore>,
+    pub ledger: std::sync::Arc<InMemoryLedger>,
+    pub series: std::sync::Arc<InMemoryTimeSeries>,
+    pub publisher: std::sync::Arc<InMemorySignalPublisher>,
+    pub source: std::sync::Arc<InMemoryReconciliationSource>,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        Self {
+            hot: std::sync::Arc::new(InMemoryHotStore::default()),
+            ledger: std::sync::Arc::new(InMemoryLedger::default()),
+            series: std::sync::Arc::new(InMemoryTimeSeries::default()),
+            publisher: std::sync::Arc::new(InMemorySignalPublisher::default()),
+            source: std::sync::Arc::new(InMemoryReconciliationSource::default()),
+        }
+    }
+
+    pub fn delta_flusher(&self) -> DeltaFlusher {
+        DeltaFlusher::new(self.hot.clone(), self.ledger.clone(), self.series.clone())
+    }
+
+    pub fn popularity_publisher(&self) -> PopularityPublisher {
+        PopularityPublisher::new(self.hot.clone(), self.publisher.clone())
+    }
+
+    pub fn reconciler(&self, tolerance: i64) -> Reconciler {
+        Reconciler::new(
+            self.hot.clone(),
+            self.ledger.clone(),
+            self.source.clone(),
+            tolerance,
+        )
+    }
+
+    /// A generous default read timeout that never trips in tests.
+    pub fn batch_get_handler(&self) -> BatchGetHandler {
+        BatchGetHandler::new(
+            self.hot.clone(),
+            self.ledger.clone(),
+            std::time::Duration::from_secs(5),
+        )
+    }
+
+    pub fn trending_handler(&self) -> TrendingHandler {
+        TrendingHandler::new(self.hot.clone())
+    }
+
+    pub fn time_series_handler(&self) -> TimeSeriesHandler {
+        TimeSeriesHandler::new(self.series.clone())
+    }
+}
+
+impl Default for Fixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/services/counter/src/application/fakes.rs
+++ b/crates/services/counter/src/application/fakes.rs
@@ -276,6 +276,37 @@ impl CounterLedger for InMemoryLedger {
             .insert(mkey(entity, metric), value);
         Ok(())
     }
+
+    async fn list_reconcilable(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(EntityRef, Metric)>, CounterError> {
+        self.guard()?;
+        let totals = self.totals.lock().unwrap();
+        let mut pairs: Vec<(String, EntityRef, Metric)> = totals
+            .keys()
+            .filter_map(|(kind, id, metric)| {
+                let metric = Metric::try_from_str(metric).ok()?;
+                if !matches!(metric, Metric::Follower | Metric::Following) {
+                    return None;
+                }
+                let entity = EntityRef::new(
+                    crate::domain::EntityKind::try_from_str(kind).ok()?,
+                    crate::domain::EntityId::new(id.clone()).ok()?,
+                );
+                let cursor = format!("{kind}:{id}:{}", metric.as_str());
+                Some((cursor, entity, metric))
+            })
+            .collect();
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(pairs
+            .into_iter()
+            .filter(|(cursor, _, _)| after.map(|a| cursor.as_str() > a).unwrap_or(true))
+            .take(limit.max(0) as usize)
+            .map(|(_, entity, metric)| (entity, metric))
+            .collect())
+    }
 }
 
 // ── Cold tier (Scylla time-series analogue) ───────────────────────────────────

--- a/crates/services/counter/src/application/mod.rs
+++ b/crates/services/counter/src/application/mod.rs
@@ -1,0 +1,29 @@
+//! The counter-analytics application layer — use-case orchestration over the
+//! domain and the ports.
+//!
+//! ## Handler shape
+//! The write-side use cases ([`command::DeltaFlusher`], [`command::PopularityPublisher`])
+//! are plain application-service structs (not `cqrs::CommandHandler`s): the flush
+//! returns a rich [`command::FlushReport`], and the popularity publisher is a
+//! slow-loop side effect — neither fits the command-bus request/response shape.
+//! The read-side use cases ([`query::BatchGetHandler`], [`query::TrendingHandler`],
+//! [`query::TimeSeriesHandler`]) implement [`cqrs::QueryHandler`] and ride the
+//! query bus.
+//!
+//! ## Ports
+//! Every external dependency is an `async_trait` port in [`port`], injected as an
+//! `Arc<dyn …>` at the composition root, so the handlers never name a concrete
+//! adapter. In-memory fakes back the unit tests.
+
+pub mod command;
+pub mod port;
+pub mod query;
+
+#[cfg(test)]
+pub mod fakes;
+
+pub use command::{DeltaFlusher, FlushReport, PopularityPublisher};
+pub use port::{CounterLedger, CounterStore, FlushOutcome, SignalPublisher, TimeSeriesStore};
+pub use query::{
+    BatchGetHandler, RunBatchGet, RunTimeSeries, RunTrending, TimeSeriesHandler, TrendingHandler,
+};

--- a/crates/services/counter/src/application/port/counter_ledger.rs
+++ b/crates/services/counter/src/application/port/counter_ledger.rs
@@ -47,4 +47,26 @@ pub trait CounterLedger: Send + Sync + 'static {
         metric: Metric,
         value: i64,
     ) -> Result<(), CounterError>;
+
+    /// Page through the `(entity, metric)` pairs the reconciliation loop can correct
+    /// — those whose metric has an authoritative source (today: follower/following).
+    /// `after` is the opaque cursor of the last pair from the previous page
+    /// (`"{kind}:{id}:{metric}"`); `None` starts from the beginning. An empty result
+    /// signals the end of the sweep (the loop wraps back to the start).
+    async fn list_reconcilable(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(EntityRef, Metric)>, CounterError>;
+}
+
+/// The opaque reconciliation cursor for a pair — must match the ordering key the
+/// ledger pages by.
+pub fn reconcile_cursor(entity: &EntityRef, metric: Metric) -> String {
+    format!(
+        "{}:{}:{}",
+        entity.kind.as_str(),
+        entity.id.as_str(),
+        metric.as_str()
+    )
 }

--- a/crates/services/counter/src/application/port/counter_ledger.rs
+++ b/crates/services/counter/src/application/port/counter_ledger.rs
@@ -1,0 +1,50 @@
+use async_trait::async_trait;
+
+use crate::domain::{EntityRef, Metric, WindowDelta};
+use crate::error::CounterError;
+
+/// The result of an idempotent durable flush.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlushOutcome {
+    /// The window was applied to the durable total for the first time.
+    Applied,
+    /// This `(entity, metric, window_id)` was already flushed — a redelivery. The
+    /// durable total was NOT changed (no double-add). The consumer commits
+    /// regardless.
+    AlreadyApplied,
+}
+
+/// The warm counter tier (Postgres) — the auditable materialized totals and the
+/// reconciliation ledger. Low write rate (batched window flushes only), the
+/// source of the cache-aside fallback when the hot tier is cold.
+///
+/// The idempotency guarantee lives here: [`flush_window`](CounterLedger::flush_window)
+/// is keyed by `(entity, metric, window_id)`, so a worker crash + Kafka
+/// redelivery re-applies the *same* window as a no-op. This is what makes
+/// at-least-once delivery safe for the durable total.
+#[async_trait]
+pub trait CounterLedger: Send + Sync + 'static {
+    /// Apply a closed window's scalar contribution to the durable total,
+    /// idempotently on `(entity, metric, window_id)`. Returns
+    /// [`FlushOutcome::AlreadyApplied`] for a redelivery.
+    async fn flush_window(&self, delta: &WindowDelta) -> Result<FlushOutcome, CounterError>;
+
+    /// Read the durable total for one `(entity, metric)` — the cache-aside
+    /// fallback used when the hot tier misses or is unavailable. `None` when the
+    /// pair has never been flushed.
+    async fn read_total(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError>;
+
+    /// Reconciliation-only: overwrite the durable total to an authoritative value,
+    /// healing accumulated drift against the owning source-of-record. Subsequent
+    /// window flushes resume adding from the corrected baseline.
+    async fn set_total(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+        value: i64,
+    ) -> Result<(), CounterError>;
+}

--- a/crates/services/counter/src/application/port/counter_store.rs
+++ b/crates/services/counter/src/application/port/counter_store.rs
@@ -1,0 +1,51 @@
+use async_trait::async_trait;
+
+use crate::domain::{CountSnapshot, EntityRef, Metric, TrendingItem, TrendingScope, WindowDelta};
+use crate::error::CounterError;
+
+/// The hot counter tier (Redis) — the only store on the sub-millisecond read
+/// path, and the canonical home of the live magnitudes, the HyperLogLog unique
+/// estimators, and the Count-Min-Sketch trending sketches.
+///
+/// Writes are *deltas*: a [`WindowDelta`] folds into the live counter (`INCRBY`
+/// the net sum) or the HyperLogLog (`PFADD` the distinct members), and feeds the
+/// trending sketch. Reads are a batched multi-get (`HMGET` / `PFCOUNT`). The
+/// adapter (Phase 4) owns the shard re-aggregation and the fail-open behaviour;
+/// this port is the contract the handlers hold.
+#[async_trait]
+pub trait CounterStore: Send + Sync + 'static {
+    /// Fold one closed window's delta into the hot tier (live counter / HLL +
+    /// trending). Idempotency is NOT this tier's job — at-least-once redelivery of
+    /// approximate metrics is tolerated, and exact metrics are corrected by the
+    /// reconciliation loop; durable idempotency lives in [`CounterLedger`].
+    async fn apply_delta(&self, delta: &WindowDelta) -> Result<(), CounterError>;
+
+    /// Read the requested metrics for a batch of entities in one round-trip — the
+    /// `BatchGetCounters` hot path. Returns one snapshot per entity, in the same
+    /// order as `entities`.
+    async fn read(
+        &self,
+        entities: &[EntityRef],
+        metrics: &[Metric],
+    ) -> Result<Vec<CountSnapshot>, CounterError>;
+
+    /// Top-`limit` trending entities for a scope, ranked from the Count-Min Sketch
+    /// + bounded heap. Approximate by design.
+    async fn top_k(
+        &self,
+        scope: TrendingScope,
+        scope_key: Option<&str>,
+        metric: Metric,
+        limit: usize,
+    ) -> Result<Vec<TrendingItem>, CounterError>;
+
+    /// Reconciliation-only: overwrite the hot counter for an exact (sum) metric to
+    /// an authoritative value, healing accumulated drift. Not an additive delta —
+    /// the live counter is set, not incremented.
+    async fn overwrite(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+        value: i64,
+    ) -> Result<(), CounterError>;
+}

--- a/crates/services/counter/src/application/port/mod.rs
+++ b/crates/services/counter/src/application/port/mod.rs
@@ -16,7 +16,7 @@ pub mod reconciliation_source;
 pub mod signal_publisher;
 pub mod time_series;
 
-pub use counter_ledger::{CounterLedger, FlushOutcome};
+pub use counter_ledger::{CounterLedger, FlushOutcome, reconcile_cursor};
 pub use counter_store::CounterStore;
 pub use reconciliation_source::ReconciliationSource;
 pub use signal_publisher::SignalPublisher;

--- a/crates/services/counter/src/application/port/mod.rs
+++ b/crates/services/counter/src/application/port/mod.rs
@@ -1,0 +1,23 @@
+//! Outbound ports — the only contracts the application layer holds against the
+//! outside world. Concrete adapters (Redis hot store, Postgres ledger, Scylla
+//! time-series, Kafka signal publisher, plus the inbound event-decode layer) live
+//! in `infrastructure` (Phase 4) and are injected at the composition root. Each is
+//! an `async_trait` so it can be held as `Arc<dyn …>`; in-memory fakes back the
+//! unit tests.
+//!
+//! The three storage ports mirror the three tiers: [`CounterStore`] (hot Redis,
+//! the only one on the sub-ms read path), [`CounterLedger`] (warm Postgres, the
+//! auditable totals + idempotency), [`TimeSeriesStore`] (cold Scylla, history).
+//! [`SignalPublisher`] is the single outbound stream.
+
+pub mod counter_ledger;
+pub mod counter_store;
+pub mod reconciliation_source;
+pub mod signal_publisher;
+pub mod time_series;
+
+pub use counter_ledger::{CounterLedger, FlushOutcome};
+pub use counter_store::CounterStore;
+pub use reconciliation_source::ReconciliationSource;
+pub use signal_publisher::SignalPublisher;
+pub use time_series::TimeSeriesStore;

--- a/crates/services/counter/src/application/port/reconciliation_source.rs
+++ b/crates/services/counter/src/application/port/reconciliation_source.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+
+use crate::domain::{EntityRef, Metric};
+use crate::error::CounterError;
+
+/// Reads the authoritative exact count from the service that owns the underlying
+/// set — `engagement` for reaction-derived metrics (likes), `social-graph` for
+/// follower/following.
+///
+/// This is what makes an *exact* metric reconcilable: the fast hot counter drifts
+/// under at-least-once delivery, and the reconciliation loop periodically queries
+/// the true magnitude here to correct it. A source that does not own a given
+/// metric (or does not recognise the entity) returns `None`, and the reconciler
+/// leaves that pair untouched.
+///
+/// The concrete gRPC-backed implementation is a deferred follow-up — it needs the
+/// live `engagement` / `social-graph` services and a count RPC on each. This port
+/// is the contract the [`Reconciler`](crate::application::command::Reconciler)
+/// drives, and an in-memory fake backs its unit tests.
+#[async_trait]
+pub trait ReconciliationSource: Send + Sync + 'static {
+    async fn authoritative_count(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError>;
+}

--- a/crates/services/counter/src/application/port/signal_publisher.rs
+++ b/crates/services/counter/src/application/port/signal_publisher.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+
+use crate::domain::{EntityRef, PopularityScore};
+use crate::error::CounterError;
+
+/// Publishes the coarse popularity signal on `counter.v1.popularity`.
+///
+/// This is the only thing counter-analytics publishes. It is a *slow-loop*
+/// emission derived from already-aggregated magnitudes (never per-event), consumed
+/// by `search` (its `PopularityScore` ranking input) and `timeline`. The concrete
+/// adapter (Phase 4) is a Kafka producer; this port keeps the slow-loop publisher
+/// (Phase 5) free of any transport detail.
+#[async_trait]
+pub trait SignalPublisher: Send + Sync + 'static {
+    /// Emit the current coarse popularity score for an entity.
+    async fn publish_popularity(
+        &self,
+        entity: &EntityRef,
+        score: PopularityScore,
+    ) -> Result<(), CounterError>;
+}

--- a/crates/services/counter/src/application/port/time_series.rs
+++ b/crates/services/counter/src/application/port/time_series.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+
+use crate::domain::{TimeSeriesBucket, TimeSeriesQuery, WindowDelta};
+use crate::error::CounterError;
+
+/// The cold time-series tier (ScyllaDB TWCS) — the historical per-bucket rollups,
+/// TTL'd, never on the hot read path.
+///
+/// Writes append a window's scalar contribution into the appropriate time bucket
+/// (the adapter rolls fine windows up into hour/day buckets). The one read,
+/// [`range`](TimeSeriesStore::range), backs `GetTimeSeries`; it is explicitly NOT
+/// sub-millisecond and is off the feed-render path.
+#[async_trait]
+pub trait TimeSeriesStore: Send + Sync + 'static {
+    /// Append a closed window's scalar contribution to the historical series for
+    /// its `(entity, metric)`. Idempotency follows the same `(entity, metric,
+    /// window_id)` key as the ledger.
+    async fn append(&self, delta: &WindowDelta) -> Result<(), CounterError>;
+
+    /// Read the historical buckets for one `(entity, metric)` over a range, at the
+    /// requested granularity. Ordered by `bucket_start` ascending.
+    async fn range(&self, query: &TimeSeriesQuery) -> Result<Vec<TimeSeriesBucket>, CounterError>;
+}

--- a/crates/services/counter/src/application/query/get_counters.rs
+++ b/crates/services/counter/src/application/query/get_counters.rs
@@ -1,0 +1,160 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use cqrs::{Envelope, Query, QueryHandler};
+use error::AppError;
+
+use crate::application::port::{CounterLedger, CounterStore};
+use crate::domain::{BatchGetQuery, BatchReadout, CountSnapshot, CounterValue, EntityRef, Metric};
+use crate::error::CounterError;
+
+/// The query-bus wrapper around a validated [`BatchGetQuery`]. Validation / proto
+/// mapping happens at the edge (Phase 5); by here the query is well-formed.
+#[derive(Debug, Clone)]
+pub struct RunBatchGet {
+    pub query: BatchGetQuery,
+}
+
+impl Query for RunBatchGet {
+    type Response = BatchReadout;
+}
+
+/// Serves `BatchGetCounters`. Reads the hot tier under a hard timeout; on a hot-tier
+/// outage **or** a timeout it **fails open** to the warm ledger (stale-but-served)
+/// rather than erroring the feed.
+pub struct BatchGetHandler {
+    hot: Arc<dyn CounterStore>,
+    ledger: Arc<dyn CounterLedger>,
+    read_timeout: Duration,
+}
+
+impl BatchGetHandler {
+    pub fn new(
+        hot: Arc<dyn CounterStore>,
+        ledger: Arc<dyn CounterLedger>,
+        read_timeout: Duration,
+    ) -> Self {
+        Self {
+            hot,
+            ledger,
+            read_timeout,
+        }
+    }
+
+    /// Rebuild snapshots from the durable ledger when the hot tier is unavailable.
+    async fn fallback(
+        &self,
+        entities: &[EntityRef],
+        metrics: &[Metric],
+    ) -> Result<Vec<CountSnapshot>, CounterError> {
+        let mut out = Vec::with_capacity(entities.len());
+        for entity in entities {
+            let mut values = Vec::new();
+            for &metric in metrics {
+                if let Some(total) = self.ledger.read_total(entity, metric).await? {
+                    values.push(CounterValue::new(metric, total));
+                }
+            }
+            out.push(CountSnapshot::new(entity.clone(), values));
+        }
+        Ok(out)
+    }
+}
+
+impl QueryHandler<RunBatchGet> for BatchGetHandler {
+    type Error = CounterError;
+
+    async fn handle(&self, envelope: Envelope<RunBatchGet>) -> Result<BatchReadout, Self::Error> {
+        let query = envelope.payload.query;
+        let metrics = query.effective_metrics();
+
+        // A slow hot tier must shed load rather than queue: bound the read and treat
+        // an elapse exactly like a transient store fault — fail open to the ledger.
+        let read = tokio::time::timeout(self.read_timeout, self.hot.read(&query.entities, &metrics));
+        let degraded_fallback = || async {
+            let snapshots = self.fallback(&query.entities, &metrics).await?;
+            Ok(BatchReadout {
+                snapshots,
+                degraded: true,
+            })
+        };
+
+        match read.await {
+            Ok(Ok(snapshots)) => Ok(BatchReadout {
+                snapshots,
+                degraded: false,
+            }),
+            // Hot tier down → serve stale from the ledger. Only a transient store
+            // fault degrades; a genuine fault (bad request, bug) still propagates.
+            Ok(Err(e)) if e.is_retryable() => degraded_fallback().await,
+            Ok(Err(e)) => Err(e),
+            // Timed out → degrade.
+            Err(_elapsed) => degraded_fallback().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{EntityId, EntityKind};
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    fn run(query: BatchGetQuery) -> Envelope<RunBatchGet> {
+        Envelope::new(Uuid::now_v7(), RunBatchGet { query })
+    }
+
+    #[tokio::test]
+    async fn reads_hot_tier() {
+        let fx = Fixture::new();
+        fx.hot.seed(&post("p1"), Metric::View, 42);
+        fx.hot.seed(&post("p1"), Metric::Like, 7);
+
+        let q = BatchGetQuery::new(vec![post("p1")], vec![Metric::View, Metric::Like]).unwrap();
+        let out = fx.batch_get_handler().handle(run(q)).await.unwrap();
+
+        assert!(!out.degraded);
+        assert_eq!(out.snapshots.len(), 1);
+        assert_eq!(out.snapshots[0].get(Metric::View), Some(42));
+        assert_eq!(out.snapshots[0].get(Metric::Like), Some(7));
+    }
+
+    #[tokio::test]
+    async fn fails_open_to_ledger_when_hot_unavailable() {
+        let fx = Fixture::new();
+        // Durable total exists; hot tier is down.
+        fx.ledger.seed_total(&post("p1"), Metric::View, 1000);
+        fx.hot.set_unavailable(true);
+
+        let q = BatchGetQuery::new(vec![post("p1")], vec![Metric::View]).unwrap();
+        let out = fx.batch_get_handler().handle(run(q)).await.unwrap();
+
+        assert!(out.degraded); // stale-but-served
+        assert_eq!(out.snapshots[0].get(Metric::View), Some(1000));
+    }
+
+    #[tokio::test]
+    async fn slow_hot_tier_times_out_and_degrades() {
+        let fx = Fixture::new();
+        fx.ledger.seed_total(&post("p1"), Metric::View, 777);
+        // Hot read is healthy but slow; the handler's hard timeout sheds it.
+        fx.hot.set_read_delay(std::time::Duration::from_millis(200));
+
+        let handler = BatchGetHandler::new(
+            fx.hot.clone(),
+            fx.ledger.clone(),
+            std::time::Duration::from_millis(20),
+        );
+        let q = BatchGetQuery::new(vec![post("p1")], vec![Metric::View]).unwrap();
+        let out = handler.handle(run(q)).await.unwrap();
+
+        assert!(out.degraded);
+        assert_eq!(out.snapshots[0].get(Metric::View), Some(777));
+    }
+}

--- a/crates/services/counter/src/application/query/get_time_series.rs
+++ b/crates/services/counter/src/application/query/get_time_series.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+use error::AppError;
+
+use crate::application::port::TimeSeriesStore;
+use crate::domain::{TimeSeriesBucket, TimeSeriesQuery};
+use crate::error::CounterError;
+
+/// The query-bus wrapper around a validated [`TimeSeriesQuery`].
+#[derive(Debug, Clone)]
+pub struct RunTimeSeries {
+    pub query: TimeSeriesQuery,
+}
+
+impl Query for RunTimeSeries {
+    type Response = Vec<TimeSeriesBucket>;
+}
+
+/// Serves `GetTimeSeries` from the cold tier. This is the one read allowed to
+/// touch Scylla; it is not on the feed path. Fails **open** to an empty series on a
+/// transient store outage.
+pub struct TimeSeriesHandler {
+    series: Arc<dyn TimeSeriesStore>,
+}
+
+impl TimeSeriesHandler {
+    pub fn new(series: Arc<dyn TimeSeriesStore>) -> Self {
+        Self { series }
+    }
+}
+
+impl QueryHandler<RunTimeSeries> for TimeSeriesHandler {
+    type Error = CounterError;
+
+    async fn handle(
+        &self,
+        envelope: Envelope<RunTimeSeries>,
+    ) -> Result<Vec<TimeSeriesBucket>, Self::Error> {
+        match self.series.range(&envelope.payload.query).await {
+            Ok(buckets) => Ok(buckets),
+            Err(e) if e.is_retryable() => Ok(Vec::new()), // degrade to empty
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{EntityId, EntityKind, EntityRef, Metric, TimeGranularity};
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    #[tokio::test]
+    async fn returns_buckets_in_range() {
+        let fx = Fixture::new();
+        let t0 = Utc.timestamp_opt(1_000, 0).unwrap();
+        let t1 = Utc.timestamp_opt(2_000, 0).unwrap();
+        fx.series.seed_bucket(&post("p1"), Metric::View, t0, 5);
+        fx.series.seed_bucket(&post("p1"), Metric::View, t1, 8);
+
+        let q = TimeSeriesQuery::new(
+            post("p1"),
+            Metric::View,
+            TimeGranularity::Hour,
+            Utc.timestamp_opt(0, 0).unwrap(),
+            Utc.timestamp_opt(10_000, 0).unwrap(),
+        )
+        .unwrap();
+        let buckets = fx
+            .time_series_handler()
+            .handle(Envelope::new(Uuid::now_v7(), RunTimeSeries { query: q }))
+            .await
+            .unwrap();
+
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets[0].value, 5);
+        assert_eq!(buckets[1].value, 8);
+    }
+}

--- a/crates/services/counter/src/application/query/get_trending.rs
+++ b/crates/services/counter/src/application/query/get_trending.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use cqrs::{Envelope, Query, QueryHandler};
+use error::AppError;
+
+use crate::application::port::CounterStore;
+use crate::domain::{TrendingItem, TrendingQuery};
+use crate::error::CounterError;
+
+/// The query-bus wrapper around a validated [`TrendingQuery`].
+#[derive(Debug, Clone)]
+pub struct RunTrending {
+    pub query: TrendingQuery,
+}
+
+impl Query for RunTrending {
+    type Response = Vec<TrendingItem>;
+}
+
+/// Serves `GetTrending` from the hot tier's Count-Min-Sketch + heap. Fails **open**
+/// to an empty ranking on a transient store outage.
+pub struct TrendingHandler {
+    hot: Arc<dyn CounterStore>,
+}
+
+impl TrendingHandler {
+    pub fn new(hot: Arc<dyn CounterStore>) -> Self {
+        Self { hot }
+    }
+}
+
+impl QueryHandler<RunTrending> for TrendingHandler {
+    type Error = CounterError;
+
+    async fn handle(&self, envelope: Envelope<RunTrending>) -> Result<Vec<TrendingItem>, Self::Error> {
+        let q = envelope.payload.query;
+        match self
+            .hot
+            .top_k(q.scope, q.scope_key.as_deref(), q.metric, q.limit)
+            .await
+        {
+            Ok(items) => Ok(items),
+            Err(e) if e.is_retryable() => Ok(Vec::new()), // degrade to empty
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::domain::{EntityId, EntityKind, EntityRef, Metric, TrendingScope};
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    fn run(query: TrendingQuery) -> Envelope<RunTrending> {
+        Envelope::new(Uuid::now_v7(), RunTrending { query })
+    }
+
+    #[tokio::test]
+    async fn ranks_by_score_descending() {
+        let fx = Fixture::new();
+        fx.hot.seed_trending(Metric::View, &post("low"), 10);
+        fx.hot.seed_trending(Metric::View, &post("high"), 100);
+        fx.hot.seed_trending(Metric::View, &post("mid"), 50);
+
+        let q = TrendingQuery::new(TrendingScope::Global, None, Metric::View, 2).unwrap();
+        let items = fx.trending_handler().handle(run(q)).await.unwrap();
+
+        assert_eq!(items.len(), 2); // limited
+        assert_eq!(items[0].entity.id.as_str(), "high");
+        assert_eq!(items[0].rank, 0);
+        assert_eq!(items[1].entity.id.as_str(), "mid");
+        assert_eq!(items[1].rank, 1);
+    }
+
+    #[tokio::test]
+    async fn fails_open_to_empty() {
+        let fx = Fixture::new();
+        fx.hot.seed_trending(Metric::View, &post("p1"), 10);
+        fx.hot.set_unavailable(true);
+
+        let q = TrendingQuery::new(TrendingScope::Global, None, Metric::View, 10).unwrap();
+        let items = fx.trending_handler().handle(run(q)).await.unwrap();
+        assert!(items.is_empty());
+    }
+}

--- a/crates/services/counter/src/application/query/mod.rs
+++ b/crates/services/counter/src/application/query/mod.rs
@@ -1,0 +1,11 @@
+//! Read-side use cases. Each implements [`cqrs::QueryHandler`] and rides the query
+//! bus. All three are fail-open: a transient store outage degrades the response
+//! (ledger fallback / empty results), it never errors the caller's page.
+
+pub mod get_counters;
+pub mod get_time_series;
+pub mod get_trending;
+
+pub use get_counters::{BatchGetHandler, RunBatchGet};
+pub use get_time_series::{RunTimeSeries, TimeSeriesHandler};
+pub use get_trending::{RunTrending, TrendingHandler};

--- a/crates/services/counter/src/config.rs
+++ b/crates/services/counter/src/config.rs
@@ -1,0 +1,88 @@
+//! Environment-sourced configuration, resolved once at boot and threaded into the
+//! composition root ([`crate::app`]). Each backend's connection config comes from
+//! its own `from_env`; counter-specific knobs are read here.
+
+use std::time::Duration;
+
+use postgres_storage::PostgresConfig;
+use redis_storage::RedisConfig;
+use scylla_storage::ScyllaConfig;
+use transport::kafka::config::KafkaClientConfig;
+
+use crate::domain::WindowSize;
+
+const DEFAULT_WINDOW_MS: u64 = 5_000;
+const DEFAULT_POPULARITY_INTERVAL_S: u64 = 60;
+const DEFAULT_READ_TIMEOUT_MS: u64 = 50;
+const DEFAULT_RECONCILE_INTERVAL_S: u64 = 3_600;
+const DEFAULT_DRIFT_TOLERANCE: i64 = 5;
+
+/// Fully-resolved counter configuration shared by both binaries (the read server
+/// uses the storage configs; the worker additionally uses Kafka + the windowing
+/// knobs).
+pub struct CounterConfig {
+    pub postgres: PostgresConfig,
+    pub redis: RedisConfig,
+    pub scylla: ScyllaConfig,
+    pub kafka: KafkaClientConfig,
+    /// Tumbling pre-aggregation window — the N→1 collapse width.
+    pub aggregation_window: WindowSize,
+    /// How often the worker drains closed windows and flushes them.
+    pub flush_interval: Duration,
+    /// Slow-loop cadence for publishing the coarse popularity signal.
+    pub popularity_interval: Duration,
+    /// Hard per-request hot-read timeout; on elapse the read fails open (stale).
+    pub read_timeout: Duration,
+    /// Cadence of the reconciliation loop (reserved — the concrete source that
+    /// drives it is a deferred follow-up).
+    pub reconcile_interval: Duration,
+    /// Absolute drift tolerated before reconciliation corrects an exact counter.
+    pub drift_tolerance: i64,
+}
+
+impl CounterConfig {
+    pub fn from_env() -> Self {
+        let window_ms = env_u64("COUNTER_AGGREGATION_WINDOW_MS", DEFAULT_WINDOW_MS);
+        // A zero window would be rejected by the VO; fall back to the safe default.
+        let aggregation_window =
+            WindowSize::from_millis(window_ms).unwrap_or_else(|_| safe_window());
+
+        let flush_ms = env_u64("COUNTER_FLUSH_INTERVAL_MS", window_ms);
+
+        Self {
+            postgres: PostgresConfig::from_env(),
+            redis: RedisConfig::from_env(),
+            scylla: ScyllaConfig::from_env(),
+            kafka: KafkaClientConfig::from_env(),
+            aggregation_window,
+            flush_interval: Duration::from_millis(flush_ms),
+            popularity_interval: Duration::from_secs(env_u64(
+                "COUNTER_POPULARITY_INTERVAL_S",
+                DEFAULT_POPULARITY_INTERVAL_S,
+            )),
+            read_timeout: Duration::from_millis(env_u64(
+                "COUNTER_READ_TIMEOUT_MS",
+                DEFAULT_READ_TIMEOUT_MS,
+            )),
+            reconcile_interval: Duration::from_secs(env_u64(
+                "COUNTER_RECONCILE_INTERVAL_S",
+                DEFAULT_RECONCILE_INTERVAL_S,
+            )),
+            drift_tolerance: std::env::var("COUNTER_DRIFT_TOLERANCE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_DRIFT_TOLERANCE),
+        }
+    }
+}
+
+fn safe_window() -> WindowSize {
+    WindowSize::from_millis(DEFAULT_WINDOW_MS).expect("default window is non-zero")
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/crates/services/counter/src/config.rs
+++ b/crates/services/counter/src/config.rs
@@ -33,11 +33,13 @@ pub struct CounterConfig {
     pub popularity_interval: Duration,
     /// Hard per-request hot-read timeout; on elapse the read fails open (stale).
     pub read_timeout: Duration,
-    /// Cadence of the reconciliation loop (reserved — the concrete source that
-    /// drives it is a deferred follow-up).
+    /// Cadence of the reconciliation sweep loop.
     pub reconcile_interval: Duration,
     /// Absolute drift tolerated before reconciliation corrects an exact counter.
     pub drift_tolerance: i64,
+    /// gRPC endpoint of `social-graph` — the authoritative source for
+    /// follower/following counts the reconciliation loop queries.
+    pub social_graph_endpoint: String,
 }
 
 impl CounterConfig {
@@ -72,6 +74,8 @@ impl CounterConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(DEFAULT_DRIFT_TOLERANCE),
+            social_graph_endpoint: std::env::var("COUNTER_SOCIAL_GRAPH_GRPC_ENDPOINT")
+                .unwrap_or_else(|_| "http://localhost:50053".to_owned()),
         }
     }
 }

--- a/crates/services/counter/src/domain/aggregator.rs
+++ b/crates/services/counter/src/domain/aggregator.rs
@@ -1,0 +1,312 @@
+use std::collections::{BTreeSet, HashMap};
+
+use chrono::{DateTime, Utc};
+
+use crate::domain::observation::Observation;
+use crate::domain::value_object::{Aggregation, EntityRef, MemberId, Metric, WindowId, WindowSize};
+use crate::error::CounterError;
+
+/// The aggregation + idempotency key for one folded window: `(entity, metric,
+/// window)`. The durable flush is keyed by exactly this tuple, which is what makes
+/// re-flushing a redelivered window a no-op UPSERT rather than a double-add.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WindowKey {
+    pub entity: EntityRef,
+    pub metric: Metric,
+    pub window: WindowId,
+}
+
+/// Mutable fold state for one open window. A `Sum` metric accumulates a signed
+/// running total; a `Cardinality` metric collects distinct members (deduped) to
+/// be `PFADD`-ed downstream.
+#[derive(Debug, Default)]
+struct WindowAccumulator {
+    sum: i64,
+    members: BTreeSet<MemberId>,
+}
+
+/// The single delta emitted when a window closes — the result of collapsing N
+/// observations into 1. For a `Sum` metric, `sum` is the net signed magnitude and
+/// `unique_members` is empty; for a `Cardinality` metric, `unique_members` are the
+/// distinct actors to fold into the HyperLogLog and `sum` is `0`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowDelta {
+    pub key: WindowKey,
+    pub sum: i64,
+    pub unique_members: Vec<MemberId>,
+}
+
+impl WindowDelta {
+    pub fn entity(&self) -> &EntityRef {
+        &self.key.entity
+    }
+
+    pub fn metric(&self) -> Metric {
+        self.key.metric
+    }
+
+    pub fn window(&self) -> WindowId {
+        self.key.window
+    }
+
+    /// The single scalar contribution this window makes to a running total: the
+    /// net `sum` for an additive metric, or the count of distinct members for a
+    /// cardinality metric. Used by the durable and time-series tiers, which store
+    /// scalars; the hot tier instead `PFADD`s the members directly to keep the
+    /// cardinality estimate exact across windows.
+    pub fn scalar(&self) -> i64 {
+        match self.metric().aggregation() {
+            Aggregation::Sum => self.sum,
+            Aggregation::Cardinality => self.unique_members.len() as i64,
+        }
+    }
+}
+
+/// The windowed pre-aggregator — the heart of the write-amplification funnel.
+///
+/// It folds a stream of [`Observation`]s into one [`WindowDelta`] per `(entity,
+/// metric, window)`, collapsing millions of `+1`s into a single delta before any
+/// of them reaches a store. It is pure and clock-injected: an observation lands in
+/// a window purely by its **event time**, and windows close purely against an
+/// injected **watermark** — never `Utc::now()`. This makes the whole collapse
+/// deterministic and unit-testable without a broker, a timer, or a store.
+#[derive(Debug)]
+pub struct WindowAggregator {
+    size: WindowSize,
+    buckets: HashMap<WindowKey, WindowAccumulator>,
+}
+
+impl WindowAggregator {
+    pub fn new(size: WindowSize) -> Self {
+        Self {
+            size,
+            buckets: HashMap::new(),
+        }
+    }
+
+    /// Number of open (not-yet-flushed) windows currently held.
+    pub fn pending(&self) -> usize {
+        self.buckets.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buckets.is_empty()
+    }
+
+    /// Fold one observation into its window. A cardinality observation missing its
+    /// member is a malformed event (the decode layer must always supply one),
+    /// surfaced as `CTR-9001 DomainViolation`.
+    pub fn fold(&mut self, obs: Observation) -> Result<(), CounterError> {
+        let window = WindowId::for_event(self.size, obs.occurred_at);
+        let key = WindowKey {
+            entity: obs.entity,
+            metric: obs.metric,
+            window,
+        };
+        let acc = self.buckets.entry(key).or_default();
+
+        match obs.metric.aggregation() {
+            Aggregation::Sum => {
+                // Saturating: a window total can never realistically overflow i64,
+                // but we never want a panic on the ingestion path.
+                acc.sum = acc.sum.saturating_add(obs.amount);
+            }
+            Aggregation::Cardinality => {
+                let member = obs.unique_member.ok_or_else(|| CounterError::DomainViolation {
+                    field: "unique_member".to_owned(),
+                    message: format!(
+                        "cardinality metric '{}' requires a member id",
+                        obs.metric.as_str()
+                    ),
+                })?;
+                acc.members.insert(member);
+            }
+        }
+        Ok(())
+    }
+
+    /// Remove and return the deltas for every window that has fully elapsed
+    /// relative to `watermark`. Open windows are retained for further folding. The
+    /// result is deterministically ordered for stable testing and reproducible
+    /// flush batches.
+    pub fn drain_closed(&mut self, watermark: DateTime<Utc>) -> Vec<WindowDelta> {
+        let closed: Vec<WindowKey> = self
+            .buckets
+            .keys()
+            .filter(|k| k.window.is_closed_at(self.size, watermark))
+            .cloned()
+            .collect();
+        self.remove_and_collect(closed)
+    }
+
+    /// Remove and return deltas for *all* open windows, regardless of watermark —
+    /// for graceful shutdown, where holding back un-elapsed windows would lose
+    /// data.
+    pub fn drain_all(&mut self) -> Vec<WindowDelta> {
+        let all: Vec<WindowKey> = self.buckets.keys().cloned().collect();
+        self.remove_and_collect(all)
+    }
+
+    fn remove_and_collect(&mut self, keys: Vec<WindowKey>) -> Vec<WindowDelta> {
+        let mut deltas: Vec<WindowDelta> = keys
+            .into_iter()
+            .filter_map(|key| {
+                self.buckets.remove(&key).map(|acc| WindowDelta {
+                    key,
+                    sum: acc.sum,
+                    unique_members: acc.members.into_iter().collect(),
+                })
+            })
+            .collect();
+        deltas.sort_by(|a, b| {
+            (
+                a.key.entity.kind.as_str(),
+                a.key.entity.id.as_str(),
+                a.key.metric.as_str(),
+                a.key.window.index(),
+            )
+                .cmp(&(
+                    b.key.entity.kind.as_str(),
+                    b.key.entity.id.as_str(),
+                    b.key.metric.as_str(),
+                    b.key.window.index(),
+                ))
+        });
+        deltas
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use error::AppError;
+
+    use super::*;
+    use crate::domain::value_object::{EntityId, EntityKind};
+
+    fn size() -> WindowSize {
+        WindowSize::from_millis(5_000).unwrap()
+    }
+
+    fn post(id: &str) -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new(id).unwrap())
+    }
+
+    fn at(millis: i64) -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(millis).unwrap()
+    }
+
+    /// The defining property: N observations collapse to 1 delta.
+    #[test]
+    fn collapses_n_views_into_one_delta() {
+        let mut agg = WindowAggregator::new(size());
+        for _ in 0..1_000_000 {
+            let obs = Observation::sum(post("viral"), Metric::View, 1, at(1_000)).unwrap();
+            agg.fold(obs).unwrap();
+        }
+        assert_eq!(agg.pending(), 1);
+
+        let deltas = agg.drain_closed(at(10_000));
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].sum, 1_000_000);
+        assert_eq!(deltas[0].metric(), Metric::View);
+        assert!(deltas[0].unique_members.is_empty());
+        assert!(agg.is_empty());
+    }
+
+    #[test]
+    fn signed_deltas_net_out() {
+        let mut agg = WindowAggregator::new(size());
+        agg.fold(Observation::sum(post("p"), Metric::Like, 1, at(1_000)).unwrap())
+            .unwrap();
+        agg.fold(Observation::sum(post("p"), Metric::Like, 1, at(1_001)).unwrap())
+            .unwrap();
+        agg.fold(Observation::sum(post("p"), Metric::Like, -1, at(1_002)).unwrap())
+            .unwrap();
+
+        let deltas = agg.drain_all();
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].sum, 1); // +1 +1 -1
+    }
+
+    #[test]
+    fn unique_members_are_deduped() {
+        let mut agg = WindowAggregator::new(size());
+        for who in ["alice", "alice", "bob", "carol", "bob"] {
+            let obs = Observation::unique(
+                post("p"),
+                Metric::UniqueViewer,
+                MemberId::new(who).unwrap(),
+                at(1_000),
+            )
+            .unwrap();
+            agg.fold(obs).unwrap();
+        }
+        let deltas = agg.drain_all();
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].unique_members.len(), 3); // alice, bob, carol
+        assert_eq!(deltas[0].sum, 0);
+    }
+
+    #[test]
+    fn distinct_windows_yield_distinct_deltas() {
+        let mut agg = WindowAggregator::new(size());
+        // window 0 ([0,5000)) and window 2 ([10000,15000))
+        agg.fold(Observation::sum(post("p"), Metric::View, 1, at(1_000)).unwrap())
+            .unwrap();
+        agg.fold(Observation::sum(post("p"), Metric::View, 1, at(12_000)).unwrap())
+            .unwrap();
+        assert_eq!(agg.pending(), 2);
+
+        let deltas = agg.drain_all();
+        assert_eq!(deltas.len(), 2);
+        assert_eq!(deltas[0].window().index(), 0);
+        assert_eq!(deltas[1].window().index(), 2);
+    }
+
+    #[test]
+    fn distinct_metrics_on_same_entity_are_separate() {
+        let mut agg = WindowAggregator::new(size());
+        agg.fold(Observation::sum(post("p"), Metric::View, 5, at(1_000)).unwrap())
+            .unwrap();
+        agg.fold(Observation::sum(post("p"), Metric::Like, 2, at(1_000)).unwrap())
+            .unwrap();
+        let deltas = agg.drain_all();
+        assert_eq!(deltas.len(), 2);
+        // deterministic order: "like" < "view"
+        assert_eq!(deltas[0].metric(), Metric::Like);
+        assert_eq!(deltas[1].metric(), Metric::View);
+    }
+
+    #[test]
+    fn watermark_holds_back_open_windows() {
+        let mut agg = WindowAggregator::new(size());
+        agg.fold(Observation::sum(post("p"), Metric::View, 1, at(12_000)).unwrap())
+            .unwrap(); // window 2 = [10000,15000)
+
+        // watermark inside the window → nothing closed yet
+        let drained = agg.drain_closed(at(14_999));
+        assert!(drained.is_empty());
+        assert_eq!(agg.pending(), 1);
+
+        // watermark at the window end → it closes
+        let drained = agg.drain_closed(at(15_000));
+        assert_eq!(drained.len(), 1);
+        assert!(agg.is_empty());
+    }
+
+    #[test]
+    fn cardinality_observation_without_member_is_rejected() {
+        let mut agg = WindowAggregator::new(size());
+        // Construct a malformed observation directly (bypassing the smart ctor).
+        let bad = Observation {
+            entity: post("p"),
+            metric: Metric::UniqueViewer,
+            amount: 0,
+            unique_member: None,
+            occurred_at: at(1_000),
+        };
+        let err = agg.fold(bad).unwrap_err();
+        assert_eq!(err.error_code(), "CTR-9001");
+    }
+}

--- a/crates/services/counter/src/domain/mod.rs
+++ b/crates/services/counter/src/domain/mod.rs
@@ -1,0 +1,32 @@
+//! The pure domain layer for counter-analytics — the aggregation model and the
+//! windowed fold that turns a firehose of observations into flushable deltas.
+//!
+//! The centre of gravity is the [`aggregator`]: a clock-injected, I/O-free
+//! transform that collapses N [`observation::Observation`]s into one
+//! [`aggregator::WindowDelta`] per `(entity, metric, window)`. Everything here is
+//! deterministic and unit-testable without containers, a broker, or a wall clock.
+//!
+//! The probabilistic structures themselves (HyperLogLog for unique cardinality,
+//! Count-Min Sketch for trending) live in the infrastructure tier — the domain's
+//! job is only to *classify* which metric uses which strategy
+//! ([`value_object::Metric::aggregation`]) and to carry the inputs/outputs
+//! ([`value_object::MemberId`] in, [`read::Cardinality`] out). That keeps the
+//! domain free of any specific estimator implementation.
+
+pub mod aggregator;
+pub mod observation;
+pub mod query;
+pub mod read;
+pub mod value_object;
+
+pub use aggregator::{WindowAggregator, WindowDelta, WindowKey};
+pub use observation::Observation;
+pub use query::{
+    BatchGetQuery, BatchReadout, TimeGranularity, TimeSeriesBucket, TimeSeriesQuery, TrendingItem,
+    TrendingQuery, TrendingScope,
+};
+pub use read::{Cardinality, CountSnapshot, CounterValue};
+pub use value_object::{
+    Aggregation, EntityId, EntityKind, EntityRef, MemberId, Metric, MetricKind, PopularityScore,
+    PopularityWeights, WindowId, WindowSize,
+};

--- a/crates/services/counter/src/domain/observation.rs
+++ b/crates/services/counter/src/domain/observation.rs
@@ -1,0 +1,111 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::value_object::{Aggregation, EntityRef, MemberId, Metric};
+use crate::error::CounterError;
+
+/// The single inbound atom the aggregator folds — the distilled, validated form
+/// of one engagement.
+///
+/// Every wire event the service consumes (a view, an impression, a like/unlike, a
+/// follow/unfollow) is decoded (Phase 4) into one or more `Observation`s, so the
+/// fold never sees a topic, a schema, or a byte. One wire event may yield several
+/// observations: a view event becomes both a `View` (`+1`, sum) **and** a
+/// `UniqueViewer` (member-carrying, cardinality).
+///
+/// The shape is uniform on purpose:
+/// * for [`Aggregation::Sum`] metrics, `amount` is the signed delta (`+1` like,
+///   `-1` unlike, `+1/-1` follow) and `unique_member` is ignored;
+/// * for [`Aggregation::Cardinality`] metrics, `unique_member` is the actor folded
+///   into the HyperLogLog and `amount` is ignored.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Observation {
+    pub entity: EntityRef,
+    pub metric: Metric,
+    pub amount: i64,
+    pub unique_member: Option<MemberId>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+impl Observation {
+    /// A signed additive observation for a [`Aggregation::Sum`] metric. Rejects a
+    /// cardinality metric (which needs a member, not an amount) as `CTR-2002
+    /// InvalidDelta`.
+    pub fn sum(
+        entity: EntityRef,
+        metric: Metric,
+        amount: i64,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<Self, CounterError> {
+        if metric.aggregation() != Aggregation::Sum {
+            return Err(CounterError::InvalidDelta {
+                reason: format!("metric '{}' is not a sum metric", metric.as_str()),
+            });
+        }
+        Ok(Self {
+            entity,
+            metric,
+            amount,
+            unique_member: None,
+            occurred_at,
+        })
+    }
+
+    /// A distinct-member observation for a [`Aggregation::Cardinality`] metric.
+    /// Rejects a sum metric as `CTR-2002 InvalidDelta`.
+    pub fn unique(
+        entity: EntityRef,
+        metric: Metric,
+        member: MemberId,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<Self, CounterError> {
+        if metric.aggregation() != Aggregation::Cardinality {
+            return Err(CounterError::InvalidDelta {
+                reason: format!("metric '{}' is not a cardinality metric", metric.as_str()),
+            });
+        }
+        Ok(Self {
+            entity,
+            metric,
+            amount: 0,
+            unique_member: Some(member),
+            occurred_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use error::AppError;
+
+    use super::*;
+    use crate::domain::value_object::{EntityId, EntityKind};
+
+    fn post() -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new("p1").unwrap())
+    }
+
+    fn t() -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(1_000).unwrap()
+    }
+
+    #[test]
+    fn sum_observation_rejects_cardinality_metric() {
+        let err = Observation::sum(post(), Metric::UniqueViewer, 1, t()).unwrap_err();
+        assert_eq!(err.error_code(), "CTR-2002");
+    }
+
+    #[test]
+    fn unique_observation_rejects_sum_metric() {
+        let m = MemberId::new("v1").unwrap();
+        let err = Observation::unique(post(), Metric::View, m, t()).unwrap_err();
+        assert_eq!(err.error_code(), "CTR-2002");
+    }
+
+    #[test]
+    fn signed_amounts_are_preserved() {
+        let unlike = Observation::sum(post(), Metric::Like, -1, t()).unwrap();
+        assert_eq!(unlike.amount, -1);
+        assert!(unlike.unique_member.is_none());
+    }
+}

--- a/crates/services/counter/src/domain/query.rs
+++ b/crates/services/counter/src/domain/query.rs
@@ -1,0 +1,254 @@
+//! Validated read inputs and result shapes for the query path. Mirrors the proto
+//! surface (Phase 1) but is the domain's own vocabulary — proto ↔ domain mapping
+//! lives at the edge (Phase 5), so these never depend on the generated types.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::read::CountSnapshot;
+use crate::domain::value_object::{EntityRef, Metric};
+use crate::error::CounterError;
+
+/// Hard ceiling on a single `BatchGetCounters` request, so one call can never fan
+/// a feed page into an unbounded multi-get.
+pub const MAX_BATCH: usize = 256;
+
+/// Hard ceiling on a trending result; the server clamps `limit` to this.
+pub const MAX_TRENDING: usize = 100;
+
+/// A validated batch counter read. Empty or oversized batches are rejected as
+/// `CTR-1001 InvalidCounterQuery`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchGetQuery {
+    pub entities: Vec<EntityRef>,
+    /// Restrict to these metrics; empty ⇒ all metrics for each entity kind.
+    pub metrics: Vec<Metric>,
+}
+
+impl BatchGetQuery {
+    pub fn new(entities: Vec<EntityRef>, metrics: Vec<Metric>) -> Result<Self, CounterError> {
+        if entities.is_empty() {
+            return Err(CounterError::InvalidCounterQuery {
+                reason: "at least one entity is required".to_owned(),
+            });
+        }
+        if entities.len() > MAX_BATCH {
+            return Err(CounterError::InvalidCounterQuery {
+                reason: format!("batch of {} exceeds max {MAX_BATCH}", entities.len()),
+            });
+        }
+        Ok(Self { entities, metrics })
+    }
+
+    /// The metrics to serve for an entity: the requested subset, or all metrics
+    /// when none were specified.
+    pub fn effective_metrics(&self) -> Vec<Metric> {
+        if self.metrics.is_empty() {
+            Metric::ALL.to_vec()
+        } else {
+            self.metrics.clone()
+        }
+    }
+}
+
+/// The result of a batch counter read: one snapshot per requested entity, plus a
+/// fail-open marker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchReadout {
+    pub snapshots: Vec<CountSnapshot>,
+    /// True when the hot tier was unavailable and these snapshots were served from
+    /// the warm-ledger fallback (stale-but-served), or are otherwise degraded. The
+    /// read never errors the feed — it degrades.
+    pub degraded: bool,
+}
+
+/// The aggregation scope for a trending query. `Global` ranks across the network;
+/// the others rank within a `scope_key` qualifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TrendingScope {
+    Global,
+    Hashtag,
+    Category,
+    Region,
+}
+
+impl TrendingScope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TrendingScope::Global => "global",
+            TrendingScope::Hashtag => "hashtag",
+            TrendingScope::Category => "category",
+            TrendingScope::Region => "region",
+        }
+    }
+
+    /// Whether this scope requires a non-empty `scope_key`.
+    pub fn needs_key(&self) -> bool {
+        !matches!(self, TrendingScope::Global)
+    }
+}
+
+/// A validated trending query. A non-global scope without a key is rejected as
+/// `CTR-1004 InvalidTrendingScope`; `limit` is clamped to `[1, MAX_TRENDING]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrendingQuery {
+    pub scope: TrendingScope,
+    pub scope_key: Option<String>,
+    pub metric: Metric,
+    pub limit: usize,
+}
+
+impl TrendingQuery {
+    pub fn new(
+        scope: TrendingScope,
+        scope_key: Option<String>,
+        metric: Metric,
+        limit: usize,
+    ) -> Result<Self, CounterError> {
+        let scope_key = scope_key.filter(|k| !k.trim().is_empty());
+        if scope.needs_key() && scope_key.is_none() {
+            return Err(CounterError::InvalidTrendingScope {
+                scope: scope.as_str().to_owned(),
+            });
+        }
+        let limit = limit.clamp(1, MAX_TRENDING);
+        Ok(Self {
+            scope,
+            scope_key,
+            metric,
+            limit,
+        })
+    }
+}
+
+/// One ranked trending result — an approximate Count-Min-Sketch score, never an
+/// exact count.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TrendingItem {
+    pub entity: EntityRef,
+    pub score: i64,
+    pub rank: u32,
+}
+
+/// Bucket size for a historical time-series query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimeGranularity {
+    Hour,
+    Day,
+    Week,
+}
+
+impl TimeGranularity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TimeGranularity::Hour => "hour",
+            TimeGranularity::Day => "day",
+            TimeGranularity::Week => "week",
+        }
+    }
+}
+
+/// A validated time-series query. An empty or inverted range is rejected as
+/// `CTR-1003 InvalidTimeRange`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimeSeriesQuery {
+    pub entity: EntityRef,
+    pub metric: Metric,
+    pub granularity: TimeGranularity,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}
+
+impl TimeSeriesQuery {
+    pub fn new(
+        entity: EntityRef,
+        metric: Metric,
+        granularity: TimeGranularity,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Self, CounterError> {
+        if end <= start {
+            return Err(CounterError::InvalidTimeRange {
+                reason: "end must be strictly after start".to_owned(),
+            });
+        }
+        Ok(Self {
+            entity,
+            metric,
+            granularity,
+            start,
+            end,
+        })
+    }
+}
+
+/// One historical bucket: its start instant and the metric value over the bucket.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TimeSeriesBucket {
+    pub bucket_start: DateTime<Utc>,
+    pub value: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use error::AppError;
+
+    use super::*;
+    use crate::domain::value_object::{EntityId, EntityKind};
+
+    fn post() -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new("p1").unwrap())
+    }
+
+    fn at(s: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(s, 0).unwrap()
+    }
+
+    #[test]
+    fn batch_rejects_empty() {
+        let err = BatchGetQuery::new(vec![], vec![]).unwrap_err();
+        assert_eq!(err.error_code(), "CTR-1001");
+    }
+
+    #[test]
+    fn batch_empty_metrics_means_all() {
+        let q = BatchGetQuery::new(vec![post()], vec![]).unwrap();
+        assert_eq!(q.effective_metrics().len(), Metric::ALL.len());
+    }
+
+    #[test]
+    fn trending_global_needs_no_key() {
+        let q = TrendingQuery::new(TrendingScope::Global, None, Metric::View, 10).unwrap();
+        assert_eq!(q.limit, 10);
+    }
+
+    #[test]
+    fn trending_scoped_requires_key() {
+        let err =
+            TrendingQuery::new(TrendingScope::Hashtag, Some("  ".to_owned()), Metric::View, 10)
+                .unwrap_err();
+        assert_eq!(err.error_code(), "CTR-1004");
+    }
+
+    #[test]
+    fn trending_limit_is_clamped() {
+        let q = TrendingQuery::new(TrendingScope::Global, None, Metric::View, 9_999).unwrap();
+        assert_eq!(q.limit, MAX_TRENDING);
+        let q = TrendingQuery::new(TrendingScope::Global, None, Metric::View, 0).unwrap();
+        assert_eq!(q.limit, 1);
+    }
+
+    #[test]
+    fn time_series_rejects_inverted_range() {
+        let err = TimeSeriesQuery::new(
+            post(),
+            Metric::View,
+            TimeGranularity::Day,
+            at(100),
+            at(100),
+        )
+        .unwrap_err();
+        assert_eq!(err.error_code(), "CTR-1003");
+    }
+}

--- a/crates/services/counter/src/domain/read.rs
+++ b/crates/services/counter/src/domain/read.rs
@@ -1,0 +1,132 @@
+//! The domain read model — the shapes served back on the query path, and the
+//! pure derivation of the coarse popularity signal from them.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{
+    EntityRef, Metric, MetricKind, PopularityScore, PopularityWeights,
+};
+
+/// A unique-cardinality estimate (what `PFCOUNT` returns for a HyperLogLog).
+/// Distinct from a plain count to keep the approximate nature visible in the
+/// type: this is never an exact distinct count, only an estimate within the
+/// structure's error bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Cardinality(u64);
+
+impl Cardinality {
+    pub fn new(estimate: u64) -> Self {
+        Self(estimate)
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+/// One served magnitude for an entity: the metric, its value, and the provenance
+/// (`Exact` vs `Approximate`) so the caller can render precision honestly. Carries
+/// no actor identity — the boundary that keeps "how many?" separate from "who?".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CounterValue {
+    pub metric: Metric,
+    pub value: i64,
+    pub kind: MetricKind,
+}
+
+impl CounterValue {
+    /// Build a value, stamping the provenance from the metric's intrinsic kind.
+    pub fn new(metric: Metric, value: i64) -> Self {
+        Self {
+            metric,
+            value,
+            kind: metric.kind(),
+        }
+    }
+}
+
+/// The set of served magnitudes for one entity reference.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CountSnapshot {
+    pub entity: EntityRef,
+    pub values: Vec<CounterValue>,
+}
+
+impl CountSnapshot {
+    pub fn new(entity: EntityRef, values: Vec<CounterValue>) -> Self {
+        Self { entity, values }
+    }
+
+    /// The value for a metric, if present in this snapshot.
+    pub fn get(&self, metric: Metric) -> Option<i64> {
+        self.values
+            .iter()
+            .find(|v| v.metric == metric)
+            .map(|v| v.value)
+    }
+
+    /// Derive the coarse popularity signal for this entity from its magnitudes.
+    ///
+    /// A deterministic weighted blend — this is the slow-loop transform whose
+    /// output is published on `counter.v1.popularity` and projected by `search`.
+    /// It is intentionally cheap and side-effect-free: popularity is recomputed
+    /// from already-aggregated counts, never from per-event work.
+    pub fn popularity(&self, weights: &PopularityWeights) -> PopularityScore {
+        let total: f64 = self
+            .values
+            .iter()
+            .map(|v| weights.for_metric(v.metric) * v.value as f64)
+            .sum();
+        PopularityScore::new(total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_object::{EntityId, EntityKind};
+
+    fn post() -> EntityRef {
+        EntityRef::new(EntityKind::Post, EntityId::new("p1").unwrap())
+    }
+
+    #[test]
+    fn counter_value_stamps_provenance_from_metric() {
+        assert_eq!(CounterValue::new(Metric::Like, 5).kind, MetricKind::Exact);
+        assert_eq!(
+            CounterValue::new(Metric::View, 9).kind,
+            MetricKind::Approximate
+        );
+    }
+
+    #[test]
+    fn popularity_is_weighted_blend() {
+        let snap = CountSnapshot::new(
+            post(),
+            vec![
+                CounterValue::new(Metric::View, 100), // 100 * 0.1 = 10
+                CounterValue::new(Metric::Like, 10),  // 10  * 1.0 = 10
+                CounterValue::new(Metric::Share, 5),  // 5   * 3.0 = 15
+                CounterValue::new(Metric::Follower, 999), // weight 0 → ignored
+            ],
+        );
+        let score = snap.popularity(&PopularityWeights::default());
+        assert_eq!(score.value(), 35.0);
+    }
+
+    #[test]
+    fn empty_snapshot_has_zero_popularity() {
+        let snap = CountSnapshot::new(post(), vec![]);
+        assert_eq!(
+            snap.popularity(&PopularityWeights::default()),
+            PopularityScore::ZERO
+        );
+    }
+
+    #[test]
+    fn get_returns_metric_value() {
+        let snap = CountSnapshot::new(post(), vec![CounterValue::new(Metric::View, 42)]);
+        assert_eq!(snap.get(Metric::View), Some(42));
+        assert_eq!(snap.get(Metric::Like), None);
+    }
+}

--- a/crates/services/counter/src/domain/value_object/entity.rs
+++ b/crates/services/counter/src/domain/value_object/entity.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::CounterError;
+
+/// The kind of entity a counter is attached to. Counter-analytics owns no entity;
+/// this is a *reference* discriminant for a record owned by another service
+/// (`post` / `profile` / `media` / `comment`, or a hashtag keyed by its tag).
+///
+/// The `as_str` form is the stable storage discriminant used in Redis keys,
+/// ledger rows, and time-series partitions — it is part of the storage contract,
+/// so treat changes as a migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EntityKind {
+    Post,
+    Profile,
+    Media,
+    Hashtag,
+    Comment,
+}
+
+impl EntityKind {
+    /// Stable lowercase discriminant used for key/partition naming and event
+    /// mapping.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EntityKind::Post => "post",
+            EntityKind::Profile => "profile",
+            EntityKind::Media => "media",
+            EntityKind::Hashtag => "hashtag",
+            EntityKind::Comment => "comment",
+        }
+    }
+
+    /// Parse the stable discriminant. An unrecognized value is a contract fault,
+    /// surfaced as `CTR-9001 DomainViolation`.
+    pub fn try_from_str(s: &str) -> Result<Self, CounterError> {
+        match s {
+            "post" => Ok(EntityKind::Post),
+            "profile" => Ok(EntityKind::Profile),
+            "media" => Ok(EntityKind::Media),
+            "hashtag" => Ok(EntityKind::Hashtag),
+            "comment" => Ok(EntityKind::Comment),
+            other => Err(CounterError::DomainViolation {
+                field: "entity_type".to_owned(),
+                message: format!("unknown entity kind '{other}'"),
+            }),
+        }
+    }
+}
+
+/// An opaque entity id owned by the upstream service. Counter never interprets it
+/// beyond equality + key composition. A blank id is a malformed event, surfaced
+/// as `CTR-9002 InvalidIdentifier`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EntityId(String);
+
+impl EntityId {
+    pub fn new(value: impl Into<String>) -> Result<Self, CounterError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(CounterError::InvalidIdentifier("entity_id".to_owned()));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A reference to the entity a count is attached to: `(kind, id)`. This is the
+/// unit counter-analytics aggregates magnitudes *for* — it stores nothing else
+/// about the entity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EntityRef {
+    pub kind: EntityKind,
+    pub id: EntityId,
+}
+
+impl EntityRef {
+    pub fn new(kind: EntityKind, id: EntityId) -> Self {
+        Self { kind, id }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn entity_kind_round_trips() {
+        for kind in [
+            EntityKind::Post,
+            EntityKind::Profile,
+            EntityKind::Media,
+            EntityKind::Hashtag,
+            EntityKind::Comment,
+        ] {
+            assert_eq!(EntityKind::try_from_str(kind.as_str()).unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn entity_kind_rejects_unknown() {
+        let err = EntityKind::try_from_str("account").unwrap_err();
+        assert_eq!(err.error_code(), "CTR-9001");
+    }
+
+    #[test]
+    fn entity_id_rejects_blank() {
+        let err = EntityId::new("   ").unwrap_err();
+        assert_eq!(err.error_code(), "CTR-9002");
+    }
+
+    #[test]
+    fn entity_id_accepts_non_empty() {
+        assert_eq!(EntityId::new("post-1").unwrap().as_str(), "post-1");
+    }
+}

--- a/crates/services/counter/src/domain/value_object/member.rs
+++ b/crates/services/counter/src/domain/value_object/member.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::CounterError;
+
+/// The actor/viewer id folded into a HyperLogLog for a cardinality metric (unique
+/// viewers, reach).
+///
+/// Privacy note (the boundary): a `MemberId` exists only **transiently**, inside
+/// an open aggregation window, to be `PFADD`-ed into a probabilistic estimator.
+/// It is never persisted as identity and never leaves the service — the HLL keeps
+/// no membership, only an estimate. This is what lets counter answer "how many
+/// unique viewers?" without ever owning "who viewed?" (that edge state is not
+/// counter's to hold).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct MemberId(String);
+
+impl MemberId {
+    pub fn new(value: impl Into<String>) -> Result<Self, CounterError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(CounterError::InvalidIdentifier("member_id".to_owned()));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn accepts_non_empty() {
+        assert_eq!(MemberId::new("viewer-1").unwrap().as_str(), "viewer-1");
+    }
+
+    #[test]
+    fn rejects_blank() {
+        let err = MemberId::new("").unwrap_err();
+        assert_eq!(err.error_code(), "CTR-9002");
+    }
+}

--- a/crates/services/counter/src/domain/value_object/metric.rs
+++ b/crates/services/counter/src/domain/value_object/metric.rs
@@ -1,0 +1,178 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::CounterError;
+
+/// Whether a served count is reconcilable against an authoritative set, or an
+/// accepted estimate. This is the single most load-bearing classification in the
+/// domain: it decides whether at-least-once double-counting is a bug or a
+/// tolerated property, and whether the reconciliation loop (Phase 7) is even
+/// applicable to the metric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MetricKind {
+    /// A window onto a set another service authoritatively owns (likes, follows).
+    /// Served fast and approximate on the hot path, but **periodically reconciled**
+    /// to exactness against the source-of-record. Double-counting here is a defect.
+    Exact,
+    /// Firehose telemetry no one audits per-unit (views, unique viewers). Served
+    /// from sharded counters / HyperLogLog within a documented error bound;
+    /// at-least-once double-counting is **tolerated by design** and never
+    /// reconciled per-unit.
+    Approximate,
+}
+
+/// How a metric is aggregated. Orthogonal to [`MetricKind`]: a `Sum` metric may be
+/// `Exact` (likes) or `Approximate` (views); a `Cardinality` metric is always
+/// `Approximate`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Aggregation {
+    /// Signed additive magnitude (`+1` like, `-1` unlike, `+1/-1` follow). Folded
+    /// by summing deltas; served from a counter (`INCRBY` / sharded `INCRBY`).
+    Sum,
+    /// Distinct-element count over actor/viewer ids. Folded by collecting members;
+    /// served from a HyperLogLog (`PFADD` / `PFCOUNT`). Requires a member id per
+    /// observation.
+    Cardinality,
+}
+
+/// The metric being counted across the fleet. The exact-vs-approximate split and
+/// the aggregation strategy are intrinsic properties of the metric, decided here
+/// once so every layer (fold, store adapter, reconciliation, read) agrees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Metric {
+    View,
+    Impression,
+    Click,
+    Like,
+    Share,
+    Comment,
+    Follower,
+    Following,
+    UniqueViewer,
+    Reach,
+}
+
+impl Metric {
+    /// Every metric, for exhaustive iteration in tests and "all metrics" reads.
+    pub const ALL: [Metric; 10] = [
+        Metric::View,
+        Metric::Impression,
+        Metric::Click,
+        Metric::Like,
+        Metric::Share,
+        Metric::Comment,
+        Metric::Follower,
+        Metric::Following,
+        Metric::UniqueViewer,
+        Metric::Reach,
+    ];
+
+    /// Stable lowercase discriminant used in keys, ledger rows, and event mapping.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Metric::View => "view",
+            Metric::Impression => "impression",
+            Metric::Click => "click",
+            Metric::Like => "like",
+            Metric::Share => "share",
+            Metric::Comment => "comment",
+            Metric::Follower => "follower",
+            Metric::Following => "following",
+            Metric::UniqueViewer => "unique_viewer",
+            Metric::Reach => "reach",
+        }
+    }
+
+    /// Parse the stable discriminant. An unrecognized value is surfaced as
+    /// `CTR-1002 UnsupportedMetric`.
+    pub fn try_from_str(s: &str) -> Result<Self, CounterError> {
+        Metric::ALL
+            .into_iter()
+            .find(|m| m.as_str() == s)
+            .ok_or_else(|| CounterError::UnsupportedMetric {
+                metric: s.to_owned(),
+            })
+    }
+
+    /// Reconcilable (`Exact`) vs accepted estimate (`Approximate`).
+    pub fn kind(&self) -> MetricKind {
+        match self {
+            // Windows onto sets owned by `engagement` / `social-graph` / `comment`.
+            Metric::Like
+            | Metric::Share
+            | Metric::Comment
+            | Metric::Follower
+            | Metric::Following => MetricKind::Exact,
+            // Firehose telemetry, accepted approximate.
+            Metric::View
+            | Metric::Impression
+            | Metric::Click
+            | Metric::UniqueViewer
+            | Metric::Reach => MetricKind::Approximate,
+        }
+    }
+
+    /// Additive sum vs distinct-element cardinality.
+    pub fn aggregation(&self) -> Aggregation {
+        match self {
+            Metric::UniqueViewer | Metric::Reach => Aggregation::Cardinality,
+            _ => Aggregation::Sum,
+        }
+    }
+
+    /// Whether folding an observation of this metric requires a unique member id
+    /// (true for cardinality metrics, which estimate distinct actors).
+    pub fn requires_member(&self) -> bool {
+        matches!(self.aggregation(), Aggregation::Cardinality)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn all_metrics_round_trip() {
+        for m in Metric::ALL {
+            assert_eq!(Metric::try_from_str(m.as_str()).unwrap(), m);
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_metric() {
+        let err = Metric::try_from_str("dwell_time").unwrap_err();
+        assert_eq!(err.error_code(), "CTR-1002");
+    }
+
+    #[test]
+    fn cardinality_metrics_are_always_approximate() {
+        for m in Metric::ALL {
+            if m.aggregation() == Aggregation::Cardinality {
+                assert_eq!(m.kind(), MetricKind::Approximate, "{m:?}");
+                assert!(m.requires_member(), "{m:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn exact_metrics_are_reconcilable_sums() {
+        for m in [
+            Metric::Like,
+            Metric::Share,
+            Metric::Comment,
+            Metric::Follower,
+            Metric::Following,
+        ] {
+            assert_eq!(m.kind(), MetricKind::Exact);
+            assert_eq!(m.aggregation(), Aggregation::Sum);
+            assert!(!m.requires_member());
+        }
+    }
+
+    #[test]
+    fn views_are_approximate_sums() {
+        assert_eq!(Metric::View.kind(), MetricKind::Approximate);
+        assert_eq!(Metric::View.aggregation(), Aggregation::Sum);
+    }
+}

--- a/crates/services/counter/src/domain/value_object/mod.rs
+++ b/crates/services/counter/src/domain/value_object/mod.rs
@@ -1,0 +1,14 @@
+//! Pure value objects for the counter aggregation model. No I/O, no clock reads
+//! (time is injected as `DateTime<Utc>` parameters), no store awareness.
+
+pub mod entity;
+pub mod member;
+pub mod metric;
+pub mod popularity;
+pub mod window;
+
+pub use entity::{EntityId, EntityKind, EntityRef};
+pub use member::MemberId;
+pub use metric::{Aggregation, Metric, MetricKind};
+pub use popularity::{PopularityScore, PopularityWeights};
+pub use window::{WindowId, WindowSize};

--- a/crates/services/counter/src/domain/value_object/popularity.rs
+++ b/crates/services/counter/src/domain/value_object/popularity.rs
@@ -1,0 +1,95 @@
+use serde::{Deserialize, Serialize};
+
+use super::metric::Metric;
+
+/// A coarse, non-negative popularity signal derived on a slow loop from counter
+/// snapshots.
+///
+/// This is the value counter-analytics publishes on `counter.v1.popularity` and
+/// that `search` projects into its `PopularityScore` ranking input (it currently
+/// projects zero — this signal unblocks it). It is deliberately *coarse*: derived
+/// periodically from aggregated magnitudes, never per-event, so it never causes
+/// write-amplification downstream.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct PopularityScore(f64);
+
+impl PopularityScore {
+    pub const ZERO: Self = Self(0.0);
+
+    /// Clamp to non-negative; a negative popularity is meaningless.
+    pub fn new(value: f64) -> Self {
+        Self(if value.is_finite() { value.max(0.0) } else { 0.0 })
+    }
+
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+impl Default for PopularityScore {
+    fn default() -> Self {
+        PopularityScore::ZERO
+    }
+}
+
+/// Per-metric weights blended into a [`PopularityScore`]. The defaults encode a
+/// deliberate ordering: a deep engagement (share) counts for more than a cheap
+/// one (a view), so virality outranks raw reach. Tunable without touching the
+/// fold or the read path.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PopularityWeights {
+    pub view: f64,
+    pub like: f64,
+    pub share: f64,
+    pub comment: f64,
+}
+
+impl Default for PopularityWeights {
+    fn default() -> Self {
+        Self {
+            view: 0.1,
+            like: 1.0,
+            share: 3.0,
+            comment: 2.0,
+        }
+    }
+}
+
+impl PopularityWeights {
+    /// The weight applied to a metric; metrics without a weight contribute nothing
+    /// to the coarse score (followers, impressions, etc. are not popularity
+    /// inputs by default).
+    pub fn for_metric(&self, metric: Metric) -> f64 {
+        match metric {
+            Metric::View => self.view,
+            Metric::Like => self.like,
+            Metric::Share => self.share,
+            Metric::Comment => self.comment,
+            _ => 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_negative_and_non_finite_to_zero() {
+        assert_eq!(PopularityScore::new(-3.0).value(), 0.0);
+        assert_eq!(PopularityScore::new(f64::NAN).value(), 0.0);
+        assert_eq!(PopularityScore::new(f64::INFINITY).value(), 0.0);
+    }
+
+    #[test]
+    fn preserves_non_negative() {
+        assert_eq!(PopularityScore::new(12.5).value(), 12.5);
+    }
+
+    #[test]
+    fn default_weights_rank_share_above_view() {
+        let w = PopularityWeights::default();
+        assert!(w.for_metric(Metric::Share) > w.for_metric(Metric::View));
+        assert_eq!(w.for_metric(Metric::Follower), 0.0);
+    }
+}

--- a/crates/services/counter/src/domain/value_object/window.rs
+++ b/crates/services/counter/src/domain/value_object/window.rs
@@ -1,0 +1,137 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CounterError;
+
+/// The width of a tumbling pre-aggregation window, in milliseconds. This is the
+/// knob that sets the N→1 collapse ratio: all observations for one `(entity,
+/// metric)` within a window fold into a single delta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowSize {
+    millis: u64,
+}
+
+impl WindowSize {
+    /// Build a window size. Zero is rejected — a zero-width window cannot
+    /// aggregate (surfaced as `CTR-9001 DomainViolation`).
+    pub fn from_millis(millis: u64) -> Result<Self, CounterError> {
+        if millis == 0 {
+            return Err(CounterError::DomainViolation {
+                field: "window_ms".to_owned(),
+                message: "window size must be non-zero".to_owned(),
+            });
+        }
+        Ok(Self { millis })
+    }
+
+    pub fn millis(&self) -> u64 {
+        self.millis
+    }
+}
+
+/// The identity of a tumbling window: `floor(event_millis / window_ms)`.
+///
+/// This is the linchpin of idempotent durability. The durable flush is keyed by
+/// `(entity, metric, window_id)`, so a worker crash and Kafka redelivery
+/// re-aggregate the *same* `WindowId` and re-apply the *same* delta — an
+/// idempotent UPSERT, never a double-add. It is derived purely from **event
+/// time** (injected), never from a wall clock, so the same event always lands in
+/// the same window regardless of when it is processed. (Counter's analogue of
+/// search's monotonic `DocVersion`.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct WindowId(u64);
+
+impl WindowId {
+    /// The window an event falls into, given the window size. A pre-epoch event
+    /// time floors to window `0`.
+    pub fn for_event(size: WindowSize, occurred_at: DateTime<Utc>) -> Self {
+        let millis = occurred_at.timestamp_millis();
+        let millis = if millis < 0 { 0 } else { millis as u64 };
+        Self(millis / size.millis())
+    }
+
+    /// Reconstruct from a stored index (e.g. when replaying a durable row).
+    pub fn from_index(index: u64) -> Self {
+        Self(index)
+    }
+
+    pub fn index(&self) -> u64 {
+        self.0
+    }
+
+    /// Inclusive start of this window, in epoch milliseconds, under `size`.
+    pub fn start_millis(&self, size: WindowSize) -> u64 {
+        self.0 * size.millis()
+    }
+
+    /// Exclusive end of this window, in epoch milliseconds, under `size`.
+    pub fn end_millis(&self, size: WindowSize) -> u64 {
+        self.start_millis(size) + size.millis()
+    }
+
+    /// Whether this window has fully elapsed relative to a watermark — i.e. no
+    /// further events can land in it, so it is safe to flush. The watermark is the
+    /// event-time frontier (injected), not a wall clock.
+    pub fn is_closed_at(&self, size: WindowSize, watermark: DateTime<Utc>) -> bool {
+        let wm = watermark.timestamp_millis();
+        let wm = if wm < 0 { 0 } else { wm as u64 };
+        self.end_millis(size) <= wm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn at(millis: i64) -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(millis).unwrap()
+    }
+
+    #[test]
+    fn zero_window_rejected() {
+        assert!(WindowSize::from_millis(0).is_err());
+    }
+
+    #[test]
+    fn events_in_same_window_share_id() {
+        let size = WindowSize::from_millis(5_000).unwrap();
+        let a = WindowId::for_event(size, at(10_000));
+        let b = WindowId::for_event(size, at(14_999));
+        assert_eq!(a, b);
+        assert_eq!(a.index(), 2);
+    }
+
+    #[test]
+    fn window_boundary_splits() {
+        let size = WindowSize::from_millis(5_000).unwrap();
+        let a = WindowId::for_event(size, at(14_999));
+        let b = WindowId::for_event(size, at(15_000));
+        assert_ne!(a, b);
+        assert_eq!(b.index(), 3);
+    }
+
+    #[test]
+    fn start_and_end_bracket_the_window() {
+        let size = WindowSize::from_millis(5_000).unwrap();
+        let w = WindowId::for_event(size, at(12_345));
+        assert_eq!(w.start_millis(size), 10_000);
+        assert_eq!(w.end_millis(size), 15_000);
+    }
+
+    #[test]
+    fn closes_only_once_fully_elapsed() {
+        let size = WindowSize::from_millis(5_000).unwrap();
+        let w = WindowId::from_index(2); // [10_000, 15_000)
+        assert!(!w.is_closed_at(size, at(14_999)));
+        assert!(w.is_closed_at(size, at(15_000)));
+        assert!(w.is_closed_at(size, at(20_000)));
+    }
+
+    #[test]
+    fn pre_epoch_floors_to_window_zero() {
+        let size = WindowSize::from_millis(5_000).unwrap();
+        assert_eq!(WindowId::for_event(size, at(-1)).index(), 0);
+    }
+}

--- a/crates/services/counter/src/error.rs
+++ b/crates/services/counter/src/error.rs
@@ -1,0 +1,309 @@
+use error::{AppError, Severity};
+use http::StatusCode;
+use thiserror::Error;
+
+/// Canonical domain and application error type for the counter-analytics
+/// microservice.
+///
+/// The `CTR-XXXX` namespace is grouped by concern so a code alone localizes the
+/// fault: 1xxx read/query, 2xxx aggregation/window, 3xxx flush/write-behind,
+/// 4xxx store availability (the fail-open core), 5xxx reconciliation/drift (the
+/// Phase-7 correctness surface), 8xxx inbound event decode / source mapping,
+/// 9xxx cross-cutting (domain/parse, event consumption).
+///
+/// ## Code catalogue
+///
+/// | Code     | Variant                  | HTTP | Severity | Retryable |
+/// |----------|--------------------------|------|----------|-----------|
+/// | CTR-1001 | InvalidCounterQuery      | 422  | Low      | No        |
+/// | CTR-1002 | UnsupportedMetric        | 422  | Low      | No        |
+/// | CTR-1003 | InvalidTimeRange         | 422  | Low      | No        |
+/// | CTR-1004 | InvalidTrendingScope     | 422  | Low      | No        |
+/// | CTR-2001 | WindowAggregationFailed  | 500  | Medium   | No        |
+/// | CTR-2002 | InvalidDelta             | 422  | Medium   | No        |
+/// | CTR-2003 | ProbabilisticError       | 500  | Medium   | No        |
+/// | CTR-3001 | FlushFailed              | 500  | **High** | **Yes**   |
+/// | CTR-3002 | CacheWriteFailed         | 500  | Medium   | **Yes**   |
+/// | CTR-3003 | SignalPublishFailed      | 500  | Medium   | **Yes**   |
+/// | CTR-4001 | HotStoreUnavailable      | 503  | **High** | **Yes**   |
+/// | CTR-4002 | LedgerUnavailable        | 503  | **High** | **Yes**   |
+/// | CTR-4003 | TimeSeriesUnavailable    | 503  | **High** | **Yes**   |
+/// | CTR-4004 | StoreTimeout             | 504  | **High** | **Yes**   |
+/// | CTR-5001 | ReconciliationFailed     | 500  | Medium   | No        |
+/// | CTR-5002 | DriftThresholdExceeded   | 500  | **High** | No        |
+/// | CTR-5003 | SourceReplayFailed       | 500  | Medium   | **Yes**   |
+/// | CTR-8001 | EventDecodeFailed        | 422  | Medium   | No        |
+/// | CTR-8002 | UnknownEventType         | 422  | Low      | No        |
+/// | CTR-8003 | UnmappedMetric           | 422  | Medium   | No        |
+/// | CTR-9001 | DomainViolation          | 422  | Medium   | No        |
+/// | CTR-9002 | InvalidIdentifier        | 422  | Low      | No        |
+/// | CTR-9003 | EventConsumeFailed       | 500  | Medium   | No        |
+/// | VAL-*    | Validation (delegated)   | 422  | Low      | No        |
+///
+/// > **Fail-open semantics.** Counter-analytics is a derived, best-effort
+/// > read-model. The `4xxx` store faults are *transient*: on the **read** path
+/// > they degrade to a stale-but-served snapshot (never a 5xx that blocks a feed
+/// > render); on the **ingestion** path their `is_retryable` flags drive the
+/// > `run_consumer` retry/DLQ classification — a redelivered event re-flushes the
+/// > same idempotent window, a poison event (`CTR-8001`) is dead-lettered, and an
+/// > unmapped/unknown event (`CTR-8002`) is a harmless skip folded into `Ok` so
+/// > the offset still commits. Counts are eventually consistent and periodically
+/// > reconciled (`5xxx`); they are never in a synchronous write path.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CounterError {
+    // ── Delegated ─────────────────────────────────────────────────────────────
+    #[error(transparent)]
+    Validation(#[from] validation::ValidationError),
+
+    // ── Read / query (CTR-1xxx) ───────────────────────────────────────────────
+    #[error("invalid counter query: {reason}")]
+    InvalidCounterQuery { reason: String },
+
+    #[error("unsupported metric: '{metric}'")]
+    UnsupportedMetric { metric: String },
+
+    #[error("invalid time-series range or granularity: {reason}")]
+    InvalidTimeRange { reason: String },
+
+    #[error("invalid trending scope: '{scope}'")]
+    InvalidTrendingScope { scope: String },
+
+    // ── Aggregation / window (CTR-2xxx) ───────────────────────────────────────
+    #[error("failed to aggregate counter window: {reason}")]
+    WindowAggregationFailed { reason: String },
+
+    #[error("invalid counter delta: {reason}")]
+    InvalidDelta { reason: String },
+
+    /// A HyperLogLog / Count-Min-Sketch operation failed (encode/decode/merge).
+    #[error("probabilistic structure operation failed: {reason}")]
+    ProbabilisticError { reason: String },
+
+    // ── Flush / write-behind (CTR-3xxx) ───────────────────────────────────────
+    /// A batched, window-keyed flush to the durable tier (Postgres ledger / Scylla
+    /// time-series) failed. Retryable: the flush is idempotent on `(entity, metric,
+    /// window_id)`, so a replay re-applies the same window without double-counting.
+    #[error("durable flush failed: {reason}")]
+    FlushFailed { reason: String },
+
+    #[error("hot-store write failed: {reason}")]
+    CacheWriteFailed { reason: String },
+
+    #[error("failed to publish the popularity signal: {reason}")]
+    SignalPublishFailed { reason: String },
+
+    // ── Store availability · the fail-open core (CTR-4xxx) ────────────────────
+    #[error("the hot counter store (Redis) is unavailable")]
+    HotStoreUnavailable,
+
+    #[error("the warm counter ledger (Postgres) is unavailable")]
+    LedgerUnavailable,
+
+    #[error("the cold time-series store (Scylla) is unavailable")]
+    TimeSeriesUnavailable,
+
+    #[error("a counter store operation timed out")]
+    StoreTimeout,
+
+    // ── Reconciliation / drift · Phase-7 correctness (CTR-5xxx) ───────────────
+    #[error("reconciliation run failed: {reason}")]
+    ReconciliationFailed { reason: String },
+
+    /// The drift between the fast approximate hot count and the authoritative
+    /// replayed total exceeded tolerance — a correctness alarm, not a transient
+    /// fault.
+    #[error("counter drift exceeded tolerance for '{metric}': {detail}")]
+    DriftThresholdExceeded { metric: String, detail: String },
+
+    /// Could not query the owning source-of-record to rebuild an exact count;
+    /// retryable (the SoR may be briefly unavailable).
+    #[error("source replay for reconciliation failed: {reason}")]
+    SourceReplayFailed { reason: String },
+
+    // ── Inbound event decode / source mapping (CTR-8xxx) ──────────────────────
+    #[error("failed to decode event from topic '{topic}': {reason}")]
+    EventDecodeFailed { topic: String, reason: String },
+
+    /// An event type this consumer does not aggregate; usually folded into an
+    /// `Ok` skip rather than dead-lettered.
+    #[error("unknown event type: '{event_type}'")]
+    UnknownEventType { event_type: String },
+
+    #[error("event could not be mapped to a counter metric: {reason}")]
+    UnmappedMetric { reason: String },
+
+    // ── Cross-cutting (CTR-9xxx) ──────────────────────────────────────────────
+    #[error("domain invariant violated on '{field}': {message}")]
+    DomainViolation { field: String, message: String },
+
+    #[error("invalid identifier: '{0}'")]
+    InvalidIdentifier(String),
+
+    #[error("failed to consume event: {0}")]
+    EventConsumeFailed(String),
+}
+
+impl AppError for CounterError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            CounterError::Validation(e) => e.error_code(),
+
+            CounterError::InvalidCounterQuery { .. } => "CTR-1001",
+            CounterError::UnsupportedMetric { .. } => "CTR-1002",
+            CounterError::InvalidTimeRange { .. } => "CTR-1003",
+            CounterError::InvalidTrendingScope { .. } => "CTR-1004",
+
+            CounterError::WindowAggregationFailed { .. } => "CTR-2001",
+            CounterError::InvalidDelta { .. } => "CTR-2002",
+            CounterError::ProbabilisticError { .. } => "CTR-2003",
+
+            CounterError::FlushFailed { .. } => "CTR-3001",
+            CounterError::CacheWriteFailed { .. } => "CTR-3002",
+            CounterError::SignalPublishFailed { .. } => "CTR-3003",
+
+            CounterError::HotStoreUnavailable => "CTR-4001",
+            CounterError::LedgerUnavailable => "CTR-4002",
+            CounterError::TimeSeriesUnavailable => "CTR-4003",
+            CounterError::StoreTimeout => "CTR-4004",
+
+            CounterError::ReconciliationFailed { .. } => "CTR-5001",
+            CounterError::DriftThresholdExceeded { .. } => "CTR-5002",
+            CounterError::SourceReplayFailed { .. } => "CTR-5003",
+
+            CounterError::EventDecodeFailed { .. } => "CTR-8001",
+            CounterError::UnknownEventType { .. } => "CTR-8002",
+            CounterError::UnmappedMetric { .. } => "CTR-8003",
+
+            CounterError::DomainViolation { .. } => "CTR-9001",
+            CounterError::InvalidIdentifier(_) => "CTR-9002",
+            CounterError::EventConsumeFailed(_) => "CTR-9003",
+        }
+    }
+
+    fn http_status(&self) -> StatusCode {
+        match self {
+            CounterError::Validation(e) => e.http_status(),
+
+            CounterError::HotStoreUnavailable
+            | CounterError::LedgerUnavailable
+            | CounterError::TimeSeriesUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+
+            CounterError::StoreTimeout => StatusCode::GATEWAY_TIMEOUT,
+
+            CounterError::WindowAggregationFailed { .. }
+            | CounterError::ProbabilisticError { .. }
+            | CounterError::FlushFailed { .. }
+            | CounterError::CacheWriteFailed { .. }
+            | CounterError::SignalPublishFailed { .. }
+            | CounterError::ReconciliationFailed { .. }
+            | CounterError::DriftThresholdExceeded { .. }
+            | CounterError::SourceReplayFailed { .. }
+            | CounterError::EventConsumeFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+
+            _ => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            CounterError::Validation(e) => e.severity(),
+
+            CounterError::FlushFailed { .. }
+            | CounterError::HotStoreUnavailable
+            | CounterError::LedgerUnavailable
+            | CounterError::TimeSeriesUnavailable
+            | CounterError::StoreTimeout
+            | CounterError::DriftThresholdExceeded { .. } => Severity::High,
+
+            CounterError::WindowAggregationFailed { .. }
+            | CounterError::InvalidDelta { .. }
+            | CounterError::ProbabilisticError { .. }
+            | CounterError::CacheWriteFailed { .. }
+            | CounterError::SignalPublishFailed { .. }
+            | CounterError::ReconciliationFailed { .. }
+            | CounterError::SourceReplayFailed { .. }
+            | CounterError::EventDecodeFailed { .. }
+            | CounterError::UnmappedMetric { .. }
+            | CounterError::DomainViolation { .. }
+            | CounterError::EventConsumeFailed(_) => Severity::Medium,
+
+            _ => Severity::Low,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            CounterError::Validation(e) => e.is_retryable(),
+            CounterError::FlushFailed { .. }
+            | CounterError::CacheWriteFailed { .. }
+            | CounterError::SignalPublishFailed { .. }
+            | CounterError::HotStoreUnavailable
+            | CounterError::LedgerUnavailable
+            | CounterError::TimeSeriesUnavailable
+            | CounterError::StoreTimeout
+            | CounterError::SourceReplayFailed { .. } => true,
+            _ => false,
+        }
+    }
+
+    fn category(&self) -> &'static str {
+        match self {
+            CounterError::Validation(e) => e.category(),
+            _ => "CTR",
+        }
+    }
+
+    fn user_facing_message(&self) -> &'static str {
+        match self {
+            CounterError::Validation(e) => e.user_facing_message(),
+
+            CounterError::InvalidCounterQuery { .. }
+            | CounterError::UnsupportedMetric { .. }
+            | CounterError::InvalidTimeRange { .. }
+            | CounterError::InvalidTrendingScope { .. } => {
+                "Your counter request could not be processed."
+            }
+
+            CounterError::HotStoreUnavailable
+            | CounterError::LedgerUnavailable
+            | CounterError::TimeSeriesUnavailable
+            | CounterError::StoreTimeout => {
+                "Counts are temporarily unavailable. Please try again."
+            }
+
+            _ => "An internal counter error occurred.",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant must carry a stable, correctly-prefixed `CTR-XXXX` code and
+    /// agree with the documented retry classification that drives `run_consumer`.
+    #[test]
+    fn codes_are_stable_and_prefixed() {
+        let store_down = CounterError::HotStoreUnavailable;
+        assert_eq!(store_down.error_code(), "CTR-4001");
+        assert!(store_down.is_retryable());
+        assert_eq!(store_down.http_status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(store_down.severity(), Severity::High);
+
+        let poison = CounterError::EventDecodeFailed {
+            topic: "view.v1.events".into(),
+            reason: "bad frame".into(),
+        };
+        assert_eq!(poison.error_code(), "CTR-8001");
+        assert!(!poison.is_retryable()); // poison → DLQ, never an infinite retry
+
+        let skip = CounterError::UnknownEventType {
+            event_type: "post.archived".into(),
+        };
+        assert_eq!(skip.error_code(), "CTR-8002");
+        assert!(!skip.is_retryable()); // folded into Ok at the consumer
+
+        assert_eq!(store_down.category(), "CTR");
+    }
+}

--- a/crates/services/counter/src/infrastructure/consumer/mod.rs
+++ b/crates/services/counter/src/infrastructure/consumer/mod.rs
@@ -1,0 +1,119 @@
+//! The worker's ingestion path — the async command side.
+//!
+//! Each consumer runs on the shared at-least-once
+//! [`run_consumer`](transport::kafka::consumer::run_consumer) runner (manual commit,
+//! bounded retry + jitter, DLQ on poison/exhaustion). A decoded event is distilled
+//! into [`Observation`]s and folded into the **shared** [`WindowAggregator`]; a
+//! separate [`run_flush_loop`] drains closed windows on a ticker and fans them out
+//! through the [`DeltaFlusher`], then publishes the coarse popularity signal for the
+//! entities just touched.
+//!
+//! Durability note (the at-least-once windowing gap): events are committed once
+//! folded into the in-memory aggregator, before the window is flushed. A worker
+//! crash with un-flushed windows therefore loses a few seconds of aggregation —
+//! acceptable by design (approximate metrics tolerate it; exact metrics are healed
+//! by the Phase-7 reconciliation loop). Graceful shutdown drains everything first.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::sync::Mutex;
+use transport::kafka::consumer::{KafkaConsumerHandle, ProcessOutcome, RetryPolicy, run_consumer};
+use transport::kafka::envelope::ConsumablePayload;
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::command::{DeltaFlusher, PopularityPublisher};
+use crate::domain::{Observation, WindowAggregator};
+use crate::error::CounterError;
+
+/// Lets the at-least-once runner classify a failure: delegate to the error's own
+/// retry verdict — transient store faults retry; decode / domain faults are poison
+/// and dead-letter immediately.
+impl transport::kafka::consumer::ClassifyError for CounterError {
+    fn is_retryable(&self) -> bool {
+        <Self as error::AppError>::is_retryable(self)
+    }
+}
+
+/// Runs a fold consumer: decode each event into observations and fold them into the
+/// shared aggregator. `map` is the per-topic distillation (`map_view`, `map_reaction`,
+/// …); `run_consumer` owns deserialization, so poison bytes dead-letter before they
+/// reach `map`.
+pub async fn run_fold_consumer<T, M>(
+    label: &'static str,
+    consumer: KafkaConsumerHandle,
+    producer: KafkaProducerHandle,
+    aggregator: Arc<Mutex<WindowAggregator>>,
+    map: M,
+) where
+    T: ConsumablePayload + Clone,
+    M: Fn(T) -> Result<Vec<Observation>, CounterError> + Copy + Send + Sync + 'static,
+{
+    tracing::info!(label, "counter consumer started");
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<T, _>(&consumer, &producer, &policy, move |event| {
+        let aggregator = Arc::clone(&aggregator);
+        let event = event.clone();
+        Box::pin(async move {
+            let outcome = async {
+                let observations = map(event)?;
+                let mut agg = aggregator.lock().await;
+                for obs in observations {
+                    agg.fold(obs)?;
+                }
+                Ok::<(), CounterError>(())
+            }
+            .await;
+            ProcessOutcome::from_result(outcome)
+        })
+    })
+    .await;
+    if let Err(e) = result {
+        tracing::error!(label, error = %e, "counter consumer stopped");
+    }
+}
+
+/// Drains closed windows on a ticker, flushes them across the three tiers, and
+/// publishes the coarse popularity signal for the entities touched by the batch.
+pub async fn run_flush_loop(
+    aggregator: Arc<Mutex<WindowAggregator>>,
+    flusher: Arc<DeltaFlusher>,
+    popularity: Arc<PopularityPublisher>,
+    flush_interval: Duration,
+) {
+    tracing::info!("counter flush loop started");
+    let mut ticker = tokio::time::interval(flush_interval);
+    loop {
+        ticker.tick().await;
+        let deltas = {
+            let mut agg = aggregator.lock().await;
+            agg.drain_closed(Utc::now())
+        };
+        if deltas.is_empty() {
+            continue;
+        }
+
+        match flusher.flush(&deltas).await {
+            Ok(report) => tracing::debug!(applied = report.applied, "counter windows flushed"),
+            Err(error) => {
+                // The drained windows are lost (see the module durability note);
+                // exact metrics are healed by reconciliation, approximate tolerate it.
+                tracing::error!(%error, "counter flush failed; dropped windows");
+                continue;
+            }
+        }
+
+        // Coarse popularity refresh for the distinct entities just touched.
+        let mut seen = HashSet::new();
+        for delta in &deltas {
+            let entity = delta.entity();
+            if seen.insert((entity.kind, entity.id.as_str().to_owned()))
+                && let Err(error) = popularity.publish(entity).await
+            {
+                tracing::warn!(%error, "popularity publish failed");
+            }
+        }
+    }
+}

--- a/crates/services/counter/src/infrastructure/decode/decoder.rs
+++ b/crates/services/counter/src/infrastructure/decode/decoder.rs
@@ -1,0 +1,233 @@
+//! Pure wire → [`Observation`] distillation. One inbound event yields zero or more
+//! observations (a view becomes both a `View` sum and a `UniqueViewer` member; a
+//! follow becomes a `Follower` on the followee and a `Following` on the follower).
+//!
+//! This is engine-free and fully unit-tested; the consumer wiring (Phase 5) owns
+//! deserialization (so poison bytes dead-letter before reaching here) and then
+//! calls these `map_*` functions on the already-decoded wire enum.
+
+use chrono::{DateTime, TimeZone, Utc};
+
+use crate::domain::{EntityId, EntityKind, EntityRef, MemberId, Metric, Observation};
+use crate::error::CounterError;
+use crate::infrastructure::decode::wire::{FollowWire, HitWire, ReactionWire};
+
+fn at(ms: i64) -> DateTime<Utc> {
+    Utc.timestamp_millis_opt(ms).single().unwrap_or_else(Utc::now)
+}
+
+fn entity(kind: &str, id: &str) -> Result<EntityRef, CounterError> {
+    Ok(EntityRef::new(
+        EntityKind::try_from_str(kind)?,
+        EntityId::new(id)?,
+    ))
+}
+
+/// `view.v1.events` → a `View` sum (`+1`) plus, when the viewer is known, a
+/// `UniqueViewer` member for the HyperLogLog.
+pub fn map_view(wire: HitWire) -> Result<Vec<Observation>, CounterError> {
+    let e = entity(&wire.entity_type, &wire.entity_id)?;
+    let mut out = vec![Observation::sum(e.clone(), Metric::View, 1, at(wire.occurred_at_ms))?];
+    if let Some(actor) = wire.actor_id {
+        out.push(Observation::unique(
+            e,
+            Metric::UniqueViewer,
+            MemberId::new(actor)?,
+            at(wire.occurred_at_ms),
+        )?);
+    }
+    Ok(out)
+}
+
+/// `impression.v1.events` → an `Impression` sum plus, when the actor is known, a
+/// `Reach` member (unique accounts reached).
+pub fn map_impression(wire: HitWire) -> Result<Vec<Observation>, CounterError> {
+    let e = entity(&wire.entity_type, &wire.entity_id)?;
+    let mut out = vec![Observation::sum(
+        e.clone(),
+        Metric::Impression,
+        1,
+        at(wire.occurred_at_ms),
+    )?];
+    if let Some(actor) = wire.actor_id {
+        out.push(Observation::unique(
+            e,
+            Metric::Reach,
+            MemberId::new(actor)?,
+            at(wire.occurred_at_ms),
+        )?);
+    }
+    Ok(out)
+}
+
+/// `click.v1.events` → a `Click` sum (`+1`). Clicks are not deduplicated.
+pub fn map_click(wire: HitWire) -> Result<Vec<Observation>, CounterError> {
+    let e = entity(&wire.entity_type, &wire.entity_id)?;
+    Ok(vec![Observation::sum(
+        e,
+        Metric::Click,
+        1,
+        at(wire.occurred_at_ms),
+    )?])
+}
+
+/// `engagement.reactions` → a `Like` magnitude on the post. A brand-new reaction
+/// is `+1`, a removal is `-1`, and a *replacement* (an upsert carrying a prior
+/// `old_kind`) is a no-op — the reaction count did not change.
+pub fn map_reaction(wire: ReactionWire) -> Result<Vec<Observation>, CounterError> {
+    match wire {
+        ReactionWire::Upserted(e) if e.old_kind.is_some() => Ok(Vec::new()), // replacement
+        ReactionWire::Upserted(e) => Ok(vec![Observation::sum(
+            entity("post", &e.post_id)?,
+            Metric::Like,
+            1,
+            at(e.event_at_ms),
+        )?]),
+        ReactionWire::Removed(e) => Ok(vec![Observation::sum(
+            entity("post", &e.post_id)?,
+            Metric::Like,
+            -1,
+            at(e.event_at_ms),
+        )?]),
+    }
+}
+
+/// A social-graph follow change → a `Follower` magnitude on the followee and a
+/// `Following` magnitude on the follower (`+1` follow, `-1` unfollow), so both
+/// counts stay consistent from a single event.
+pub fn map_follow(wire: FollowWire) -> Result<Vec<Observation>, CounterError> {
+    let (change, amount) = match wire {
+        FollowWire::Followed(c) => (c, 1),
+        FollowWire::Unfollowed(c) => (c, -1),
+    };
+    let when = at(change.occurred_at_ms);
+    Ok(vec![
+        Observation::sum(
+            entity("profile", &change.followee_id)?,
+            Metric::Follower,
+            amount,
+            when,
+        )?,
+        Observation::sum(
+            entity("profile", &change.follower_id)?,
+            Metric::Following,
+            amount,
+            when,
+        )?,
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+    use crate::infrastructure::decode::wire::{
+        FollowChangeWire, ReactionRemovedWire, ReactionUpsertedWire,
+    };
+
+    #[test]
+    fn view_with_viewer_yields_view_and_unique() {
+        let obs = map_view(HitWire {
+            entity_type: "post".into(),
+            entity_id: "p1".into(),
+            actor_id: Some("viewer-1".into()),
+            occurred_at_ms: 1_000,
+        })
+        .unwrap();
+        assert_eq!(obs.len(), 2);
+        assert_eq!(obs[0].metric, Metric::View);
+        assert_eq!(obs[0].amount, 1);
+        assert_eq!(obs[1].metric, Metric::UniqueViewer);
+        assert_eq!(obs[1].unique_member.as_ref().unwrap().as_str(), "viewer-1");
+    }
+
+    #[test]
+    fn view_without_viewer_is_sum_only() {
+        let obs = map_view(HitWire {
+            entity_type: "post".into(),
+            entity_id: "p1".into(),
+            actor_id: None,
+            occurred_at_ms: 1_000,
+        })
+        .unwrap();
+        assert_eq!(obs.len(), 1);
+        assert_eq!(obs[0].metric, Metric::View);
+    }
+
+    #[test]
+    fn unknown_entity_kind_is_rejected() {
+        let err = map_view(HitWire {
+            entity_type: "account".into(),
+            entity_id: "a1".into(),
+            actor_id: None,
+            occurred_at_ms: 1,
+        })
+        .unwrap_err();
+        assert_eq!(err.error_code(), "CTR-9001");
+    }
+
+    #[test]
+    fn new_reaction_is_plus_one_like() {
+        let obs = map_reaction(ReactionWire::Upserted(ReactionUpsertedWire {
+            post_id: "p1".into(),
+            old_kind: None,
+            event_at_ms: 1,
+        }))
+        .unwrap();
+        assert_eq!(obs.len(), 1);
+        assert_eq!(obs[0].metric, Metric::Like);
+        assert_eq!(obs[0].amount, 1);
+    }
+
+    #[test]
+    fn replaced_reaction_is_a_no_op() {
+        let obs = map_reaction(ReactionWire::Upserted(ReactionUpsertedWire {
+            post_id: "p1".into(),
+            old_kind: Some("heart".into()),
+            event_at_ms: 1,
+        }))
+        .unwrap();
+        assert!(obs.is_empty());
+    }
+
+    #[test]
+    fn removed_reaction_is_minus_one_like() {
+        let obs = map_reaction(ReactionWire::Removed(ReactionRemovedWire {
+            post_id: "p1".into(),
+            event_at_ms: 1,
+        }))
+        .unwrap();
+        assert_eq!(obs[0].amount, -1);
+    }
+
+    #[test]
+    fn follow_updates_both_sides() {
+        let obs = map_follow(FollowWire::Followed(FollowChangeWire {
+            follower_id: "alice".into(),
+            followee_id: "bob".into(),
+            occurred_at_ms: 1,
+        }))
+        .unwrap();
+        assert_eq!(obs.len(), 2);
+        // followee gains a Follower
+        assert_eq!(obs[0].metric, Metric::Follower);
+        assert_eq!(obs[0].entity.id.as_str(), "bob");
+        assert_eq!(obs[0].amount, 1);
+        // follower gains a Following
+        assert_eq!(obs[1].metric, Metric::Following);
+        assert_eq!(obs[1].entity.id.as_str(), "alice");
+    }
+
+    #[test]
+    fn unfollow_decrements_both_sides() {
+        let obs = map_follow(FollowWire::Unfollowed(FollowChangeWire {
+            follower_id: "alice".into(),
+            followee_id: "bob".into(),
+            occurred_at_ms: 1,
+        }))
+        .unwrap();
+        assert_eq!(obs[0].amount, -1);
+        assert_eq!(obs[1].amount, -1);
+    }
+}

--- a/crates/services/counter/src/infrastructure/decode/mod.rs
+++ b/crates/services/counter/src/infrastructure/decode/mod.rs
@@ -1,0 +1,10 @@
+//! The inbound event-decode layer: counter-owned wire DTOs ([`wire`]) and the pure
+//! `map_*` distillation into domain [`Observation`](crate::domain::Observation)s
+//! ([`decoder`]). Engine-free and unit-tested; the consumer (Phase 5) deserializes
+//! the bytes and drives these mappers.
+
+pub mod decoder;
+pub mod wire;
+
+pub use decoder::{map_click, map_follow, map_impression, map_reaction, map_view};
+pub use wire::{FollowWire, HitWire, ReactionWire};

--- a/crates/services/counter/src/infrastructure/decode/wire.rs
+++ b/crates/services/counter/src/infrastructure/decode/wire.rs
@@ -1,0 +1,73 @@
+//! Counter-owned deserialization DTOs for the events it consumes.
+//!
+//! Counter must not depend on the `engagement` / `social-graph` crates (a sideways
+//! services→services edge the tiering forbids), so it owns its read schema:
+//! minimal, lenient structs that match the published JSON. Extra fields are
+//! ignored, so an additive change upstream never breaks a consumer.
+//!
+//! Integration reality (mirrors `search`'s honesty about thin events):
+//! * `view` / `impression` / `click` are **counter-owned firehose schemas** — no
+//!   upstream producer exists yet; the edge/BFF will produce telemetry matching
+//!   these shapes. They are notifications, and counts need nothing more than the
+//!   `(entity, actor?, time)` they carry — no hydration.
+//! * `engagement.reactions` **matches the live upstream schema** (`engagement`
+//!   publishes it today, internally tagged on `event_type`, snake_case).
+//! * `social-graph` follow events are a **counter-owned schema** pending an
+//!   upstream follow stream (an upstream prerequisite, like `profile.v1.events`
+//!   is for search).
+
+use serde::Deserialize;
+
+// ── view / impression / click — counter-owned firehose schema ─────────────────
+
+/// One engagement hit on an entity. `actor_id`, when present, is folded into the
+/// unique-cardinality estimator (unique viewers / reach); it is never stored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HitWire {
+    pub entity_type: String,
+    pub entity_id: String,
+    #[serde(default)]
+    pub actor_id: Option<String>,
+    pub occurred_at_ms: i64,
+}
+
+// ── engagement.reactions — MATCHES the upstream engagement schema ─────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "event_type", rename_all = "snake_case")]
+pub enum ReactionWire {
+    Upserted(ReactionUpsertedWire),
+    Removed(ReactionRemovedWire),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReactionUpsertedWire {
+    pub post_id: String,
+    /// Present ⇒ this upsert *replaced* a prior reaction, so the reaction count is
+    /// unchanged (net-zero like delta). Absent ⇒ a brand-new reaction (`+1`).
+    #[serde(default)]
+    pub old_kind: Option<String>,
+    pub event_at_ms: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReactionRemovedWire {
+    pub post_id: String,
+    pub event_at_ms: i64,
+}
+
+// ── social-graph follow — counter-owned schema (upstream stream is a prereq) ──
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FollowWire {
+    Followed(FollowChangeWire),
+    Unfollowed(FollowChangeWire),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FollowChangeWire {
+    pub follower_id: String,
+    pub followee_id: String,
+    pub occurred_at_ms: i64,
+}

--- a/crates/services/counter/src/infrastructure/grpc/handler.rs
+++ b/crates/services/counter/src/infrastructure/grpc/handler.rs
@@ -1,0 +1,288 @@
+//! gRPC request handler for `counter.v1`. Each method translates an inbound
+//! Protobuf request into a validated domain query, runs it through the query-bus
+//! handler with a fresh correlation id, and maps the domain result (or
+//! [`CounterError`]) back to Protobuf / [`Status`].
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cqrs::{Envelope, QueryHandler};
+use error::AppError;
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+use crate::application::query::{
+    BatchGetHandler, RunBatchGet, RunTimeSeries, RunTrending, TimeSeriesHandler, TrendingHandler,
+};
+use crate::domain::{
+    BatchGetQuery, BatchReadout, CountSnapshot, EntityId, EntityKind, EntityRef, Metric,
+    MetricKind, TimeGranularity, TimeSeriesBucket, TimeSeriesQuery, TrendingItem, TrendingQuery,
+    TrendingScope,
+};
+use crate::error::CounterError;
+
+pub use counter_api as proto;
+
+/// gRPC handler for `counter.v1.CounterService`. Holds the three read handlers.
+#[derive(Clone)]
+pub struct CounterServiceHandler {
+    batch: Arc<BatchGetHandler>,
+    trending: Arc<TrendingHandler>,
+    timeseries: Arc<TimeSeriesHandler>,
+}
+
+impl CounterServiceHandler {
+    pub fn new(
+        batch: Arc<BatchGetHandler>,
+        trending: Arc<TrendingHandler>,
+        timeseries: Arc<TimeSeriesHandler>,
+    ) -> Self {
+        Self {
+            batch,
+            trending,
+            timeseries,
+        }
+    }
+
+    pub async fn batch_get_counters(
+        &self,
+        request: Request<proto::BatchGetCountersRequest>,
+    ) -> Result<Response<proto::BatchGetCountersResponse>, Status> {
+        let req = request.into_inner();
+        let entities = req
+            .entities
+            .into_iter()
+            .map(entity_from_proto)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_status)?;
+        let metrics = req.metrics.into_iter().filter_map(metric_from_proto).collect();
+
+        let query = BatchGetQuery::new(entities, metrics).map_err(to_status)?;
+        let readout = self
+            .batch
+            .handle(Envelope::new(Uuid::now_v7(), RunBatchGet { query }))
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(batch_to_proto(readout)))
+    }
+
+    pub async fn get_trending(
+        &self,
+        request: Request<proto::GetTrendingRequest>,
+    ) -> Result<Response<proto::GetTrendingResponse>, Status> {
+        let req = request.into_inner();
+        let scope = scope_from_proto(req.scope);
+        let metric = metric_from_proto(req.metric).ok_or_else(|| {
+            Status::invalid_argument("unsupported or unspecified trending metric")
+        })?;
+        let scope_key = optional(req.scope_key);
+        let query = TrendingQuery::new(scope, scope_key, metric, req.limit.max(0) as usize)
+            .map_err(to_status)?;
+        let items = self
+            .trending
+            .handle(Envelope::new(Uuid::now_v7(), RunTrending { query }))
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::GetTrendingResponse {
+            entries: items.into_iter().map(trending_to_proto).collect(),
+            degraded: false,
+        }))
+    }
+
+    pub async fn get_time_series(
+        &self,
+        request: Request<proto::GetTimeSeriesRequest>,
+    ) -> Result<Response<proto::GetTimeSeriesResponse>, Status> {
+        let req = request.into_inner();
+        let entity = entity_from_proto(
+            req.entity
+                .ok_or_else(|| Status::invalid_argument("entity is required"))?,
+        )
+        .map_err(to_status)?;
+        let metric = metric_from_proto(req.metric)
+            .ok_or_else(|| Status::invalid_argument("unsupported or unspecified metric"))?;
+        let granularity = granularity_from_proto(req.granularity);
+        let start = ts_to_dt(req.start).ok_or_else(|| Status::invalid_argument("invalid start"))?;
+        let end = ts_to_dt(req.end).ok_or_else(|| Status::invalid_argument("invalid end"))?;
+
+        let query =
+            TimeSeriesQuery::new(entity, metric, granularity, start, end).map_err(to_status)?;
+        let buckets = self
+            .timeseries
+            .handle(Envelope::new(Uuid::now_v7(), RunTimeSeries { query }))
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(proto::GetTimeSeriesResponse {
+            buckets: buckets.into_iter().map(bucket_to_proto).collect(),
+            kind: value_kind_to_proto(metric.kind()),
+            degraded: false,
+        }))
+    }
+}
+
+// ── proto → domain ────────────────────────────────────────────────────────────
+
+fn entity_from_proto(e: proto::EntityRef) -> Result<EntityRef, CounterError> {
+    let kind = entity_kind_from_proto(e.entity_type).ok_or_else(|| CounterError::DomainViolation {
+        field: "entity_type".to_owned(),
+        message: "unspecified or unknown entity type".to_owned(),
+    })?;
+    Ok(EntityRef::new(kind, EntityId::new(e.id)?))
+}
+
+fn entity_kind_from_proto(v: i32) -> Option<EntityKind> {
+    use proto::CounterEntityType as P;
+    match P::try_from(v).ok()? {
+        P::Post => Some(EntityKind::Post),
+        P::Profile => Some(EntityKind::Profile),
+        P::Media => Some(EntityKind::Media),
+        P::Hashtag => Some(EntityKind::Hashtag),
+        P::Comment => Some(EntityKind::Comment),
+        P::Unspecified => None,
+    }
+}
+
+fn metric_from_proto(v: i32) -> Option<Metric> {
+    use proto::CounterMetric as P;
+    match P::try_from(v).ok()? {
+        P::View => Some(Metric::View),
+        P::Impression => Some(Metric::Impression),
+        P::Click => Some(Metric::Click),
+        P::Like => Some(Metric::Like),
+        P::Share => Some(Metric::Share),
+        P::Comment => Some(Metric::Comment),
+        P::Follower => Some(Metric::Follower),
+        P::Following => Some(Metric::Following),
+        P::UniqueViewer => Some(Metric::UniqueViewer),
+        P::Reach => Some(Metric::Reach),
+        P::Unspecified => None,
+    }
+}
+
+fn scope_from_proto(v: i32) -> TrendingScope {
+    use proto::TrendingScope as P;
+    match P::try_from(v).unwrap_or(P::Global) {
+        P::Hashtag => TrendingScope::Hashtag,
+        P::Category => TrendingScope::Category,
+        P::Region => TrendingScope::Region,
+        _ => TrendingScope::Global,
+    }
+}
+
+fn granularity_from_proto(v: i32) -> TimeGranularity {
+    use proto::TimeGranularity as P;
+    match P::try_from(v).unwrap_or(P::Day) {
+        P::Hour => TimeGranularity::Hour,
+        P::Week => TimeGranularity::Week,
+        _ => TimeGranularity::Day,
+    }
+}
+
+fn ts_to_dt(ts: Option<prost_types::Timestamp>) -> Option<DateTime<Utc>> {
+    let ts = ts?;
+    DateTime::from_timestamp(ts.seconds, ts.nanos.max(0) as u32)
+}
+
+fn optional(s: String) -> Option<String> {
+    Some(s).filter(|s| !s.trim().is_empty())
+}
+
+// ── domain → proto ────────────────────────────────────────────────────────────
+
+fn batch_to_proto(readout: BatchReadout) -> proto::BatchGetCountersResponse {
+    proto::BatchGetCountersResponse {
+        snapshots: readout
+            .snapshots
+            .into_iter()
+            .map(|s| snapshot_to_proto(s, readout.degraded))
+            .collect(),
+        degraded: readout.degraded,
+    }
+}
+
+fn snapshot_to_proto(snap: CountSnapshot, degraded: bool) -> proto::CounterSnapshot {
+    proto::CounterSnapshot {
+        entity: Some(entity_to_proto(&snap.entity)),
+        values: snap
+            .values
+            .into_iter()
+            .map(|v| proto::CounterValue {
+                metric: metric_to_proto(v.metric),
+                value: v.value,
+                kind: value_kind_to_proto(v.kind),
+            })
+            .collect(),
+        degraded,
+    }
+}
+
+fn entity_to_proto(e: &EntityRef) -> proto::EntityRef {
+    proto::EntityRef {
+        entity_type: entity_kind_to_proto(e.kind),
+        id: e.id.as_str().to_owned(),
+    }
+}
+
+fn entity_kind_to_proto(kind: EntityKind) -> i32 {
+    use proto::CounterEntityType as P;
+    (match kind {
+        EntityKind::Post => P::Post,
+        EntityKind::Profile => P::Profile,
+        EntityKind::Media => P::Media,
+        EntityKind::Hashtag => P::Hashtag,
+        EntityKind::Comment => P::Comment,
+    }) as i32
+}
+
+fn metric_to_proto(m: Metric) -> i32 {
+    use proto::CounterMetric as P;
+    (match m {
+        Metric::View => P::View,
+        Metric::Impression => P::Impression,
+        Metric::Click => P::Click,
+        Metric::Like => P::Like,
+        Metric::Share => P::Share,
+        Metric::Comment => P::Comment,
+        Metric::Follower => P::Follower,
+        Metric::Following => P::Following,
+        Metric::UniqueViewer => P::UniqueViewer,
+        Metric::Reach => P::Reach,
+    }) as i32
+}
+
+fn value_kind_to_proto(kind: MetricKind) -> i32 {
+    use proto::CounterValueKind as P;
+    (match kind {
+        MetricKind::Exact => P::Exact,
+        MetricKind::Approximate => P::Approximate,
+    }) as i32
+}
+
+fn trending_to_proto(item: TrendingItem) -> proto::TrendingEntry {
+    proto::TrendingEntry {
+        entity: Some(entity_to_proto(&item.entity)),
+        score: item.score,
+        rank: item.rank as i32,
+    }
+}
+
+fn bucket_to_proto(b: TimeSeriesBucket) -> proto::TimeSeriesBucket {
+    proto::TimeSeriesBucket {
+        bucket_start: Some(prost_types::Timestamp {
+            seconds: b.bucket_start.timestamp(),
+            nanos: b.bucket_start.timestamp_subsec_nanos() as i32,
+        }),
+        value: b.value,
+    }
+}
+
+fn to_status(err: CounterError) -> Status {
+    let message = err.to_string();
+    match err.http_status().as_u16() {
+        400 | 422 => Status::invalid_argument(message),
+        404 => Status::not_found(message),
+        503 => Status::unavailable(message),
+        504 => Status::deadline_exceeded(message),
+        _ => Status::internal(message),
+    }
+}

--- a/crates/services/counter/src/infrastructure/grpc/mod.rs
+++ b/crates/services/counter/src/infrastructure/grpc/mod.rs
@@ -1,0 +1,8 @@
+//! gRPC ingress for the `counter.v1` service (read-only).
+
+pub mod handler;
+pub mod server;
+
+pub use handler::{CounterServiceHandler, proto};
+pub use proto::counter_service_server::CounterServiceServer;
+pub use server::FILE_DESCRIPTOR_SET;

--- a/crates/services/counter/src/infrastructure/grpc/server.rs
+++ b/crates/services/counter/src/infrastructure/grpc/server.rs
@@ -1,0 +1,32 @@
+use tonic::{Request, Response, Status};
+
+use super::handler::{CounterServiceHandler, proto};
+use proto::counter_service_server::CounterService;
+
+/// Encoded protobuf descriptor set for gRPC server reflection, emitted by
+/// `counter-api`'s `build.rs`.
+pub const FILE_DESCRIPTOR_SET: &[u8] = counter_api::FILE_DESCRIPTOR_SET;
+
+#[tonic::async_trait]
+impl CounterService for CounterServiceHandler {
+    async fn batch_get_counters(
+        &self,
+        request: Request<proto::BatchGetCountersRequest>,
+    ) -> Result<Response<proto::BatchGetCountersResponse>, Status> {
+        self.batch_get_counters(request).await
+    }
+
+    async fn get_trending(
+        &self,
+        request: Request<proto::GetTrendingRequest>,
+    ) -> Result<Response<proto::GetTrendingResponse>, Status> {
+        self.get_trending(request).await
+    }
+
+    async fn get_time_series(
+        &self,
+        request: Request<proto::GetTimeSeriesRequest>,
+    ) -> Result<Response<proto::GetTimeSeriesResponse>, Status> {
+        self.get_time_series(request).await
+    }
+}

--- a/crates/services/counter/src/infrastructure/kafka_signal_publisher.rs
+++ b/crates/services/counter/src/infrastructure/kafka_signal_publisher.rs
@@ -1,0 +1,60 @@
+//! The outbound popularity signal over Kafka (`counter.v1.popularity`).
+//!
+//! The only thing counter-analytics publishes. A coarse, slow-loop emission
+//! consumed by `search` (its `PopularityScore` ranking input) and `timeline`.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use transport::error::TransportError;
+use transport::kafka::envelope::EventEnvelope;
+use transport::kafka::producer::handle::KafkaProducerHandle;
+
+use crate::application::port::SignalPublisher;
+use crate::domain::{EntityRef, PopularityScore};
+use crate::error::CounterError;
+
+const TOPIC_POPULARITY: &str = "counter.v1.popularity";
+
+/// The wire payload of a popularity snapshot. Deliberately tiny: a reference and a
+/// coarse score — no per-actor data, nothing volatile.
+#[derive(Debug, Clone, Serialize)]
+pub struct PopularityEvent {
+    pub entity_type: String,
+    pub entity_id: String,
+    pub score: f64,
+}
+
+fn transport_err(e: TransportError) -> CounterError {
+    CounterError::SignalPublishFailed {
+        reason: e.to_string(),
+    }
+}
+
+pub struct KafkaSignalPublisher {
+    producer: KafkaProducerHandle,
+}
+
+impl KafkaSignalPublisher {
+    pub fn new(producer: KafkaProducerHandle) -> Self {
+        Self { producer }
+    }
+}
+
+#[async_trait]
+impl SignalPublisher for KafkaSignalPublisher {
+    async fn publish_popularity(
+        &self,
+        entity: &EntityRef,
+        score: PopularityScore,
+    ) -> Result<(), CounterError> {
+        let key = format!("{}:{}", entity.kind.as_str(), entity.id.as_str());
+        let payload = PopularityEvent {
+            entity_type: entity.kind.as_str().to_owned(),
+            entity_id: entity.id.as_str().to_owned(),
+            score: score.value(),
+        };
+        let envelope = EventEnvelope::new(TOPIC_POPULARITY, key, payload)
+            .with_header("entity_type", entity.kind.as_str());
+        self.producer.publish(envelope).await.map_err(transport_err)
+    }
+}

--- a/crates/services/counter/src/infrastructure/mod.rs
+++ b/crates/services/counter/src/infrastructure/mod.rs
@@ -16,6 +16,7 @@ pub mod decode;
 pub mod grpc;
 pub mod kafka_signal_publisher;
 pub mod pg_counter_ledger;
+pub mod reconcile;
 pub mod redis_counter_store;
 pub mod scylla_time_series;
 

--- a/crates/services/counter/src/infrastructure/mod.rs
+++ b/crates/services/counter/src/infrastructure/mod.rs
@@ -1,0 +1,25 @@
+//! Infrastructure adapters — the concrete implementations of the application
+//! ports, plus the inbound event-decode layer.
+//!
+//! * [`redis_counter_store`] — hot tier (fred, Lua-issued HLL/sorted-set ops)
+//! * [`pg_counter_ledger`] — warm tier (sqlx, idempotent window-keyed UPSERT)
+//! * [`scylla_time_series`] — cold tier (Scylla TWCS counter rollups)
+//! * [`kafka_signal_publisher`] — the `counter.v1.popularity` producer
+//! * [`decode`] — counter-owned wire DTOs + the pure wire→`Observation` mappers
+//!
+//! Per the integration-test standard, the storage/transport adapters are
+//! compile-checked here; their live behaviour is exercised by the gated suite in
+//! Phase 6. The decode layer is pure and unit-tested in place.
+
+pub mod consumer;
+pub mod decode;
+pub mod grpc;
+pub mod kafka_signal_publisher;
+pub mod pg_counter_ledger;
+pub mod redis_counter_store;
+pub mod scylla_time_series;
+
+pub use kafka_signal_publisher::{KafkaSignalPublisher, PopularityEvent};
+pub use pg_counter_ledger::PgCounterLedger;
+pub use redis_counter_store::RedisCounterStore;
+pub use scylla_time_series::ScyllaTimeSeriesStore;

--- a/crates/services/counter/src/infrastructure/pg_counter_ledger.rs
+++ b/crates/services/counter/src/infrastructure/pg_counter_ledger.rs
@@ -1,0 +1,129 @@
+//! The warm counter tier over Postgres (sqlx) — the auditable durable totals and
+//! the idempotency ledger.
+//!
+//! Idempotency is a single atomic statement. A window is recorded in
+//! `counter_windows` with `ON CONFLICT DO NOTHING`; the total in `counter_totals`
+//! is advanced **only** when that insert was new. A redelivered `(entity, metric,
+//! window_id)` therefore changes nothing and reports [`FlushOutcome::AlreadyApplied`].
+//!
+//! Schema (owned by the `migrator`, applied before rollout — see Phase 6):
+//! ```sql
+//! CREATE TABLE counter_windows (
+//!   entity_kind text, entity_id text, metric text, window_id bigint,
+//!   PRIMARY KEY (entity_kind, entity_id, metric, window_id));
+//! CREATE TABLE counter_totals (
+//!   entity_kind text, entity_id text, metric text, total bigint NOT NULL,
+//!   PRIMARY KEY (entity_kind, entity_id, metric));
+//! ```
+
+use async_trait::async_trait;
+use postgres_storage::TransactionManager;
+
+use crate::application::port::{CounterLedger, FlushOutcome};
+use crate::domain::{EntityRef, Metric, WindowDelta};
+use crate::error::CounterError;
+
+/// Atomically: record the window (idempotent), and advance the total only if the
+/// window was new. Returns whether the window was applied for the first time.
+const FLUSH_SQL: &str = r#"
+WITH ins AS (
+    INSERT INTO counter_windows (entity_kind, entity_id, metric, window_id)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT DO NOTHING
+    RETURNING 1
+), upd AS (
+    INSERT INTO counter_totals (entity_kind, entity_id, metric, total)
+    SELECT $1, $2, $3, $5 FROM ins
+    ON CONFLICT (entity_kind, entity_id, metric) DO UPDATE
+        SET total = counter_totals.total + EXCLUDED.total
+    RETURNING 1
+)
+SELECT EXISTS (SELECT 1 FROM ins) AS applied
+"#;
+
+const READ_TOTAL_SQL: &str = r#"
+SELECT total FROM counter_totals
+WHERE entity_kind = $1 AND entity_id = $2 AND metric = $3
+"#;
+
+/// Reconciliation overwrite: set the durable total to an authoritative value.
+const SET_TOTAL_SQL: &str = r#"
+INSERT INTO counter_totals (entity_kind, entity_id, metric, total)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (entity_kind, entity_id, metric) DO UPDATE SET total = EXCLUDED.total
+"#;
+
+fn flush_err(e: sqlx::Error) -> CounterError {
+    CounterError::FlushFailed {
+        reason: e.to_string(),
+    }
+}
+
+/// Ledger reads fall back nowhere (they *are* the fallback), so a fault here is the
+/// unavailable (retryable) variant.
+fn read_err(_e: sqlx::Error) -> CounterError {
+    CounterError::LedgerUnavailable
+}
+
+pub struct PgCounterLedger {
+    tx: TransactionManager,
+}
+
+impl PgCounterLedger {
+    pub fn new(tx: TransactionManager) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl CounterLedger for PgCounterLedger {
+    async fn flush_window(&self, delta: &WindowDelta) -> Result<FlushOutcome, CounterError> {
+        let applied: bool = sqlx::query_scalar(FLUSH_SQL)
+            .bind(delta.entity().kind.as_str())
+            .bind(delta.entity().id.as_str())
+            .bind(delta.metric().as_str())
+            .bind(delta.window().index() as i64)
+            .bind(delta.scalar())
+            .fetch_one(self.tx.pool())
+            .await
+            .map_err(flush_err)?;
+
+        Ok(if applied {
+            FlushOutcome::Applied
+        } else {
+            FlushOutcome::AlreadyApplied
+        })
+    }
+
+    async fn read_total(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError> {
+        let total: Option<i64> = sqlx::query_scalar(READ_TOTAL_SQL)
+            .bind(entity.kind.as_str())
+            .bind(entity.id.as_str())
+            .bind(metric.as_str())
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(read_err)?;
+        Ok(total)
+    }
+
+    async fn set_total(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+        value: i64,
+    ) -> Result<(), CounterError> {
+        sqlx::query(SET_TOTAL_SQL)
+            .bind(entity.kind.as_str())
+            .bind(entity.id.as_str())
+            .bind(metric.as_str())
+            .bind(value)
+            .execute(self.tx.pool())
+            .await
+            .map_err(flush_err)?;
+        Ok(())
+    }
+}

--- a/crates/services/counter/src/infrastructure/pg_counter_ledger.rs
+++ b/crates/services/counter/src/infrastructure/pg_counter_ledger.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use postgres_storage::TransactionManager;
 
 use crate::application::port::{CounterLedger, FlushOutcome};
-use crate::domain::{EntityRef, Metric, WindowDelta};
+use crate::domain::{EntityId, EntityKind, EntityRef, Metric, WindowDelta};
 use crate::error::CounterError;
 
 /// Atomically: record the window (idempotent), and advance the total only if the
@@ -51,6 +51,17 @@ const SET_TOTAL_SQL: &str = r#"
 INSERT INTO counter_totals (entity_kind, entity_id, metric, total)
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (entity_kind, entity_id, metric) DO UPDATE SET total = EXCLUDED.total
+"#;
+
+/// Page the reconcilable pairs (metrics with an authoritative source) by a synthetic
+/// `kind:id:metric` cursor, so a pair is never split across pages.
+const LIST_RECONCILABLE_SQL: &str = r#"
+SELECT entity_kind, entity_id, metric
+FROM counter_totals
+WHERE metric IN ('follower', 'following')
+  AND ($1::text IS NULL OR (entity_kind || ':' || entity_id || ':' || metric) > $1)
+ORDER BY (entity_kind || ':' || entity_id || ':' || metric)
+LIMIT $2
 "#;
 
 fn flush_err(e: sqlx::Error) -> CounterError {
@@ -125,5 +136,28 @@ impl CounterLedger for PgCounterLedger {
             .await
             .map_err(flush_err)?;
         Ok(())
+    }
+
+    async fn list_reconcilable(
+        &self,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(EntityRef, Metric)>, CounterError> {
+        let rows: Vec<(String, String, String)> = sqlx::query_as(LIST_RECONCILABLE_SQL)
+            .bind(after)
+            .bind(limit)
+            .fetch_all(self.tx.pool())
+            .await
+            .map_err(read_err)?;
+
+        // A row that fails to parse is a schema/data anomaly, not a reconcilable
+        // pair — skip it rather than abort the sweep.
+        Ok(rows
+            .into_iter()
+            .filter_map(|(kind, id, metric)| {
+                let entity = EntityRef::new(EntityKind::try_from_str(&kind).ok()?, EntityId::new(id).ok()?);
+                Some((entity, Metric::try_from_str(&metric).ok()?))
+            })
+            .collect())
     }
 }

--- a/crates/services/counter/src/infrastructure/reconcile/grpc_source.rs
+++ b/crates/services/counter/src/infrastructure/reconcile/grpc_source.rs
@@ -1,0 +1,77 @@
+//! The concrete reconciliation source: authoritative follower/following counts
+//! from `social-graph` over gRPC.
+//!
+//! Integration reality (mirrors the decode layer's honesty): only the
+//! social-graph-owned profile metrics have a true authoritative count RPC today.
+//! `social-graph` is the transactional system-of-record for the follow graph, so
+//! its counts are correct and worth reconciling against. Like/Share/Comment
+//! reconciliation stays deferred — `engagement` exposes *weighted reaction scores*
+//! (not a reaction count), and its share/comment counters are the approximate ones
+//! this service supersedes; reconciling against them would be circular.
+
+use async_trait::async_trait;
+use social_graph_api::GetRelationStatusRequest;
+use social_graph_api::social_graph_service_client::SocialGraphServiceClient;
+use tonic::Code;
+use tonic::transport::Channel;
+
+use crate::application::port::ReconciliationSource;
+use crate::domain::{EntityKind, EntityRef, Metric};
+use crate::error::CounterError;
+
+/// Resolves authoritative counts from `social-graph`. The channel is cheap to
+/// clone (it is `Arc`-backed), so each call clones the client.
+pub struct GrpcReconciliationSource {
+    social_graph: SocialGraphServiceClient<Channel>,
+}
+
+impl GrpcReconciliationSource {
+    pub fn new(social_graph: Channel) -> Self {
+        Self {
+            social_graph: SocialGraphServiceClient::new(social_graph),
+        }
+    }
+}
+
+#[async_trait]
+impl ReconciliationSource for GrpcReconciliationSource {
+    async fn authoritative_count(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, CounterError> {
+        // Pick the field; bail for any metric this source does not own.
+        let want_followers = match metric {
+            Metric::Follower => true,
+            Metric::Following => false,
+            _ => return Ok(None),
+        };
+        if entity.kind != EntityKind::Profile {
+            return Ok(None);
+        }
+
+        // The counts in the view are "for the target profile" regardless of actor;
+        // a self-relation query is the simplest way to read them.
+        let mut client = self.social_graph.clone();
+        let request = GetRelationStatusRequest {
+            actor_id: entity.id.as_str().to_owned(),
+            target_id: entity.id.as_str().to_owned(),
+        };
+        match client.get_relation_status(request).await {
+            Ok(response) => {
+                let view = response.into_inner();
+                Ok(Some(if want_followers {
+                    view.target_followers_count
+                } else {
+                    view.target_following_count
+                }))
+            }
+            // Unknown profile / no relations → nothing to reconcile against.
+            Err(status) if status.code() == Code::NotFound => Ok(None),
+            // Anything else is a transient source fault: the loop logs and moves on.
+            Err(status) => Err(CounterError::SourceReplayFailed {
+                reason: format!("social-graph get_relation_status: {}", status.message()),
+            }),
+        }
+    }
+}

--- a/crates/services/counter/src/infrastructure/reconcile/mod.rs
+++ b/crates/services/counter/src/infrastructure/reconcile/mod.rs
@@ -1,0 +1,57 @@
+//! The concrete reconciliation source (gRPC to `social-graph`) and the supervised
+//! sweep loop that drives the [`Reconciler`](crate::application::command::Reconciler)
+//! over the ledger's reconcilable pairs.
+
+pub mod grpc_source;
+
+pub use grpc_source::GrpcReconciliationSource;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::application::command::Reconciler;
+use crate::application::port::{CounterLedger, reconcile_cursor};
+
+/// Reconcilable pairs fetched per tick. Bounds the sweep's work; the cursor pages
+/// across ticks so the whole reconcilable set is covered over time.
+const RECONCILE_BATCH: i64 = 100;
+
+/// Periodically sweeps the reconcilable `(entity, metric)` pairs, correcting any
+/// exact-counter drift against the authoritative source. Pages by an opaque cursor
+/// and wraps back to the start when the sweep completes. Errors are logged and the
+/// sweep continues — reconciliation is best-effort background healing.
+pub async fn run_reconcile_loop(
+    reconciler: Arc<Reconciler>,
+    ledger: Arc<dyn CounterLedger>,
+    interval: Duration,
+) {
+    tracing::info!("counter reconcile loop started");
+    let mut ticker = tokio::time::interval(interval);
+    let mut cursor: Option<String> = None;
+    loop {
+        ticker.tick().await;
+
+        let batch = match ledger.list_reconcilable(cursor.as_deref(), RECONCILE_BATCH).await {
+            Ok(batch) => batch,
+            Err(error) => {
+                tracing::warn!(%error, "reconcile candidate scan failed");
+                continue;
+            }
+        };
+
+        if batch.is_empty() {
+            cursor = None; // sweep complete — wrap to the start next tick
+            continue;
+        }
+
+        if let Some((entity, metric)) = batch.last() {
+            cursor = Some(reconcile_cursor(entity, *metric));
+        }
+
+        for (entity, metric) in &batch {
+            if let Err(error) = reconciler.reconcile(entity, *metric).await {
+                tracing::warn!(%error, metric = metric.as_str(), "reconcile failed");
+            }
+        }
+    }
+}

--- a/crates/services/counter/src/infrastructure/redis_counter_store.rs
+++ b/crates/services/counter/src/infrastructure/redis_counter_store.rs
@@ -1,0 +1,249 @@
+//! The hot counter tier over Redis (fred).
+//!
+//! All non-trivial commands are issued through Lua `eval` / `redis.call(...)` —
+//! the same pattern `engagement` and `geo-discovery` use — so the adapter does not
+//! depend on fred's typed HyperLogLog / sorted-set method signatures. Each script
+//! touches a **single key**, keeping it Redis-Cluster-safe.
+//!
+//! Key layout (every per-entity key carries a `{kind:id}` hash tag so one entity's
+//! keys share a cluster slot):
+//! * `counter:c:{kind:id}`            — HASH, field per sum metric (live counter)
+//! * `counter:h:{kind:id}:{metric}`   — HyperLogLog per cardinality metric
+//! * `counter:t:{scope}:{key}:{metric}` — sorted set, the trending board
+//!
+//! Sharded hot writes need no Lua coordination: many workers issuing `HINCRBY`
+//! against the same entity hash is already atomic in Redis, which *is* the stage-2
+//! re-aggregation of the producer-side shard fan-out.
+
+use async_trait::async_trait;
+use fred::interfaces::LuaInterface;
+use redis_storage::RedisClient;
+
+use crate::application::port::CounterStore;
+use crate::domain::{
+    Aggregation, CountSnapshot, CounterValue, EntityId, EntityKind, EntityRef, Metric, TrendingItem,
+    TrendingScope, WindowDelta,
+};
+use crate::error::CounterError;
+
+const HINCRBY: &str = "return redis.call('HINCRBY', KEYS[1], ARGV[1], ARGV[2])";
+const HSET: &str = "return redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])";
+const ZINCRBY: &str = "return redis.call('ZINCRBY', KEYS[1], ARGV[1], ARGV[2])";
+const PFADD: &str = "return redis.call('PFADD', KEYS[1], unpack(ARGV))";
+const HMGET: &str = "return redis.call('HMGET', KEYS[1], unpack(ARGV))";
+const PFCOUNT: &str = "return redis.call('PFCOUNT', KEYS[1])";
+const ZREVRANGE: &str = "return redis.call('ZREVRANGE', KEYS[1], 0, ARGV[1], 'WITHSCORES')";
+
+fn hash_key(e: &EntityRef) -> String {
+    format!("counter:c:{{{}:{}}}", e.kind.as_str(), e.id.as_str())
+}
+
+fn hll_key(e: &EntityRef, metric: Metric) -> String {
+    format!(
+        "counter:h:{{{}:{}}}:{}",
+        e.kind.as_str(),
+        e.id.as_str(),
+        metric.as_str()
+    )
+}
+
+fn trend_key(scope: TrendingScope, scope_key: Option<&str>, metric: Metric) -> String {
+    format!(
+        "counter:t:{}:{}:{}",
+        scope.as_str(),
+        scope_key.unwrap_or("_"),
+        metric.as_str()
+    )
+}
+
+fn member(e: &EntityRef) -> String {
+    format!("{}:{}", e.kind.as_str(), e.id.as_str())
+}
+
+fn parse_member(s: &str) -> Option<EntityRef> {
+    let (kind, id) = s.split_once(':')?;
+    Some(EntityRef::new(
+        EntityKind::try_from_str(kind).ok()?,
+        EntityId::new(id).ok()?,
+    ))
+}
+
+fn write_err(e: fred::error::Error) -> CounterError {
+    CounterError::CacheWriteFailed {
+        reason: e.to_string(),
+    }
+}
+
+/// Hot-tier reads degrade to the warm ledger, so a fred error on the read path is
+/// reported as the unavailable (retryable) variant that drives fail-open.
+fn read_err(_e: fred::error::Error) -> CounterError {
+    CounterError::HotStoreUnavailable
+}
+
+pub struct RedisCounterStore {
+    client: RedisClient,
+}
+
+impl RedisCounterStore {
+    pub fn new(client: RedisClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl CounterStore for RedisCounterStore {
+    async fn apply_delta(&self, delta: &WindowDelta) -> Result<(), CounterError> {
+        let metric = delta.metric();
+        match metric.aggregation() {
+            Aggregation::Sum => {
+                let _: i64 = self
+                    .client
+                    .inner
+                    .eval(
+                        HINCRBY,
+                        vec![hash_key(delta.entity())],
+                        vec![metric.as_str().to_owned(), delta.sum.to_string()],
+                    )
+                    .await
+                    .map_err(write_err)?;
+                // Feed the global trending board (scoped boards need context a bare
+                // delta lacks, so only GLOBAL is fed here).
+                let _: f64 = self
+                    .client
+                    .inner
+                    .eval(
+                        ZINCRBY,
+                        vec![trend_key(TrendingScope::Global, None, metric)],
+                        vec![delta.sum.to_string(), member(delta.entity())],
+                    )
+                    .await
+                    .map_err(write_err)?;
+            }
+            Aggregation::Cardinality => {
+                if delta.unique_members.is_empty() {
+                    return Ok(());
+                }
+                let members: Vec<String> = delta
+                    .unique_members
+                    .iter()
+                    .map(|m| m.as_str().to_owned())
+                    .collect();
+                let _: i64 = self
+                    .client
+                    .inner
+                    .eval(PFADD, vec![hll_key(delta.entity(), metric)], members)
+                    .await
+                    .map_err(write_err)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn read(
+        &self,
+        entities: &[EntityRef],
+        metrics: &[Metric],
+    ) -> Result<Vec<CountSnapshot>, CounterError> {
+        let sum_metrics: Vec<Metric> = metrics
+            .iter()
+            .copied()
+            .filter(|m| m.aggregation() == Aggregation::Sum)
+            .collect();
+        let card_metrics: Vec<Metric> = metrics
+            .iter()
+            .copied()
+            .filter(|m| m.aggregation() == Aggregation::Cardinality)
+            .collect();
+
+        let mut out = Vec::with_capacity(entities.len());
+        for entity in entities {
+            let mut values = Vec::new();
+
+            if !sum_metrics.is_empty() {
+                let fields: Vec<String> =
+                    sum_metrics.iter().map(|m| m.as_str().to_owned()).collect();
+                let raw: Vec<Option<String>> = self
+                    .client
+                    .inner
+                    .eval(HMGET, vec![hash_key(entity)], fields)
+                    .await
+                    .map_err(read_err)?;
+                for (metric, cell) in sum_metrics.iter().zip(raw) {
+                    if let Some(v) = cell.and_then(|s| s.parse::<i64>().ok()) {
+                        values.push(CounterValue::new(*metric, v));
+                    }
+                }
+            }
+
+            for &metric in &card_metrics {
+                let count: i64 = self
+                    .client
+                    .inner
+                    .eval(PFCOUNT, vec![hll_key(entity, metric)], Vec::<String>::new())
+                    .await
+                    .map_err(read_err)?;
+                if count > 0 {
+                    values.push(CounterValue::new(metric, count));
+                }
+            }
+
+            out.push(CountSnapshot::new(entity.clone(), values));
+        }
+        Ok(out)
+    }
+
+    async fn top_k(
+        &self,
+        scope: TrendingScope,
+        scope_key: Option<&str>,
+        metric: Metric,
+        limit: usize,
+    ) -> Result<Vec<TrendingItem>, CounterError> {
+        let stop = (limit as i64) - 1;
+        let flat: Vec<String> = self
+            .client
+            .inner
+            .eval(
+                ZREVRANGE,
+                vec![trend_key(scope, scope_key, metric)],
+                vec![stop.to_string()],
+            )
+            .await
+            .map_err(read_err)?;
+
+        let items = flat
+            .chunks_exact(2)
+            .enumerate()
+            .filter_map(|(rank, pair)| {
+                let entity = parse_member(&pair[0])?;
+                let score = pair[1].parse::<f64>().ok()? as i64;
+                Some(TrendingItem {
+                    entity,
+                    score,
+                    rank: rank as u32,
+                })
+            })
+            .collect();
+        Ok(items)
+    }
+
+    async fn overwrite(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+        value: i64,
+    ) -> Result<(), CounterError> {
+        // Set, not increment — reconciliation healing the live counter to truth.
+        let _: i64 = self
+            .client
+            .inner
+            .eval(
+                HSET,
+                vec![hash_key(entity)],
+                vec![metric.as_str().to_owned(), value.to_string()],
+            )
+            .await
+            .map_err(write_err)?;
+        Ok(())
+    }
+}

--- a/crates/services/counter/src/infrastructure/scylla_time_series.rs
+++ b/crates/services/counter/src/infrastructure/scylla_time_series.rs
@@ -1,0 +1,142 @@
+//! The cold time-series tier over ScyllaDB (TWCS).
+//!
+//! Window deltas are rolled up into coarse hour buckets via a `counter` column, so
+//! a high-volume stream of fine windows collapses into a few additive cells per
+//! entity/metric. The single range read backs `GetTimeSeries`; it is off the feed
+//! path and uses the latency-relaxed read profile.
+//!
+//! Schema (owned by the `migrator`):
+//! ```cql
+//! CREATE TABLE counter.timeseries (
+//!   entity_kind text, entity_id text, metric text,
+//!   bucket_start timestamp,
+//!   value counter,
+//!   PRIMARY KEY ((entity_kind, entity_id, metric), bucket_start)
+//! ) WITH compaction = { 'class': 'TimeWindowCompactionStrategy' };
+//! ```
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use scylla::observability::history::HistoryListener;
+use scylla::statement::unprepared::Statement;
+use scylla::value::{Counter, CqlTimestamp};
+use scylla_storage::{ProfileKind, ScyllaClient, ScyllaStorageError};
+
+use crate::domain::{TimeSeriesBucket, TimeSeriesQuery, WindowDelta, WindowSize};
+use crate::error::CounterError;
+
+const HOUR_MS: i64 = 3_600_000;
+
+fn scylla_write_err(e: scylla::errors::ExecutionError) -> CounterError {
+    CounterError::FlushFailed {
+        reason: ScyllaStorageError::from(e).to_string(),
+    }
+}
+
+fn scylla_read_err(_e: impl ToString) -> CounterError {
+    CounterError::TimeSeriesUnavailable
+}
+
+/// Floor an epoch-millis instant to the start of its hour bucket.
+fn hour_bucket(ms: i64) -> i64 {
+    (ms.div_euclid(HOUR_MS)) * HOUR_MS
+}
+
+pub struct ScyllaTimeSeriesStore {
+    client: Arc<ScyllaClient>,
+    window_size: WindowSize,
+}
+
+impl ScyllaTimeSeriesStore {
+    pub fn new(client: Arc<ScyllaClient>, window_size: WindowSize) -> Self {
+        Self {
+            client,
+            window_size,
+        }
+    }
+
+    fn stmt(&self, cql: &str, profile: ProfileKind) -> Statement {
+        let mut s = Statement::new(cql);
+        s.set_execution_profile_handle(Some(
+            self.client
+                .profiles
+                .get(profile)
+                .clone()
+                .into_handle_with_label("counter-timeseries".to_string()),
+        ));
+        s.set_history_listener(Arc::clone(&self.client.history_listener) as Arc<dyn HistoryListener>);
+        s
+    }
+}
+
+#[async_trait]
+impl crate::application::port::TimeSeriesStore for ScyllaTimeSeriesStore {
+    async fn append(&self, delta: &WindowDelta) -> Result<(), CounterError> {
+        let bucket = hour_bucket(delta.window().start_millis(self.window_size) as i64);
+        let stmt = self.stmt(
+            "UPDATE counter.timeseries SET value = value + ? \
+             WHERE entity_kind = ? AND entity_id = ? AND metric = ? AND bucket_start = ?",
+            ProfileKind::Strict,
+        );
+        self.client
+            .session
+            .execute_unpaged(
+                stmt,
+                (
+                    // A counter increment must be bound as the `Counter` newtype —
+                    // a bare i64 serializes as BigInt, which the prepared-statement
+                    // type check rejects against a `counter` column.
+                    Counter(delta.scalar()),
+                    delta.entity().kind.as_str(),
+                    delta.entity().id.as_str(),
+                    delta.metric().as_str(),
+                    CqlTimestamp(bucket),
+                ),
+            )
+            .await
+            .map_err(scylla_write_err)?;
+        Ok(())
+    }
+
+    async fn range(&self, query: &TimeSeriesQuery) -> Result<Vec<TimeSeriesBucket>, CounterError> {
+        let stmt = self.stmt(
+            "SELECT bucket_start, value FROM counter.timeseries \
+             WHERE entity_kind = ? AND entity_id = ? AND metric = ? \
+             AND bucket_start >= ? AND bucket_start < ?",
+            ProfileKind::Fast,
+        );
+        let rows = self
+            .client
+            .session
+            .execute_unpaged(
+                stmt,
+                (
+                    query.entity.kind.as_str(),
+                    query.entity.id.as_str(),
+                    query.metric.as_str(),
+                    CqlTimestamp(query.start.timestamp_millis()),
+                    CqlTimestamp(query.end.timestamp_millis()),
+                ),
+            )
+            .await
+            .map_err(scylla_read_err)?
+            .into_rows_result()
+            .map_err(scylla_read_err)?;
+
+        let mut out = Vec::new();
+        for row in rows
+            .rows::<(CqlTimestamp, Counter)>()
+            .map_err(scylla_read_err)?
+        {
+            let (ts, value) = row.map_err(scylla_read_err)?;
+            if let Some(bucket_start) = chrono::DateTime::from_timestamp_millis(ts.0) {
+                out.push(TimeSeriesBucket {
+                    bucket_start,
+                    value: value.0,
+                });
+            }
+        }
+        Ok(out)
+    }
+}

--- a/crates/services/counter/src/lib.rs
+++ b/crates/services/counter/src/lib.rs
@@ -1,0 +1,56 @@
+//! `counter` — the platform's **real-time counter aggregator and analytics
+//! System-of-Reference**: it absorbs the engagement/view firehose, serves coarse
+//! magnitudes back to the fleet at sub-millisecond latency, and owns no entity.
+//!
+//! This service is a System-of-*Reference*, never a System-of-Record. Every
+//! count it holds is a derived materialization of truth that lives elsewhere —
+//! reconstructable, at any moment, by replaying the owning services' event
+//! streams. That single framing sets its boundaries:
+//!
+//! * it answers **"how many?"** (views, likes, shares, followers, reach), never
+//!   **"who?"** or **"which ones?"** — the per-actor edge state (who liked, who
+//!   follows) belongs to `engagement` (reactions) and `social-graph` (follows).
+//!   This service counts magnitudes; it cannot tell you whether Alice follows
+//!   Bob, only that Bob has 4.2M followers.
+//! * the **content/identity services** (`post` / `profile` / `media`) own the
+//!   authoritative entity; this service holds only the aggregate counts attached
+//!   to a reference.
+//! * it **supersedes** `engagement`'s ad-hoc raw counters (the `views`/`shares`
+//!   strings and the approximate interaction-counter table): `engagement` keeps
+//!   weighted reaction *scoring* and the per-profile reaction *edge state*, and
+//!   delegates raw magnitude counting here.
+//! * `search` and `timeline` consume the coarse, periodic `counter.v1.popularity`
+//!   signal this service publishes — never a per-event count, never a synchronous
+//!   call.
+//!
+//! The architectural commitment is a deliberate split into **two deployables**:
+//! a **low-latency read server** (`counter-server`, stateless gRPC over the hot
+//! Redis tier) and a **heavy stream worker** (`counter-worker`, the windowed
+//! firehose aggregator + durable write-behind + reconciliation + popularity
+//! publisher). They scale on different axes and share no failure domain — a
+//! worker GC pause can never add latency to a feed-hydration read. The command
+//! side is **100% Kafka consumers** (there is no write/increment RPC). Posture is
+//! **best-effort, fail-open, eventually-consistent**: a counter outage degrades
+//! to stale-but-served counts, it never blocks a like, a follow, or a publish.
+//! See `project_counter_analytics_blueprint` for the full design.
+//!
+//! ## Module roadmap (built phase by phase)
+//! Phase 0 (now): [`error`] — the canonical `CTR-XXXX` namespace.
+//! Phase 2: `domain` (CounterDelta + MetricKind[exact-vs-approximate] + the pure
+//! windowed-fold aggregator + HLL/CMS abstractions + popularity derivation) ·
+//! Phase 3: `application` + ports (CounterStore / CounterLedger / TimeSeriesStore
+//! / SignalPublisher + ingestion & query handlers) · Phase 4: `infrastructure`
+//! (Redis hot / Postgres warm-ledger / Scylla TWCS cold / Kafka popularity
+//! publisher + event-decode) · Phase 5: `app` (composition roots) + `service`
+//! (the two runtime wirings — read server + stream worker).
+
+pub mod app;
+pub mod application;
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod infrastructure;
+pub mod service;
+
+pub use error::CounterError;
+pub use service::{CounterReadService, CounterWorkerService};

--- a/crates/services/counter/src/service.rs
+++ b/crates/services/counter/src/service.rs
@@ -1,0 +1,279 @@
+//! Adapts the counter composition roots to the fleet [`service_runtime::Service`]
+//! contract — **twice**, because counter-analytics is two deployables that share a
+//! domain but no process or failure domain:
+//!
+//! * [`CounterReadService`] (`counter-server`) — the low-latency read API. Builds
+//!   the storage ports, composes the gRPC read handler, serves `counter.v1` on
+//!   :50064, and reports Redis liveness. No consumers, no aggregation.
+//! * [`CounterWorkerService`] (`counter-worker`) — the stream processor. Builds the
+//!   ports + the Kafka signal producer, spawns the five supervised firehose/domain
+//!   consumers folding into a shared [`WindowAggregator`], and runs the drain/flush
+//!   loop that fans windows out across the tiers and publishes popularity. Exposes
+//!   no domain RPC (only health + reflection on its port).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use fred::interfaces::LuaInterface;
+use redis_storage::RedisClient;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tokio::sync::Mutex;
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
+use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
+use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
+
+use crate::app::{Ports, compose_read};
+use crate::application::command::{DeltaFlusher, PopularityPublisher};
+use crate::application::port::SignalPublisher;
+use crate::config::CounterConfig;
+use crate::domain::{Observation, WindowAggregator};
+use crate::error::CounterError;
+use crate::infrastructure::consumer::{run_flush_loop, run_fold_consumer};
+use crate::infrastructure::decode::{
+    FollowWire, HitWire, ReactionWire, map_click, map_follow, map_impression, map_reaction, map_view,
+};
+use crate::infrastructure::grpc::{
+    CounterServiceHandler, CounterServiceServer, FILE_DESCRIPTOR_SET,
+};
+use crate::infrastructure::kafka_signal_publisher::KafkaSignalPublisher;
+use transport::kafka::envelope::ConsumablePayload;
+
+const VIEW_TOPIC: &str = "view.v1.events";
+const IMPRESSION_TOPIC: &str = "impression.v1.events";
+const CLICK_TOPIC: &str = "click.v1.events";
+const REACTION_TOPIC: &str = "engagement.reactions";
+const FOLLOW_TOPIC: &str = "social-graph.follows";
+
+const VIEW_GROUP: &str = "counter-view-aggregator";
+const IMPRESSION_GROUP: &str = "counter-impression-aggregator";
+const CLICK_GROUP: &str = "counter-click-aggregator";
+const REACTION_GROUP: &str = "counter-reaction-aggregator";
+const FOLLOW_GROUP: &str = "counter-follow-aggregator";
+
+/// Backoff before respawning a consumer after its runner returns.
+const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
+
+type CounterServer = CounterServiceServer<CounterServiceHandler>;
+
+// ── Read server ───────────────────────────────────────────────────────────────
+
+/// The counter read API as hosted by [`service_runtime`].
+pub struct CounterReadService {
+    handler: CounterServiceHandler,
+    redis: RedisClient,
+}
+
+#[async_trait]
+impl Service for CounterReadService {
+    const NAME: &'static str = "counter";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <CounterServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let CounterConfig {
+            postgres,
+            redis,
+            scylla,
+            aggregation_window,
+            read_timeout,
+            ..
+        } = CounterConfig::from_env();
+        let ports = Ports::build(postgres, redis, scylla, aggregation_window)
+            .await
+            .map_err(|e| anyhow::anyhow!("counter read ports build: {e}"))?;
+        let handler = compose_read(
+            Arc::clone(&ports.store),
+            Arc::clone(&ports.ledger),
+            Arc::clone(&ports.series),
+            read_timeout,
+        );
+        Ok(Self {
+            handler,
+            redis: ports.redis,
+        })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        vec![redis_probe(self.redis.clone())]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+        routes.add_service(reflection);
+        routes.add_service(CounterServiceServer::new(self.handler));
+        Ok(())
+    }
+}
+
+// ── Stream worker ───────────────────────────────────────────────────────────--
+
+/// The counter stream processor as hosted by [`service_runtime`]. Exposes no domain
+/// RPC; it serves only health + reflection on its port while the supervised
+/// consumers and the flush loop do the work.
+pub struct CounterWorkerService {
+    redis: RedisClient,
+}
+
+#[async_trait]
+impl Service for CounterWorkerService {
+    const NAME: &'static str = "counter-worker";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = <CounterServer as tonic::server::NamedService>::NAME;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        // `..` ignores the read-path + reconciliation knobs: the read timeout is the
+        // read server's, and the reconciliation loop is wired but not spawned here —
+        // its concrete `ReconciliationSource` (gRPC to engagement / social-graph) is a
+        // deferred follow-up. The `Reconciler` itself is built + unit-tested; once a
+        // source exists, spawn a supervised loop over `drift_tolerance` /
+        // `reconcile_interval` exactly like the consumers below.
+        let CounterConfig {
+            postgres,
+            redis,
+            scylla,
+            kafka,
+            aggregation_window,
+            flush_interval,
+            ..
+        } = CounterConfig::from_env();
+
+        let ports = Ports::build(postgres, redis, scylla, aggregation_window)
+            .await
+            .map_err(|e| anyhow::anyhow!("counter worker ports build: {e}"))?;
+
+        // Outbound signal producer (built once; the popularity loop reuses it).
+        let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+            .build()
+            .context("build popularity producer")?;
+        let publisher: Arc<dyn SignalPublisher> = Arc::new(KafkaSignalPublisher::new(producer));
+
+        let flusher = Arc::new(DeltaFlusher::new(
+            Arc::clone(&ports.store),
+            Arc::clone(&ports.ledger),
+            Arc::clone(&ports.series),
+        ));
+        let popularity = Arc::new(PopularityPublisher::new(Arc::clone(&ports.store), publisher));
+        let aggregator = Arc::new(Mutex::new(WindowAggregator::new(aggregation_window)));
+
+        // Five supervised consumers fold into the one shared aggregator.
+        spawn_consumer::<HitWire, _>(VIEW_TOPIC, VIEW_GROUP, "view", &aggregator, map_view);
+        spawn_consumer::<HitWire, _>(
+            IMPRESSION_TOPIC,
+            IMPRESSION_GROUP,
+            "impression",
+            &aggregator,
+            map_impression,
+        );
+        spawn_consumer::<HitWire, _>(CLICK_TOPIC, CLICK_GROUP, "click", &aggregator, map_click);
+        spawn_consumer::<ReactionWire, _>(
+            REACTION_TOPIC,
+            REACTION_GROUP,
+            "reaction",
+            &aggregator,
+            map_reaction,
+        );
+        spawn_consumer::<FollowWire, _>(
+            FOLLOW_TOPIC,
+            FOLLOW_GROUP,
+            "follow",
+            &aggregator,
+            map_follow,
+        );
+
+        // The drain/flush + popularity loop.
+        tokio::spawn(run_flush_loop(
+            Arc::clone(&aggregator),
+            flusher,
+            popularity,
+            flush_interval,
+        ));
+
+        Ok(Self { redis: ports.redis })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        vec![redis_probe(self.redis.clone())]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+        routes.add_service(reflection);
+        Ok(())
+    }
+}
+
+// ── Shared wiring helpers ─────────────────────────────────────────────────────
+
+/// A hot-tier liveness probe: a trivial `EVAL 'return 1'` round-trip to Redis.
+fn redis_probe(redis: RedisClient) -> Arc<dyn HealthProbe> {
+    Arc::new(FnProbe::new("redis", move || {
+        let redis = redis.clone();
+        async move {
+            let _: i64 = redis
+                .inner
+                .eval("return 1", Vec::<String>::new(), Vec::<String>::new())
+                .await
+                .map_err(|e: fred::error::Error| anyhow::anyhow!(e.to_string()))?;
+            Ok(())
+        }
+    }))
+}
+
+/// Spawns a supervised fold consumer: rebuilds its Kafka handles and restarts after
+/// a backoff whenever the runner returns.
+fn spawn_consumer<T, M>(
+    topic: &'static str,
+    group: &'static str,
+    label: &'static str,
+    aggregator: &Arc<Mutex<WindowAggregator>>,
+    map: M,
+) where
+    T: ConsumablePayload + Clone,
+    M: Fn(T) -> Result<Vec<Observation>, CounterError> + Copy + Send + Sync + 'static,
+{
+    let aggregator = Arc::clone(aggregator);
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(topic, group) {
+                Ok((consumer, producer)) => {
+                    run_fold_consumer::<T, _>(
+                        label,
+                        consumer,
+                        producer,
+                        Arc::clone(&aggregator),
+                        map,
+                    )
+                    .await;
+                    tracing::warn!(label, "consumer exited; respawning after backoff");
+                }
+                Err(error) => tracing::error!(label, %error, "failed to build consumer; retrying"),
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Builds a manual-commit consumer (subscribed to `topic`) and the dead-letter
+/// producer the runner needs. Kafka config is read fresh per respawn.
+fn build_consumer(
+    topic: &str,
+    group: &str,
+) -> anyhow::Result<(KafkaConsumerHandle, KafkaProducerHandle)> {
+    let kafka = KafkaClientConfig::from_env();
+    let consumer = KafkaConsumerBuilder::new(ConsumerConfig::new(kafka.clone(), group))
+        .subscribe(topic)
+        .build()
+        .with_context(|| format!("build consumer for {topic}"))?;
+    let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+        .build()
+        .with_context(|| format!("build dead-letter producer for {topic}"))?;
+    Ok((consumer, producer))
+}

--- a/crates/services/counter/src/service.rs
+++ b/crates/services/counter/src/service.rs
@@ -26,13 +26,16 @@ use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig
 use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
 use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
 
+use tonic::transport::Channel;
+
 use crate::app::{Ports, compose_read};
-use crate::application::command::{DeltaFlusher, PopularityPublisher};
-use crate::application::port::SignalPublisher;
+use crate::application::command::{DeltaFlusher, PopularityPublisher, Reconciler};
+use crate::application::port::{ReconciliationSource, SignalPublisher};
 use crate::config::CounterConfig;
 use crate::domain::{Observation, WindowAggregator};
 use crate::error::CounterError;
 use crate::infrastructure::consumer::{run_flush_loop, run_fold_consumer};
+use crate::infrastructure::reconcile::{GrpcReconciliationSource, run_reconcile_loop};
 use crate::infrastructure::decode::{
     FollowWire, HitWire, ReactionWire, map_click, map_follow, map_impression, map_reaction, map_view,
 };
@@ -127,12 +130,6 @@ impl Service for CounterWorkerService {
     const GRPC_SERVICE_NAME: &'static str = <CounterServer as tonic::server::NamedService>::NAME;
 
     async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
-        // `..` ignores the read-path + reconciliation knobs: the read timeout is the
-        // read server's, and the reconciliation loop is wired but not spawned here —
-        // its concrete `ReconciliationSource` (gRPC to engagement / social-graph) is a
-        // deferred follow-up. The `Reconciler` itself is built + unit-tested; once a
-        // source exists, spawn a supervised loop over `drift_tolerance` /
-        // `reconcile_interval` exactly like the consumers below.
         let CounterConfig {
             postgres,
             redis,
@@ -140,6 +137,9 @@ impl Service for CounterWorkerService {
             kafka,
             aggregation_window,
             flush_interval,
+            reconcile_interval,
+            drift_tolerance,
+            social_graph_endpoint,
             ..
         } = CounterConfig::from_env();
 
@@ -192,6 +192,25 @@ impl Service for CounterWorkerService {
             flusher,
             popularity,
             flush_interval,
+        ));
+
+        // The reconciliation sweep: heal exact-counter drift against social-graph.
+        // Lazy connect — a cold start does not require the dependency to be up.
+        let social_graph = Channel::from_shared(social_graph_endpoint)
+            .context("invalid social-graph endpoint")?
+            .connect_lazy();
+        let source: Arc<dyn ReconciliationSource> =
+            Arc::new(GrpcReconciliationSource::new(social_graph));
+        let reconciler = Arc::new(Reconciler::new(
+            Arc::clone(&ports.store),
+            Arc::clone(&ports.ledger),
+            source,
+            drift_tolerance,
+        ));
+        tokio::spawn(run_reconcile_loop(
+            reconciler,
+            Arc::clone(&ports.ledger),
+            reconcile_interval,
         ));
 
         Ok(Self { redis: ports.redis })

--- a/crates/services/counter/tests/counter_it/harness/mod.rs
+++ b/crates/services/counter/tests/counter_it/harness/mod.rs
@@ -1,0 +1,227 @@
+//! Integration harness: boots ephemeral Redis + Postgres + Scylla, applies the
+//! `.sql` / `.cql` migrations, and wires the real counter adapters against them.
+//! Isolation is by fresh per-scenario entity ids (UUID) — the shared containers
+//! run every scenario in parallel.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, TimeZone, Utc};
+use uuid::Uuid;
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+use counter::application::command::{DeltaFlusher, FlushReport, Reconciler};
+use counter::application::port::{
+    CounterLedger, CounterStore, ReconciliationSource, TimeSeriesStore,
+};
+use counter::domain::{
+    CountSnapshot, EntityId, EntityKind, EntityRef, Metric, Observation, TimeSeriesBucket,
+    TimeSeriesQuery, TrendingItem, TrendingScope, WindowAggregator, WindowDelta, WindowSize,
+};
+use counter::infrastructure::pg_counter_ledger::PgCounterLedger;
+use counter::infrastructure::redis_counter_store::RedisCounterStore;
+use counter::infrastructure::scylla_time_series::ScyllaTimeSeriesStore;
+
+use postgres_storage::config::StatementLogLevel;
+use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
+use redis_storage::{RedisClientBuilder, RedisConfig};
+use scylla_storage::{ScyllaConfig, ScyllaSessionBuilder};
+
+const PG_MIGRATIONS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/postgres");
+const SCYLLA_MIGRATIONS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/scylla");
+const WINDOW_MS: u64 = 5_000;
+
+pub struct Harness {
+    pub store: Arc<dyn CounterStore>,
+    pub ledger: Arc<dyn CounterLedger>,
+    pub series: Arc<dyn TimeSeriesStore>,
+    flusher: DeltaFlusher,
+    window: WindowSize,
+}
+
+impl Harness {
+    pub async fn start() -> Self {
+        let pg_url = test_support::containers::postgres_ready(PG_MIGRATIONS).await;
+        let redis_endpoint = test_support::containers::redis_endpoint().await;
+        let scylla_cp = test_support::containers::scylla_ready("counter", SCYLLA_MIGRATIONS).await;
+
+        let pg_config = PostgresConfig {
+            database_url: pg_url,
+            max_connections: 8,
+            min_connections: 1,
+            acquire_timeout: Duration::from_secs(5),
+            idle_timeout: None,
+            max_lifetime: None,
+            statement_log_level: StatementLogLevel::Debug,
+            slow_statement_threshold: Duration::from_millis(500),
+        };
+        let pool = PgPoolBuilder::build(pg_config).await.expect("it: pg pool");
+        let tx = TransactionManager::new(pool);
+
+        let redis = RedisClientBuilder::new(RedisConfig {
+            hosts: vec![redis_endpoint],
+            ..RedisConfig::default()
+        })
+        .build()
+        .await
+        .expect("it: redis client");
+
+        let scylla = Arc::new(
+            ScyllaSessionBuilder::new(ScyllaConfig {
+                contact_points: vec![scylla_cp],
+                keyspace: None,
+                ..ScyllaConfig::default()
+            })
+            .build()
+            .await
+            .expect("it: scylla client"),
+        );
+
+        let window = WindowSize::from_millis(WINDOW_MS).unwrap();
+        let store: Arc<dyn CounterStore> = Arc::new(RedisCounterStore::new(redis));
+        let ledger: Arc<dyn CounterLedger> = Arc::new(PgCounterLedger::new(tx));
+        let series: Arc<dyn TimeSeriesStore> =
+            Arc::new(ScyllaTimeSeriesStore::new(scylla, window));
+        let flusher = DeltaFlusher::new(Arc::clone(&store), Arc::clone(&ledger), Arc::clone(&series));
+
+        Self {
+            store,
+            ledger,
+            series,
+            flusher,
+            window,
+        }
+    }
+
+    pub fn window(&self) -> WindowSize {
+        self.window
+    }
+
+    /// Fold observations into a fresh window aggregator, drain everything, and flush
+    /// across the three tiers. Returns the flush report.
+    pub async fn ingest(&self, observations: Vec<Observation>) -> FlushReport {
+        let deltas = self.fold(observations);
+        self.flusher.flush(&deltas).await.expect("it: flush")
+    }
+
+    /// Fold observations into deltas without flushing (so a scenario can flush the
+    /// same deltas twice to prove idempotency).
+    pub fn fold(&self, observations: Vec<Observation>) -> Vec<WindowDelta> {
+        let mut agg = WindowAggregator::new(self.window);
+        for o in observations {
+            agg.fold(o).expect("it: fold");
+        }
+        agg.drain_all()
+    }
+
+    pub async fn flush(&self, deltas: &[WindowDelta]) -> FlushReport {
+        self.flusher.flush(deltas).await.expect("it: flush")
+    }
+
+    pub async fn read(&self, entity: &EntityRef, metrics: &[Metric]) -> CountSnapshot {
+        self.store
+            .read(std::slice::from_ref(entity), metrics)
+            .await
+            .expect("it: read")
+            .pop()
+            .expect("it: one snapshot")
+    }
+
+    pub async fn total(&self, entity: &EntityRef, metric: Metric) -> Option<i64> {
+        self.ledger.read_total(entity, metric).await.expect("it: total")
+    }
+
+    pub async fn top_k(&self, metric: Metric, limit: usize) -> Vec<TrendingItem> {
+        self.store
+            .top_k(TrendingScope::Global, None, metric, limit)
+            .await
+            .expect("it: top_k")
+    }
+
+    pub async fn range(&self, query: &TimeSeriesQuery) -> Vec<TimeSeriesBucket> {
+        self.series.range(query).await.expect("it: range")
+    }
+
+    /// A reconciler over the live store + ledger and a caller-supplied authoritative
+    /// source.
+    pub fn reconciler(&self, source: Arc<dyn ReconciliationSource>, tolerance: i64) -> Reconciler {
+        Reconciler::new(
+            Arc::clone(&self.store),
+            Arc::clone(&self.ledger),
+            source,
+            tolerance,
+        )
+    }
+}
+
+/// An authoritative-count source whose values the scenario sets — stands in for the
+/// gRPC call to engagement / social-graph.
+#[derive(Default)]
+pub struct FixedSource {
+    counts: std::sync::Mutex<HashMap<(String, String, String), i64>>,
+}
+
+impl FixedSource {
+    pub fn set(&self, entity: &EntityRef, metric: Metric, value: i64) {
+        self.counts.lock().unwrap().insert(
+            (
+                entity.kind.as_str().to_owned(),
+                entity.id.as_str().to_owned(),
+                metric.as_str().to_owned(),
+            ),
+            value,
+        );
+    }
+}
+
+#[async_trait]
+impl ReconciliationSource for FixedSource {
+    async fn authoritative_count(
+        &self,
+        entity: &EntityRef,
+        metric: Metric,
+    ) -> Result<Option<i64>, counter::CounterError> {
+        Ok(self
+            .counts
+            .lock()
+            .unwrap()
+            .get(&(
+                entity.kind.as_str().to_owned(),
+                entity.id.as_str().to_owned(),
+                metric.as_str().to_owned(),
+            ))
+            .copied())
+    }
+}
+
+// ── Builders ──────────────────────────────────────────────────────────────────
+
+/// A fresh, scenario-isolated post entity.
+pub fn fresh_post() -> EntityRef {
+    EntityRef::new(
+        EntityKind::Post,
+        EntityId::new(format!("post-{}", Uuid::now_v7())).unwrap(),
+    )
+}
+
+pub fn at(ms: i64) -> DateTime<Utc> {
+    Utc.timestamp_millis_opt(ms).unwrap()
+}
+
+pub fn view(entity: &EntityRef, ms: i64) -> Observation {
+    Observation::sum(entity.clone(), Metric::View, 1, at(ms)).unwrap()
+}
+
+pub fn unique_view(entity: &EntityRef, member: &str, ms: i64) -> Observation {
+    use counter::domain::MemberId;
+    Observation::unique(
+        entity.clone(),
+        Metric::UniqueViewer,
+        MemberId::new(member).unwrap(),
+        at(ms),
+    )
+    .unwrap()
+}

--- a/crates/services/counter/tests/counter_it/mod.rs
+++ b/crates/services/counter/tests/counter_it/mod.rs
@@ -1,0 +1,5 @@
+//! Counter integration suite: the harness (boots Redis + Postgres + Scylla and
+//! wires the real adapters) and the scenarios.
+
+mod harness;
+mod scenarios;

--- a/crates/services/counter/tests/counter_it/scenarios/aggregate.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/aggregate.rs
@@ -1,0 +1,46 @@
+//! The firehose collapse, end-to-end over the real hot tier.
+
+use counter::domain::Metric;
+
+use super::super::harness::{Harness, fresh_post, unique_view, view};
+
+#[tokio::test]
+async fn collapses_views_into_live_total() {
+    let h = Harness::start().await;
+    let post = fresh_post();
+
+    // 1000 views, all inside one window → one delta → one HINCRBY of +1000.
+    let observations = (0..1000).map(|i| view(&post, 1_000 + i)).collect();
+    let report = h.ingest(observations).await;
+    assert_eq!(report.applied, 1);
+
+    // Real Redis HINCRBY result.
+    let snap = h.read(&post, &[Metric::View]).await;
+    assert_eq!(snap.get(Metric::View), Some(1000));
+
+    // And the durable total landed too.
+    assert_eq!(h.total(&post, Metric::View).await, Some(1000));
+}
+
+#[tokio::test]
+async fn estimates_unique_viewers_within_hll_error() {
+    let h = Harness::start().await;
+    let post = fresh_post();
+
+    // 500 distinct viewers, each seen 3× — the duplicates must collapse.
+    let mut observations = Vec::new();
+    for v in 0..500 {
+        for _ in 0..3 {
+            observations.push(unique_view(&post, &format!("viewer-{v}"), 1_000));
+        }
+    }
+    h.ingest(observations).await;
+
+    // Real PFCOUNT over the HyperLogLog; ~0.81% std error, generous bound here.
+    let snap = h.read(&post, &[Metric::UniqueViewer]).await;
+    let estimate = snap.get(Metric::UniqueViewer).expect("unique viewer estimate");
+    assert!(
+        (estimate - 500).abs() <= 25,
+        "HLL estimate {estimate} not within ±25 of 500"
+    );
+}

--- a/crates/services/counter/tests/counter_it/scenarios/idempotency.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/idempotency.rs
@@ -1,0 +1,31 @@
+//! The idempotency guarantee, proven against the real Postgres flush CTE: a
+//! redelivered window advances nothing, across every tier.
+
+use counter::domain::Metric;
+
+use super::super::harness::{Harness, fresh_post, view};
+
+#[tokio::test]
+async fn redelivered_window_does_not_double_count() {
+    let h = Harness::start().await;
+    let post = fresh_post();
+
+    // One window of 100 views, folded but not yet flushed.
+    let deltas = h.fold((0..100).map(|i| view(&post, 1_000 + i)).collect());
+
+    // First flush applies everywhere.
+    let first = h.flush(&deltas).await;
+    assert_eq!(first.applied, 1);
+    assert_eq!(h.total(&post, Metric::View).await, Some(100));
+    assert_eq!(h.read(&post, &[Metric::View]).await.get(Metric::View), Some(100));
+
+    // The exact same window (same window_id) redelivered: the CTE's
+    // ON CONFLICT DO NOTHING gates the total, and the flusher gates the hot write.
+    let second = h.flush(&deltas).await;
+    assert_eq!(second.applied, 0);
+    assert_eq!(second.already_applied, 1);
+
+    // Neither the durable total nor the hot counter moved.
+    assert_eq!(h.total(&post, Metric::View).await, Some(100));
+    assert_eq!(h.read(&post, &[Metric::View]).await.get(Metric::View), Some(100));
+}

--- a/crates/services/counter/tests/counter_it/scenarios/mod.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/mod.rs
@@ -1,0 +1,7 @@
+//! Live scenarios over the real Redis + Postgres + Scylla adapters.
+
+mod aggregate;
+mod idempotency;
+mod reconcile;
+mod timeseries;
+mod trending;

--- a/crates/services/counter/tests/counter_it/scenarios/reconcile.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/reconcile.rs
@@ -1,0 +1,44 @@
+//! Reconciliation against the owning source-of-record, healing both live tiers.
+
+use std::sync::Arc;
+
+use counter::application::command::ReconcileOutcome;
+use counter::domain::{EntityId, EntityKind, EntityRef, Metric};
+
+use super::super::harness::{FixedSource, Harness, at};
+
+fn like(entity: &EntityRef, ms: i64) -> counter::domain::Observation {
+    counter::domain::Observation::sum(entity.clone(), Metric::Like, 1, at(ms)).unwrap()
+}
+
+fn fresh_profile() -> EntityRef {
+    EntityRef::new(
+        EntityKind::Profile,
+        EntityId::new(format!("profile-{}", uuid::Uuid::now_v7())).unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn corrects_exact_counter_drift_on_both_tiers() {
+    let h = Harness::start().await;
+    let profile = fresh_profile();
+
+    // The hot/durable Like count drifted to 95 (e.g. a lost window).
+    h.ingest((0..95).map(|i| like(&profile, 1_000 + i)).collect()).await;
+    assert_eq!(h.total(&profile, Metric::Like).await, Some(95));
+
+    // The authoritative source (engagement) says the true count is 100.
+    let source = Arc::new(FixedSource::default());
+    source.set(&profile, Metric::Like, 100);
+
+    let outcome = h
+        .reconciler(source, 2)
+        .reconcile(&profile, Metric::Like)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, ReconcileOutcome::Corrected { from: 95, to: 100 });
+    // Both the durable ledger (set_total) and the hot counter (overwrite) healed.
+    assert_eq!(h.total(&profile, Metric::Like).await, Some(100));
+    assert_eq!(h.read(&profile, &[Metric::Like]).await.get(Metric::Like), Some(100));
+}

--- a/crates/services/counter/tests/counter_it/scenarios/reconcile.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/reconcile.rs
@@ -42,3 +42,31 @@ async fn corrects_exact_counter_drift_on_both_tiers() {
     assert_eq!(h.total(&profile, Metric::Like).await, Some(100));
     assert_eq!(h.read(&profile, &[Metric::Like]).await.get(Metric::Like), Some(100));
 }
+
+#[tokio::test]
+async fn candidate_scan_finds_follower_pairs_on_live_ledger() {
+    use counter::domain::Observation;
+
+    let h = Harness::start().await;
+    let profile = fresh_profile();
+
+    // Accumulate a follower count so a reconcilable row exists in counter_totals.
+    let observations = (0..30)
+        .map(|i| Observation::sum(profile.clone(), Metric::Follower, 1, at(1_000 + i)).unwrap())
+        .collect();
+    h.ingest(observations).await;
+
+    // The real Postgres candidate scan (synthetic-key cursor) must surface this
+    // profile's follower pair; approximate metrics (views) never appear.
+    let pairs = h.ledger.list_reconcilable(None, 1_000).await.unwrap();
+    assert!(
+        pairs
+            .iter()
+            .any(|(e, m)| e.id.as_str() == profile.id.as_str() && *m == Metric::Follower),
+        "live candidate scan should include the seeded follower pair"
+    );
+    assert!(
+        pairs.iter().all(|(_, m)| matches!(m, Metric::Follower | Metric::Following)),
+        "only follower/following are reconcilable"
+    );
+}

--- a/crates/services/counter/tests/counter_it/scenarios/timeseries.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/timeseries.rs
@@ -1,0 +1,29 @@
+//! Cold-tier rollup + range read over the real Scylla counter table.
+
+use counter::domain::{Metric, TimeGranularity, TimeSeriesQuery};
+
+use super::super::harness::{Harness, at, fresh_post, view};
+
+#[tokio::test]
+async fn rolls_windows_into_time_buckets() {
+    let h = Harness::start().await;
+    let post = fresh_post();
+
+    // Two distinct windows that floor into the same hour bucket: window 0 (sum 2)
+    // and window 1 (sum 1). The Scylla counter must accumulate them to 3.
+    h.ingest(vec![view(&post, 1_000), view(&post, 2_000)]).await;
+    h.ingest(vec![view(&post, 6_000)]).await;
+
+    let query = TimeSeriesQuery::new(
+        post.clone(),
+        Metric::View,
+        TimeGranularity::Hour,
+        at(-1_000_000),
+        at(3_600_000),
+    )
+    .unwrap();
+    let buckets = h.range(&query).await;
+
+    let total: i64 = buckets.iter().map(|b| b.value).sum();
+    assert_eq!(total, 3, "hour bucket should accumulate both windows");
+}

--- a/crates/services/counter/tests/counter_it/scenarios/trending.rs
+++ b/crates/services/counter/tests/counter_it/scenarios/trending.rs
@@ -1,0 +1,30 @@
+//! Trending ranking over the real sorted-set board (`ZINCRBY` / `ZREVRANGE`).
+
+use counter::domain::{EntityRef, Metric};
+
+use super::super::harness::{Harness, fresh_post, view};
+
+#[tokio::test]
+async fn ranks_entities_by_score() {
+    let h = Harness::start().await;
+    let low = fresh_post();
+    let mid = fresh_post();
+    let high = fresh_post();
+
+    h.ingest((0..10).map(|i| view(&low, 1_000 + i)).collect()).await;
+    h.ingest((0..100).map(|i| view(&high, 1_000 + i)).collect()).await;
+    h.ingest((0..50).map(|i| view(&mid, 1_000 + i)).collect()).await;
+
+    // The global board is shared across parallel scenarios, so assert the relative
+    // order of *our* three entities rather than absolute positions.
+    let board = h.top_k(Metric::View, 10_000).await;
+    let ids: Vec<&str> = board.iter().map(|t| t.entity.id.as_str()).collect();
+    let pos = |e: &EntityRef| {
+        ids.iter()
+            .position(|id| *id == e.id.as_str())
+            .unwrap_or_else(|| panic!("entity {} missing from board", e.id.as_str()))
+    };
+
+    assert!(pos(&high) < pos(&mid), "high should outrank mid");
+    assert!(pos(&mid) < pos(&low), "mid should outrank low");
+}

--- a/crates/services/counter/tests/integration.rs
+++ b/crates/services/counter/tests/integration.rs
@@ -1,0 +1,33 @@
+//! Live, container-backed integration suite for the counter-analytics service.
+//!
+//! Counter's whole point is absorbing a firehose across three storage tiers, so
+//! this suite boots real **Redis** (hot counters / HLL / trending), **Postgres**
+//! (the durable ledger + idempotency), and **ScyllaDB** (the cold time-series),
+//! and drives the production write/read path over the real adapters. It exercises
+//! exactly what cannot be unit-tested: that `HINCRBY` / `PFADD` / `PFCOUNT` /
+//! `ZREVRANGE` behave as the domain assumes, that the idempotent flush CTE truly
+//! prevents a double-add on redelivery, and that the Scylla counter rollup +
+//! range read round-trip.
+//!
+//! Ingestion is driven through the real `WindowAggregator` → `DeltaFlusher` with
+//! fully-formed observations; the wire decode layer is pure and unit-tested, so it
+//! is out of scope here.
+//!
+//! Gated behind `integration-counter` so the default `cargo test -p counter` stays
+//! hermetic and Docker-free. Run the live suite:
+//!
+//! ```text
+//! cargo test -p counter --features integration-counter -- --nocapture
+//! ```
+//!
+//! Coverage:
+//! - **aggregate** — N folded view observations collapse to the correct live total
+//!   (real `HINCRBY`); distinct viewers estimate within HLL error (`PFADD`/`PFCOUNT`).
+//! - **idempotency** — re-flushing the same window leaves the durable total
+//!   unchanged (the ledger CTE), reported as `already_applied`.
+//! - **trending** — relative ranking of entities by score (`ZREVRANGE`).
+//! - **timeseries** — window scalars roll into Scylla counter buckets and read back
+//!   over a range.
+#![cfg(feature = "integration-counter")]
+
+mod counter_it;


### PR DESCRIPTION
Lands the **counter-analytics** service on `develop`. Cherry-picked from `feat/media-service` (where it was developed and tested) so `develop` gets a clean two-commit history with no duplicate-media noise.

> **Why cherry-pick, not merge `feat/media-service`:** media is already on `develop` via #461; `feat/media-service` carries a byte-identical *duplicate* media commit that would conflict on a direct merge. The counter commits touch disjoint paths, so cherry-pick `-x` excludes the dup by construction and preserves lineage (`cherry picked from …`).

## Commits
- `7bf01933` ← #462 — the counter-analytics service (all 8 phases)
- `66e4d944` ← #465 — concrete gRPC reconciliation source + supervised sweep loop, and migrator registration

## What it is
TIER-1, fail-open, System-of-Reference real-time counter aggregator. Absorbs the view/like/share/follow firehose so it never melts a transactional row; answers "how many?", never "who?".

- **Two deployables:** `counter-server` (:50064 read API) + `counter-worker` (firehose aggregation, no domain RPC).
- **Write-amplification funnel:** sharded ingest → windowed N→1 pre-aggregation → Redis → idempotent batched write-behind. No per-event durable write.
- **3 tiers:** Redis hot (HLL/sorted-set trending via Lua) · Postgres warm (auditable totals + idempotency CTE) · Scylla TWCS cold.
- **Publishes** `counter.v1.popularity` (unblocks search's `PopularityScore`); supersedes engagement's raw counters.
- **Reconciliation:** heals exact-counter drift against `social-graph` (follower/following) via a supervised sweep.
- **Migrations** registered in `migrator` (Postgres ledger + Scylla time-series).

## Delta & verification
- Net diff vs `develop`: **74 files, +7,030/-1** — counter + migrator + workspace manifest only (no media).
- `cargo check --workspace` green · `cargo test -p counter` → **67 passed** · `cargo build -p migrator` green · `Cargo.lock` clean (no drift).
- Live integration suite (`integration-counter`): **7 scenarios green** on real Redis + Postgres + Scylla (run during development).

## Deferred (external, documented)
Upstream firehose producers (view/impression/click) · social-graph follow-event stream prereq · standalone popularity cadence · shard-fan-out producer · graceful-shutdown drain hook · like/share/comment reconciliation (needs a reaction-count RPC on engagement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)