### PR TITLE
feat(realtime): client-facing real-time delivery plane — WSS gateway + Kafka fan-out dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -411,8 +412,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1226,6 +1229,12 @@ dependencies = [
  "lock_api",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -4334,6 +4343,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "realtime"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "auth-context",
+ "axum 0.8.8",
+ "chrono",
+ "dashmap 7.0.0-rc2",
+ "error",
+ "fred",
+ "futures-util",
+ "http",
+ "jsonwebtoken",
+ "prost 0.14.4",
+ "prost-types",
+ "realtime-api",
+ "redis-storage",
+ "serde",
+ "serde_json",
+ "service-runtime",
+ "test-support",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-reflection",
+ "tracing",
+ "transport",
+ "uuid",
+ "validation",
+]
+
+[[package]]
+name = "realtime-api"
+version = "0.1.0"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "realtime-dispatcher"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "realtime",
+ "service-runtime",
+ "tokio",
+]
+
+[[package]]
+name = "realtime-gateway"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "realtime",
+ "service-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "redis-protocol"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5914,6 +5987,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6369,6 +6454,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/services/search",
     "crates/services/media",
     "crates/services/counter",
+    "crates/services/realtime",
     "crates/apps/chat-server",
     "crates/apps/profile-server",
     "crates/apps/social-graph-server",
@@ -50,6 +51,8 @@ members = [
     "crates/apps/media-server",
     "crates/apps/counter-server",
     "crates/apps/counter-worker",
+    "crates/apps/realtime-gateway",
+    "crates/apps/realtime-dispatcher",
     "crates/apps/migrator",
     "crates/contracts/social-graph-api",
     "crates/contracts/account-api",
@@ -66,6 +69,7 @@ members = [
     "crates/contracts/search-api",
     "crates/contracts/media-api",
     "crates/contracts/counter-api",
+    "crates/contracts/realtime-api",
 ]
 resolver = "2"
 
@@ -118,6 +122,7 @@ moderation-api = { path = "crates/contracts/moderation-api" }
 search-api = { path = "crates/contracts/search-api" }
 media-api = { path = "crates/contracts/media-api" }
 counter-api = { path = "crates/contracts/counter-api" }
+realtime-api = { path = "crates/contracts/realtime-api" }
 account          = { path = "crates/services/account" }
 chat             = { path = "crates/services/chat" }
 profile          = { path = "crates/services/profile" }
@@ -133,6 +138,7 @@ moderation       = { path = "crates/services/moderation" }
 search           = { path = "crates/services/search" }
 media            = { path = "crates/services/media" }
 counter          = { path = "crates/services/counter" }
+realtime         = { path = "crates/services/realtime" }
 
 
 # Communs

--- a/crates/apps/realtime-dispatcher/Cargo.toml
+++ b/crates/apps/realtime-dispatcher/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                 = "realtime-dispatcher"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the realtime FAN-OUT path — the stateless dispatcher: consumes the upstream Kafka event streams, resolves which gateway node owns each recipient via the connection registry, and publishes the event to that node's hop channel."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# No-op entrypoint today. Phase 5 wires this as the fan-out worker: supervised
+# `run_consumer` loops over the upstream streams (chat / notification /
+# counter.v1.popularity / post.v1.events), the connection-registry lookup that
+# resolves recipient -> owning node(s), and the targeted publish to each node's
+# Redis Pub/Sub hop channel. It serves no domain RPC — only the gRPC
+# health/reflection endpoint on its own port (default :50067). Throughput-bound;
+# scaled independently of `realtime-gateway`.
+[dependencies]
+realtime        = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/realtime-dispatcher/src/main.rs
+++ b/crates/apps/realtime-dispatcher/src/main.rs
@@ -1,0 +1,16 @@
+//! `realtime-dispatcher` — the deployable binary for the realtime **fan-out path**.
+//!
+//! Serves only the gRPC health/reflection plane via [`service_runtime::serve`] on
+//! :50067, while [`RealtimeDispatcherService::build`] spawns the supervised
+//! `run_consumer` loops that decode upstream events and fan them out to the owning
+//! gateway nodes. Scaled independently of `realtime-gateway`.
+
+use realtime::RealtimeDispatcherService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("REALTIME_DISPATCHER_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50067".to_owned())
+        .parse()?;
+    service_runtime::serve::<RealtimeDispatcherService>(addr).await
+}

--- a/crates/apps/realtime-gateway/Cargo.toml
+++ b/crates/apps/realtime-gateway/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                 = "realtime-gateway"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Deployable binary for the realtime EDGE plane — the stateful gateway: terminates the client WebSocket connections, owns the per-node connection table, writes the presence registry, subscribes to its node-hop channel, and drains gracefully on rollout."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# No-op entrypoint today. Phase 5 wires this as the stateful edge: the public WSS
+# accept loop with bounded per-connection mailboxes + shedding, the handshake
+# token verification, the connection/presence registry writes, the node-hop
+# (Redis Pub/Sub) subscription, the heartbeat reaper, the graceful-drain hook, and
+# the internal gRPC health/reflection endpoint on :50066. Memory/FD-bound; scaled
+# (and autoscaled on connection-count + memory, NOT CPU) independently of
+# `realtime-dispatcher`.
+[dependencies]
+realtime        = { workspace = true }
+service-runtime = { workspace = true }
+
+tokio  = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/apps/realtime-gateway/src/main.rs
+++ b/crates/apps/realtime-gateway/src/main.rs
@@ -1,0 +1,17 @@
+//! `realtime-gateway` — the deployable binary for the realtime **edge plane**.
+//!
+//! Runs two listeners: the internal gRPC health/reflection plane via
+//! [`service_runtime::serve`] on :50066, while [`RealtimeGatewayService::build`]
+//! spawns the public WSS server (default :8443) and the node-channel subscriber as
+//! background tasks. Scaled — and autoscaled on connection-count + memory, NOT
+//! CPU — independently of `realtime-dispatcher`.
+
+use realtime::RealtimeGatewayService;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let addr = std::env::var("REALTIME_GATEWAY_GRPC_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:50066".to_owned())
+        .parse()?;
+    service_runtime::serve::<RealtimeGatewayService>(addr).await
+}

--- a/crates/contracts/proto/realtime/v1/enums.proto
+++ b/crates/contracts/proto/realtime/v1/enums.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package realtime.v1;
+
+option java_package = "com.coreplatform.realtime.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/realtime/v1;realtimev1";
+
+// The multiplex channel CLASS a frame belongs to. A channel is a (class, key)
+// pair (see ChannelRef): the class selects the kind of stream, the key scopes it
+// to a specific subject. One physical WSS socket carries every class at once —
+// that multiplexing is the whole point of the plane (one socket per device).
+//
+// Authorization is by ownership of the key (see ChannelRef): DM / NOTIFICATION /
+// PRESENCE keys MUST equal the connection's pinned identity; COUNTER / FEED keys
+// are public entity ids. The realtime plane performs no other authorization —
+// content visibility was decided upstream when the event was emitted.
+enum ChannelClass {
+    CHANNEL_CLASS_UNSPECIFIED  = 0;
+    // Direct messages / chat. Key = the owning user id. At-least-once.
+    CHANNEL_CLASS_DM           = 1;
+    // Notification + badge updates. Key = the owning user id. At-least-once.
+    CHANNEL_CLASS_NOTIFICATION = 2;
+    // Presence (online/away). Key = the owning user id. Fire-and-forget.
+    CHANNEL_CLASS_PRESENCE     = 3;
+    // Live engagement magnitudes for an entity. Key = the entity id. Public,
+    // fire-and-forget (a dropped tick is superseded by the next).
+    CHANNEL_CLASS_COUNTER      = 4;
+    // Selective live feed signals. Key = the entity/author id. Fire-and-forget.
+    CHANNEL_CLASS_FEED         = 5;
+}
+
+// Server→client control directives, carried in a Control frame. These drive the
+// client's connection state machine; they are not domain events.
+enum ServerControl {
+    SERVER_CONTROL_UNSPECIFIED     = 0;
+    // Acknowledges a Subscribe for `channel`.
+    SERVER_CONTROL_SUBSCRIBED      = 1;
+    // Acknowledges an Unsubscribe for `channel`.
+    SERVER_CONTROL_UNSUBSCRIBED    = 2;
+    // The edge token is expiring/expired (RTM-1002). The client must silently
+    // refresh via `auth` and send an AuthRefresh (or re-handshake).
+    SERVER_CONTROL_REAUTH_REQUIRED = 3;
+    // The node is draining on rollout (RTM-5003). The client must reconnect —
+    // elsewhere — after `reconnect_after_ms` PLUS its own jitter (the jitter is
+    // mandatory: it prevents a reconnect thundering-herd into the auth path).
+    SERVER_CONTROL_RECONNECT       = 4;
+    // The connection exceeded a limit (subscriptions / frame rate / size).
+    SERVER_CONTROL_RATE_LIMITED    = 5;
+    // A terminal or per-request error; carries a stable RTM-XXXX `code`.
+    SERVER_CONTROL_ERROR           = 6;
+}
+
+// Why the gateway closed (or is about to close) a connection. Maps to the
+// RTM-1xxx / RTM-5xxx lifecycle codes so client telemetry can attribute churn.
+enum CloseReason {
+    CLOSE_REASON_UNSPECIFIED         = 0;
+    // Graceful node drain on rollout (RTM-5003) — reconnect with backoff+jitter.
+    CLOSE_REASON_DRAINING            = 1;
+    // No heartbeat pong within the deadline; half-open connection reaped (RTM-5002).
+    CLOSE_REASON_HEARTBEAT_TIMEOUT   = 2;
+    // The per-connection send queue overflowed; slow consumer shed (RTM-5001).
+    CLOSE_REASON_SEND_QUEUE_OVERFLOW = 3;
+    // The session's edge token expired and was not refreshed (RTM-1002).
+    CLOSE_REASON_AUTH_EXPIRED        = 4;
+    // A transport/framing/protocol violation (RTM-2xxx).
+    CLOSE_REASON_PROTOCOL_ERROR      = 5;
+}

--- a/crates/contracts/proto/realtime/v1/messages.proto
+++ b/crates/contracts/proto/realtime/v1/messages.proto
@@ -1,0 +1,169 @@
+syntax = "proto3";
+
+package realtime.v1;
+
+import "realtime/v1/enums.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "com.coreplatform.realtime.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/realtime/v1;realtimev1";
+
+// ── Channel addressing ────────────────────────────────────────────────────────
+
+// A channel is a (class, key) pair. The key is the qualifier the class scopes
+// to: the user id for DM / NOTIFICATION / PRESENCE (which MUST equal the
+// connection's pinned identity — this is the plane's only authorization), or the
+// entity id for COUNTER / FEED (public). A connection subscribes to a set of
+// these; a frame is delivered on exactly one.
+message ChannelRef {
+    ChannelClass class = 1;
+    string       key   = 2;
+}
+
+// A per-channel resume cursor: the last `stream_seq` the client durably
+// processed on that channel. Presented on reconnect (see Resume) so the client
+// can drive its catch-up — note the authoritative backfill comes from the owning
+// SoR (`chat` / `notification`), NOT from the realtime plane, which buffers
+// nothing.
+message ChannelCursor {
+    ChannelRef channel    = 1;
+    uint64     stream_seq = 2;
+}
+
+// ── Client → server frames (protobuf-encoded, carried over WSS) ───────────────
+
+// Everything a client sends after the handshake. The handshake itself carries
+// the edge token out-of-band (WS upgrade headers / subprotocol) and is verified
+// ONCE; frames below are never re-authenticated per message.
+message ClientFrame {
+    oneof body {
+        Subscribe   subscribe    = 1;
+        Unsubscribe unsubscribe  = 2;
+        ClientAck   ack          = 3;
+        Pong        pong         = 4;
+        AuthRefresh auth_refresh = 5;
+        Resume      resume       = 6;
+    }
+}
+
+// Subscribe to channels. Each is authorized against the pinned identity; a
+// forbidden key yields a Control(ERROR, RTM-3001) and is not added.
+message Subscribe {
+    repeated ChannelRef channels = 1;
+}
+
+message Unsubscribe {
+    repeated ChannelRef channels = 1;
+}
+
+// Acknowledge receipt up to `stream_seq` on an at-least-once channel (DM /
+// NOTIFICATION). Advances the server's per-(connection,channel) ack watermark.
+message ClientAck {
+    ChannelRef channel    = 1;
+    uint64     stream_seq = 2;
+}
+
+// Reply to a server Ping; echoes the nonce. Liveness only — its absence within
+// the deadline reaps the connection (RTM-5002).
+message Pong {
+    uint64 nonce = 1;
+}
+
+// Supply a freshly-minted edge token before the current one expires, so the
+// session continues without a full reconnect.
+message AuthRefresh {
+    string edge_token = 1;
+}
+
+// Sent right after a reconnect: the client's last-seen cursors per channel. The
+// gateway re-subscribes and resumes live flow; gap-fill for anything older than
+// what the plane still has in flight is the client's responsibility against the
+// owning SoR.
+message Resume {
+    repeated ChannelCursor cursors = 1;
+}
+
+// ── Server → client frames (protobuf-encoded, carried over WSS) ───────────────
+
+message ServerFrame {
+    oneof body {
+        Event   event   = 1;
+        Ping    ping    = 2;
+        Control control = 3;
+    }
+}
+
+// The core delivery frame: an already-authorized, already-serialized domain
+// event addressed to a channel. The realtime plane is a courier — `payload` is
+// OPAQUE to it (bytes produced upstream by `chat` / `notification` / `counter`),
+// never inspected, never stored.
+message Event {
+    ChannelRef channel = 1;
+    // Monotonic per-(connection, channel) sequence. The client dedupes on it,
+    // acks on it (at-least-once channels), and presents it as its resume cursor.
+    uint64     stream_seq = 2;
+    // Whether the client must ClientAck this event (at-least-once: DM /
+    // NOTIFICATION) or it is fire-and-forget (PRESENCE / COUNTER / FEED).
+    bool       ack_required = 3;
+    // The opaque upstream payload. NOT interpreted by the realtime plane.
+    bytes      payload = 4;
+    // Routing/telemetry hint for the client (e.g. "chat.message", "notif.badge",
+    // "counter.popularity"). Advisory; not a contract on `payload`'s schema.
+    string     event_type = 5;
+    // When the source event was emitted (event-time, propagated from upstream).
+    google.protobuf.Timestamp emitted_at = 6;
+}
+
+// Server liveness probe; the client must answer with a Pong echoing `nonce`.
+message Ping {
+    uint64 nonce = 1;
+}
+
+// A control directive driving the client connection state machine.
+message Control {
+    ServerControl control = 1;
+    // For SUBSCRIBED / UNSUBSCRIBED: the affected channel.
+    ChannelRef    channel = 2;
+    // For ERROR / RATE_LIMITED: the stable RTM-XXXX code and a human message.
+    string        code    = 3;
+    string        message = 4;
+    // For RECONNECT: base delay before reconnecting; the client ADDS jitter on
+    // top (mandatory, to avoid a reconnect herd).
+    uint32        reconnect_after_ms = 5;
+}
+
+// ── Node-hop fabric · internal (dispatcher → the owning gateway node) ─────────
+
+// What travels from the dispatcher to the gateway node that owns a recipient's
+// socket — fabric-agnostic. In v1 it is published, serialized, on that node's
+// Redis Pub/Sub channel (`node:{node_id}`); the gRPC RealtimeDispatchService
+// (see service.proto) carries the SAME message when the swappable backpressure
+// variant is wired. The owning node resolves `recipient_user_id` to its local
+// connection(s) and emits an `Event` frame on each subscribed socket.
+message DeliverEnvelope {
+    // The target user; the gateway maps it to that user's local connection(s).
+    string     recipient_user_id   = 1;
+    // Optional: restrict delivery to one device; empty ⇒ all of the user's
+    // connections on this node.
+    string     recipient_device_id = 2;
+    ChannelRef channel             = 3;
+    bool       ack_required        = 4;
+    // Opaque upstream payload, forwarded verbatim into the Event frame.
+    bytes      payload             = 5;
+    string     event_type          = 6;
+    google.protobuf.Timestamp emitted_at = 7;
+    // Idempotency key derived from the source event, so a Kafka redelivery (the
+    // dispatcher runs under `run_consumer`, at-least-once) does not double-emit
+    // on a reconnected client that already saw it.
+    string     idempotency_key     = 8;
+}
+
+// The result of a node-hop delivery.
+message DeliverAck {
+    // How many local connections the event was written to. Zero is normal and
+    // benign: the dispatcher's registry was momentarily stale and the recipient
+    // is no longer on this node — a fail-open miss the client recovers from on
+    // its next reconnect/resync.
+    uint32 delivered = 1;
+}

--- a/crates/contracts/proto/realtime/v1/service.proto
+++ b/crates/contracts/proto/realtime/v1/service.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package realtime.v1;
+
+import "realtime/v1/messages.proto";
+
+option java_package = "com.coreplatform.realtime.v1";
+option java_multiple_files = true;
+option go_package = "github.com/coreplatform/realtime/v1;realtimev1";
+
+// RealtimeDispatchService is the INTERNAL, node-addressed delivery surface of the
+// realtime plane — the gRPC variant of the `NodeChannel` port (dispatcher → the
+// gateway node that owns a recipient's connection).
+//
+// It is NOT client-facing. Clients never speak gRPC to this service; they speak
+// the protobuf `ClientFrame` / `ServerFrame` envelope over WSS (see
+// messages.proto). The gateway's only OTHER internal surface is gRPC health +
+// reflection, provided by the shared runtime — there is no domain RPC here.
+//
+// LOCKED (see project_realtime_blueprint): v1 wires the node hop as Redis
+// Pub/Sub — fire-and-forget, fail-open — carrying the same `DeliverEnvelope`.
+// This service is the documented, swappable alternative for when per-node
+// backpressure / flow-control is needed; defining it now keeps the port's shape
+// fixed so the fabric can change without a contract change.
+service RealtimeDispatchService {
+
+    // Deliver one resolved event to the connection(s) this gateway node owns for
+    // the envelope's recipient. Idempotent on `idempotency_key`. A `delivered`
+    // count of zero is a benign fail-open miss (stale registry), not an error.
+    rpc DeliverToNode(DeliverEnvelope) returns (DeliverAck);
+}

--- a/crates/contracts/realtime-api/Cargo.toml
+++ b/crates/contracts/realtime-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name        = "realtime-api"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Generated gRPC + transport contract for realtime.v1 — the client-facing WSS envelope (ClientFrame/ServerFrame) and the internal node-hop dispatch surface (server + client stubs and reflection descriptor)."
+
+[dependencies]
+tonic       = { workspace = true }
+tonic-prost = { workspace = true }
+prost       = { workspace = true }
+prost-types = { workspace = true }
+
+[build-dependencies]
+tonic-prost-build = { workspace = true }

--- a/crates/contracts/realtime-api/build.rs
+++ b/crates/contracts/realtime-api/build.rs
@@ -1,0 +1,25 @@
+//! Compiles the realtime.v1 contract into server + client stubs plus a reflection
+//! descriptor set, from the shared contracts/proto root (the single IDL source).
+//!
+//! Note: this contract has two audiences. The `ClientFrame` / `ServerFrame`
+//! messages are the client-facing WSS transport envelope (encoded with prost,
+//! framed over WebSocket — no gRPC to the client); the `RealtimeDispatchService`
+//! is the internal node-hop surface. Both are generated from the same module.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("realtime_descriptor.bin");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(
+            &[
+                "../proto/realtime/v1/enums.proto",
+                "../proto/realtime/v1/messages.proto",
+                "../proto/realtime/v1/service.proto",
+            ],
+            &["../proto/"],
+        )?;
+    Ok(())
+}

--- a/crates/contracts/realtime-api/src/lib.rs
+++ b/crates/contracts/realtime-api/src/lib.rs
@@ -1,0 +1,32 @@
+//! `realtime-api` — the generated contract for `realtime.v1` (server + client
+//! stubs + descriptor), compiled from the shared `contracts/proto` IDL.
+//! Consumers depend on this crate instead of recompiling the `.proto` files.
+//!
+//! This contract is unusual in the fleet: it has **two audiences**.
+//!
+//! * **Client-facing transport (not gRPC).** `ClientFrame` / `ServerFrame` are
+//!   the multiplexed WSS envelope. Clients connect over WebSocket Secure and
+//!   exchange these prost-encoded frames; one socket per device carries every
+//!   channel class (`dm` / `notif` / `presence` / `counter` / `feed`) at once.
+//!   The handshake authenticates the edge token ONCE; frames are never
+//!   re-authenticated per message. `Event.payload` is opaque — the plane forwards
+//!   upstream bytes verbatim and never inspects or stores them.
+//!
+//! * **Internal node-hop (gRPC).** `RealtimeDispatchService.DeliverToNode` is the
+//!   dispatcher → owning-gateway-node delivery surface — the gRPC variant of the
+//!   `NodeChannel` port, carrying a `DeliverEnvelope`. v1 wires this hop as Redis
+//!   Pub/Sub (fire-and-forget, fail-open) carrying the same message; the service
+//!   is defined so the fabric can swap without a contract change.
+//!
+//! Contract posture (the delivery guarantee): the realtime plane is a
+//! System-of-Connection, never a System of Record. A delivery miss costs latency,
+//! never data — durability lives in the owning SoRs (`chat` / `notification` /
+//! `counter`) and clients resume from a `ChannelCursor` on reconnect. Its only
+//! authorization is channel-key ownership (a connection may subscribe only to
+//! channels scoped to its pinned identity). See `project_realtime_blueprint`.
+
+tonic::include_proto!("realtime.v1");
+
+/// Encoded protobuf descriptor set for gRPC server reflection.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("realtime_descriptor");

--- a/crates/services/realtime/Cargo.toml
+++ b/crates/services/realtime/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name        = "realtime"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+authors.workspace    = true
+repository.workspace = true
+description = "Realtime delivery microservice — the platform's client-facing live push/delivery plane (System-of-Connection, never a System of Record): terminates millions of multiplexed WebSocket connections, fans internal events out to the exact device, owns no entity."
+
+# ── Phase 0 scaffold ──────────────────────────────────────────────────────────
+# Only the canonical error namespace (RTM-XXXX) lives here today. Subsequent
+# phases add: the transport envelope + internal gRPC contract (Phase 1), domain/
+# (Phase 2: Connection + identity-pinned Session + Subscription/channel-scope
+# authz + the sequence/ack & presence state machines — pure), application/ + ports
+# (Phase 3: ConnectionRegistry / NodeChannel / TokenVerifier / EventSource +
+# handshake/subscribe/deliver/reap/drain handlers + in-memory fakes),
+# infrastructure/ adapters (Phase 4: the WebSocket server with bounded per-conn
+# mailboxes + shedding, the fred Redis registry, the Redis Pub/Sub node-hop, the
+# auth-context token verifier, the run_consumer event consumers), and the TWO
+# composition roots — the stateful edge gateway and the stateless fan-out
+# dispatcher (Phase 5). Dependencies grow per phase — kept minimal here.
+[dependencies]
+# ── Shared platform infrastructure ────────────────────────────────────────────
+error      = { workspace = true }
+validation = { workspace = true }
+
+# ── Domain types (Phase 2): pure, clock-injected connection model ─────────────
+# `serde` for value-object (de)serialization across later tier boundaries;
+# `chrono` for the injected wall clock (heartbeat freshness, token expiry).
+serde  = { workspace = true }
+chrono = { workspace = true }
+
+# ── Application layer (Phase 3): async ports held as Arc<dyn …> ────────────────
+async-trait = { workspace = true }
+
+# ── Runtime + composition (Phase 5) ───────────────────────────────────────────
+# The gateway is the fleet's first dual-listener service: a public WSS plane
+# (axum ws) plus the internal gRPC health plane (service-runtime). The dispatcher
+# runs run_consumer fan-out loops. tokio drives both; dashmap is the node-local
+# connection table; uuid mints connection ids; futures-util splits the socket.
+service-runtime = { workspace = true }
+tokio           = { workspace = true }
+axum            = { workspace = true, features = ["ws"] }
+futures-util    = { workspace = true }
+dashmap         = { workspace = true }
+uuid            = { workspace = true }
+anyhow          = { workspace = true }
+tonic           = { workspace = true }
+tonic-reflection = { workspace = true }
+
+# ── Infrastructure adapters (Phase 4) ─────────────────────────────────────────
+# Contract: the realtime.v1 proto types (client envelope + node-hop). Routing
+# fabric + node hop = Redis via fred (Lua single-key writes + sharded SPUBLISH).
+# Auth = the shared auth-context JWT decoder. Kafka classification = transport.
+realtime-api = { workspace = true }
+prost        = { workspace = true }
+prost-types  = { workspace = true }
+redis-storage = { workspace = true }
+fred         = { workspace = true, features = ["partial-tracing", "i-scripts"] }
+transport    = { workspace = true }
+auth-context = { workspace = true }
+jsonwebtoken = { workspace = true }
+serde_json   = { workspace = true }
+tracing      = { workspace = true }
+
+# ── Error handling ────────────────────────────────────────────────────────────
+thiserror = { workspace = true }
+http      = { workspace = true }
+
+[features]
+# Gates the live, container-backed integration suite (Phase 6, tests/integration.rs).
+# Off by default so `cargo test -p realtime` stays a fast, infra-free unit run; the
+# live suite boots a real Redis and drives the routing fabric + node hop over the
+# real adapters. Opt-in via `cargo test -p realtime --features integration-realtime`.
+integration-realtime = []
+
+[dev-dependencies]
+# Live integration suite (Phase 6): containers + the real adapters' public surface.
+test-support  = { workspace = true }
+realtime-api  = { workspace = true }
+redis-storage = { workspace = true }
+prost         = { workspace = true }
+fred          = { workspace = true }
+tokio         = { workspace = true }
+uuid          = { workspace = true }
+chrono        = { workspace = true }

--- a/crates/services/realtime/README.fr.md
+++ b/crates/services/realtime/README.fr.md
@@ -1,0 +1,291 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: 474e6e05598cc47a03f4e7b3b44be1e8ca316eda439bf7bef1bf2669c5c9095e
+  translated_at: 2026-06-26
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, variables
+> d'environnement, topics Kafka, identifiants) sont volontairement laissés en anglais.
+
+# `realtime` — Maintenir des millions de connexions clientes vivantes, livrer chaque événement à l'appareil exact à l'instant où il se produit, et ne détenir aucune vérité
+
+> **Fiche de service** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Propriétaire** | `<TODO: équipe>` · `<TODO: #canal-slack>` |
+> | **Astreinte / escalade** | `<TODO: rotation-astreinte>` → `<TODO: politique-escalade>` |
+> | **Palier** | **TIER-1** — la surface temps réel sans laquelle une application à hyper-échelle paraît cassée, mais **dérivée et fail-open** : ni System of Record, ni dans un quelconque chemin d'écriture synchrone ; une panne dégrade vers « se reconnecter et resynchroniser », elle ne perd ni ne bloque jamais un message |
+> | **Déployable** | **deux** binaires — `crates/apps/realtime-gateway` (bord avec état, détient les connexions) **et** `crates/apps/realtime-dispatcher` (worker de diffusion sans état). Crate bibliothèque : `crates/services/realtime` |
+> | **Écouteurs** | **deux plans** (le premier de la flotte) — un plan client public **WSS** (défaut `:8443`, derrière un LB L4) sur la gateway, et un plan interne **gRPC** de santé/contrôle (`:50066` gateway · `:50067` dispatcher) |
+> | **Datastores** | **Redis** uniquement — le registre de connexion/présence (routage `user → node`) + le tissu de saut inter-nœud Pub/Sub. Ne détient aucune entité, ne persiste aucun message |
+> | **Async** | consomme les événements de message `chat`, `notification.v1.events`, `counter.v1.popularity`, `post.v1.events` (Kafka). Ne publie rien de référence |
+> | **Appelants amont** | clients utilisateurs finaux via WSS (mobile / web) — **pas** les services internes |
+> | **Dépendances aval** | Redis, Kafka, et `auth` (vérification du jeton de bord via la bibliothèque `auth-context` — une vérification, pas un appel). La durabilité des messages/notifications reste dans `chat` / `notification` |
+> | **SLO** | `<TODO>` dispo · événement→appareil p99 `< <TODO ~250> ms` pour les utilisateurs en ligne · établissement de connexion p99 `< <TODO> ms` |
+
+---
+
+## 🎯 Vue d'ensemble & rôle du service
+
+`realtime` est le **plan de livraison temps réel orienté client** de la plateforme : il termine des millions de connexions clientes longue durée et multiplexées, diffuse les événements internes vers l'appareil exact qui doit les voir, et ne détient **aucune** entité. Chaque octet qu'il relaie est déjà durable dans son service propriétaire — `chat` a persisté le message, `notification` a persisté le badge, `counter` détient la magnitude. C'est un System-of-**Connection / Delivery**, jamais un System of Record.
+
+Le problème difficile qu'il résout est double. D'abord, **le piège de charge inversée du polling** : à hyper-échelle, des clients qui interrogent le bord couplent le QPS des services cœur au nombre d'utilisateurs *inactifs* — chaque sondage vide paie un coût complet TLS + auth + diffusion pour ne rien livrer, pointant un DDoS auto-infligé vers le maillage interne. Le push inverse cela pour que le travail interne suive les *événements*, pas les paires d'yeux. Ensuite, **la prolifération des connexions** : `chat` et `notification` ont chacun développé leur propre streaming orienté client, de sorte qu'un seul appareil détient plusieurs sockets avec des heartbeats redondants réveillant la radio indépendamment. Realtime fusionne cela en **une seule socket multiplexée par appareil** et réduit ces services à des *producteurs* d'événements.
+
+**Objectifs cœur :** (1) une connexion persistante et multiplexée par appareil — économe en batterie et compatible pare-feu ; (2) les événements voyagent cœur → appareil sans nouvel appel synchrone dans le maillage (Kafka en entrée, diffusion ciblée en sortie) ; (3) le plan est une **cloison structurelle** — des millions de connexions instables terminent ici et n'atteignent jamais le maillage gRPC, qui ne voit qu'un ensemble borné de pairs gateway stables ; (4) la posture est **fail-open** — un raté de livraison coûte de la latence, jamais des données, car la durabilité vit dans les SoR et les clients resynchronisent à la reconnexion.
+
+| Préoccupation | Chemin | Contrat de latence | Notes |
+|---|---|---|---|
+| **Transport client** | WSS sur `:443`/`:8443`, enveloppe multiplexée | persistant | une socket par appareil ; canaux logiques (`dm` / `notif` / `presence` / `counter:<id>`) |
+| **Ingestion** | consommateurs Kafka async (`run_consumer`) dans `realtime-dispatcher` | aucun (hors chemin d'écriture) | résoudre destinataire → nœud propriétaire → publication ciblée |
+| **Dernier saut** | lookup registre → saut inter-nœud (Redis Pub/Sub) → écriture socket | sous-seconde pour les utilisateurs en ligne | best-effort ; un raté est resynchronisé depuis le SoR à la reconnexion |
+
+---
+
+## 📐 Architecture & concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), Kafka pour l'ingestion, Redis pour le tissu de routage. Le choix structurel déterminant est **deux déployables** : la gateway de bord avec état et le dispatcher de diffusion sans état partagent une crate de domaine mais aucun processus, déploiement ou domaine de défaillance. Un nœud gateway qui sature la mémoire sur les connexions ne doit jamais pouvoir faire vaciller un service cœur.
+
+```
+                       Internet — millions de clients mobile/web
+                                     │  WSS :443
+                              ┌──────┴───────┐
+                              │  LB L4       │   (pas de terminaison WS en L7 — éviter le mur des ports éphémères)
+                              └──────┬───────┘
+                  ┌──────────────────┼──────────────────┐
+            ┌─────┴─────┐      ┌─────┴─────┐      ┌──────┴────┐
+            │ gateway 0 │ ···  │ gateway 7 │ ···  │ gateway N │   realtime-gateway (bord avec état)
+            └─────┬─────┘      └─────┬─────┘      └──────┬────┘   autoscale sur conns + mém (PAS CPU)
+                  │  écritures registre / abo node:{id}       │
+                  └────────────────┬─────────────────────────┘
+                            ┌──────┴──────┐        ┌────────────────┐
+                            │    Redis    │◄───────│   dispatcher   │  realtime-dispatcher
+                            │ registre +  │ publie │  run_consumer  │  (diffusion sans état)
+                            │  pub/sub    │  vers  └───────┬────────┘
+                            └─────────────┘ node:{id}      │ consomme
+                                                     ┌─────┴──────┐
+                                                     │   Kafka    │  chat · notification ·
+                                                     │ (existant) │  counter.v1.popularity · post.v1
+                                                     └─────┬──────┘
+                                          ┌────────────────┴────────────────┐
+                                          │  maillage gRPC cœur (SoR) — protégé│  émet-une-fois ; ne voit jamais un client
+                                          └───────────────────────────────────┘
+```
+
+**Le pont interne→externe comporte trois étapes.** (A) Les services cœur **émettent une fois** vers Kafka — le plan n'ajoute aucun nouvel appel synchrone vers l'intérieur. (B) Le dispatcher résout le destinataire contre le **registre de connexion** (`presence:{user_id}` → le(s) nœud(s) détenant les sockets vivantes de cet utilisateur) — livraison *ciblée*, jamais diffusion-puis-filtrage. (C) Le dernier saut publie l'événement sur le canal Redis du nœud propriétaire ; la gateway le remet à la boîte aux lettres bornée de la connexion et écrit la socket. Cœur à appareil = un saut Kafka + un saut Redis + une écriture socket.
+
+> **Invariants** (et où ils sont appliqués) :
+> - **Le plan ne stocke rien.** Il détient la connexion et le registre de routage éphémère, jamais le contenu. Un raté de registre (destinataire hors ligne) est un no-op — la durabilité et le chemin de push vers téléphone verrouillé appartiennent à `chat` / `notification` — domain + application.
+> - **Authentifier une fois, au handshake.** Le jeton de bord est vérifié à l'upgrade WS via `auth-context` ; jamais re-vérifié par trame (cela réintroduirait le coût maillage par-message que le plan existe pour éliminer) — frontière infrastructure.
+> - **La seule autorisation est la propriété de portée de canal.** Une connexion ne peut s'abonner qu'aux canaux liés à son identité épinglée (Alice → `dm:alice`, jamais `dm:bob`). La visibilité fine du contenu a été autorisée en amont à l'émission de l'événement — domain.
+> - **Un consommateur lent est délesté, pas tamponné.** Chaque connexion a une file d'envoi bornée ; en débordement, le plan jette/déconnecte plutôt que de laisser un mauvais réseau gonfler la mémoire du nœud — infrastructure.
+> - **Fail-open, toujours.** Un événement live perdu n'est jamais un message perdu ; le client resynchronise depuis le SoR via son jeton de séquence à la reconnexion — application.
+
+---
+
+## 📊 Objectifs de niveau de service (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objectif | Fenêtre | Mesuré par |
+|---|---|---|---|
+| Disponibilité (handshakes réussis / non-`UNAVAILABLE`) | `<TODO 99.9%>` | glissant 30j | `<metric>` |
+| Latence événement→appareil p99 (utilisateurs en ligne) | `< <TODO 250> ms` | 1h | `<metric>` |
+| Établissement de connexion p99 | `< <TODO> ms` | 1h | `<metric>` |
+| Plafond mémoire par connexion | `< <TODO> KB` | live | RSS / open_connections |
+
+**Budget d'erreur :** `<TODO>`. **À l'épuisement :** `<gel des déploiements | page>`. Comme `realtime` est fail-open, l'objectif de *disponibilité* couvre la dégradation de la livraison live (reconnexion-et-resynchronisation), pas la durabilité — la durabilité appartient aux SoR amont et sort du budget de ce service.
+
+---
+
+## 🔗 Dépendances & rayon d'impact &nbsp;·&nbsp; OPS
+
+**Aval — ce dont `realtime` a besoin pour fonctionner :**
+
+| Dépendance | Rôle | Si en panne → | Dégradation |
+|---|---|---|---|
+| Redis | registre de connexion/présence + saut inter-nœud Pub/Sub | le dispatcher ne peut résoudre / publier | **Souple** — la livraison live cale ; les clients resynchronisent depuis les SoR à la reconnexion ; aucune perte |
+| Kafka | ingestion des événements amont | la diffusion cesse d'avancer | **Souple** — les mises à jour live retardent ; rien de perdu (commit manuel) ; les clients rattrapent via le SoR |
+| `auth` (via `auth-context`) | vérification du jeton de bord au handshake | les nouvelles connexions ne peuvent s'authentifier | **Dure pour les nouvelles connexions** — les connexions existantes intactes jusqu'à l'expiration du jeton |
+
+**Amont — qui dépend de `realtime` (votre rayon d'impact si VOUS tombez) :**
+
+| Appelant | Utilise | Impact visible utilisateur si `realtime` est en panne |
+|---|---|---|
+| clients utilisateurs finaux | le flux WSS live | les DM / notifications / compteurs live cessent d'arriver *instantanément* — ils apparaissent à la prochaine ouverture ou reconnexion (resynchronisés depuis `chat` / `notification`) ; **rien n'est perdu** |
+
+> **Chemin critique ?** **Non** — dérivé, async, fail-open. `realtime` n'est jamais dans le chemin synchrone d'envoi d'un message, de persistance d'une notification, ou d'une quelconque écriture. Il accélère la livraison ; il ne la détient pas.
+
+---
+
+## 🔌 Interfaces publiques & contrat d'API &nbsp;·&nbsp; CORE
+
+### Transport client — enveloppe WSS multiplexée *(Phase 1)*
+
+La surface orientée client n'est **pas** du gRPC. Les clients se connectent via **WebSocket Secure** et échangent une **enveloppe** binaire compacte à préfixe de longueur — `{ stream_seq, channel, ack_required, payload }` — qui impose des canaux logiques (`dm`, `notif`, `presence`, `counter:<id>`, `control`) sur une seule socket physique. Le handshake porte le jeton de bord ; ensuite les trames ne sont pas ré-authentifiées. `WebTransport` sur HTTP/3 est une voie successeur différée conçue d'avance, que le client négocie et depuis laquelle il bascule en repli.
+
+### gRPC interne — santé / contrôle *(Phase 1)*
+
+Le plan interne est uniquement opérationnel : santé + reflection sur `:50066` (gateway) / `:50067` (dispatcher), plus le RPC optionnel de livraison dispatcher↔gateway si le tissu de saut inter-nœud quitte Redis Pub/Sub. **Il n'y a aucun gRPC orienté client et aucun RPC d'écriture de domaine.**
+
+### Ports Rust (contrat hexagonal) *(Phase 3)*
+
+```rust
+#[async_trait] pub trait ConnectionRegistry { /* bind · resolve(user → nodes) · evict — le tissu de routage */ }
+#[async_trait] pub trait NodeChannel        { /* subscribe(node) · publish(node, event) — le dernier saut */ }
+#[async_trait] pub trait TokenVerifier      { /* vérifier le jeton de bord au handshake (auth-context) */ }
+#[async_trait] pub trait EventSource        { /* les flux Kafka amont que le dispatcher diffuse */ }
+```
+
+### Contrat d'erreur
+
+Chaque défaillance implémente `error::AppError` avec un code `RTM-XXXX` stable, mappé vers gRPC `Status` / HTTP par la crate partagée `error` :
+
+| Plage | Classe |
+|---|---|
+| `RTM-1xxx` | handshake / authentification de connexion |
+| `RTM-2xxx` | transport / framing / protocole |
+| `RTM-3xxx` | autorisation d'abonnement (propriété de portée de canal) |
+| `RTM-4xxx` | disponibilité du tissu de livraison (cœur fail-open ; retryable) |
+| `RTM-5xxx` | cycle de vie de connexion / contre-pression |
+| `RTM-8xxx` | décodage / routage d'événement entrant (dispatcher) |
+| `RTM-9xxx` | transversal (domaine/parse, consommation d'événement) |
+
+---
+
+## 📨 Événements & contrat async &nbsp;·&nbsp; CORE
+
+> Les topics Kafka sont une API. Un changement de schéma dans un topic consommé casse la livraison exactement comme un changement de proto.
+
+**Publie :** rien de référence. (La présence, si exposée, est de la liveness interne uniquement — voir le blueprint ; ce n'est pas un flux System-of-Record.)
+
+**Consomme :**
+
+| Topic | Groupe de consommateurs | Rôle | En cas de poison/épuisement |
+|---|---|---|---|
+| `<chat message events>` | `realtime-chat-fanout` | livrer les DM / messages aux destinataires en ligne | DLQ `<...>.dlq` |
+| `notification.v1.events` | `realtime-notif-fanout` | livrer les mises à jour notification/badge en live | DLQ `notification.v1.events.dlq` |
+| `counter.v1.popularity` | `realtime-counter-fanout` | livrer les pics d'engagement live aux spectateurs d'une entité | DLQ `counter.v1.popularity.dlq` |
+| `post.v1.events` | `realtime-post-fanout` | livrer les signaux de fil live (sélectif) | DLQ `post.v1.events.dlq` |
+
+> **Contrat d'exécution (obligatoire) :** tous les consommateurs du dispatcher tournent sous `run_consumer` — commit manuel après un résultat terminal, retry borné avec backoff + jitter, DLQ à l'épuisement/poison, reconstruction depuis le dernier offset commité sur erreur broker. **Idempotence :** la diffusion est naturellement idempotente — un événement redélivré ré-résout le registre et re-livre ; les trames live dupliquées sont inoffensives (le client déduplique sur `stream_seq`). Un événement non-routable/inconnu (`RTM-8002` / `RTM-8003`) est replié en `Ok` pour que l'offset commite quand même.
+
+---
+
+## 🌩️ Modes de défaillance & dégradation &nbsp;·&nbsp; OPS
+
+| Défaillance | Symptôme | Comportement du service | Action opérateur |
+|---|---|---|---|
+| Redis registre/pub-sub en panne | la livraison live cale | **fail-open** — les événements patientent/retry ; les clients resynchronisent depuis les SoR à la reconnexion ; aucune perte | restaurer Redis ; la diffusion reprend |
+| Kafka indisponible | les mises à jour live retardent | le dispatcher patiente ; offsets non commités → aucune perte | restaurer les brokers ; rattrapage |
+| `auth` injoignable | les nouveaux handshakes échouent | connexions existantes intactes ; nouvelles connexions rejetées (`RTM-1001`) jusqu'au rétablissement | restaurer `auth` ; vérifier la config `auth-context` |
+| Client lent/bloqué | la file d'une connexion se remplit | **délestage** — jeter le plus ancien / déconnecter (`RTM-5001`) ; mémoire du nœud protégée | aucune (par conception) |
+| Connexion semi-ouverte | fuite de FD + slot de registre | le reaper de heartbeat la périme (`RTM-5002`), libère le slot, bascule la présence hors ligne | aucune (par conception) ; surveiller les métriques du reaper |
+| Déploiement / drain de nœud | les connexions doivent migrer | stop-accept → trame de contrôle de reconnexion **avec backoff jitter** (`RTM-5003`) → drain | aucune (par conception) ; surveiller les métriques de troupeau de reconnexion |
+| Troupeau de reconnexion | pic de handshake auth au déploiement | le backoff jitter client + l'étalement du LB L4 l'absorbent | confirmer la config jitter ; échelonner les déploiements |
+
+**Contre-pression & limites :** file d'envoi bornée par connexion (délestage en débordement) ; plafond d'abonnements par connexion ; plafond de taille de trame entrante ; reaping par échéance de heartbeat ; autoscale sur connexions + mémoire (un nœud inactif-mais-plein est à ~0% CPU — l'autoscaling basé CPU sous-provisionne jusqu'à l'OOM).
+
+---
+
+## 📦 Intégration & utilisation &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+realtime = { path = "crates/services/realtime" }
+```
+
+Bibliothèque uniquement. Implémentera [`service_runtime::Service`](../../platform/service-runtime/README.md) **deux fois** (Phase 5) : `realtime::service::RealtimeGatewayService` (le binaire `realtime-gateway` — la boucle d'acceptation WSS, les écritures de registre, l'abonnement au saut inter-nœud, le hook de drain, la santé gRPC interne) et `realtime::service::RealtimeDispatcherService` (le binaire `realtime-dispatcher` — les boucles de diffusion `run_consumer` supervisées, aucun RPC de domaine). Télémétrie, config + hot-reload, santé et arrêt gracieux sont détenus par le runtime.
+
+> **État de build :** **complet jusqu'à la Phase 7** (les 8 phases : scaffold → contrat → domaine → application+ports → adaptateurs → câblage gateway+dispatcher → IT live → durcissement). 52 tests unitaires plus une suite live `integration-realtime` (Redis réel) couvrent le domaine, le codec proto, la mailbox bornée-à-délestage, la table de routage locale au nœud (avec délestage-sous-pression et `broadcast_drain` gracieux) et le pont de bout en bout (fan-out → résolution registre → saut inter-nœud → trame socket). Revu côté sécurité : aucun jeton ni PII dans les logs, le payload opaque n'est jamais journalisé, et aucun panic dans le chemin chaud d'acceptation ou de livraison.
+>
+> **Différé (explicite, pas des lacunes) :** le test d'intégration de la boucle d'acceptation WebSocket + auth/JWKS (nécessite un IdP live et un client WS de qualité navigateur — le tissu de routage *est* couvert en live) ; l'IT live du dispatcher Kafka (le runner `run_consumer` est couvert par la suite de `transport`) ; la voie de transport WebTransport / HTTP-3 ; la présence comme flux orienté produit ; le routage cross-région / multi-PoP ; la variante de contre-pression `NodeChannel` en gRPC interne ; le câblage `SIGTERM` → `broadcast_drain` ; et la consolidation du streaming client `chat` + `notification` (coexistence d'abord).
+>
+> **Autorisation (exigence de déploiement) :** `realtime` authentifie le jeton de bord une fois au handshake WS (via `auth-context`) et n'autorise les abonnements que par propriété de portée de canal. Il n'effectue aucune autorisation au niveau du contenu — les événements sont autorisés en amont à l'émission.
+
+---
+
+## ⚙️ Configuration & environnement d'exécution &nbsp;·&nbsp; CORE
+
+### Variables spécifiques à `realtime` *(remplies par phase)*
+
+| Variable | Requise | Défaut | Description |
+|---|---|---|---|
+| `REALTIME_GATEWAY_WS_ADDR` | Non | `0.0.0.0:8443` | adresse d'écoute WSS client publique (gateway) |
+| `REALTIME_GATEWAY_GRPC_ADDR` | Non | `0.0.0.0:50066` | adresse gRPC interne de santé/contrôle de la gateway |
+| `REALTIME_DISPATCHER_GRPC_ADDR` | Non | `0.0.0.0:50067` | adresse santé/reflection du dispatcher (aucun RPC de domaine) |
+| `REALTIME_HEARTBEAT_INTERVAL_MS` | Non | `<TODO 30000>` | cadence de ping applicatif (maintient le binding NAT, reaper des semi-ouvertes) |
+| `REALTIME_HEARTBEAT_TIMEOUT_MS` | Non | `<TODO 90000>` | échéance de pong avant qu'une connexion soit reapée |
+| `REALTIME_SEND_QUEUE_CAP` | Non | `<TODO>` | profondeur de file sortante par connexion avant délestage |
+| `REALTIME_MAX_SUBSCRIPTIONS` | Non | `<TODO>` | plafond d'abonnements de canal par connexion |
+| `REALTIME_MAX_FRAME_BYTES` | Non | `<TODO>` | plafond de taille de trame entrante |
+| `REALTIME_NODE_ID` | Non | `<hostname>` | identité de ce nœud gateway pour le registre + le canal de saut inter-nœud |
+
+### Variables d'infrastructure héritées
+
+| Variable | Requise | Défaut | Description |
+|---|---|---|---|
+| `REDIS_URL` | **Oui** | — | registre de connexion/présence + saut inter-nœud Pub/Sub |
+| `KAFKA_BROKERS` | **Oui** (dispatcher) | — | ingestion des événements amont |
+| `<auth-context verification config>` | **Oui** | — | vérification du jeton de bord (ES256) au handshake |
+
+### Fonctionnalités à la compilation
+- `integration-realtime` *(Phase 6)* — active la suite d'intégration live adossée à des conteneurs (Redis + Kafka réels).
+
+---
+
+## 🚀 Déploiement, migrations & rollback &nbsp;·&nbsp; OPS
+
+- **Deux déployables, mis à l'échelle indépendamment.** `realtime-gateway` s'échelonne avec le nombre de connexions concurrentes + la mémoire ; `realtime-dispatcher` s'échelonne avec le débit d'événements. Publiés ensemble (même image/tag), déployés et autoscalés séparément.
+- **Aucune migration de schéma.** Le plan ne détient aucun store durable — seulement de l'état de routage Redis éphémère (avec TTL, auto-réparant).
+- **Le drain gracieux est une exigence de release.** Au déploiement, la gateway doit stop-accept, émettre une trame de contrôle de reconnexion avec backoff jitter côté client, puis drainer — sans jitter, chaque déploiement déclenche un troupeau de reconnexion vers le chemin de handshake auth.
+- **Load balancing L4**, pas L7 : terminer le WS sur un proxy L7 reflète des millions de connexions et heurte le mur des ports éphémères.
+- **Rollback :** sûr — les deux binaires sont sans état au-dessus de Redis/Kafka ; le dispatcher reprend depuis les derniers offsets commités, la gateway ré-accepte les connexions (les clients se reconnectent avec backoff).
+
+---
+
+## 📈 Télémétrie, performance & métriques &nbsp;·&nbsp; CORE
+
+- **Runtime :** Tokio multi-thread, I/O async sur epoll/kqueue — une connexion inactive est un future garé, pas un thread. `realtime-gateway` exécute la boucle d'acceptation + les boîtes aux lettres par connexion + le reaper de heartbeat ; `realtime-dispatcher` exécute les consommateurs de diffusion. Souscripteur tracing/OTel global installé avant serve ; trace-context W3C propagé à travers la frontière Kafka.
+
+| Signal | Pourquoi c'est important | Alerte suggérée |
+|---|---|---|
+| Connexions ouvertes / nœud | signal de capacité + autoscale | proche du plafond du nœud ⇒ scale |
+| Mémoire par connexion (RSS / conns) | le plafond de coût C10M | `> SLO` ⇒ investiguer fuite / délestage |
+| Latence événement→appareil p99 | réactivité live | `> SLO` ⇒ investiguer registre / saut inter-nœud |
+| Taux de délestage de file d'envoi (`RTM-5001`) | pression de consommateur lent | pic soutenu ⇒ investiguer clients / réseau |
+| Taux de reap de heartbeat (`RTM-5002`) | churn des semi-ouvertes | pic anormal ⇒ investiguer réseau / LB |
+| Taux de reconnexion | troupeau / churn au déploiement | pic hors-déploiement ⇒ investiguer perte de nœud |
+| Taux de production DLQ (`*.dlq`) | ingestion empoisonnée / retry épuisé | tout taux soutenu ⇒ page |
+
+---
+
+## 🛠️ Développement local &nbsp;·&nbsp; CORE
+
+```bash
+cargo build -p realtime && cargo clippy -p realtime --all-targets
+cargo test  -p realtime                                    # run unitaire rapide, sans infra
+docker compose up -d redis kafka                           # compose racine du repo (Phase 6)
+cargo test  -p realtime --features integration-realtime    # suite live (Phase 6)
+```
+
+---
+
+## 🚨 Dépannage & runbook &nbsp;·&nbsp; CORE
+
+> Format : **symptôme → cause racine → mitigation.** Une entrée par classe d'incident réelle.
+
+**1. Les messages n'arrivent qu'à la réouverture de l'app, pas en live.**
+Cause racine : Redis registre/pub-sub dégradé, ou retard du dispatcher — diffusion live calée. Mitigation : vérifier la santé Redis et le lag des groupes de consommateurs ; le message est durable dans `chat`/`notification`, donc les clients rattrapent à la reconnexion — aucune perte ; la livraison live se rétablit quand le tissu se rétablit.
+
+**2. La mémoire du nœud grimpe vers l'OOM alors que le CPU est presque inactif.**
+Cause racine : accumulation de connexions ou tamponnage de consommateur lent. Mitigation : confirmer que le plafond de file d'envoi par connexion et le délestage sont actifs ; vérifier la métrique de taux de délestage ; autoscale sur connexions + mémoire, pas CPU — un nœud plein et inactif est à ~0% CPU.
+
+**3. Chaque déploiement déclenche un pic auth/handshake.**
+Cause racine : troupeau de reconnexion — clients se reconnectant sans jitter au drain. Mitigation : confirmer le backoff jitter dans la trame de contrôle de drain et le SDK client ; échelonner les déploiements de nœuds.
+
+**4. Certains utilisateurs ne reçoivent jamais d'événements live ; les FD/slots de registre fuient.**
+Cause racine : connexions semi-ouvertes que le noyau retient encore. Mitigation : confirmer l'intervalle/timeout du reaper de heartbeat ; vérifier la métrique de taux de reap ; le reaping libère le FD + le slot de registre et bascule la présence hors ligne.
+
+**5. Un client peut voir le flux d'un autre utilisateur.**
+Cause racine (critique) : une faille d'autorisation de portée de canal. Mitigation : cela doit être impossible — les abonnements sont autorisés contre l'identité épinglée (`RTM-3001`) ; traiter toute occurrence comme un incident de sécurité et auditer le chemin d'abonnement.

--- a/crates/services/realtime/README.md
+++ b/crates/services/realtime/README.md
@@ -1,0 +1,280 @@
+# `realtime` — Hold millions of live client connections, deliver every event to the exact device the instant it happens, and own none of the truth
+
+> **Service Card** &nbsp;·&nbsp; CORE
+>
+> | | |
+> |---|---|
+> | **Owner** | `<TODO: team>` · `<TODO: #slack-channel>` |
+> | **On-call / escalation** | `<TODO: oncall-rotation>` → `<TODO: escalation-policy>` |
+> | **Tier** | **TIER-1** — the live surface a hyperscale app feels broken without, but **derived and fail-open**: not a System of Record, not in any synchronous write path; an outage degrades to "reconnect and re-sync", it never loses or blocks a message |
+> | **Deployable** | **two** binaries — `crates/apps/realtime-gateway` (stateful edge, holds the connections) **and** `crates/apps/realtime-dispatcher` (stateless fan-out worker). Library crate: `crates/services/realtime` |
+> | **Listeners** | **two planes** (the fleet's first) — a public **WSS** client plane (default `:8443`, behind an L4 LB) on the gateway, and an internal **gRPC** health/control plane (`:50066` gateway · `:50067` dispatcher) |
+> | **Datastores** | **Redis** only — the connection/presence registry (`user → node` routing) + the node-hop Pub/Sub fabric. Owns no entity, persists no message |
+> | **Async** | consumes `chat` message events, `notification.v1.events`, `counter.v1.popularity`, `post.v1.events` (Kafka). Publishes nothing of record |
+> | **Upstream callers** | end-user clients over WSS (mobile / web) — **not** internal services |
+> | **Downstream deps** | Redis, Kafka, and `auth` (edge-token verification via the `auth-context` library — a verify, not a call). Message/notification durability stays in `chat` / `notification` |
+> | **SLO** | `<TODO>` avail · event→device p99 `< <TODO ~250> ms` for online users · connection setup p99 `< <TODO> ms` |
+
+---
+
+## 🎯 Overview & Service Role
+
+`realtime` is the platform's **client-facing live delivery plane**: it terminates millions of long-lived, multiplexed client connections, fans internal events out to the exact device that should see them, and owns **no** entity. Every byte it forwards is already durable in its owning service — `chat` persisted the message, `notification` persisted the badge, `counter` holds the magnitude. It is a System-of-**Connection / Delivery**, never a System of Record.
+
+The hard problem it solves is twofold. First, **the inverted-load trap of polling**: at hyperscale, clients polling the edge couple core-service QPS to the count of *idle* users — every empty poll pays a full TLS + auth + fan-out cost to deliver nothing, pointing a self-inflicted DDoS at the internal mesh. Push inverts this so internal work tracks *events*, not eyeballs. Second, **connection sprawl**: `chat` and `notification` each grew their own client-facing streaming, so a single device holds multiple sockets with redundant heartbeats waking the radio independently. Realtime collapses that into **one multiplexed socket per device** and reduces those services to event *producers*.
+
+**Core objectives:** (1) one persistent, multiplexed connection per device — battery- and firewall-friendly; (2) events travel core → device with no new synchronous call into the mesh (Kafka in, targeted fan-out out); (3) the plane is a **structural bulkhead** — millions of flaky connections terminate here and never reach the gRPC mesh, which only sees a bounded set of stable gateway peers; (4) posture is **fail-open** — a delivery miss costs latency, never data, because durability lives in the SoRs and clients re-sync on reconnect.
+
+| Concern | Path | Latency contract | Notes |
+|---|---|---|---|
+| **Client transport** | WSS on `:443`/`:8443`, multiplexed envelope | persistent | one socket per device; logical channels (`dm` / `notif` / `presence` / `counter:<id>`) |
+| **Ingestion** | async Kafka consumers (`run_consumer`) in `realtime-dispatcher` | none (off the write path) | resolve recipient → owning node → targeted publish |
+| **Last hop** | registry lookup → node-hop (Redis Pub/Sub) → socket write | sub-second for online users | best-effort; a miss is re-synced from the SoR on reconnect |
+
+---
+
+## 📐 Architecture & Concepts
+
+Hexagonal / DDD (`domain` → `application` → `infrastructure`), Kafka for ingestion, Redis for the routing fabric. The defining structural choice is **two deployables**: the stateful edge gateway and the stateless fan-out dispatcher share a domain crate but no process, deployment, or failure domain. A gateway node OOMing on connections must never be able to brown out a core service.
+
+```
+                       Internet — millions of mobile/web clients
+                                     │  WSS :443
+                              ┌──────┴───────┐
+                              │  L4 Load Bal │   (no L7 WS termination — avoid the ephemeral-port wall)
+                              └──────┬───────┘
+                  ┌──────────────────┼──────────────────┐
+            ┌─────┴─────┐      ┌─────┴─────┐      ┌──────┴────┐
+            │ gateway 0 │ ···  │ gateway 7 │ ···  │ gateway N │   realtime-gateway (stateful edge)
+            └─────┬─────┘      └─────┬─────┘      └──────┬────┘   autoscale on conns + mem (NOT CPU)
+                  │  registry writes / node:{id} subscribe   │
+                  └────────────────┬─────────────────────────┘
+                            ┌──────┴──────┐        ┌────────────────┐
+                            │    Redis    │◄───────│   dispatcher   │  realtime-dispatcher
+                            │ registry +  │ publish│  run_consumer  │  (stateless fan-out)
+                            │  pub/sub    │  to    └───────┬────────┘
+                            └─────────────┘ node:{id}      │ consume
+                                                     ┌─────┴──────┐
+                                                     │   Kafka    │  chat · notification ·
+                                                     │ (existing) │  counter.v1.popularity · post.v1
+                                                     └─────┬──────┘
+                                          ┌────────────────┴────────────────┐
+                                          │  core gRPC mesh (SoRs) — shielded │  emit-once; never sees a client
+                                          └───────────────────────────────────┘
+```
+
+**The internal→external bridge is three stages.** (A) Core services **emit once** to Kafka — the plane adds no new synchronous call inward. (B) The dispatcher resolves the recipient against the **connection registry** (`presence:{user_id}` → the node(s) holding that user's live sockets) — *targeted* delivery, never broadcast-and-filter. (C) The last hop publishes the event to the owning node's Redis channel; the gateway hands it to the connection's bounded mailbox and writes the socket. Core to device = one Kafka hop + one Redis hop + one socket write.
+
+> **Invariants** (and where enforced):
+> - **The plane stores nothing.** It owns the connection and the ephemeral routing registry, never content. A registry miss (recipient offline) is a no-op — durability and the locked-phone push path belong to `chat` / `notification` — domain + application.
+> - **Authenticate once, at the handshake.** The edge token is verified at the WS upgrade via `auth-context`; never re-verified per frame (that would reintroduce the per-message mesh cost the plane exists to kill) — infrastructure boundary.
+> - **The only authorization is channel-scope ownership.** A connection may subscribe only to channels scoped to its pinned identity (Alice → `dm:alice`, never `dm:bob`). Fine-grained "is this content visible" was authorized upstream when the event was emitted — domain.
+> - **A slow consumer is shed, not buffered.** Each connection has a bounded send queue; on overflow the plane drops/disconnects rather than letting one bad network balloon node memory — infrastructure.
+> - **Fail-open, always.** A lost live event is never a lost message; the client re-syncs from the SoR via its sequence token on reconnect — application.
+
+---
+
+## 📊 Service Level Objectives (SLO) &nbsp;·&nbsp; OPS
+
+| SLI | Objective | Window | Measured by |
+|---|---|---|---|
+| Availability (successful handshakes / non-`UNAVAILABLE`) | `<TODO 99.9%>` | 30d rolling | `<metric>` |
+| Event→device latency p99 (online users) | `< <TODO 250> ms` | 1h | `<metric>` |
+| Connection setup p99 | `< <TODO> ms` | 1h | `<metric>` |
+| Per-connection memory ceiling | `< <TODO> KB` | live | RSS / open_connections |
+
+**Error budget:** `<TODO>`. **On burn:** `<freeze rollout | page>`. Because `realtime` is fail-open, the *availability* objective covers live-delivery degradation (reconnect-and-re-sync), not durability — durability is owned by the upstream SoRs and is out of this service's budget.
+
+---
+
+## 🔗 Dependencies & Blast Radius &nbsp;·&nbsp; OPS
+
+**Downstream — what `realtime` needs to function:**
+
+| Dependency | Purpose | If down → | Degradation |
+|---|---|---|---|
+| Redis | connection/presence registry + node-hop Pub/Sub | dispatcher can't resolve / publish | **Soft** — live delivery stalls; clients re-sync from SoRs on reconnect; no data lost |
+| Kafka | upstream event ingestion | fan-out stops advancing | **Soft** — live updates lag; nothing lost (manual commit); clients catch up via SoR |
+| `auth` (via `auth-context`) | edge-token verification at handshake | new connections can't authenticate | **Hard for new connects** — existing connections unaffected until token expiry |
+
+**Upstream — who depends on `realtime` (your blast radius if YOU fail):**
+
+| Caller | Uses | User-visible impact if `realtime` is down |
+|---|---|---|
+| end-user clients | the live WSS stream | DMs / notifications / live counters stop arriving *instantly* — they appear on next app open or reconnect (re-synced from `chat` / `notification`); **nothing is lost** |
+
+> **Critical path?** **No** — derived, async, fail-open. `realtime` is never in the synchronous path of sending a message, persisting a notification, or any write. It accelerates delivery; it does not own it.
+
+---
+
+## 🔌 Public Interfaces & API Contract &nbsp;·&nbsp; CORE
+
+### Client transport — WSS multiplexed envelope *(Phase 1)*
+
+The client-facing surface is **not** gRPC. Clients connect over **WebSocket Secure** and exchange a compact, length-prefixed binary **envelope** — `{ stream_seq, channel, ack_required, payload }` — that imposes logical channels (`dm`, `notif`, `presence`, `counter:<id>`, `control`) over one physical socket. The handshake carries the edge token; thereafter frames are not re-authenticated. `WebTransport` over HTTP/3 is a designed-in, deferred successor lane the client negotiates and falls back from.
+
+### Internal gRPC — health / control *(Phase 1)*
+
+The internal plane is operational only: health + reflection on `:50066` (gateway) / `:50067` (dispatcher), plus the optional dispatcher↔gateway delivery RPC if the node-hop fabric moves off Redis Pub/Sub. **There is no client-facing gRPC and no domain write RPC.**
+
+### Rust ports (hexagonal contract) *(Phase 3)*
+
+```rust
+#[async_trait] pub trait ConnectionRegistry { /* bind · resolve(user → nodes) · evict — the routing fabric */ }
+#[async_trait] pub trait NodeChannel        { /* subscribe(node) · publish(node, event) — the last hop */ }
+#[async_trait] pub trait TokenVerifier      { /* verify the edge token at handshake (auth-context) */ }
+#[async_trait] pub trait EventSource        { /* the upstream Kafka streams the dispatcher fans out */ }
+```
+
+### Error contract
+
+Every fault implements `error::AppError` with a stable `RTM-XXXX` code, mapped to gRPC `Status` / HTTP by the shared `error` crate:
+
+| Range | Class |
+|---|---|
+| `RTM-1xxx` | connection handshake / authentication |
+| `RTM-2xxx` | transport / framing / protocol |
+| `RTM-3xxx` | subscription authorization (channel-scope ownership) |
+| `RTM-4xxx` | delivery-fabric availability (fail-open core; retryable) |
+| `RTM-5xxx` | connection lifecycle / backpressure |
+| `RTM-8xxx` | inbound event decode / routing (dispatcher) |
+| `RTM-9xxx` | cross-cutting (domain/parse, event consumption) |
+
+---
+
+## 📨 Events & Async Contract &nbsp;·&nbsp; CORE
+
+> Kafka topics are an API. A schema change in a consumed topic breaks delivery exactly like a proto change.
+
+**Publishes:** none of record. (Presence, if surfaced, is internal liveness only — see the blueprint; it is not a System-of-Record stream.)
+
+**Consumes:**
+
+| Topic | Consumer group | Purpose | On poison/exhaustion |
+|---|---|---|---|
+| `<chat message events>` | `realtime-chat-fanout` | deliver DMs / messages to online recipients | DLQ `<...>.dlq` |
+| `notification.v1.events` | `realtime-notif-fanout` | deliver notification/badge updates live | DLQ `notification.v1.events.dlq` |
+| `counter.v1.popularity` | `realtime-counter-fanout` | deliver live engagement spikes to viewers of an entity | DLQ `counter.v1.popularity.dlq` |
+| `post.v1.events` | `realtime-post-fanout` | deliver live feed signals (selective) | DLQ `post.v1.events.dlq` |
+
+> **Runtime contract (mandatory):** all dispatcher consumers run under `run_consumer` — manual commit after a terminal outcome, bounded retry with backoff + jitter, DLQ on exhaustion/poison, rebuild-from-last-committed-offset on broker error. **Idempotency:** fan-out is naturally idempotent — a redelivered event re-resolves the registry and re-delivers; duplicate live frames are harmless (the client dedupes on `stream_seq`). An unroutable/unknown event (`RTM-8002` / `RTM-8003`) is folded into `Ok` so the offset still commits.
+
+---
+
+## 🌩️ Failure Modes & Degradation &nbsp;·&nbsp; OPS
+
+| Failure | Symptom | Service behavior | Operator action |
+|---|---|---|---|
+| Redis registry/pub-sub down | live delivery stalls | **fail-open** — events queue/retry; clients re-sync from SoRs on reconnect; no loss | restore Redis; fan-out resumes |
+| Kafka unavailable | live updates lag | dispatcher idles; offsets uncommitted → no loss | restore brokers; catch up |
+| `auth` unreachable | new handshakes fail | existing connections unaffected; new connects rejected (`RTM-1001`) until recovery | restore `auth`; verify `auth-context` config |
+| Slow/wedged client | one connection's queue fills | **shed** — drop oldest / disconnect (`RTM-5001`); node memory protected | none (by design) |
+| Half-open connection | FD + registry slot leak | heartbeat reaper times it out (`RTM-5002`), frees the slot, flips presence offline | none (by design); watch reaper metrics |
+| Node rollout / drain | connections must move | stop-accept → reconnect control frame **with jittered backoff** (`RTM-5003`) → drain | none (by design); watch reconnect-herd metrics |
+| Reconnect thundering herd | auth handshake spike on deploy | client jittered backoff + the L4 LB spread absorb it | confirm jitter config; stagger rollouts |
+
+**Backpressure & limits:** bounded per-connection send queue (shed on overflow); per-connection subscription cap; inbound frame-size cap; heartbeat deadline reaping; autoscale on connections + memory (an idle-but-full node is ~0% CPU — CPU-based autoscaling under-provisions into OOM).
+
+---
+
+## 📦 Integration & Usage &nbsp;·&nbsp; CORE
+
+```toml
+[dependencies]
+realtime = { path = "crates/services/realtime" }
+```
+
+Library-only. Will implement [`service_runtime::Service`](../../platform/service-runtime/README.md) **twice** (Phase 5): `realtime::service::RealtimeGatewayService` (the `realtime-gateway` binary — the WSS accept loop, registry writes, node-hop subscription, drain hook, internal gRPC health) and `realtime::service::RealtimeDispatcherService` (the `realtime-dispatcher` binary — the supervised `run_consumer` fan-out loops, no domain RPC). Telemetry, config + hot-reload, health, and graceful shutdown are owned by the runtime.
+
+> **Build status:** **complete through Phase 7** (all 8 phases: scaffold → contract → domain → application+ports → adapters → gateway+dispatcher wiring → live IT → hardening). 52 unit tests plus a live `integration-realtime` suite (real Redis) cover the domain, the proto codec, the bounded-shed mailbox, the node-local routing table (incl. shed-under-pressure and graceful `broadcast_drain`), and the end-to-end bridge (fan-out → registry resolve → node hop → socket frame). Security-reviewed: no token or PII in logs, the opaque payload is never logged, and there is no panic in the accept or delivery hot path.
+>
+> **Deferred (explicit, not gaps):** the live WebSocket-accept-loop + auth/JWKS integration test (needs a live IdP and a browser-grade WS client — the routing fabric *is* covered live); the live Kafka dispatcher IT (the `run_consumer` runner is covered by `transport`'s own suite); the WebTransport / HTTP-3 transport lane; presence as a product-facing stream; cross-region / multi-PoP routing; the internal-gRPC `NodeChannel` backpressure variant; the `SIGTERM` → `broadcast_drain` runtime wiring; and the `chat` + `notification` client-streaming consolidation (coexist-first).
+>
+> **Authorization (deployment requirement):** `realtime` authenticates the edge token once at the WS handshake (via `auth-context`) and authorizes subscriptions only by channel-scope ownership. It performs no content-level authorization — events are authorized upstream at emit time.
+
+---
+
+## ⚙️ Configuration & Runtime Environment &nbsp;·&nbsp; CORE
+
+### `realtime`-specific variables *(filled per phase)*
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `REALTIME_GATEWAY_WS_ADDR` | No | `0.0.0.0:8443` | public WSS client listen address (gateway) |
+| `REALTIME_GATEWAY_GRPC_ADDR` | No | `0.0.0.0:50066` | gateway internal gRPC health/control address |
+| `REALTIME_DISPATCHER_GRPC_ADDR` | No | `0.0.0.0:50067` | dispatcher health/reflection address (no domain RPC) |
+| `REALTIME_HEARTBEAT_INTERVAL_MS` | No | `<TODO 30000>` | app-level ping cadence (keeps NAT binding, reaps half-open) |
+| `REALTIME_HEARTBEAT_TIMEOUT_MS` | No | `<TODO 90000>` | pong deadline before a connection is reaped |
+| `REALTIME_SEND_QUEUE_CAP` | No | `<TODO>` | per-connection outbound queue depth before shedding |
+| `REALTIME_MAX_SUBSCRIPTIONS` | No | `<TODO>` | per-connection channel-subscription cap |
+| `REALTIME_MAX_FRAME_BYTES` | No | `<TODO>` | inbound frame size cap |
+| `REALTIME_NODE_ID` | No | `<hostname>` | this gateway node's identity for the registry + node-hop channel |
+
+### Inherited infrastructure variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `REDIS_URL` | **Yes** | — | connection/presence registry + node-hop Pub/Sub |
+| `KAFKA_BROKERS` | **Yes** (dispatcher) | — | upstream event ingestion |
+| `<auth-context verification config>` | **Yes** | — | edge-token (ES256) verification at handshake |
+
+### Compile-time features
+- `integration-realtime` *(Phase 6)* — gates the live, container-backed integration suite (real Redis + Kafka).
+
+---
+
+## 🚀 Deployment, Migrations & Rollback &nbsp;·&nbsp; OPS
+
+- **Two deployables, scaled independently.** `realtime-gateway` scales with concurrent connection count + memory; `realtime-dispatcher` scales with event throughput. Released together (same image/tag), rolled and autoscaled separately.
+- **No schema migrations.** The plane owns no durable store — only ephemeral Redis routing state (TTL'd, self-healing).
+- **Graceful drain is a release requirement.** On rollout the gateway must stop-accept, emit a reconnect control frame with client-side jittered backoff, then drain — without jitter, every deploy triggers a reconnect thundering-herd into the auth handshake path.
+- **L4 load balancing**, not L7: terminating WS at an L7 proxy mirrors millions of connections and hits the ephemeral-port wall.
+- **Rollback:** safe — both binaries are stateless over Redis/Kafka; the dispatcher resumes from last committed offsets, the gateway re-accepts connections (clients reconnect with backoff).
+
+---
+
+## 📈 Telemetry, Performance & Metrics &nbsp;·&nbsp; CORE
+
+- **Runtime:** multi-threaded Tokio, async I/O over epoll/kqueue — an idle connection is a parked future, not a thread. `realtime-gateway` runs the accept loop + per-connection mailboxes + the heartbeat reaper; `realtime-dispatcher` runs the fan-out consumers. Global tracing/OTel subscriber installed before serve; W3C trace-context propagated across the Kafka boundary.
+
+| Signal | Why it matters | Suggested alert |
+|---|---|---|
+| Open connections / node | capacity + autoscale signal | approaching node ceiling ⇒ scale |
+| Per-connection memory (RSS / conns) | the C10M cost ceiling | `> SLO` ⇒ investigate leak / shedding |
+| Event→device latency p99 | live responsiveness | `> SLO` ⇒ investigate registry / node-hop |
+| Send-queue shed rate (`RTM-5001`) | slow-consumer pressure | sustained spike ⇒ investigate clients / network |
+| Heartbeat reap rate (`RTM-5002`) | half-open churn | abnormal spike ⇒ investigate network / LB |
+| Reconnect rate | herd / churn on deploy | spike off-deploy ⇒ investigate node loss |
+| DLQ produce rate (`*.dlq`) | poison / retry-exhausted ingestion | any sustained rate ⇒ page |
+
+---
+
+## 🛠️ Local Development &nbsp;·&nbsp; CORE
+
+```bash
+cargo build -p realtime && cargo clippy -p realtime --all-targets
+cargo test  -p realtime                                    # fast, infra-free unit run
+docker compose up -d redis kafka                           # repo-root compose (Phase 6)
+cargo test  -p realtime --features integration-realtime    # live suite (Phase 6)
+```
+
+---
+
+## 🚨 Troubleshooting & Runbook &nbsp;·&nbsp; CORE
+
+> Format: **symptom → root cause → mitigation.** One entry per real incident class.
+
+**1. Messages arrive only on app reopen, not live.**
+Root cause: Redis registry/pub-sub degraded, or dispatcher lag — live fan-out stalled. Mitigation: check Redis health and consumer-group lag; the message is durable in `chat`/`notification`, so clients catch up on reconnect — no loss; live delivery recovers when the fabric does.
+
+**2. Node memory climbing toward OOM while CPU is near idle.**
+Root cause: connection accumulation or slow-consumer buffering. Mitigation: confirm the per-connection send-queue cap and shedding are active; check the shed-rate metric; autoscale on connections + memory, not CPU — a full idle node is ~0% CPU.
+
+**3. Every deploy triggers an auth/handshake spike.**
+Root cause: reconnect thundering-herd — clients reconnecting without jitter on drain. Mitigation: confirm jittered backoff in the drain control frame and client SDK; stagger node rollouts.
+
+**4. Some users never receive live events; FDs/registry slots leak.**
+Root cause: half-open connections the kernel still holds. Mitigation: confirm the heartbeat reaper interval/timeout; check the reap-rate metric; reaping frees the FD + registry slot and flips presence offline.
+
+**5. A client can see another user's stream.**
+Root cause (critical): a channel-scope authorization gap. Mitigation: this must be impossible — subscriptions are authorized against the pinned identity (`RTM-3001`); treat any occurrence as a security incident and audit the subscribe path.

--- a/crates/services/realtime/src/app.rs
+++ b/crates/services/realtime/src/app.rs
@@ -1,0 +1,86 @@
+//! The realtime composition roots.
+//!
+//! [`Adapters::build`] is the I/O variant that constructs the live port adapters
+//! from config (the Redis routing fabric + node hop, the auth-context verifier),
+//! plus the concrete [`RedisClient`] / [`RedisSubscriber`] the runtime needs for
+//! the health probe and the node-channel subscription. Both binaries build from
+//! it: the gateway uses every field; the dispatcher uses only the registry + node
+//! channel for fan-out.
+
+use std::sync::Arc;
+
+use auth_context::{
+    AuthContextConfig, JwksCache, JwksClient, JwksRefresher, JwtDecoder, OidcClaimsExtractor,
+};
+use jsonwebtoken::Algorithm;
+use redis_storage::{RedisClient, RedisClientBuilder, RedisSubscriber, RedisSubscriberBuilder};
+
+use crate::application::port::{ConnectionRegistry, NodeChannel, TokenVerifier};
+use crate::config::RealtimeConfig;
+use crate::infrastructure::auth_context_verifier::AuthContextTokenVerifier;
+use crate::infrastructure::redis_connection_registry::RedisConnectionRegistry;
+use crate::infrastructure::redis_node_channel::RedisNodeChannel;
+
+/// The live adapter set the binaries build from.
+pub struct Adapters {
+    pub registry: Arc<dyn ConnectionRegistry>,
+    pub node_channel: Arc<dyn NodeChannel>,
+    pub verifier: Arc<dyn TokenVerifier>,
+    /// Retained for the runtime's hot-tier liveness probe.
+    pub redis: RedisClient,
+    /// A dedicated subscriber connection for the gateway's node-channel
+    /// (`SSUBSCRIBE`) loop.
+    pub subscriber: RedisSubscriber,
+}
+
+impl Adapters {
+    pub async fn build(config: &RealtimeConfig) -> anyhow::Result<Self> {
+        let redis = RedisClientBuilder::new(config.redis.clone()).build().await?;
+        let subscriber = RedisSubscriberBuilder::new(config.redis.clone()).build().await?;
+
+        let registry: Arc<dyn ConnectionRegistry> = Arc::new(RedisConnectionRegistry::new(
+            redis.clone(),
+            config.registry_ttl.as_millis() as i64,
+        ));
+        let node_channel: Arc<dyn NodeChannel> = Arc::new(RedisNodeChannel::new(redis.clone()));
+        let verifier: Arc<dyn TokenVerifier> =
+            Arc::new(AuthContextTokenVerifier::new(
+                build_decoder(&config.auth),
+                config.device_claim.clone(),
+            ));
+
+        Ok(Self {
+            registry,
+            node_channel,
+            verifier,
+            redis,
+            subscriber,
+        })
+    }
+}
+
+/// Build the ES256 edge-token decoder and start its JWKS refresher.
+///
+/// The refresher is detached (its `JoinHandle` is dropped, which keeps the task
+/// running for the process lifetime); the cache it warms is shared with the
+/// decoder. A cold start does not require the IdP to be reachable — verification
+/// fails closed (`RTM-1001`) until the first successful JWKS fetch.
+fn build_decoder(
+    auth: &AuthContextConfig,
+) -> Arc<JwtDecoder<auth_context::OidcClaims, OidcClaimsExtractor>> {
+    let cache = JwksCache::new();
+    let client = JwksClient::new(auth.jwks_url.clone(), auth.fetch_timeout);
+    let _refresher = JwksRefresher::spawn(
+        client,
+        cache.clone(),
+        auth.refresh_interval,
+        auth.max_backoff,
+    );
+    // The edge token is ES256; accept RS256 too in case the JWKS mixes key types.
+    Arc::new(JwtDecoder::with_algorithms(
+        auth,
+        cache,
+        OidcClaimsExtractor::default(),
+        vec![Algorithm::ES256, Algorithm::RS256],
+    ))
+}

--- a/crates/services/realtime/src/application/event.rs
+++ b/crates/services/realtime/src/application/event.rs
@@ -1,0 +1,33 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::{ChannelRef, DeviceId, UserId};
+
+/// The application's unit of fan-out and delivery: one already-authorized event,
+/// addressed to a recipient on a channel, carrying an opaque payload.
+///
+/// This is a transport-agnostic DTO — it is *not* a proto type. The dispatcher's
+/// Kafka decode layer (Phase 4) builds it from an upstream event; the node-hop
+/// adapter maps it to/from `realtime.v1.DeliverEnvelope`; the gateway turns it
+/// into a `realtime.v1.Event` frame. The realtime plane never inspects `payload`
+/// — it is bytes produced upstream by `chat` / `notification` / `counter`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliverableEvent {
+    /// The user the event is addressed to. The registry resolves this to the
+    /// node(s) holding the user's live sockets.
+    pub recipient: UserId,
+    /// Restrict delivery to one device; `None` ⇒ all of the recipient's
+    /// connections (the common case).
+    pub device_id: Option<DeviceId>,
+    pub channel: ChannelRef,
+    /// Opaque upstream payload, forwarded verbatim — never interpreted or stored.
+    pub payload: Vec<u8>,
+    /// Routing/telemetry hint (e.g. `"chat.message"`); advisory, not a contract
+    /// on `payload`'s schema.
+    pub event_type: String,
+    /// Event-time, propagated from the source event.
+    pub emitted_at: DateTime<Utc>,
+    /// Idempotency key from the source event, so a Kafka redelivery (the
+    /// dispatcher runs at-least-once under `run_consumer`) does not double-emit on
+    /// a client that already saw it.
+    pub idempotency_key: String,
+}

--- a/crates/services/realtime/src/application/fakes.rs
+++ b/crates/services/realtime/src/application/fakes.rs
@@ -1,0 +1,248 @@
+//! In-memory fakes for the four ports, plus a [`Fixture`] composition root, for
+//! the application unit tests. They model the semantics that matter — the
+//! registry's `user → placements` routing, its fail-open `unavailable` toggle, the
+//! node channel's per-node publish record — without any container.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, TimeZone, Utc};
+
+use crate::application::event::DeliverableEvent;
+use crate::application::fanout::FanOutHandler;
+use crate::application::handshake::HandshakeHandler;
+use crate::application::lifecycle::ReapHandler;
+use crate::application::port::{
+    ConnectionLocation, ConnectionRegistry, EventSource, NodeChannel, TokenVerifier,
+};
+use crate::domain::{DeviceId, NodeId, Session, UserId};
+use crate::error::RealtimeError;
+
+// ── TokenVerifier (auth-context analogue) ─────────────────────────────────────
+
+/// Maps a raw token string to the `(user, device)` it authenticates. An unseeded
+/// token is rejected.
+#[derive(Default)]
+pub struct FakeTokenVerifier {
+    valid: Mutex<HashMap<String, (String, String)>>,
+}
+
+impl FakeTokenVerifier {
+    /// Register a token that verifies to `(user, device)`, with a one-hour expiry
+    /// from the verification clock.
+    pub fn seed_valid(&self, token: &str, user: &str, device: &str) {
+        self.valid
+            .lock()
+            .unwrap()
+            .insert(token.to_owned(), (user.to_owned(), device.to_owned()));
+    }
+}
+
+#[async_trait]
+impl TokenVerifier for FakeTokenVerifier {
+    async fn verify(
+        &self,
+        edge_token: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Session, RealtimeError> {
+        let guard = self.valid.lock().unwrap();
+        match guard.get(edge_token) {
+            Some((user, device)) => Ok(Session::new(
+                UserId::new(user.clone())?,
+                DeviceId::new(device.clone())?,
+                now + Duration::hours(1),
+            )),
+            None => Err(RealtimeError::HandshakeRejected {
+                reason: "unrecognized edge token".to_owned(),
+            }),
+        }
+    }
+}
+
+// ── ConnectionRegistry (Redis routing analogue) ───────────────────────────────
+
+#[derive(Default)]
+pub struct InMemoryRegistry {
+    placements: Mutex<Vec<ConnectionLocation>>,
+    unavailable: AtomicBool,
+}
+
+impl InMemoryRegistry {
+    pub fn seed(&self, location: ConnectionLocation) {
+        self.placements.lock().unwrap().push(location);
+    }
+
+    pub fn set_unavailable(&self, down: bool) {
+        self.unavailable.store(down, Ordering::SeqCst);
+    }
+
+    fn guard(&self) -> Result<(), RealtimeError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(RealtimeError::RegistryUnavailable);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ConnectionRegistry for InMemoryRegistry {
+    async fn bind(&self, location: &ConnectionLocation) -> Result<(), RealtimeError> {
+        self.guard()?;
+        self.placements.lock().unwrap().push(location.clone());
+        Ok(())
+    }
+
+    async fn evict(
+        &self,
+        user_id: &UserId,
+        connection_id: &crate::domain::ConnectionId,
+    ) -> Result<(), RealtimeError> {
+        self.guard()?;
+        self.placements.lock().unwrap().retain(|loc| {
+            !(loc.user_id == *user_id && loc.connection_id == *connection_id)
+        });
+        Ok(())
+    }
+
+    async fn resolve(&self, user_id: &UserId) -> Result<Vec<ConnectionLocation>, RealtimeError> {
+        self.guard()?;
+        Ok(self
+            .placements
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|loc| loc.user_id == *user_id)
+            .cloned()
+            .collect())
+    }
+}
+
+// ── NodeChannel (Redis Pub/Sub analogue) ──────────────────────────────────────
+
+#[derive(Default)]
+pub struct FakeNodeChannel {
+    published: Mutex<Vec<(NodeId, DeliverableEvent)>>,
+    unavailable: AtomicBool,
+}
+
+impl FakeNodeChannel {
+    pub fn set_unavailable(&self, down: bool) {
+        self.unavailable.store(down, Ordering::SeqCst);
+    }
+
+    pub fn publish_count(&self) -> usize {
+        self.published.lock().unwrap().len()
+    }
+
+    pub fn published_to(&self, node: &str) -> usize {
+        self.published
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n.as_str() == node)
+            .count()
+    }
+}
+
+#[async_trait]
+impl NodeChannel for FakeNodeChannel {
+    async fn publish(
+        &self,
+        node_id: &NodeId,
+        event: &DeliverableEvent,
+    ) -> Result<(), RealtimeError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(RealtimeError::NodeChannelUnavailable);
+        }
+        self.published
+            .lock()
+            .unwrap()
+            .push((node_id.clone(), event.clone()));
+        Ok(())
+    }
+}
+
+// ── EventSource (Kafka feed analogue) ─────────────────────────────────────────
+
+#[derive(Default)]
+pub struct FakeEventSource {
+    queue: Mutex<VecDeque<DeliverableEvent>>,
+}
+
+impl FakeEventSource {
+    pub fn push(&self, event: DeliverableEvent) {
+        self.queue.lock().unwrap().push_back(event);
+    }
+
+    pub fn is_drained(&self) -> bool {
+        self.queue.lock().unwrap().is_empty()
+    }
+}
+
+#[async_trait]
+impl EventSource for FakeEventSource {
+    async fn next_event(&self) -> Result<Option<DeliverableEvent>, RealtimeError> {
+        Ok(self.queue.lock().unwrap().pop_front())
+    }
+}
+
+// ── Composition root ──────────────────────────────────────────────────────────
+
+/// Wires the fakes into the application handlers, the way the real composition
+/// roots (Phase 5) wire the live adapters.
+pub struct Fixture {
+    pub verifier: Arc<FakeTokenVerifier>,
+    pub registry: Arc<InMemoryRegistry>,
+    pub channel: Arc<FakeNodeChannel>,
+    pub source: Arc<FakeEventSource>,
+    pub node_id: NodeId,
+    pub subscription_cap: usize,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        Self {
+            verifier: Arc::new(FakeTokenVerifier::default()),
+            registry: Arc::new(InMemoryRegistry::default()),
+            channel: Arc::new(FakeNodeChannel::default()),
+            source: Arc::new(FakeEventSource::default()),
+            node_id: NodeId::new("node-test").unwrap(),
+            subscription_cap: 64,
+        }
+    }
+
+    /// A fixed wall clock for deterministic tests.
+    pub fn fixed_now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 26, 12, 0, 0).unwrap()
+    }
+
+    pub fn now(&self) -> DateTime<Utc> {
+        Self::fixed_now()
+    }
+
+    pub fn handshake(&self) -> HandshakeHandler {
+        HandshakeHandler::new(
+            self.verifier.clone(),
+            self.registry.clone(),
+            self.node_id.clone(),
+            self.subscription_cap,
+        )
+    }
+
+    pub fn fanout(&self) -> FanOutHandler {
+        FanOutHandler::new(self.registry.clone(), self.channel.clone())
+    }
+
+    pub fn reap(&self) -> ReapHandler {
+        ReapHandler::new(self.registry.clone())
+    }
+}
+
+impl Default for Fixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/services/realtime/src/application/fanout.rs
+++ b/crates/services/realtime/src/application/fanout.rs
@@ -1,0 +1,194 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::application::event::DeliverableEvent;
+use crate::application::port::{ConnectionRegistry, EventSource, NodeChannel};
+use crate::domain::NodeId;
+use crate::error::RealtimeError;
+
+/// The outcome of fanning one event out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FanOutOutcome {
+    /// How many distinct gateway nodes the event was published to.
+    pub nodes_published: usize,
+    /// True when the recipient had no live connection (a fail-open no-op).
+    pub offline: bool,
+}
+
+/// The dispatcher's core use case: resolve a recipient against the registry and
+/// publish the event to each owning node (deduplicated, so a user with two
+/// devices on the same node is published to once).
+///
+/// **Fail-open is the defining behaviour:** a recipient with no live connection
+/// is a successful no-op, never an error — the message is durable upstream and the
+/// client re-syncs on reconnect. Only a genuine *fabric* fault (registry or node
+/// channel down → `RTM-4001` / `RTM-4002`, retryable) propagates, so the
+/// `run_consumer` driver can retry without committing the offset.
+pub struct FanOutHandler {
+    registry: Arc<dyn ConnectionRegistry>,
+    channel: Arc<dyn NodeChannel>,
+}
+
+impl FanOutHandler {
+    pub fn new(registry: Arc<dyn ConnectionRegistry>, channel: Arc<dyn NodeChannel>) -> Self {
+        Self { registry, channel }
+    }
+
+    pub async fn fan_out(
+        &self,
+        event: &DeliverableEvent,
+    ) -> Result<FanOutOutcome, RealtimeError> {
+        let locations = self.registry.resolve(&event.recipient).await?;
+
+        // Optionally restrict to a single device; otherwise every placement.
+        let targets = locations.iter().filter(|loc| match &event.device_id {
+            Some(device) => &loc.device_id == device,
+            None => true,
+        });
+
+        let mut published_nodes: HashSet<NodeId> = HashSet::new();
+        for loc in targets {
+            // Dedupe by node: two devices on one node get a single publish.
+            if published_nodes.insert(loc.node_id.clone()) {
+                self.channel.publish(&loc.node_id, event).await?;
+            }
+        }
+
+        if published_nodes.is_empty() {
+            return Ok(FanOutOutcome {
+                nodes_published: 0,
+                offline: true,
+            });
+        }
+        Ok(FanOutOutcome {
+            nodes_published: published_nodes.len(),
+            offline: false,
+        })
+    }
+}
+
+/// Drive the dispatcher: pull events from `source` and fan each one out until the
+/// source is drained. This is the testable core of the fan-out worker; the
+/// production binary (Phase 5) wraps the Kafka `run_consumer` runtime around the
+/// same [`FanOutHandler::fan_out`] call (manual commit, backoff/jitter, DLQ).
+pub async fn run_dispatch(
+    source: &dyn EventSource,
+    handler: &FanOutHandler,
+) -> Result<(), RealtimeError> {
+    while let Some(event) = source.next_event().await? {
+        handler.fan_out(&event).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::application::port::ConnectionLocation;
+    use crate::domain::{ChannelClass, ChannelKey, ChannelRef, ConnectionId, DeviceId, UserId};
+
+    fn event_for(recipient: &str, device: Option<&str>) -> DeliverableEvent {
+        DeliverableEvent {
+            recipient: UserId::new(recipient).unwrap(),
+            device_id: device.map(|d| DeviceId::new(d).unwrap()),
+            channel: ChannelRef::new(ChannelClass::Dm, ChannelKey::new(recipient).unwrap()),
+            payload: b"hello".to_vec(),
+            event_type: "chat.message".to_owned(),
+            emitted_at: Fixture::fixed_now(),
+            idempotency_key: "evt-1".to_owned(),
+        }
+    }
+
+    fn location(user: &str, device: &str, conn: &str, node: &str) -> ConnectionLocation {
+        ConnectionLocation {
+            user_id: UserId::new(user).unwrap(),
+            device_id: DeviceId::new(device).unwrap(),
+            connection_id: ConnectionId::new(conn).unwrap(),
+            node_id: crate::domain::NodeId::new(node).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn publishes_to_each_owning_node() {
+        let fx = Fixture::new();
+        fx.registry.seed(location("alice", "phone", "c1", "node-1"));
+        fx.registry.seed(location("alice", "tablet", "c2", "node-2"));
+
+        let out = fx.fanout().fan_out(&event_for("alice", None)).await.unwrap();
+
+        assert!(!out.offline);
+        assert_eq!(out.nodes_published, 2);
+        assert_eq!(fx.channel.publish_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn dedupes_multiple_devices_on_the_same_node() {
+        let fx = Fixture::new();
+        fx.registry.seed(location("alice", "phone", "c1", "node-1"));
+        fx.registry.seed(location("alice", "web", "c2", "node-1"));
+
+        let out = fx.fanout().fan_out(&event_for("alice", None)).await.unwrap();
+
+        assert_eq!(out.nodes_published, 1); // one publish for the shared node
+        assert_eq!(fx.channel.publish_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn offline_recipient_is_a_fail_open_noop() {
+        let fx = Fixture::new();
+        // Registry has nobody for "ghost".
+        let out = fx.fanout().fan_out(&event_for("ghost", None)).await.unwrap();
+
+        assert!(out.offline);
+        assert_eq!(out.nodes_published, 0);
+        assert_eq!(fx.channel.publish_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn device_targeted_event_reaches_only_that_device() {
+        let fx = Fixture::new();
+        fx.registry.seed(location("alice", "phone", "c1", "node-1"));
+        fx.registry.seed(location("alice", "tablet", "c2", "node-2"));
+
+        let out = fx
+            .fanout()
+            .fan_out(&event_for("alice", Some("tablet")))
+            .await
+            .unwrap();
+
+        assert_eq!(out.nodes_published, 1);
+        assert_eq!(fx.channel.published_to("node-2"), 1);
+        assert_eq!(fx.channel.published_to("node-1"), 0);
+    }
+
+    #[tokio::test]
+    async fn registry_fault_propagates_as_retryable() {
+        let fx = Fixture::new();
+        fx.registry.set_unavailable(true);
+
+        let err = fx
+            .fanout()
+            .fan_out(&event_for("alice", None))
+            .await
+            .unwrap_err();
+        assert_eq!(err.error_code(), "RTM-4001");
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn run_dispatch_drains_the_source() {
+        let fx = Fixture::new();
+        fx.registry.seed(location("alice", "phone", "c1", "node-1"));
+        fx.source.push(event_for("alice", None));
+        fx.source.push(event_for("alice", None));
+        fx.source.push(event_for("ghost", None)); // offline → no-op, still consumed
+
+        run_dispatch(fx.source.as_ref(), &fx.fanout()).await.unwrap();
+
+        assert!(fx.source.is_drained());
+        assert_eq!(fx.channel.publish_count(), 2);
+    }
+}

--- a/crates/services/realtime/src/application/handshake.rs
+++ b/crates/services/realtime/src/application/handshake.rs
@@ -1,0 +1,125 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+
+use crate::application::port::{ConnectionLocation, ConnectionRegistry, TokenVerifier};
+use crate::domain::{Connection, ConnectionId, NodeId};
+use crate::error::RealtimeError;
+
+/// Authenticates a WebSocket handshake and registers the resulting connection.
+///
+/// This is the one place the plane authenticates — verify the edge token once,
+/// pin the resulting [`crate::domain::Session`] to a fresh [`Connection`], and
+/// publish the connection's placement to the registry so the dispatcher can route
+/// to it. Everything afterwards (subscribe, ack, deliver) trusts that pinned
+/// identity and is never re-authenticated.
+pub struct HandshakeHandler {
+    verifier: Arc<dyn TokenVerifier>,
+    registry: Arc<dyn ConnectionRegistry>,
+    /// This gateway node's identity — every connection accepted here lives on it.
+    node_id: NodeId,
+    /// The per-connection subscription cap (protects node memory).
+    subscription_cap: usize,
+}
+
+impl HandshakeHandler {
+    pub fn new(
+        verifier: Arc<dyn TokenVerifier>,
+        registry: Arc<dyn ConnectionRegistry>,
+        node_id: NodeId,
+        subscription_cap: usize,
+    ) -> Self {
+        Self {
+            verifier,
+            registry,
+            node_id,
+            subscription_cap,
+        }
+    }
+
+    /// Accept a handshake: verify `edge_token`, open a [`Connection`] under the
+    /// server-assigned `connection_id`, and bind its placement in the registry.
+    /// Returns the live connection for the gateway's per-socket task to own.
+    ///
+    /// Authentication failure (`RTM-1001` / `RTM-1002`) or a registry fault
+    /// (`RTM-4001`) aborts the handshake — the socket is rejected, not half-open.
+    pub async fn accept(
+        &self,
+        edge_token: &str,
+        connection_id: ConnectionId,
+        now: DateTime<Utc>,
+    ) -> Result<Connection, RealtimeError> {
+        let session = self.verifier.verify(edge_token, now).await?;
+
+        let connection = Connection::open(
+            connection_id,
+            self.node_id.clone(),
+            session.clone(),
+            self.subscription_cap,
+            now,
+        );
+
+        let location = ConnectionLocation {
+            user_id: session.user_id,
+            device_id: session.device_id,
+            connection_id: connection.id().clone(),
+            node_id: self.node_id.clone(),
+        };
+        self.registry.bind(&location).await?;
+
+        Ok(connection)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::application::port::ConnectionRegistry;
+    use crate::domain::{ConnectionState, UserId};
+
+    #[tokio::test]
+    async fn accepts_valid_token_and_binds_the_connection() {
+        let fx = Fixture::new();
+        fx.verifier.seed_valid("good-token", "alice", "dev-1");
+
+        let conn = fx
+            .handshake()
+            .accept("good-token", ConnectionId::new("conn-1").unwrap(), fx.now())
+            .await
+            .unwrap();
+
+        assert_eq!(conn.state(), ConnectionState::Active);
+        assert_eq!(conn.user_id().as_str(), "alice");
+        // The placement is now resolvable by the dispatcher.
+        let located = fx
+            .registry
+            .resolve(&UserId::new("alice").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(located.len(), 1);
+        assert_eq!(located[0].connection_id.as_str(), "conn-1");
+        assert_eq!(located[0].node_id, fx.node_id);
+    }
+
+    #[tokio::test]
+    async fn rejects_an_invalid_token() {
+        let fx = Fixture::new();
+        let err = fx
+            .handshake()
+            .accept("bogus", ConnectionId::new("conn-1").unwrap(), fx.now())
+            .await
+            .unwrap_err();
+        assert_eq!(err.error_code(), "RTM-1001");
+        // Nothing was bound.
+        assert!(
+            fx.registry
+                .resolve(&UserId::new("alice").unwrap())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/services/realtime/src/application/lifecycle.rs
+++ b/crates/services/realtime/src/application/lifecycle.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use crate::application::port::ConnectionRegistry;
+use crate::domain::{ConnectionId, UserId};
+use crate::error::RealtimeError;
+
+/// Tears down a connection's registry presence when it ends — whether by a clean
+/// client disconnect, a heartbeat reap (`RTM-5002`), or a send-queue shed
+/// (`RTM-5001`).
+///
+/// The matching domain transition (`Connection::close` / `begin_drain`) and the
+/// reconnect control frame on a drain (`SERVER_CONTROL_RECONNECT`) are owned by
+/// the gateway's per-socket task (domain + transport). This handler owns the one
+/// *port* side effect of teardown: evicting the routing slot so the dispatcher
+/// stops resolving the recipient to a node that no longer holds them. `evict` is
+/// idempotent, so a double teardown (reap racing a disconnect) is harmless.
+pub struct ReapHandler {
+    registry: Arc<dyn ConnectionRegistry>,
+}
+
+impl ReapHandler {
+    pub fn new(registry: Arc<dyn ConnectionRegistry>) -> Self {
+        Self { registry }
+    }
+
+    pub async fn evict(
+        &self,
+        user_id: &UserId,
+        connection_id: &ConnectionId,
+    ) -> Result<(), RealtimeError> {
+        self.registry.evict(user_id, connection_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::fakes::Fixture;
+    use crate::application::port::{ConnectionLocation, ConnectionRegistry};
+    use crate::domain::{DeviceId, NodeId};
+
+    fn location(user: &str, device: &str, conn: &str, node: &str) -> ConnectionLocation {
+        ConnectionLocation {
+            user_id: UserId::new(user).unwrap(),
+            device_id: DeviceId::new(device).unwrap(),
+            connection_id: ConnectionId::new(conn).unwrap(),
+            node_id: NodeId::new(node).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn evict_frees_the_routing_slot() {
+        let fx = Fixture::new();
+        fx.registry.seed(location("alice", "phone", "c1", "node-1"));
+        fx.registry.seed(location("alice", "tablet", "c2", "node-1"));
+
+        let alice = UserId::new("alice").unwrap();
+        fx.reap()
+            .evict(&alice, &ConnectionId::new("c1").unwrap())
+            .await
+            .unwrap();
+
+        let remaining = fx.registry.resolve(&alice).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].connection_id.as_str(), "c2");
+    }
+
+    #[tokio::test]
+    async fn evicting_an_absent_connection_is_idempotent() {
+        let fx = Fixture::new();
+        let alice = UserId::new("alice").unwrap();
+        // Nothing seeded — eviction is still Ok.
+        fx.reap()
+            .evict(&alice, &ConnectionId::new("nope").unwrap())
+            .await
+            .unwrap();
+    }
+}

--- a/crates/services/realtime/src/application/mod.rs
+++ b/crates/services/realtime/src/application/mod.rs
@@ -1,0 +1,39 @@
+//! The realtime application layer — use-case orchestration over the domain and
+//! the ports.
+//!
+//! ## Handler shape
+//! The realtime plane has no synchronous read/query RPC (its internal gRPC is
+//! health + the node-hop `DeliverToNode`), so there is no query/command bus here.
+//! Use cases are plain application-service structs holding their ports as
+//! `Arc<dyn …>`:
+//! * [`HandshakeHandler`] — verify the edge token once, open a connection, bind
+//!   it in the registry (the gateway's accept path).
+//! * [`FanOutHandler`] + [`run_dispatch`] — resolve a recipient and publish to its
+//!   owning node(s); the dispatcher's core, fail-open on an offline recipient.
+//! * [`ReapHandler`] — evict a connection's routing slot on teardown.
+//!
+//! Subscribe / unsubscribe / ack are pure domain operations on
+//! [`crate::domain::Connection`] invoked directly by the gateway's per-socket
+//! task, so they need no port and no handler here.
+//!
+//! ## Ports
+//! Every external dependency is an `async_trait` port in [`port`], injected at the
+//! composition root. In-memory fakes back the unit tests; the live adapters are
+//! Phase 4.
+
+pub mod event;
+pub mod fanout;
+pub mod handshake;
+pub mod lifecycle;
+pub mod port;
+
+#[cfg(test)]
+pub mod fakes;
+
+pub use event::DeliverableEvent;
+pub use fanout::{FanOutHandler, FanOutOutcome, run_dispatch};
+pub use handshake::HandshakeHandler;
+pub use lifecycle::ReapHandler;
+pub use port::{
+    ConnectionLocation, ConnectionRegistry, EventSource, NodeChannel, TokenVerifier,
+};

--- a/crates/services/realtime/src/application/port/connection_registry.rs
+++ b/crates/services/realtime/src/application/port/connection_registry.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+
+use crate::domain::{ConnectionId, DeviceId, NodeId, UserId};
+use crate::error::RealtimeError;
+
+/// Where one live connection lives: the `(user, device, connection)` identity and
+/// the gateway `node` holding its socket. The routing fabric is a set of these
+/// keyed by user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionLocation {
+    pub user_id: UserId,
+    pub device_id: DeviceId,
+    pub connection_id: ConnectionId,
+    pub node_id: NodeId,
+}
+
+/// The connection/presence registry — the plane's only piece of state, and
+/// deliberately ephemeral. It maps a `UserId` to the node(s) currently holding
+/// that user's sockets, so the dispatcher can resolve *targeted* delivery instead
+/// of broadcasting to every node.
+///
+/// The concrete adapter (Phase 4) is Redis (`fred`, hash-tag slot-safe, TTL'd so
+/// a leaked entry self-heals). Semantics that matter:
+/// * `resolve` returning an **empty** set is normal and benign — the recipient is
+///   offline, and the caller treats it as a fail-open no-op (the event is durable
+///   upstream; the client re-syncs on reconnect). It is *not* an error.
+/// * a genuine store fault (Redis down) is `RTM-4001 RegistryUnavailable`
+///   (retryable) — on the dispatcher path this drives the `run_consumer`
+///   retry/DLQ classification.
+#[async_trait]
+pub trait ConnectionRegistry: Send + Sync + 'static {
+    /// Register a newly-established connection's placement (at handshake).
+    async fn bind(&self, location: &ConnectionLocation) -> Result<(), RealtimeError>;
+
+    /// Remove a connection's placement (on clean disconnect or heartbeat reap),
+    /// freeing its routing slot. Idempotent: evicting an absent entry is `Ok`.
+    async fn evict(
+        &self,
+        user_id: &UserId,
+        connection_id: &ConnectionId,
+    ) -> Result<(), RealtimeError>;
+
+    /// Resolve every live placement for a user. An empty result means "offline".
+    async fn resolve(&self, user_id: &UserId) -> Result<Vec<ConnectionLocation>, RealtimeError>;
+}

--- a/crates/services/realtime/src/application/port/event_source.rs
+++ b/crates/services/realtime/src/application/port/event_source.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+
+use crate::application::event::DeliverableEvent;
+use crate::error::RealtimeError;
+
+/// The dispatcher's upstream feed: the stream of already-decoded
+/// [`DeliverableEvent`]s the fan-out loop consumes.
+///
+/// In production (Phase 4/5) this is backed by the Kafka `run_consumer` pipeline
+/// over the upstream topics (`chat` messages, `notification.v1.events`,
+/// `counter.v1.popularity`, `post.v1.events`) plus the decode layer that turns a
+/// raw record into a `DeliverableEvent`. An in-memory fake backs the unit tests
+/// of the fan-out loop ([`run_dispatch`](crate::application::run_dispatch)).
+///
+/// `next_event` yields `None` when the feed is drained (shutdown / a finite test
+/// fixture). A decode/transport fault surfaces as the corresponding `RTM-8xxx` /
+/// `RTM-9xxx` error so the loop can apply the runtime's retry/DLQ policy.
+#[async_trait]
+pub trait EventSource: Send + Sync + 'static {
+    async fn next_event(&self) -> Result<Option<DeliverableEvent>, RealtimeError>;
+}

--- a/crates/services/realtime/src/application/port/mod.rs
+++ b/crates/services/realtime/src/application/port/mod.rs
@@ -1,0 +1,22 @@
+//! Outbound ports — the only contracts the application layer holds against the
+//! outside world. Concrete adapters (the `auth-context` token verifier, the Redis
+//! registry, the Redis Pub/Sub node hop, the Kafka event source + decode layer)
+//! live in `infrastructure` (Phase 4) and are injected as `Arc<dyn …>` at the
+//! composition root, so the handlers never name a concrete adapter. Each is an
+//! `async_trait`; in-memory fakes back the unit tests.
+//!
+//! * [`TokenVerifier`] — the handshake authentication seam (consulted once).
+//! * [`ConnectionRegistry`] — the routing fabric (`user → node(s)`); its empty
+//!   resolve is the fail-open "offline" signal, not an error.
+//! * [`NodeChannel`] — the last hop to the owning gateway node.
+//! * [`EventSource`] — the dispatcher's upstream (Kafka) feed.
+
+pub mod connection_registry;
+pub mod event_source;
+pub mod node_channel;
+pub mod token_verifier;
+
+pub use connection_registry::{ConnectionLocation, ConnectionRegistry};
+pub use event_source::EventSource;
+pub use node_channel::NodeChannel;
+pub use token_verifier::TokenVerifier;

--- a/crates/services/realtime/src/application/port/node_channel.rs
+++ b/crates/services/realtime/src/application/port/node_channel.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+
+use crate::application::event::DeliverableEvent;
+use crate::domain::NodeId;
+use crate::error::RealtimeError;
+
+/// The node-hop fabric: publishes a resolved event to the gateway node that owns
+/// the recipient's socket (the last leg of the internal→external bridge).
+///
+/// LOCKED (see `project_realtime_blueprint`): v1 wires this as **Redis Pub/Sub**
+/// — fire-and-forget, fail-open — publishing the event (as a
+/// `realtime.v1.DeliverEnvelope`) on the owning node's `node:{node_id}` channel.
+/// The `realtime.v1.RealtimeDispatchService` gRPC stream is the documented,
+/// swappable alternative; this port's shape is fixed so the fabric can change
+/// without touching the dispatcher.
+///
+/// A transport fault is `RTM-4002 NodeChannelUnavailable` (retryable). Note the
+/// publish is intentionally *not* a delivery confirmation: the owning node may
+/// have just lost the connection (stale registry), in which case the event is
+/// silently dropped there — a fail-open miss the client recovers from on reconnect.
+#[async_trait]
+pub trait NodeChannel: Send + Sync + 'static {
+    async fn publish(
+        &self,
+        node_id: &NodeId,
+        event: &DeliverableEvent,
+    ) -> Result<(), RealtimeError>;
+}

--- a/crates/services/realtime/src/application/port/token_verifier.rs
+++ b/crates/services/realtime/src/application/port/token_verifier.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::domain::Session;
+use crate::error::RealtimeError;
+
+/// Verifies the edge token presented at the WebSocket handshake and yields the
+/// pinned [`Session`] (the authenticated `user_id` + `device_id` + token expiry).
+///
+/// This is the plane's authentication seam. It is consulted exactly **once**, at
+/// the handshake — never per frame. The concrete adapter (Phase 4) verifies the
+/// ES256 edge token via the shared `auth-context` library; an in-memory fake
+/// backs the unit tests.
+///
+/// A missing / malformed / signature-invalid token is `RTM-1001
+/// HandshakeRejected`; a well-formed but already-expired token is `RTM-1002
+/// TokenExpired`.
+#[async_trait]
+pub trait TokenVerifier: Send + Sync + 'static {
+    async fn verify(
+        &self,
+        edge_token: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Session, RealtimeError>;
+}

--- a/crates/services/realtime/src/config.rs
+++ b/crates/services/realtime/src/config.rs
@@ -1,0 +1,101 @@
+//! Environment-sourced configuration, resolved once at boot and threaded into the
+//! composition root ([`crate::app`]). Each backend's connection config comes from
+//! its own `from_env`; realtime-specific knobs are read here.
+
+use std::time::Duration;
+
+use auth_context::AuthContextConfig;
+use redis_storage::RedisConfig;
+use transport::kafka::config::KafkaClientConfig;
+
+const DEFAULT_WS_ADDR: &str = "0.0.0.0:8443";
+const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = 30_000;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS: u64 = 90_000;
+const DEFAULT_SEND_QUEUE_CAP: usize = 256;
+const DEFAULT_MAX_SUBSCRIPTIONS: usize = 256;
+const DEFAULT_REGISTRY_TTL_MS: u64 = 120_000;
+const DEFAULT_DEVICE_CLAIM: &str = "did";
+
+/// Fully-resolved realtime configuration shared by both binaries (the gateway uses
+/// the WS/auth/heartbeat knobs; the dispatcher uses Kafka + the routing fabric).
+pub struct RealtimeConfig {
+    pub redis: RedisConfig,
+    pub kafka: KafkaClientConfig,
+    pub auth: AuthContextConfig,
+    /// This node's identity — the key the registry/node-hop address it by.
+    pub node_id: String,
+    /// Public WSS listen address for clients (gateway).
+    pub ws_addr: String,
+    /// App-level ping cadence (keeps NAT bindings, reaps half-open).
+    pub heartbeat_interval: Duration,
+    /// Deadline after which a connection with no inbound traffic is reaped.
+    pub heartbeat_timeout: Duration,
+    /// Per-connection outbound queue depth before shedding.
+    pub send_queue_cap: usize,
+    /// Per-connection channel-subscription cap.
+    pub subscription_cap: usize,
+    /// TTL applied to a connection's presence-registry entry (self-heal bound).
+    pub registry_ttl: Duration,
+    /// JWT claim carrying the device/session id on the edge token.
+    pub device_claim: String,
+}
+
+impl RealtimeConfig {
+    pub fn from_env() -> Self {
+        Self {
+            redis: RedisConfig::from_env(),
+            kafka: KafkaClientConfig::from_env(),
+            auth: auth_config_from_env(),
+            node_id: std::env::var("REALTIME_NODE_ID").unwrap_or_else(|_| default_node_id()),
+            ws_addr: std::env::var("REALTIME_GATEWAY_WS_ADDR")
+                .unwrap_or_else(|_| DEFAULT_WS_ADDR.to_owned()),
+            heartbeat_interval: Duration::from_millis(env_u64(
+                "REALTIME_HEARTBEAT_INTERVAL_MS",
+                DEFAULT_HEARTBEAT_INTERVAL_MS,
+            )),
+            heartbeat_timeout: Duration::from_millis(env_u64(
+                "REALTIME_HEARTBEAT_TIMEOUT_MS",
+                DEFAULT_HEARTBEAT_TIMEOUT_MS,
+            )),
+            send_queue_cap: env_usize("REALTIME_SEND_QUEUE_CAP", DEFAULT_SEND_QUEUE_CAP),
+            subscription_cap: env_usize("REALTIME_MAX_SUBSCRIPTIONS", DEFAULT_MAX_SUBSCRIPTIONS),
+            registry_ttl: Duration::from_millis(env_u64(
+                "REALTIME_REGISTRY_TTL_MS",
+                DEFAULT_REGISTRY_TTL_MS,
+            )),
+            device_claim: std::env::var("REALTIME_DEVICE_CLAIM")
+                .unwrap_or_else(|_| DEFAULT_DEVICE_CLAIM.to_owned()),
+        }
+    }
+}
+
+/// Build the auth-context config from realtime's env surface (JWKS + expected
+/// claims). The edge token is ES256; the decoder is built with EC algorithms in
+/// the composition root.
+fn auth_config_from_env() -> AuthContextConfig {
+    let mut cfg = AuthContextConfig {
+        jwks_url: std::env::var("REALTIME_JWKS_URL").unwrap_or_default(),
+        ..AuthContextConfig::default()
+    };
+    cfg.expected_audience = std::env::var("REALTIME_TOKEN_AUDIENCE").ok();
+    cfg.expected_issuer = std::env::var("REALTIME_TOKEN_ISSUER").ok();
+    cfg
+}
+
+fn default_node_id() -> String {
+    std::env::var("HOSTNAME").unwrap_or_else(|_| "realtime-gateway-0".to_owned())
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/crates/services/realtime/src/domain/connection.rs
+++ b/crates/services/realtime/src/domain/connection.rs
@@ -1,0 +1,327 @@
+use chrono::{DateTime, Duration, Utc};
+
+use crate::domain::session::Session;
+use crate::domain::subscription::SubscriptionSet;
+use crate::domain::value_object::{
+    ChannelRef, ConnectionId, DeviceId, NodeId, PresenceState, StreamSeq, UserId,
+};
+use crate::error::RealtimeError;
+
+/// The lifecycle state of a connection.
+///
+/// `Active → Draining → Closed` is the only legal progression. `Draining` is the
+/// graceful-rollout state: in-flight events still deliver, but no *new*
+/// subscriptions are accepted (the client has been told to reconnect elsewhere).
+/// `Closed` is terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionState {
+    Active,
+    Draining,
+    Closed,
+}
+
+/// Why a connection was closed. Mirrors `realtime.v1.CloseReason`; the proto
+/// mapping lives in the infrastructure tier. Each maps to an `RTM-1xxx`/`RTM-5xxx`
+/// lifecycle code so churn can be attributed in telemetry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseReason {
+    /// Graceful node drain on rollout (`RTM-5003`).
+    Draining,
+    /// Heartbeat deadline exceeded; half-open connection reaped (`RTM-5002`).
+    HeartbeatTimeout,
+    /// Per-connection send queue overflowed; slow consumer shed (`RTM-5001`).
+    SendQueueOverflow,
+    /// Edge token expired and was not refreshed (`RTM-1002`).
+    AuthExpired,
+    /// Transport/framing/protocol violation (`RTM-2xxx`).
+    ProtocolError,
+}
+
+impl CloseReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CloseReason::Draining => "draining",
+            CloseReason::HeartbeatTimeout => "heartbeat_timeout",
+            CloseReason::SendQueueOverflow => "send_queue_overflow",
+            CloseReason::AuthExpired => "auth_expired",
+            CloseReason::ProtocolError => "protocol_error",
+        }
+    }
+}
+
+/// The aggregate root for one live client connection: its pinned [`Session`], its
+/// [`SubscriptionSet`], its lifecycle state, and its heartbeat freshness. Pure —
+/// the wall clock is injected as `now`, and there is no I/O, transport, or store
+/// awareness. The gateway holds one of these per socket; everything the plane
+/// decides about a socket (may it subscribe here, what sequence does this event
+/// get, is it dead, is it draining, is it online) is a method on this type.
+#[derive(Debug, Clone)]
+pub struct Connection {
+    id: ConnectionId,
+    node_id: NodeId,
+    session: Session,
+    subscriptions: SubscriptionSet,
+    state: ConnectionState,
+    last_heartbeat: DateTime<Utc>,
+}
+
+impl Connection {
+    /// Open a connection on `node_id` for an already-authenticated `session`,
+    /// bounded at `subscription_cap` channels. Starts `Active` with a fresh
+    /// heartbeat at `now`.
+    pub fn open(
+        id: ConnectionId,
+        node_id: NodeId,
+        session: Session,
+        subscription_cap: usize,
+        now: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id,
+            node_id,
+            session,
+            subscriptions: SubscriptionSet::new(subscription_cap),
+            state: ConnectionState::Active,
+            last_heartbeat: now,
+        }
+    }
+
+    pub fn id(&self) -> &ConnectionId {
+        &self.id
+    }
+
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    pub fn user_id(&self) -> &UserId {
+        &self.session.user_id
+    }
+
+    pub fn device_id(&self) -> &DeviceId {
+        &self.session.device_id
+    }
+
+    pub fn state(&self) -> ConnectionState {
+        self.state
+    }
+
+    pub fn is_subscribed(&self, channel: &ChannelRef) -> bool {
+        self.subscriptions.is_subscribed(channel)
+    }
+
+    pub fn subscription_count(&self) -> usize {
+        self.subscriptions.len()
+    }
+
+    /// Subscribe to a channel: authorize it against the pinned session, then add
+    /// it to the bounded set. Rejected while `Draining` (`RTM-5003`, reconnect
+    /// elsewhere) or `Closed` (`RTM-9001`). Returns `true` if newly added.
+    pub fn subscribe(&mut self, channel: ChannelRef) -> Result<bool, RealtimeError> {
+        match self.state {
+            ConnectionState::Draining => return Err(RealtimeError::ConnectionDraining),
+            ConnectionState::Closed => {
+                return Err(RealtimeError::DomainViolation {
+                    field: "connection_state".to_owned(),
+                    message: "cannot subscribe on a closed connection".to_owned(),
+                });
+            }
+            ConnectionState::Active => {}
+        }
+        self.session.authorize(&channel)?;
+        self.subscriptions.subscribe(channel)
+    }
+
+    /// Unsubscribe from a channel. Rejected only when `Closed`.
+    pub fn unsubscribe(&mut self, channel: &ChannelRef) -> Result<(), RealtimeError> {
+        if self.state == ConnectionState::Closed {
+            return Err(RealtimeError::DomainViolation {
+                field: "connection_state".to_owned(),
+                message: "cannot unsubscribe on a closed connection".to_owned(),
+            });
+        }
+        self.subscriptions.unsubscribe(channel)
+    }
+
+    /// Assign the next stream sequence for an event about to be delivered on
+    /// `channel`. Permitted while `Active` or `Draining` (in-flight delivery
+    /// continues during a drain); rejected when `Closed`.
+    pub fn issue_seq(&mut self, channel: &ChannelRef) -> Result<StreamSeq, RealtimeError> {
+        if self.state == ConnectionState::Closed {
+            return Err(RealtimeError::DomainViolation {
+                field: "connection_state".to_owned(),
+                message: "cannot deliver to a closed connection".to_owned(),
+            });
+        }
+        self.subscriptions.issue_seq(channel)
+    }
+
+    /// Record a client ack on `channel`.
+    pub fn ack(&mut self, channel: &ChannelRef, seq: StreamSeq) -> Result<(), RealtimeError> {
+        self.subscriptions.ack(channel, seq)
+    }
+
+    /// Refresh the heartbeat (on a client Pong / any inbound frame). A no-op once
+    /// `Closed`.
+    pub fn heartbeat(&mut self, now: DateTime<Utc>) {
+        if self.state != ConnectionState::Closed {
+            self.last_heartbeat = now;
+        }
+    }
+
+    /// Whether the connection has missed its heartbeat deadline and should be
+    /// reaped (freeing its file descriptor + registry slot). Always false once
+    /// `Closed`.
+    pub fn should_reap(&self, now: DateTime<Utc>, timeout: Duration) -> bool {
+        self.state != ConnectionState::Closed
+            && now.signed_duration_since(self.last_heartbeat) > timeout
+    }
+
+    /// Whether the session's edge token has lapsed and the client must re-auth
+    /// (`RTM-1002`).
+    pub fn needs_reauth(&self, now: DateTime<Utc>) -> bool {
+        self.session.is_expired(now)
+    }
+
+    /// Begin draining (graceful rollout): `Active → Draining`. Idempotent while
+    /// already `Draining`; `RTM-9001 DomainViolation` if already `Closed`.
+    pub fn begin_drain(&mut self) -> Result<(), RealtimeError> {
+        match self.state {
+            ConnectionState::Active | ConnectionState::Draining => {
+                self.state = ConnectionState::Draining;
+                Ok(())
+            }
+            ConnectionState::Closed => Err(RealtimeError::DomainViolation {
+                field: "connection_state".to_owned(),
+                message: "cannot drain a closed connection".to_owned(),
+            }),
+        }
+    }
+
+    /// Close the connection with a reason. Terminal and idempotent.
+    pub fn close(&mut self, _reason: CloseReason) {
+        self.state = ConnectionState::Closed;
+    }
+
+    /// The derived presence for this connection: `Online` while active with a
+    /// fresh heartbeat, `Away` while active but past the heartbeat deadline (not
+    /// yet reaped — a radio sleep or flaky link), `Offline` once `Closed`.
+    pub fn presence(&self, now: DateTime<Utc>, heartbeat_timeout: Duration) -> PresenceState {
+        if self.state == ConnectionState::Closed {
+            return PresenceState::Offline;
+        }
+        if now.signed_duration_since(self.last_heartbeat) > heartbeat_timeout {
+            PresenceState::Away
+        } else {
+            PresenceState::Online
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use error::AppError;
+
+    use super::*;
+    use crate::domain::value_object::{ChannelClass, ChannelKey};
+
+    fn at(h: u32, m: u32, s: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 26, h, m, s).unwrap()
+    }
+
+    fn conn(now: DateTime<Utc>) -> Connection {
+        let session = Session::new(
+            UserId::new("alice").unwrap(),
+            DeviceId::new("dev-1").unwrap(),
+            at(13, 0, 0),
+        );
+        Connection::open(
+            ConnectionId::new("conn-1").unwrap(),
+            NodeId::new("node-7").unwrap(),
+            session,
+            8,
+            now,
+        )
+    }
+
+    fn channel(class: ChannelClass, key: &str) -> ChannelRef {
+        ChannelRef::new(class, ChannelKey::new(key).unwrap())
+    }
+
+    #[test]
+    fn opens_active_and_online() {
+        let c = conn(at(12, 0, 0));
+        assert_eq!(c.state(), ConnectionState::Active);
+        assert_eq!(
+            c.presence(at(12, 0, 10), Duration::seconds(90)),
+            PresenceState::Online
+        );
+    }
+
+    #[test]
+    fn authorizes_subscriptions_against_the_pinned_session() {
+        let mut c = conn(at(12, 0, 0));
+        c.subscribe(channel(ChannelClass::Dm, "alice")).unwrap();
+        let err = c
+            .subscribe(channel(ChannelClass::Dm, "bob"))
+            .unwrap_err();
+        assert_eq!(err.error_code(), "RTM-3001");
+    }
+
+    #[test]
+    fn draining_rejects_new_subscriptions_but_still_delivers() {
+        let mut c = conn(at(12, 0, 0));
+        let counter = channel(ChannelClass::Counter, "post-1");
+        c.subscribe(counter.clone()).unwrap();
+        c.begin_drain().unwrap();
+        // No new subscriptions while draining …
+        let err = c
+            .subscribe(channel(ChannelClass::Counter, "post-2"))
+            .unwrap_err();
+        assert_eq!(err.error_code(), "RTM-5003");
+        // … but an already-subscribed channel still gets sequenced.
+        assert_eq!(c.issue_seq(&counter).unwrap().get(), 1);
+    }
+
+    #[test]
+    fn closed_connection_rejects_everything_and_is_offline() {
+        let mut c = conn(at(12, 0, 0));
+        c.close(CloseReason::HeartbeatTimeout);
+        assert_eq!(
+            c.subscribe(channel(ChannelClass::Dm, "alice"))
+                .unwrap_err()
+                .error_code(),
+            "RTM-9001"
+        );
+        assert_eq!(
+            c.presence(at(12, 0, 1), Duration::seconds(90)),
+            PresenceState::Offline
+        );
+        // close is idempotent; drain after close is a violation.
+        c.close(CloseReason::Draining);
+        assert_eq!(c.begin_drain().unwrap_err().error_code(), "RTM-9001");
+    }
+
+    #[test]
+    fn heartbeat_governs_reaping_and_presence() {
+        let mut c = conn(at(12, 0, 0));
+        let timeout = Duration::seconds(90);
+        // Fresh: online, not reapable.
+        assert!(!c.should_reap(at(12, 1, 0), timeout));
+        assert_eq!(c.presence(at(12, 1, 0), timeout), PresenceState::Online);
+        // Overdue: away, reapable.
+        assert!(c.should_reap(at(12, 2, 0), timeout));
+        assert_eq!(c.presence(at(12, 2, 0), timeout), PresenceState::Away);
+        // A heartbeat resets the clock.
+        c.heartbeat(at(12, 2, 0));
+        assert!(!c.should_reap(at(12, 2, 30), timeout));
+    }
+
+    #[test]
+    fn needs_reauth_after_token_expiry() {
+        let c = conn(at(12, 0, 0));
+        assert!(!c.needs_reauth(at(12, 59, 59)));
+        assert!(c.needs_reauth(at(13, 0, 0)));
+    }
+}

--- a/crates/services/realtime/src/domain/mod.rs
+++ b/crates/services/realtime/src/domain/mod.rs
@@ -1,0 +1,35 @@
+//! The pure domain layer for the realtime delivery plane — the connection model
+//! and the rules that govern a live socket.
+//!
+//! The centre of gravity is the [`connection::Connection`] aggregate: a
+//! clock-injected, I/O-free model of one client socket that owns its pinned
+//! [`session::Session`], its bounded [`subscription::SubscriptionSet`], its
+//! lifecycle state machine, and its heartbeat freshness. Every decision the plane
+//! makes about a socket is a method here and is unit-testable without a broker, a
+//! WebSocket, Redis, or a wall clock.
+//!
+//! Two rules are load-bearing and live in this layer:
+//! * **Channel-scope authorization** ([`session::Session::authorize`]) — the
+//!   plane's only authorization: a connection may subscribe only to channels
+//!   whose key it owns. Content visibility was decided upstream at emit time.
+//! * **Per-`(connection, channel)` sequencing** ([`value_object::SequenceState`])
+//!   — the monotonic stream sequence + ack watermark that drive client dedup and
+//!   at-least-once acknowledgement, with no durable buffer (resume gap-fill is the
+//!   client's job against the owning SoR).
+//!
+//! The proto types (`realtime-api`) are deliberately absent here; the mapping
+//! between these pure types and the generated wire types lives in the
+//! infrastructure tier.
+
+pub mod connection;
+pub mod session;
+pub mod subscription;
+pub mod value_object;
+
+pub use connection::{Connection, ConnectionState, CloseReason};
+pub use session::Session;
+pub use subscription::SubscriptionSet;
+pub use value_object::{
+    ChannelClass, ChannelKey, ChannelRef, ConnectionId, DeliveryGuarantee, DeviceId, NodeId,
+    PresenceState, SequenceState, StreamSeq, UserId,
+};

--- a/crates/services/realtime/src/domain/session.rs
+++ b/crates/services/realtime/src/domain/session.rs
@@ -1,0 +1,111 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::value_object::{ChannelRef, DeviceId, UserId};
+use crate::error::RealtimeError;
+
+/// The pinned identity of an authenticated connection.
+///
+/// A `Session` is created once, at the WebSocket handshake, from the verified
+/// edge token — and is then immutable for the connection's life. Authentication
+/// is never re-checked per frame; only the token's `expires_at` bounds the
+/// session (see [`Session::is_expired`]). This is the linchpin of the plane's
+/// security model: every authorization decision is made against this fixed
+/// identity, so a frame can never act as another user.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Session {
+    pub user_id: UserId,
+    pub device_id: DeviceId,
+    /// Absolute expiry of the edge token that authenticated this session.
+    pub expires_at: DateTime<Utc>,
+}
+
+impl Session {
+    pub fn new(user_id: UserId, device_id: DeviceId, expires_at: DateTime<Utc>) -> Self {
+        Self {
+            user_id,
+            device_id,
+            expires_at,
+        }
+    }
+
+    /// Whether the session's edge token has lapsed as of `now`. When true, the
+    /// gateway sends a re-auth directive; the client refreshes and re-presents a
+    /// token (or re-handshakes) — see `RTM-1002`.
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now >= self.expires_at
+    }
+
+    /// The plane's **one and only** authorization rule: a connection may subscribe
+    /// to a channel only if it *owns* the channel's key.
+    ///
+    /// * Identity-scoped classes (DM / NOTIFICATION / PRESENCE): the key must
+    ///   equal this session's `user_id` — you cannot tap another user's stream.
+    ///   A mismatch is `RTM-3001 ChannelForbidden` (a security-relevant denial).
+    /// * Public classes (COUNTER / FEED): any authenticated identity may
+    ///   subscribe; content visibility was already decided upstream at emit time.
+    pub fn authorize(&self, channel: &ChannelRef) -> Result<(), RealtimeError> {
+        if channel.class.is_identity_scoped() && channel.key.as_str() != self.user_id.as_str() {
+            return Err(RealtimeError::ChannelForbidden {
+                channel: channel.to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use error::AppError;
+
+    use super::*;
+    use crate::domain::value_object::{ChannelClass, ChannelKey};
+
+    fn session_for(user: &str) -> Session {
+        Session::new(
+            UserId::new(user).unwrap(),
+            DeviceId::new("dev-1").unwrap(),
+            Utc.with_ymd_and_hms(2026, 6, 26, 12, 0, 0).unwrap(),
+        )
+    }
+
+    fn channel(class: ChannelClass, key: &str) -> ChannelRef {
+        ChannelRef::new(class, ChannelKey::new(key).unwrap())
+    }
+
+    #[test]
+    fn expiry_is_inclusive_of_now() {
+        let s = session_for("alice");
+        let before = Utc.with_ymd_and_hms(2026, 6, 26, 11, 59, 59).unwrap();
+        let at = Utc.with_ymd_and_hms(2026, 6, 26, 12, 0, 0).unwrap();
+        assert!(!s.is_expired(before));
+        assert!(s.is_expired(at));
+    }
+
+    #[test]
+    fn owns_its_own_identity_scoped_channels() {
+        let s = session_for("alice");
+        s.authorize(&channel(ChannelClass::Dm, "alice")).unwrap();
+        s.authorize(&channel(ChannelClass::Notification, "alice"))
+            .unwrap();
+        s.authorize(&channel(ChannelClass::Presence, "alice"))
+            .unwrap();
+    }
+
+    #[test]
+    fn cannot_tap_another_users_stream() {
+        let s = session_for("alice");
+        let err = s.authorize(&channel(ChannelClass::Dm, "bob")).unwrap_err();
+        assert_eq!(err.error_code(), "RTM-3001");
+    }
+
+    #[test]
+    fn any_identity_may_subscribe_to_public_channels() {
+        let s = session_for("alice");
+        // A public entity stream is keyed by entity id, not the subscriber.
+        s.authorize(&channel(ChannelClass::Counter, "post-42"))
+            .unwrap();
+        s.authorize(&channel(ChannelClass::Feed, "author-9")).unwrap();
+    }
+}

--- a/crates/services/realtime/src/domain/subscription.rs
+++ b/crates/services/realtime/src/domain/subscription.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+
+use crate::domain::value_object::{ChannelRef, SequenceState, StreamSeq};
+use crate::error::RealtimeError;
+
+/// The bounded set of channels a connection is subscribed to, each carrying its
+/// own [`SequenceState`] (the per-channel sequence + ack watermark).
+///
+/// This type owns *membership and sequencing*, not authorization — the caller
+/// ([`super::connection::Connection`]) authorizes a channel against the session
+/// before adding it here. Keeping authz out of the set keeps this purely about
+/// "what is subscribed and where is its sequence".
+#[derive(Debug, Clone)]
+pub struct SubscriptionSet {
+    channels: HashMap<ChannelRef, SequenceState>,
+    cap: usize,
+}
+
+impl SubscriptionSet {
+    /// Create an empty set bounded at `cap` channels. The cap is the per-connection
+    /// subscription limit that protects node memory from an unbounded fan-in.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            channels: HashMap::new(),
+            cap,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.channels.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
+    pub fn is_subscribed(&self, channel: &ChannelRef) -> bool {
+        self.channels.contains_key(channel)
+    }
+
+    /// Subscribe to `channel`. Idempotent: re-subscribing to an existing channel
+    /// is a no-op that preserves its sequence state (so a duplicate Subscribe
+    /// never resets a client's ack progress). Returns `true` if newly added.
+    ///
+    /// Exceeding `cap` is `RTM-3002 SubscriptionLimitExceeded`.
+    pub fn subscribe(&mut self, channel: ChannelRef) -> Result<bool, RealtimeError> {
+        if self.channels.contains_key(&channel) {
+            return Ok(false);
+        }
+        if self.channels.len() >= self.cap {
+            return Err(RealtimeError::SubscriptionLimitExceeded);
+        }
+        self.channels.insert(channel, SequenceState::new());
+        Ok(true)
+    }
+
+    /// Unsubscribe from `channel`. Unsubscribing from a channel that is not
+    /// subscribed is `RTM-3003 NotSubscribed`.
+    pub fn unsubscribe(&mut self, channel: &ChannelRef) -> Result<(), RealtimeError> {
+        self.channels
+            .remove(channel)
+            .map(|_| ())
+            .ok_or_else(|| RealtimeError::NotSubscribed {
+                channel: channel.to_string(),
+            })
+    }
+
+    /// Assign the next stream sequence for an event about to be delivered on
+    /// `channel`. `RTM-3003 NotSubscribed` if the connection is not subscribed.
+    pub fn issue_seq(&mut self, channel: &ChannelRef) -> Result<StreamSeq, RealtimeError> {
+        self.channels
+            .get_mut(channel)
+            .map(SequenceState::issue)
+            .ok_or_else(|| RealtimeError::NotSubscribed {
+                channel: channel.to_string(),
+            })
+    }
+
+    /// Record a client ack up to `seq` on `channel`. `RTM-3003 NotSubscribed` if
+    /// not subscribed; `RTM-2004 SequenceViolation` if the ack exceeds what was
+    /// issued (propagated from [`SequenceState::ack`]).
+    pub fn ack(&mut self, channel: &ChannelRef, seq: StreamSeq) -> Result<(), RealtimeError> {
+        self.channels
+            .get_mut(channel)
+            .ok_or_else(|| RealtimeError::NotSubscribed {
+                channel: channel.to_string(),
+            })?
+            .ack(seq)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+    use crate::domain::value_object::{ChannelClass, ChannelKey, SequenceState};
+
+    fn channel(class: ChannelClass, key: &str) -> ChannelRef {
+        ChannelRef::new(class, ChannelKey::new(key).unwrap())
+    }
+
+    #[test]
+    fn subscribe_is_idempotent_and_preserves_sequence() {
+        let mut set = SubscriptionSet::new(8);
+        let dm = channel(ChannelClass::Dm, "alice");
+        assert!(set.subscribe(dm.clone()).unwrap()); // newly added
+        let s1 = set.issue_seq(&dm).unwrap();
+        assert_eq!(s1.get(), 1);
+        // Re-subscribe must NOT reset the sequence back to 1.
+        assert!(!set.subscribe(dm.clone()).unwrap());
+        assert_eq!(set.issue_seq(&dm).unwrap().get(), 2);
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn enforces_the_cap() {
+        let mut set = SubscriptionSet::new(1);
+        set.subscribe(channel(ChannelClass::Dm, "alice")).unwrap();
+        let err = set
+            .subscribe(channel(ChannelClass::Counter, "post-1"))
+            .unwrap_err();
+        assert_eq!(err.error_code(), "RTM-3002");
+    }
+
+    #[test]
+    fn unsubscribe_unknown_channel_is_rejected() {
+        let mut set = SubscriptionSet::new(8);
+        let err = set
+            .unsubscribe(&channel(ChannelClass::Dm, "alice"))
+            .unwrap_err();
+        assert_eq!(err.error_code(), "RTM-3003");
+    }
+
+    #[test]
+    fn issue_and_ack_on_unsubscribed_channel_are_rejected() {
+        let mut set = SubscriptionSet::new(8);
+        let dm = channel(ChannelClass::Dm, "alice");
+        assert_eq!(set.issue_seq(&dm).unwrap_err().error_code(), "RTM-3003");
+        // A valid StreamSeq value (the NotSubscribed check fires before sequencing).
+        let seq = SequenceState::new().issue();
+        assert_eq!(set.ack(&dm, seq).unwrap_err().error_code(), "RTM-3003");
+    }
+}

--- a/crates/services/realtime/src/domain/value_object/channel.rs
+++ b/crates/services/realtime/src/domain/value_object/channel.rs
@@ -1,0 +1,186 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::RealtimeError;
+
+/// The delivery guarantee a channel class carries. Drives whether a delivered
+/// event sets `ack_required` (and is tracked against an ack watermark) or is
+/// pure fire-and-forget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryGuarantee {
+    /// The client must acknowledge; the server tracks an ack watermark. Used for
+    /// DM / NOTIFICATION, where a missed item matters (and is re-synced from the
+    /// owning SoR on reconnect).
+    AtLeastOnce,
+    /// No ack; a dropped frame is superseded by the next. Used for PRESENCE /
+    /// COUNTER / FEED, where only the latest state matters.
+    FireAndForget,
+}
+
+/// The multiplex channel class. Mirrors `realtime.v1.ChannelClass` but is a pure
+/// domain type — the proto mapping (and its `+1`/`UNSPECIFIED` offset) lives in
+/// the infrastructure tier, keeping the domain free of generated types.
+///
+/// The split between *identity-scoped* (DM / NOTIFICATION / PRESENCE) and
+/// *public* (COUNTER / FEED) classes is load-bearing: it is the entire basis of
+/// the plane's authorization (see [`super::super::session::Session::authorize`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ChannelClass {
+    Dm,
+    Notification,
+    Presence,
+    Counter,
+    Feed,
+}
+
+impl ChannelClass {
+    /// Stable lowercase discriminant used in channel rendering, registry keys,
+    /// and event mapping. Part of the wire/storage contract — treat changes as a
+    /// migration.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ChannelClass::Dm => "dm",
+            ChannelClass::Notification => "notif",
+            ChannelClass::Presence => "presence",
+            ChannelClass::Counter => "counter",
+            ChannelClass::Feed => "feed",
+        }
+    }
+
+    /// Parse the stable discriminant. An unrecognized value is a contract fault,
+    /// surfaced as `RTM-9001 DomainViolation`.
+    pub fn try_from_str(s: &str) -> Result<Self, RealtimeError> {
+        match s {
+            "dm" => Ok(ChannelClass::Dm),
+            "notif" => Ok(ChannelClass::Notification),
+            "presence" => Ok(ChannelClass::Presence),
+            "counter" => Ok(ChannelClass::Counter),
+            "feed" => Ok(ChannelClass::Feed),
+            other => Err(RealtimeError::DomainViolation {
+                field: "channel_class".to_owned(),
+                message: format!("unknown channel class '{other}'"),
+            }),
+        }
+    }
+
+    /// Whether the channel key must equal the connection's pinned identity. True
+    /// for the per-user classes (DM / NOTIFICATION / PRESENCE); false for the
+    /// public entity classes (COUNTER / FEED).
+    pub fn is_identity_scoped(&self) -> bool {
+        matches!(
+            self,
+            ChannelClass::Dm | ChannelClass::Notification | ChannelClass::Presence
+        )
+    }
+
+    /// The delivery guarantee for this class.
+    pub fn delivery(&self) -> DeliveryGuarantee {
+        match self {
+            ChannelClass::Dm | ChannelClass::Notification => DeliveryGuarantee::AtLeastOnce,
+            ChannelClass::Presence | ChannelClass::Counter | ChannelClass::Feed => {
+                DeliveryGuarantee::FireAndForget
+            }
+        }
+    }
+
+    /// Convenience: whether a delivered event on this class requires a client ack.
+    pub fn ack_required(&self) -> bool {
+        self.delivery() == DeliveryGuarantee::AtLeastOnce
+    }
+}
+
+/// The qualifier a channel class scopes to: the user id for identity-scoped
+/// classes, the entity id for public ones. Opaque, non-empty.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChannelKey(String);
+
+impl ChannelKey {
+    pub fn new(value: impl Into<String>) -> Result<Self, RealtimeError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(RealtimeError::InvalidIdentifier("channel_key".to_owned()));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A channel is a `(class, key)` pair — the addressable unit a connection
+/// subscribes to and an event is delivered on.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChannelRef {
+    pub class: ChannelClass,
+    pub key: ChannelKey,
+}
+
+impl ChannelRef {
+    pub fn new(class: ChannelClass, key: ChannelKey) -> Self {
+        Self { class, key }
+    }
+}
+
+impl std::fmt::Display for ChannelRef {
+    /// Renders as `class:key` (e.g. `dm:alice`, `counter:post-42`) — the form used
+    /// in error messages and logs.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.class.as_str(), self.key.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn class_round_trips() {
+        for class in [
+            ChannelClass::Dm,
+            ChannelClass::Notification,
+            ChannelClass::Presence,
+            ChannelClass::Counter,
+            ChannelClass::Feed,
+        ] {
+            assert_eq!(ChannelClass::try_from_str(class.as_str()).unwrap(), class);
+        }
+    }
+
+    #[test]
+    fn class_rejects_unknown() {
+        let err = ChannelClass::try_from_str("mail").unwrap_err();
+        assert_eq!(err.error_code(), "RTM-9001");
+    }
+
+    #[test]
+    fn identity_scoping_and_delivery_are_consistent() {
+        // Per-user classes are identity-scoped and at-least-once (notif/dm) …
+        assert!(ChannelClass::Dm.is_identity_scoped());
+        assert!(ChannelClass::Notification.is_identity_scoped());
+        assert!(ChannelClass::Dm.ack_required());
+        assert!(ChannelClass::Notification.ack_required());
+        // … presence is identity-scoped but fire-and-forget …
+        assert!(ChannelClass::Presence.is_identity_scoped());
+        assert!(!ChannelClass::Presence.ack_required());
+        // … public entity classes are neither scoped nor acked.
+        assert!(!ChannelClass::Counter.is_identity_scoped());
+        assert!(!ChannelClass::Feed.is_identity_scoped());
+        assert!(!ChannelClass::Counter.ack_required());
+    }
+
+    #[test]
+    fn channel_renders_class_colon_key() {
+        let ch = ChannelRef::new(ChannelClass::Dm, ChannelKey::new("alice").unwrap());
+        assert_eq!(ch.to_string(), "dm:alice");
+    }
+
+    #[test]
+    fn channel_key_rejects_blank() {
+        assert_eq!(
+            ChannelKey::new("  ").unwrap_err().error_code(),
+            "RTM-9002"
+        );
+    }
+}

--- a/crates/services/realtime/src/domain/value_object/identity.rs
+++ b/crates/services/realtime/src/domain/value_object/identity.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::RealtimeError;
+
+/// Declares an opaque, non-empty `String` newtype used as a domain identifier.
+/// A blank value is a malformed input, surfaced as `RTM-9002 InvalidIdentifier`
+/// with the field name. The realtime plane never interprets these beyond equality
+/// and key composition — they are references to subjects owned elsewhere.
+macro_rules! string_id {
+    ($(#[$meta:meta])* $name:ident, $field:literal) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, RealtimeError> {
+                let value = value.into();
+                if value.trim().is_empty() {
+                    return Err(RealtimeError::InvalidIdentifier($field.to_owned()));
+                }
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+string_id!(
+    /// The authenticated end-user a connection is pinned to (from the verified
+    /// edge token). The authorization subject: identity-scoped channel keys must
+    /// equal this.
+    UserId, "user_id"
+);
+
+string_id!(
+    /// The specific device/installation behind a connection. A single `UserId`
+    /// may hold several connections (phone + tablet + web), each a distinct
+    /// `DeviceId`.
+    DeviceId, "device_id"
+);
+
+string_id!(
+    /// A single live connection, server-assigned at the handshake. Unique within
+    /// a gateway node for the connection's lifetime.
+    ConnectionId, "connection_id"
+);
+
+string_id!(
+    /// A gateway node in the edge pool. The registry maps a `UserId` to the
+    /// `NodeId`(s) holding its sockets; the dispatcher publishes to that node's
+    /// hop channel.
+    NodeId, "node_id"
+);
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn accepts_non_empty() {
+        assert_eq!(UserId::new("alice").unwrap().as_str(), "alice");
+        assert_eq!(DeviceId::new("dev-1").unwrap().as_str(), "dev-1");
+        assert_eq!(ConnectionId::new("conn-1").unwrap().as_str(), "conn-1");
+        assert_eq!(NodeId::new("node-7").unwrap().as_str(), "node-7");
+    }
+
+    #[test]
+    fn rejects_blank_with_field_named_code() {
+        let err = UserId::new("   ").unwrap_err();
+        assert_eq!(err.error_code(), "RTM-9002");
+        assert!(err.to_string().contains("user_id"));
+
+        assert_eq!(NodeId::new("").unwrap_err().error_code(), "RTM-9002");
+    }
+}

--- a/crates/services/realtime/src/domain/value_object/mod.rs
+++ b/crates/services/realtime/src/domain/value_object/mod.rs
@@ -1,0 +1,14 @@
+//! Pure value objects for the realtime delivery model. No I/O, no clock reads
+//! (time is injected as `DateTime<Utc>` parameters), no transport or store
+//! awareness, no dependency on the generated `realtime-api` types (the proto
+//! mapping lives in the infrastructure tier).
+
+pub mod channel;
+pub mod identity;
+pub mod presence;
+pub mod sequence;
+
+pub use channel::{ChannelClass, ChannelKey, ChannelRef, DeliveryGuarantee};
+pub use identity::{ConnectionId, DeviceId, NodeId, UserId};
+pub use presence::PresenceState;
+pub use sequence::{SequenceState, StreamSeq};

--- a/crates/services/realtime/src/domain/value_object/presence.rs
+++ b/crates/services/realtime/src/domain/value_object/presence.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+/// The derived liveness of a connection/user.
+///
+/// In v1 presence is **internal liveness only** (a byproduct of connection state
+/// used for reaping and the offline-push handoff to `notification`), not a
+/// product-facing contract — see `project_realtime_blueprint`. It is *derived*,
+/// never authoritative: it falls out of whether a connection is active and its
+/// heartbeat is fresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PresenceState {
+    /// An active connection with a fresh heartbeat.
+    Online,
+    /// Connected, but the heartbeat is overdue (within the reap grace window) —
+    /// likely a radio sleep or a flaky link, not yet reaped.
+    Away,
+    /// No live connection (closed, or reaped after the heartbeat deadline).
+    Offline,
+}
+
+impl PresenceState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PresenceState::Online => "online",
+            PresenceState::Away => "away",
+            PresenceState::Offline => "offline",
+        }
+    }
+}

--- a/crates/services/realtime/src/domain/value_object/sequence.rs
+++ b/crates/services/realtime/src/domain/value_object/sequence.rs
@@ -1,0 +1,152 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::RealtimeError;
+
+/// A per-`(connection, channel)` monotonic stream sequence number. Starts at 1
+/// for the first event delivered on a channel; the client dedupes on it, acks on
+/// it (at-least-once channels), and presents it as its resume cursor.
+///
+/// Sequences are scoped to a *connection*: a reconnect is a fresh connection and
+/// restarts at 1. The plane buffers nothing, so cross-connection gap-fill is the
+/// client's job against the owning SoR — the sequence is a within-connection
+/// ordering/dedup device, not a durable log offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct StreamSeq(u64);
+
+impl StreamSeq {
+    /// Wrap a raw sequence value — used at the wire boundary to reconstruct the
+    /// sequence a client acked. Whether it is in range is validated by
+    /// [`SequenceState::ack`], not here.
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for StreamSeq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The sequence + ack state for one subscribed channel on one connection.
+///
+/// Invariant: `0 <= ack_watermark < next`. `next` is the value the *next*
+/// delivered event will carry; `ack_watermark` is the highest sequence the
+/// client has acknowledged (always 0 for fire-and-forget channels, which are
+/// never acked).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequenceState {
+    next: u64,
+    ack_watermark: u64,
+}
+
+impl Default for SequenceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SequenceState {
+    pub fn new() -> Self {
+        Self {
+            next: 1,
+            ack_watermark: 0,
+        }
+    }
+
+    /// Assign the next sequence to an event about to be delivered, advancing the
+    /// counter. Infallible and monotonic.
+    pub fn issue(&mut self) -> StreamSeq {
+        let seq = self.next;
+        self.next += 1;
+        StreamSeq(seq)
+    }
+
+    /// The highest sequence handed out so far (0 if none issued yet).
+    pub fn last_issued(&self) -> u64 {
+        self.next - 1
+    }
+
+    /// The current ack watermark.
+    pub fn ack_watermark(&self) -> u64 {
+        self.ack_watermark
+    }
+
+    /// Record a client acknowledgement up to `seq`.
+    ///
+    /// * Acking beyond what was issued is impossible and rejected as
+    ///   `RTM-2004 SequenceViolation` (a malformed or hostile client).
+    /// * A duplicate / out-of-order ack at or below the current watermark is a
+    ///   benign no-op (at-least-once delivery means clients may re-ack).
+    /// * Otherwise the watermark advances to `seq`.
+    pub fn ack(&mut self, seq: StreamSeq) -> Result<(), RealtimeError> {
+        if seq.0 > self.last_issued() {
+            return Err(RealtimeError::SequenceViolation {
+                reason: format!(
+                    "ack {} exceeds last issued {}",
+                    seq.0,
+                    self.last_issued()
+                ),
+            });
+        }
+        if seq.0 > self.ack_watermark {
+            self.ack_watermark = seq.0;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn issues_monotonically_from_one() {
+        let mut s = SequenceState::new();
+        assert_eq!(s.issue().get(), 1);
+        assert_eq!(s.issue().get(), 2);
+        assert_eq!(s.issue().get(), 3);
+        assert_eq!(s.last_issued(), 3);
+    }
+
+    #[test]
+    fn ack_advances_watermark() {
+        let mut s = SequenceState::new();
+        let _ = s.issue();
+        let two = s.issue();
+        s.ack(two).unwrap();
+        assert_eq!(s.ack_watermark(), 2);
+    }
+
+    #[test]
+    fn duplicate_or_stale_ack_is_a_noop() {
+        let mut s = SequenceState::new();
+        let one = s.issue();
+        let _ = s.issue();
+        s.ack(one).unwrap();
+        s.ack(one).unwrap(); // re-ack tolerated
+        assert_eq!(s.ack_watermark(), 1);
+    }
+
+    #[test]
+    fn ack_beyond_issued_is_a_sequence_violation() {
+        let mut s = SequenceState::new();
+        let one = s.issue(); // last_issued == 1
+        let _ = one;
+        // Forge a sequence the server never handed out.
+        let forged = {
+            let mut tmp = SequenceState::new();
+            tmp.issue();
+            tmp.issue();
+            tmp.issue() // StreamSeq(3)
+        };
+        let err = s.ack(forged).unwrap_err();
+        assert_eq!(err.error_code(), "RTM-2004");
+    }
+}

--- a/crates/services/realtime/src/error.rs
+++ b/crates/services/realtime/src/error.rs
@@ -1,0 +1,342 @@
+use error::{AppError, Severity};
+use http::StatusCode;
+use thiserror::Error;
+
+/// Canonical domain and application error type for the realtime delivery
+/// microservice.
+///
+/// The `RTM-XXXX` namespace is grouped by concern so a code alone localizes the
+/// fault: 1xxx connection handshake / authentication, 2xxx transport / framing /
+/// protocol, 3xxx subscription authorization (the only authz the plane performs
+/// — channel-scope ownership), 4xxx delivery-fabric availability (the fail-open
+/// core: registry + node-hop), 5xxx connection lifecycle / backpressure, 8xxx
+/// inbound event decode / routing (the dispatcher's Kafka surface), 9xxx
+/// cross-cutting (domain/parse, event consumption).
+///
+/// ## Code catalogue
+///
+/// | Code     | Variant                     | HTTP | Severity | Retryable |
+/// |----------|-----------------------------|------|----------|-----------|
+/// | RTM-1001 | HandshakeRejected           | 401  | Medium   | No        |
+/// | RTM-1002 | TokenExpired                | 401  | Low      | No        |
+/// | RTM-1003 | UnsupportedProtocolVersion  | 426  | Low      | No        |
+/// | RTM-1004 | OriginNotAllowed            | 403  | Medium   | No        |
+/// | RTM-2001 | MalformedFrame              | 400  | Low      | No        |
+/// | RTM-2002 | UnknownChannel              | 422  | Low      | No        |
+/// | RTM-2003 | FrameTooLarge               | 413  | Low      | No        |
+/// | RTM-2004 | SequenceViolation           | 422  | Low      | No        |
+/// | RTM-3001 | ChannelForbidden            | 403  | **High** | No        |
+/// | RTM-3002 | SubscriptionLimitExceeded   | 429  | Low      | No        |
+/// | RTM-3003 | NotSubscribed               | 409  | Low      | No        |
+/// | RTM-4001 | RegistryUnavailable         | 503  | **High** | **Yes**   |
+/// | RTM-4002 | NodeChannelUnavailable      | 503  | **High** | **Yes**   |
+/// | RTM-4003 | DeliveryTimeout             | 504  | **High** | **Yes**   |
+/// | RTM-5001 | SendQueueOverflow           | 503  | Medium   | No        |
+/// | RTM-5002 | HeartbeatTimeout            | 408  | Low      | No        |
+/// | RTM-5003 | ConnectionDraining          | 503  | Low      | **Yes**   |
+/// | RTM-5004 | ConnectionClosed            | 410  | Low      | No        |
+/// | RTM-8001 | EventDecodeFailed           | 422  | Medium   | No        |
+/// | RTM-8002 | UnroutableEvent             | 422  | Low      | No        |
+/// | RTM-8003 | UnknownEventType            | 422  | Low      | No        |
+/// | RTM-9001 | DomainViolation             | 422  | Medium   | No        |
+/// | RTM-9002 | InvalidIdentifier           | 422  | Low      | No        |
+/// | RTM-9003 | EventConsumeFailed          | 500  | Medium   | No        |
+/// | VAL-*    | Validation (delegated)      | 422  | Low      | No        |
+///
+/// > **Fail-open semantics.** Realtime is a best-effort *delivery* plane, never a
+/// > System of Record. The `4xxx` delivery-fabric faults are *transient*: on the
+/// > **client** path a delivery miss degrades silently — the message is durable in
+/// > its owning SoR (`chat` / `notification`) and the client re-syncs on reconnect
+/// > via its sequence token, never a hard error; on the **dispatcher** (Kafka)
+/// > path their `is_retryable` flags drive the `run_consumer` retry/DLQ
+/// > classification — a redelivered event re-resolves the registry and re-fans-out
+/// > idempotently, a poison event (`RTM-8001`) is dead-lettered, and an
+/// > unroutable/unknown event (`RTM-8002` / `RTM-8003`) is a harmless skip folded
+/// > into `Ok` so the offset still commits. The plane stores nothing; losing a
+/// > live event costs latency, never data.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RealtimeError {
+    // ── Delegated ─────────────────────────────────────────────────────────────
+    #[error(transparent)]
+    Validation(#[from] validation::ValidationError),
+
+    // ── Connection handshake / authentication (RTM-1xxx) ──────────────────────
+    /// The WebSocket upgrade presented a missing, malformed, or invalid edge
+    /// token. Authentication happens **once**, at the handshake — never per frame.
+    #[error("connection handshake rejected: {reason}")]
+    HandshakeRejected { reason: String },
+
+    /// The session's edge token lapsed mid-connection; the client must silently
+    /// refresh via `auth` and re-handshake.
+    #[error("session token expired")]
+    TokenExpired,
+
+    #[error("unsupported client protocol version: '{version}'")]
+    UnsupportedProtocolVersion { version: String },
+
+    #[error("connection origin not allowed: '{origin}'")]
+    OriginNotAllowed { origin: String },
+
+    // ── Transport / framing / protocol (RTM-2xxx) ─────────────────────────────
+    #[error("malformed transport frame: {reason}")]
+    MalformedFrame { reason: String },
+
+    #[error("unknown multiplex channel: '{channel}'")]
+    UnknownChannel { channel: String },
+
+    #[error("inbound frame exceeds the size cap: {size} bytes")]
+    FrameTooLarge { size: usize },
+
+    #[error("resume/ack sequence out of range: {reason}")]
+    SequenceViolation { reason: String },
+
+    // ── Subscription authorization · the plane's only authz (RTM-3xxx) ────────
+    /// A connection tried to subscribe to a channel not scoped to its pinned
+    /// identity — i.e. an attempt to tap someone else's stream. Security-relevant.
+    #[error("subscription to channel '{channel}' is forbidden for this identity")]
+    ChannelForbidden { channel: String },
+
+    #[error("per-connection subscription limit exceeded")]
+    SubscriptionLimitExceeded,
+
+    #[error("not subscribed to channel '{channel}'")]
+    NotSubscribed { channel: String },
+
+    // ── Delivery fabric availability · the fail-open core (RTM-4xxx) ──────────
+    /// The connection/presence registry (Redis) is unavailable — the dispatcher
+    /// cannot resolve which node owns a recipient's socket.
+    #[error("the connection registry is unavailable")]
+    RegistryUnavailable,
+
+    /// The node-hop fabric (Redis Pub/Sub) is unavailable — a resolved event
+    /// cannot be published to the owning gateway node.
+    #[error("the node-delivery channel is unavailable")]
+    NodeChannelUnavailable,
+
+    #[error("delivery to the owning node timed out")]
+    DeliveryTimeout,
+
+    // ── Connection lifecycle / backpressure (RTM-5xxx) ────────────────────────
+    /// The per-connection send queue is full; the slow consumer is shed rather
+    /// than allowed to balloon node memory. Not retryable in place.
+    #[error("connection send queue overflowed; shedding slow consumer")]
+    SendQueueOverflow,
+
+    /// No heartbeat pong arrived within the deadline; the half-open connection is
+    /// reaped, freeing its file descriptor and registry slot.
+    #[error("heartbeat deadline exceeded; reaping connection")]
+    HeartbeatTimeout,
+
+    /// The node is draining on rollout; the client should reconnect elsewhere
+    /// with jittered backoff. Retryable from the client's perspective.
+    #[error("connection draining; reconnect with backoff")]
+    ConnectionDraining,
+
+    #[error("connection closed by peer")]
+    ConnectionClosed,
+
+    // ── Inbound event decode / routing · dispatcher surface (RTM-8xxx) ────────
+    #[error("failed to decode event from topic '{topic}': {reason}")]
+    EventDecodeFailed { topic: String, reason: String },
+
+    /// The event carries no addressable recipient (no live target); a harmless
+    /// skip folded into `Ok` so the offset still commits.
+    #[error("event has no routable recipient: {reason}")]
+    UnroutableEvent { reason: String },
+
+    /// An event type this dispatcher does not fan out; folded into an `Ok` skip
+    /// rather than dead-lettered.
+    #[error("unknown event type: '{event_type}'")]
+    UnknownEventType { event_type: String },
+
+    // ── Cross-cutting (RTM-9xxx) ──────────────────────────────────────────────
+    #[error("domain invariant violated on '{field}': {message}")]
+    DomainViolation { field: String, message: String },
+
+    #[error("invalid identifier: '{0}'")]
+    InvalidIdentifier(String),
+
+    #[error("failed to consume event: {0}")]
+    EventConsumeFailed(String),
+}
+
+impl AppError for RealtimeError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            RealtimeError::Validation(e) => e.error_code(),
+
+            RealtimeError::HandshakeRejected { .. } => "RTM-1001",
+            RealtimeError::TokenExpired => "RTM-1002",
+            RealtimeError::UnsupportedProtocolVersion { .. } => "RTM-1003",
+            RealtimeError::OriginNotAllowed { .. } => "RTM-1004",
+
+            RealtimeError::MalformedFrame { .. } => "RTM-2001",
+            RealtimeError::UnknownChannel { .. } => "RTM-2002",
+            RealtimeError::FrameTooLarge { .. } => "RTM-2003",
+            RealtimeError::SequenceViolation { .. } => "RTM-2004",
+
+            RealtimeError::ChannelForbidden { .. } => "RTM-3001",
+            RealtimeError::SubscriptionLimitExceeded => "RTM-3002",
+            RealtimeError::NotSubscribed { .. } => "RTM-3003",
+
+            RealtimeError::RegistryUnavailable => "RTM-4001",
+            RealtimeError::NodeChannelUnavailable => "RTM-4002",
+            RealtimeError::DeliveryTimeout => "RTM-4003",
+
+            RealtimeError::SendQueueOverflow => "RTM-5001",
+            RealtimeError::HeartbeatTimeout => "RTM-5002",
+            RealtimeError::ConnectionDraining => "RTM-5003",
+            RealtimeError::ConnectionClosed => "RTM-5004",
+
+            RealtimeError::EventDecodeFailed { .. } => "RTM-8001",
+            RealtimeError::UnroutableEvent { .. } => "RTM-8002",
+            RealtimeError::UnknownEventType { .. } => "RTM-8003",
+
+            RealtimeError::DomainViolation { .. } => "RTM-9001",
+            RealtimeError::InvalidIdentifier(_) => "RTM-9002",
+            RealtimeError::EventConsumeFailed(_) => "RTM-9003",
+        }
+    }
+
+    fn http_status(&self) -> StatusCode {
+        match self {
+            RealtimeError::Validation(e) => e.http_status(),
+
+            RealtimeError::HandshakeRejected { .. } | RealtimeError::TokenExpired => {
+                StatusCode::UNAUTHORIZED
+            }
+            RealtimeError::UnsupportedProtocolVersion { .. } => StatusCode::UPGRADE_REQUIRED,
+            RealtimeError::OriginNotAllowed { .. } | RealtimeError::ChannelForbidden { .. } => {
+                StatusCode::FORBIDDEN
+            }
+
+            RealtimeError::MalformedFrame { .. } => StatusCode::BAD_REQUEST,
+            RealtimeError::FrameTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+            RealtimeError::SubscriptionLimitExceeded => StatusCode::TOO_MANY_REQUESTS,
+            RealtimeError::NotSubscribed { .. } => StatusCode::CONFLICT,
+
+            RealtimeError::RegistryUnavailable
+            | RealtimeError::NodeChannelUnavailable
+            | RealtimeError::SendQueueOverflow
+            | RealtimeError::ConnectionDraining => StatusCode::SERVICE_UNAVAILABLE,
+
+            RealtimeError::DeliveryTimeout => StatusCode::GATEWAY_TIMEOUT,
+            RealtimeError::HeartbeatTimeout => StatusCode::REQUEST_TIMEOUT,
+            RealtimeError::ConnectionClosed => StatusCode::GONE,
+
+            RealtimeError::EventConsumeFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+
+            _ => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            RealtimeError::Validation(e) => e.severity(),
+
+            RealtimeError::ChannelForbidden { .. }
+            | RealtimeError::RegistryUnavailable
+            | RealtimeError::NodeChannelUnavailable
+            | RealtimeError::DeliveryTimeout => Severity::High,
+
+            RealtimeError::HandshakeRejected { .. }
+            | RealtimeError::OriginNotAllowed { .. }
+            | RealtimeError::SendQueueOverflow
+            | RealtimeError::EventDecodeFailed { .. }
+            | RealtimeError::DomainViolation { .. }
+            | RealtimeError::EventConsumeFailed(_) => Severity::Medium,
+
+            _ => Severity::Low,
+        }
+    }
+
+    fn is_retryable(&self) -> bool {
+        match self {
+            RealtimeError::Validation(e) => e.is_retryable(),
+            RealtimeError::RegistryUnavailable
+            | RealtimeError::NodeChannelUnavailable
+            | RealtimeError::DeliveryTimeout
+            | RealtimeError::ConnectionDraining => true,
+            _ => false,
+        }
+    }
+
+    fn category(&self) -> &'static str {
+        match self {
+            RealtimeError::Validation(e) => e.category(),
+            _ => "RTM",
+        }
+    }
+
+    fn user_facing_message(&self) -> &'static str {
+        match self {
+            RealtimeError::Validation(e) => e.user_facing_message(),
+
+            RealtimeError::HandshakeRejected { .. }
+            | RealtimeError::TokenExpired
+            | RealtimeError::OriginNotAllowed { .. } => {
+                "Your realtime session could not be authenticated."
+            }
+
+            RealtimeError::ChannelForbidden { .. } => {
+                "You are not allowed to subscribe to that channel."
+            }
+
+            RealtimeError::RegistryUnavailable
+            | RealtimeError::NodeChannelUnavailable
+            | RealtimeError::DeliveryTimeout
+            | RealtimeError::ConnectionDraining => {
+                "Live updates are temporarily unavailable. Reconnecting…"
+            }
+
+            _ => "A realtime delivery error occurred.",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant must carry a stable, correctly-prefixed `RTM-XXXX` code and
+    /// agree with the documented retry classification that drives `run_consumer`
+    /// on the dispatcher and the fail-open degradation on the client path.
+    #[test]
+    fn codes_are_stable_and_prefixed() {
+        // Fail-open delivery-fabric fault → retryable, drives consumer retry.
+        let registry_down = RealtimeError::RegistryUnavailable;
+        assert_eq!(registry_down.error_code(), "RTM-4001");
+        assert!(registry_down.is_retryable());
+        assert_eq!(
+            registry_down.http_status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(registry_down.severity(), Severity::High);
+        assert_eq!(registry_down.category(), "RTM");
+
+        // Security-relevant authz denial — the plane's only authorization check.
+        let forbidden = RealtimeError::ChannelForbidden {
+            channel: "dm:bob".into(),
+        };
+        assert_eq!(forbidden.error_code(), "RTM-3001");
+        assert_eq!(forbidden.http_status(), StatusCode::FORBIDDEN);
+        assert_eq!(forbidden.severity(), Severity::High);
+        assert!(!forbidden.is_retryable());
+
+        // Poison upstream event → DLQ, never an infinite retry.
+        let poison = RealtimeError::EventDecodeFailed {
+            topic: "notification.v1.events".into(),
+            reason: "bad frame".into(),
+        };
+        assert_eq!(poison.error_code(), "RTM-8001");
+        assert!(!poison.is_retryable());
+
+        // Unroutable / unknown events are folded into Ok skips at the consumer.
+        let skip = RealtimeError::UnroutableEvent {
+            reason: "recipient offline".into(),
+        };
+        assert_eq!(skip.error_code(), "RTM-8002");
+        assert!(!skip.is_retryable());
+    }
+}

--- a/crates/services/realtime/src/infrastructure/auth_context_verifier.rs
+++ b/crates/services/realtime/src/infrastructure/auth_context_verifier.rs
@@ -1,0 +1,84 @@
+//! The handshake token verifier over the shared `auth-context` JWT decoder.
+//!
+//! Verifies the ES256 edge token at the WebSocket handshake and distils it into a
+//! pinned [`Session`]: `sub` → `user_id`, `exp` → `expires_at`, and a configured
+//! custom claim → `device_id`. The edge token is minted by `auth` per device
+//! session, so the device binding rides as a claim (default key `did`).
+//!
+//! Error mapping: an expired token is `RTM-1002 TokenExpired` (the client should
+//! refresh and re-handshake); anything else — bad signature, malformed, missing
+//! claim — is `RTM-1001 HandshakeRejected`. The plane never reveals *why* beyond
+//! these two, and logs nothing token-bearing.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use auth_context::{AuthError, JwtDecoder, OidcClaims, OidcClaimsExtractor};
+use chrono::{DateTime, Utc};
+
+use crate::application::port::TokenVerifier;
+use crate::domain::{DeviceId, Session, UserId};
+use crate::error::RealtimeError;
+
+/// The OIDC decoder specialization the realtime gateway uses.
+type EdgeDecoder = JwtDecoder<OidcClaims, OidcClaimsExtractor>;
+
+pub struct AuthContextTokenVerifier {
+    decoder: Arc<EdgeDecoder>,
+    /// The custom JWT claim carrying the device/session id (default: `did`).
+    device_claim: String,
+}
+
+impl AuthContextTokenVerifier {
+    pub fn new(decoder: Arc<EdgeDecoder>, device_claim: impl Into<String>) -> Self {
+        Self {
+            decoder,
+            device_claim: device_claim.into(),
+        }
+    }
+}
+
+fn map_auth_err(e: AuthError) -> RealtimeError {
+    match e {
+        AuthError::TokenExpired => RealtimeError::TokenExpired,
+        other => RealtimeError::HandshakeRejected {
+            reason: other.to_string(),
+        },
+    }
+}
+
+#[async_trait]
+impl TokenVerifier for AuthContextTokenVerifier {
+    async fn verify(
+        &self,
+        edge_token: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Session, RealtimeError> {
+        let principal = self.decoder.decode(edge_token).await.map_err(map_auth_err)?;
+
+        let user_id = UserId::new(principal.user_id.as_str().to_owned())?;
+
+        let expires_at = DateTime::from_timestamp(principal.raw_claims.exp, 0).ok_or_else(|| {
+            RealtimeError::HandshakeRejected {
+                reason: "edge token has an invalid 'exp'".to_owned(),
+            }
+        })?;
+        // Defense in depth: the decoder already rejects expired tokens, but pin the
+        // session against our own clock too.
+        if now >= expires_at {
+            return Err(RealtimeError::TokenExpired);
+        }
+
+        let device = principal
+            .raw_claims
+            .extra
+            .get(&self.device_claim)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| RealtimeError::HandshakeRejected {
+                reason: format!("edge token is missing the '{}' device claim", self.device_claim),
+            })?;
+        let device_id = DeviceId::new(device.to_owned())?;
+
+        Ok(Session::new(user_id, device_id, expires_at))
+    }
+}

--- a/crates/services/realtime/src/infrastructure/codec.rs
+++ b/crates/services/realtime/src/infrastructure/codec.rs
@@ -1,0 +1,341 @@
+//! The pure proto mapping between the domain / [`DeliverableEvent`] and the
+//! generated `realtime.v1` wire types — the one place that knows the `realtime-api`
+//! representation, so the rest of the service stays proto-free.
+//!
+//! Three directions live here:
+//! * **outbound to the client** — build a `ServerFrame` (an [`event_frame`],
+//!   [`ping_frame`], or [`control_frame`]) from domain values.
+//! * **inbound from the client** — decode a `ClientFrame` into a pure
+//!   [`ClientIntent`] the gateway dispatches against the domain.
+//! * **node hop** — map [`DeliverableEvent`] ⇄ `DeliverEnvelope` (the bytes the
+//!   dispatcher publishes and the gateway receives).
+//!
+//! Everything is total and unit-tested; there is no I/O here.
+
+use chrono::{DateTime, Utc};
+use realtime_api as pb;
+
+use crate::application::DeliverableEvent;
+use crate::domain::{ChannelClass, ChannelKey, ChannelRef, DeviceId, StreamSeq, UserId};
+use crate::error::RealtimeError;
+
+// ── time ──────────────────────────────────────────────────────────────────────
+
+pub(crate) fn epoch() -> DateTime<Utc> {
+    DateTime::from_timestamp(0, 0).expect("unix epoch is a valid timestamp")
+}
+
+fn ts_to_pb(dt: DateTime<Utc>) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: dt.timestamp(),
+        nanos: dt.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn ts_from_pb(ts: &prost_types::Timestamp) -> DateTime<Utc> {
+    DateTime::from_timestamp(ts.seconds, ts.nanos.max(0) as u32).unwrap_or_else(epoch)
+}
+
+// ── channel class / ref ───────────────────────────────────────────────────────
+
+pub fn channel_class_to_pb(class: ChannelClass) -> pb::ChannelClass {
+    match class {
+        ChannelClass::Dm => pb::ChannelClass::Dm,
+        ChannelClass::Notification => pb::ChannelClass::Notification,
+        ChannelClass::Presence => pb::ChannelClass::Presence,
+        ChannelClass::Counter => pb::ChannelClass::Counter,
+        ChannelClass::Feed => pb::ChannelClass::Feed,
+    }
+}
+
+pub fn channel_class_from_pb(value: i32) -> Result<ChannelClass, RealtimeError> {
+    match pb::ChannelClass::try_from(value) {
+        Ok(pb::ChannelClass::Dm) => Ok(ChannelClass::Dm),
+        Ok(pb::ChannelClass::Notification) => Ok(ChannelClass::Notification),
+        Ok(pb::ChannelClass::Presence) => Ok(ChannelClass::Presence),
+        Ok(pb::ChannelClass::Counter) => Ok(ChannelClass::Counter),
+        Ok(pb::ChannelClass::Feed) => Ok(ChannelClass::Feed),
+        Ok(pb::ChannelClass::Unspecified) | Err(_) => Err(RealtimeError::MalformedFrame {
+            reason: format!("unknown channel class {value}"),
+        }),
+    }
+}
+
+pub fn channel_to_pb(channel: &ChannelRef) -> pb::ChannelRef {
+    pb::ChannelRef {
+        class: channel_class_to_pb(channel.class) as i32,
+        key: channel.key.as_str().to_owned(),
+    }
+}
+
+pub fn channel_from_pb(channel: &pb::ChannelRef) -> Result<ChannelRef, RealtimeError> {
+    Ok(ChannelRef::new(
+        channel_class_from_pb(channel.class)?,
+        ChannelKey::new(channel.key.clone())?,
+    ))
+}
+
+fn channels_from_pb(channels: &[pb::ChannelRef]) -> Result<Vec<ChannelRef>, RealtimeError> {
+    channels.iter().map(channel_from_pb).collect()
+}
+
+// ── outbound: ServerFrame builders ────────────────────────────────────────────
+
+/// Build the delivery frame for one event on a channel, stamped with the
+/// per-`(connection, channel)` sequence the gateway assigned.
+pub fn event_frame(
+    channel: &ChannelRef,
+    stream_seq: StreamSeq,
+    event: &DeliverableEvent,
+) -> pb::ServerFrame {
+    pb::ServerFrame {
+        body: Some(pb::server_frame::Body::Event(pb::Event {
+            channel: Some(channel_to_pb(channel)),
+            stream_seq: stream_seq.get(),
+            ack_required: channel.class.ack_required(),
+            payload: event.payload.clone(),
+            event_type: event.event_type.clone(),
+            emitted_at: Some(ts_to_pb(event.emitted_at)),
+        })),
+    }
+}
+
+pub fn ping_frame(nonce: u64) -> pb::ServerFrame {
+    pb::ServerFrame {
+        body: Some(pb::server_frame::Body::Ping(pb::Ping { nonce })),
+    }
+}
+
+/// Build a control frame. `channel` is set for SUBSCRIBED / UNSUBSCRIBED; `code`
+/// carries the `RTM-XXXX` for ERROR / RATE_LIMITED; `reconnect_after_ms` the base
+/// backoff for RECONNECT (the client adds jitter).
+pub fn control_frame(
+    control: pb::ServerControl,
+    channel: Option<&ChannelRef>,
+    code: &str,
+    message: &str,
+    reconnect_after_ms: u32,
+) -> pb::ServerFrame {
+    pb::ServerFrame {
+        body: Some(pb::server_frame::Body::Control(pb::Control {
+            control: control as i32,
+            channel: channel.map(channel_to_pb),
+            code: code.to_owned(),
+            message: message.to_owned(),
+            reconnect_after_ms,
+        })),
+    }
+}
+
+// ── inbound: ClientFrame → ClientIntent ───────────────────────────────────────
+
+/// A decoded client request, free of any proto type. The gateway's per-socket
+/// task dispatches these against its [`crate::domain::Connection`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientIntent {
+    Subscribe(Vec<ChannelRef>),
+    Unsubscribe(Vec<ChannelRef>),
+    Ack {
+        channel: ChannelRef,
+        stream_seq: StreamSeq,
+    },
+    Pong {
+        nonce: u64,
+    },
+    AuthRefresh {
+        edge_token: String,
+    },
+    Resume(Vec<(ChannelRef, u64)>),
+}
+
+pub fn decode_client_frame(frame: &pb::ClientFrame) -> Result<ClientIntent, RealtimeError> {
+    let body = frame
+        .body
+        .as_ref()
+        .ok_or_else(|| RealtimeError::MalformedFrame {
+            reason: "client frame has no body".to_owned(),
+        })?;
+
+    let intent = match body {
+        pb::client_frame::Body::Subscribe(s) => {
+            ClientIntent::Subscribe(channels_from_pb(&s.channels)?)
+        }
+        pb::client_frame::Body::Unsubscribe(u) => {
+            ClientIntent::Unsubscribe(channels_from_pb(&u.channels)?)
+        }
+        pb::client_frame::Body::Ack(a) => ClientIntent::Ack {
+            channel: channel_from_pb(require(&a.channel, "ack.channel")?)?,
+            stream_seq: StreamSeq::new(a.stream_seq),
+        },
+        pb::client_frame::Body::Pong(p) => ClientIntent::Pong { nonce: p.nonce },
+        pb::client_frame::Body::AuthRefresh(r) => ClientIntent::AuthRefresh {
+            edge_token: r.edge_token.clone(),
+        },
+        pb::client_frame::Body::Resume(r) => {
+            let mut cursors = Vec::with_capacity(r.cursors.len());
+            for cursor in &r.cursors {
+                cursors.push((
+                    channel_from_pb(require(&cursor.channel, "resume.channel")?)?,
+                    cursor.stream_seq,
+                ));
+            }
+            ClientIntent::Resume(cursors)
+        }
+    };
+    Ok(intent)
+}
+
+fn require<'a, T>(field: &'a Option<T>, name: &str) -> Result<&'a T, RealtimeError> {
+    field.as_ref().ok_or_else(|| RealtimeError::MalformedFrame {
+        reason: format!("missing required field '{name}'"),
+    })
+}
+
+// ── node hop: DeliverableEvent ⇄ DeliverEnvelope ──────────────────────────────
+
+pub fn envelope_to_pb(event: &DeliverableEvent) -> pb::DeliverEnvelope {
+    pb::DeliverEnvelope {
+        recipient_user_id: event.recipient.as_str().to_owned(),
+        recipient_device_id: event
+            .device_id
+            .as_ref()
+            .map(|d| d.as_str().to_owned())
+            .unwrap_or_default(),
+        channel: Some(channel_to_pb(&event.channel)),
+        ack_required: event.channel.class.ack_required(),
+        payload: event.payload.clone(),
+        event_type: event.event_type.clone(),
+        emitted_at: Some(ts_to_pb(event.emitted_at)),
+        idempotency_key: event.idempotency_key.clone(),
+    }
+}
+
+pub fn envelope_from_pb(env: &pb::DeliverEnvelope) -> Result<DeliverableEvent, RealtimeError> {
+    let channel = channel_from_pb(require(&env.channel, "envelope.channel")?)?;
+    let device_id = if env.recipient_device_id.is_empty() {
+        None
+    } else {
+        Some(DeviceId::new(env.recipient_device_id.clone())?)
+    };
+    Ok(DeliverableEvent {
+        recipient: UserId::new(env.recipient_user_id.clone())?,
+        device_id,
+        channel,
+        payload: env.payload.clone(),
+        event_type: env.event_type.clone(),
+        emitted_at: env
+            .emitted_at
+            .as_ref()
+            .map(ts_from_pb)
+            .unwrap_or_else(epoch),
+        idempotency_key: env.idempotency_key.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> DeliverableEvent {
+        DeliverableEvent {
+            recipient: UserId::new("alice").unwrap(),
+            device_id: Some(DeviceId::new("phone").unwrap()),
+            channel: ChannelRef::new(ChannelClass::Dm, ChannelKey::new("alice").unwrap()),
+            payload: b"ciphertext".to_vec(),
+            event_type: "chat.message".to_owned(),
+            emitted_at: DateTime::from_timestamp(1_750_000_000, 0).unwrap(),
+            idempotency_key: "evt-1".to_owned(),
+        }
+    }
+
+    #[test]
+    fn channel_class_round_trips_and_rejects_unspecified() {
+        for class in [
+            ChannelClass::Dm,
+            ChannelClass::Notification,
+            ChannelClass::Presence,
+            ChannelClass::Counter,
+            ChannelClass::Feed,
+        ] {
+            let i = channel_class_to_pb(class) as i32;
+            assert_eq!(channel_class_from_pb(i).unwrap(), class);
+        }
+        assert!(channel_class_from_pb(0).is_err()); // UNSPECIFIED
+        assert!(channel_class_from_pb(99).is_err()); // out of range
+    }
+
+    #[test]
+    fn deliver_envelope_round_trips() {
+        let event = sample_event();
+        let pb = envelope_to_pb(&event);
+        assert!(pb.ack_required); // DM ⇒ at-least-once
+        let back = envelope_from_pb(&pb).unwrap();
+        assert_eq!(back, event);
+    }
+
+    #[test]
+    fn envelope_without_device_maps_to_none() {
+        let mut event = sample_event();
+        event.device_id = None;
+        let pb = envelope_to_pb(&event);
+        assert!(pb.recipient_device_id.is_empty());
+        assert_eq!(envelope_from_pb(&pb).unwrap().device_id, None);
+    }
+
+    #[test]
+    fn event_frame_carries_sequence_and_opaque_payload() {
+        let event = sample_event();
+        let frame = event_frame(&event.channel, StreamSeq::new(7), &event);
+        match frame.body.unwrap() {
+            pb::server_frame::Body::Event(e) => {
+                assert_eq!(e.stream_seq, 7);
+                assert!(e.ack_required);
+                assert_eq!(e.payload, b"ciphertext");
+                assert_eq!(e.event_type, "chat.message");
+            }
+            _ => panic!("expected an Event frame"),
+        }
+    }
+
+    #[test]
+    fn decodes_a_subscribe_frame() {
+        let frame = pb::ClientFrame {
+            body: Some(pb::client_frame::Body::Subscribe(pb::Subscribe {
+                channels: vec![pb::ChannelRef {
+                    class: pb::ChannelClass::Dm as i32,
+                    key: "alice".to_owned(),
+                }],
+            })),
+        };
+        match decode_client_frame(&frame).unwrap() {
+            ClientIntent::Subscribe(chs) => {
+                assert_eq!(chs.len(), 1);
+                assert_eq!(chs[0].to_string(), "dm:alice");
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_an_ack_frame() {
+        let frame = pb::ClientFrame {
+            body: Some(pb::client_frame::Body::Ack(pb::ClientAck {
+                channel: Some(pb::ChannelRef {
+                    class: pb::ChannelClass::Notification as i32,
+                    key: "alice".to_owned(),
+                }),
+                stream_seq: 42,
+            })),
+        };
+        match decode_client_frame(&frame).unwrap() {
+            ClientIntent::Ack { stream_seq, .. } => assert_eq!(stream_seq.get(), 42),
+            other => panic!("expected Ack, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_client_frame_is_malformed() {
+        let err = decode_client_frame(&pb::ClientFrame { body: None }).unwrap_err();
+        assert_eq!(<RealtimeError as error::AppError>::error_code(&err), "RTM-2001");
+    }
+}

--- a/crates/services/realtime/src/infrastructure/consumer.rs
+++ b/crates/services/realtime/src/infrastructure/consumer.rs
@@ -1,0 +1,20 @@
+//! Inbound runtime glue for the dispatcher's Kafka consumers.
+//!
+//! Lets the shared at-least-once
+//! [`run_consumer`](transport::kafka::consumer::run_consumer) runner classify a
+//! [`RealtimeError`]: delegate to the error's own retry verdict, so transient
+//! fabric faults (`RTM-4001` / `RTM-4002`) retry while decode/domain faults
+//! (`RTM-8001`, `RTM-9xxx`) are poison and dead-letter immediately. An offline
+//! recipient is never an error (the fan-out handler folds it into `Ok`), so it
+//! commits the offset normally.
+//!
+//! The concrete consumer wiring (decode each record → `FanOutHandler::fan_out`
+//! under `run_consumer`) is assembled in the dispatcher composition root (Phase 5).
+
+use crate::error::RealtimeError;
+
+impl transport::kafka::consumer::ClassifyError for RealtimeError {
+    fn is_retryable(&self) -> bool {
+        <Self as error::AppError>::is_retryable(self)
+    }
+}

--- a/crates/services/realtime/src/infrastructure/decode.rs
+++ b/crates/services/realtime/src/infrastructure/decode.rs
@@ -1,0 +1,107 @@
+//! The dispatcher's inbound decode layer: realtime-owned wire DTOs for the
+//! upstream streams it fans out, plus the pure `map_*` distillation into a
+//! [`DeliverableEvent`].
+//!
+//! Like `counter` / `search`, realtime must not depend on the producing services'
+//! crates (a sideways services→services edge the tiering forbids), so it owns its
+//! read schema: minimal, lenient structs that match the published JSON (extra
+//! fields ignored, so an additive upstream change never breaks the consumer).
+//!
+//! Integration reality (honest about upstream readiness): only the
+//! `notification.v1.events` mapping is concrete here — `notification` publishes a
+//! per-recipient stream today. The `chat` / `counter.v1.popularity` / `post.v1`
+//! mappings follow the **same shape** (decode → address a recipient + channel →
+//! carry an opaque payload) and land as those producers are wired; they are an
+//! upstream prerequisite, not a gap in this layer. The realtime plane forwards
+//! `payload` verbatim and never interprets it.
+
+use chrono::DateTime;
+use serde::Deserialize;
+
+use crate::application::DeliverableEvent;
+use crate::domain::{ChannelClass, ChannelKey, ChannelRef, DeviceId, UserId};
+use crate::error::RealtimeError;
+use crate::infrastructure::codec::epoch;
+
+const TOPIC_NOTIFICATION: &str = "notification.v1.events";
+
+/// A notification destined for one recipient. `payload` is the already-rendered
+/// client view (badge counts / preview) the plane forwards verbatim.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NotificationWire {
+    pub recipient_id: String,
+    /// Target a single device; absent ⇒ all of the recipient's connections.
+    #[serde(default)]
+    pub device_id: Option<String>,
+    /// The notification's stable id — the delivery idempotency key.
+    pub notification_id: String,
+    pub kind: String,
+    pub created_at_ms: i64,
+    /// Opaque, client-ready payload. Forwarded as bytes; never interpreted.
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+/// Map a `notification.v1.events` record to a deliverable event on the recipient's
+/// `notif` channel (identity-scoped, at-least-once).
+pub fn map_notification(wire: NotificationWire) -> Result<DeliverableEvent, RealtimeError> {
+    let recipient = UserId::new(wire.recipient_id)?;
+    let channel = ChannelRef::new(
+        ChannelClass::Notification,
+        ChannelKey::new(recipient.as_str().to_owned())?,
+    );
+    let payload =
+        serde_json::to_vec(&wire.payload).map_err(|e| RealtimeError::EventDecodeFailed {
+            topic: TOPIC_NOTIFICATION.to_owned(),
+            reason: e.to_string(),
+        })?;
+    let device_id = wire.device_id.map(DeviceId::new).transpose()?;
+
+    Ok(DeliverableEvent {
+        recipient,
+        device_id,
+        channel,
+        payload,
+        event_type: format!("notif.{}", wire.kind),
+        emitted_at: DateTime::from_timestamp_millis(wire.created_at_ms).unwrap_or_else(epoch),
+        idempotency_key: wire.notification_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_a_notification_onto_the_recipients_notif_channel() {
+        let wire = NotificationWire {
+            recipient_id: "alice".to_owned(),
+            device_id: None,
+            notification_id: "ntf-9".to_owned(),
+            kind: "follow".to_owned(),
+            created_at_ms: 1_750_000_000_000,
+            payload: serde_json::json!({ "unread": 3 }),
+        };
+        let ev = map_notification(wire).unwrap();
+        assert_eq!(ev.recipient.as_str(), "alice");
+        // Identity-scoped: the channel key is the recipient itself.
+        assert_eq!(ev.channel.to_string(), "notif:alice");
+        assert_eq!(ev.event_type, "notif.follow");
+        assert_eq!(ev.idempotency_key, "ntf-9");
+        assert_eq!(ev.device_id, None);
+    }
+
+    #[test]
+    fn rejects_a_blank_recipient() {
+        let wire = NotificationWire {
+            recipient_id: "  ".to_owned(),
+            device_id: None,
+            notification_id: "ntf-1".to_owned(),
+            kind: "x".to_owned(),
+            created_at_ms: 0,
+            payload: serde_json::Value::Null,
+        };
+        let err = map_notification(wire).unwrap_err();
+        assert_eq!(<RealtimeError as error::AppError>::error_code(&err), "RTM-9002");
+    }
+}

--- a/crates/services/realtime/src/infrastructure/mailbox.rs
+++ b/crates/services/realtime/src/infrastructure/mailbox.rs
@@ -1,0 +1,116 @@
+use std::collections::VecDeque;
+
+/// What happened to a frame on enqueue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnqueueOutcome {
+    /// The frame was queued normally.
+    Accepted,
+    /// The queue was full; the oldest pending frame was dropped to make room.
+    /// This is the **shed** that protects node memory from a slow consumer — a
+    /// dropped fire-and-forget frame is superseded by the next; a dropped
+    /// at-least-once frame is re-synced from the SoR on reconnect.
+    SheddedOldest,
+}
+
+/// A bounded, per-connection outbound queue with drop-oldest shedding — the
+/// pure core of the C10M backpressure rule: one slow client must never be able to
+/// balloon a gateway node's memory.
+///
+/// This is a synchronous data structure; the gateway's per-socket task (Phase 5)
+/// owns one of these behind the connection's writer and drains it onto the
+/// WebSocket. Keeping the policy here, free of any socket, makes the shed
+/// semantics unit-testable. When `Reject`-style behaviour is wanted (close a
+/// wedged consumer rather than drop), the caller watches [`shed_total`] /
+/// [`is_full`] and closes with `RTM-5001 SendQueueOverflow`.
+///
+/// [`shed_total`]: ConnectionMailbox::shed_total
+/// [`is_full`]: ConnectionMailbox::is_full
+#[derive(Debug)]
+pub struct ConnectionMailbox {
+    queue: VecDeque<Vec<u8>>,
+    capacity: usize,
+    shed_total: u64,
+}
+
+impl ConnectionMailbox {
+    /// Create a mailbox holding at most `capacity` frames. `capacity` must be at
+    /// least 1.
+    pub fn new(capacity: usize) -> Self {
+        debug_assert!(capacity >= 1, "mailbox capacity must be >= 1");
+        Self {
+            queue: VecDeque::with_capacity(capacity),
+            capacity: capacity.max(1),
+            shed_total: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.queue.len() >= self.capacity
+    }
+
+    /// The total number of frames shed over this mailbox's life — a per-connection
+    /// backpressure signal the gateway exports as a metric.
+    pub fn shed_total(&self) -> u64 {
+        self.shed_total
+    }
+
+    /// Enqueue an already-serialized frame, shedding the oldest if full.
+    pub fn enqueue(&mut self, frame: Vec<u8>) -> EnqueueOutcome {
+        if self.is_full() {
+            self.queue.pop_front();
+            self.shed_total += 1;
+            self.queue.push_back(frame);
+            EnqueueOutcome::SheddedOldest
+        } else {
+            self.queue.push_back(frame);
+            EnqueueOutcome::Accepted
+        }
+    }
+
+    /// Pop the next frame to write to the socket (FIFO).
+    pub fn dequeue(&mut self) -> Option<Vec<u8>> {
+        self.queue.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_up_to_capacity_then_sheds_oldest() {
+        let mut mb = ConnectionMailbox::new(2);
+        assert_eq!(mb.enqueue(vec![1]), EnqueueOutcome::Accepted);
+        assert_eq!(mb.enqueue(vec![2]), EnqueueOutcome::Accepted);
+        assert!(mb.is_full());
+        // Third frame sheds the oldest (1), keeping the bound.
+        assert_eq!(mb.enqueue(vec![3]), EnqueueOutcome::SheddedOldest);
+        assert_eq!(mb.len(), 2);
+        assert_eq!(mb.shed_total(), 1);
+        // FIFO over what remains: 2 then 3.
+        assert_eq!(mb.dequeue(), Some(vec![2]));
+        assert_eq!(mb.dequeue(), Some(vec![3]));
+        assert_eq!(mb.dequeue(), None);
+    }
+
+    #[test]
+    fn drains_in_fifo_order() {
+        let mut mb = ConnectionMailbox::new(4);
+        for i in 0..3u8 {
+            mb.enqueue(vec![i]);
+        }
+        assert_eq!(mb.dequeue(), Some(vec![0]));
+        assert_eq!(mb.dequeue(), Some(vec![1]));
+        assert!(!mb.is_empty());
+        assert_eq!(mb.dequeue(), Some(vec![2]));
+        assert!(mb.is_empty());
+    }
+}

--- a/crates/services/realtime/src/infrastructure/mod.rs
+++ b/crates/services/realtime/src/infrastructure/mod.rs
@@ -1,0 +1,33 @@
+//! Infrastructure adapters — the concrete implementations of the application
+//! ports, plus the proto codec, the inbound decode layer, and the per-connection
+//! backpressure primitive.
+//!
+//! * [`auth_context_verifier`] — [`TokenVerifier`](crate::application::TokenVerifier)
+//!   over the shared `auth-context` JWT decoder.
+//! * [`redis_connection_registry`] — the routing fabric (fred, Lua-issued
+//!   single-key writes + `HGETALL`, TTL self-heal).
+//! * [`redis_node_channel`] — the node hop (fred sharded `SPUBLISH`).
+//! * [`codec`] — the pure `realtime.v1` proto mapping (frames + node envelope).
+//! * [`decode`] — realtime-owned wire DTOs + the pure `map_*` distillation into a
+//!   [`DeliverableEvent`](crate::application::DeliverableEvent).
+//! * [`mailbox`] — the bounded, drop-oldest per-connection send queue.
+//! * [`consumer`] — the `run_consumer` error-classification glue.
+//!
+//! Per the integration-test standard, the Redis / auth adapters are compile-checked
+//! here; their live behaviour is exercised by the gated suite in Phase 6. The
+//! codec, decode, and mailbox layers are pure and unit-tested in place.
+
+pub mod auth_context_verifier;
+pub mod codec;
+pub mod consumer;
+pub mod decode;
+pub mod mailbox;
+pub mod redis_connection_registry;
+pub mod redis_node_channel;
+pub mod runtime;
+
+pub use auth_context_verifier::AuthContextTokenVerifier;
+pub use codec::ClientIntent;
+pub use mailbox::{ConnectionMailbox, EnqueueOutcome};
+pub use redis_connection_registry::RedisConnectionRegistry;
+pub use redis_node_channel::RedisNodeChannel;

--- a/crates/services/realtime/src/infrastructure/redis_connection_registry.rs
+++ b/crates/services/realtime/src/infrastructure/redis_connection_registry.rs
@@ -1,0 +1,137 @@
+//! The connection/presence registry over Redis (fred).
+//!
+//! Layout — one HASH per user, hash-tagged so all of a user's fields share a
+//! cluster slot:
+//! * `rt:presence:{<user_id>}` — field = `connection_id`, value = JSON
+//!   `{device_id, node_id}`.
+//!
+//! Writes go through single-key Lua `eval` (the fleet pattern, Cluster-safe); the
+//! `bind` script also refreshes a TTL so a leaked entry (a connection whose evict
+//! never ran) self-heals. Reads use `HGETALL`. A fred fault on any path is
+//! reported as `RTM-4001 RegistryUnavailable` (retryable) so the dispatcher's
+//! `run_consumer` retries rather than dropping the event.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use fred::interfaces::{HashesInterface, LuaInterface};
+use redis_storage::RedisClient;
+use serde::{Deserialize, Serialize};
+
+use crate::application::port::{ConnectionLocation, ConnectionRegistry};
+use crate::domain::{ConnectionId, DeviceId, NodeId, UserId};
+use crate::error::RealtimeError;
+
+/// `HSET field value` then refresh the hash TTL; returns 1.
+const BIND: &str = "redis.call('HSET', KEYS[1], ARGV[1], ARGV[2]); \
+                    redis.call('PEXPIRE', KEYS[1], ARGV[3]); return 1";
+/// `HDEL field`; returns the number removed.
+const EVICT: &str = "return redis.call('HDEL', KEYS[1], ARGV[1])";
+
+#[derive(Serialize, Deserialize)]
+struct PlacementValue {
+    device_id: String,
+    node_id: String,
+}
+
+fn presence_key(user_id: &UserId) -> String {
+    format!("rt:presence:{{{}}}", user_id.as_str())
+}
+
+fn registry_err(e: fred::error::Error) -> RealtimeError {
+    tracing::warn!(error = %e, "connection registry redis error");
+    RealtimeError::RegistryUnavailable
+}
+
+pub struct RedisConnectionRegistry {
+    client: RedisClient,
+    /// TTL applied to each presence hash on bind; a self-heal bound on leaked
+    /// entries, refreshed on every bind/heartbeat-rebind.
+    ttl_ms: i64,
+}
+
+impl RedisConnectionRegistry {
+    pub fn new(client: RedisClient, ttl_ms: i64) -> Self {
+        Self { client, ttl_ms }
+    }
+}
+
+#[async_trait]
+impl ConnectionRegistry for RedisConnectionRegistry {
+    async fn bind(&self, location: &ConnectionLocation) -> Result<(), RealtimeError> {
+        let value = serde_json::to_string(&PlacementValue {
+            device_id: location.device_id.as_str().to_owned(),
+            node_id: location.node_id.as_str().to_owned(),
+        })
+        .map_err(|e| RealtimeError::DomainViolation {
+            field: "placement".to_owned(),
+            message: e.to_string(),
+        })?;
+
+        let _: i64 = self
+            .client
+            .inner
+            .eval(
+                BIND,
+                vec![presence_key(&location.user_id)],
+                vec![
+                    location.connection_id.as_str().to_owned(),
+                    value,
+                    self.ttl_ms.to_string(),
+                ],
+            )
+            .await
+            .map_err(registry_err)?;
+        Ok(())
+    }
+
+    async fn evict(
+        &self,
+        user_id: &UserId,
+        connection_id: &ConnectionId,
+    ) -> Result<(), RealtimeError> {
+        let _: i64 = self
+            .client
+            .inner
+            .eval(
+                EVICT,
+                vec![presence_key(user_id)],
+                vec![connection_id.as_str().to_owned()],
+            )
+            .await
+            .map_err(registry_err)?;
+        Ok(())
+    }
+
+    async fn resolve(&self, user_id: &UserId) -> Result<Vec<ConnectionLocation>, RealtimeError> {
+        let fields: HashMap<String, String> = self
+            .client
+            .inner
+            .hgetall(presence_key(user_id))
+            .await
+            .map_err(registry_err)?;
+
+        let mut out = Vec::with_capacity(fields.len());
+        for (connection_id, raw) in fields {
+            // A malformed entry is skipped, not fatal — the registry is best-effort
+            // routing metadata, and a bad row self-heals on the next bind/TTL.
+            let Ok(value) = serde_json::from_str::<PlacementValue>(&raw) else {
+                continue;
+            };
+            let (Ok(device_id), Ok(node_id), Ok(connection_id)) = (
+                DeviceId::new(value.device_id),
+                NodeId::new(value.node_id),
+                ConnectionId::new(connection_id),
+            ) else {
+                continue;
+            };
+            out.push(ConnectionLocation {
+                user_id: user_id.clone(),
+                device_id,
+                connection_id,
+                node_id,
+            });
+        }
+        Ok(out)
+    }
+}

--- a/crates/services/realtime/src/infrastructure/redis_node_channel.rs
+++ b/crates/services/realtime/src/infrastructure/redis_node_channel.rs
@@ -1,0 +1,64 @@
+//! The node-hop fabric over Redis sharded Pub/Sub (`SPUBLISH`), the same backbone
+//! `chat` uses.
+//!
+//! The dispatcher publishes a resolved event — encoded as a `realtime.v1`
+//! `DeliverEnvelope` — to the owning node's channel `rt:node:{<node_id>}`. The
+//! node-id hash tag keeps each node's channel on a single cluster slot, so
+//! `SPUBLISH` confines delivery to that shard instead of flooding the cluster the
+//! way classic `PUBLISH` would. The gateway side (`SSUBSCRIBE` on its own node
+//! channel) is wired in Phase 5.
+//!
+//! Publish is fire-and-forget and intentionally not a delivery confirmation: the
+//! owning node may have just lost the connection (a stale registry), in which case
+//! the event is dropped there — a fail-open miss the client recovers from on
+//! reconnect. A fred fault is `RTM-4002 NodeChannelUnavailable` (retryable).
+
+use async_trait::async_trait;
+use fred::interfaces::PubsubInterface;
+use prost::Message;
+use redis_storage::RedisClient;
+
+use crate::application::event::DeliverableEvent;
+use crate::application::port::NodeChannel;
+use crate::domain::NodeId;
+use crate::error::RealtimeError;
+use crate::infrastructure::codec;
+
+fn node_channel(node_id: &NodeId) -> String {
+    format!("rt:node:{{{}}}", node_id.as_str())
+}
+
+fn channel_err(e: fred::error::Error) -> RealtimeError {
+    tracing::warn!(error = %e, "node channel redis error");
+    RealtimeError::NodeChannelUnavailable
+}
+
+pub struct RedisNodeChannel {
+    client: RedisClient,
+}
+
+impl RedisNodeChannel {
+    pub fn new(client: RedisClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl NodeChannel for RedisNodeChannel {
+    async fn publish(
+        &self,
+        node_id: &NodeId,
+        event: &DeliverableEvent,
+    ) -> Result<(), RealtimeError> {
+        // prost encoding into a growable Vec is infallible.
+        let payload = codec::envelope_to_pb(event).encode_to_vec();
+
+        let _: i64 = self
+            .client
+            .inner
+            .spublish(node_channel(node_id), payload)
+            .await
+            .map_err(channel_err)?;
+        Ok(())
+    }
+}

--- a/crates/services/realtime/src/infrastructure/runtime/connection_table.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/connection_table.rs
@@ -1,0 +1,283 @@
+//! The node-local connection table: the in-process half of the routing fabric.
+//!
+//! The Redis registry answers "*which node* holds this user?"; this table answers
+//! "*which sockets on THIS node*?". The node subscriber resolves an inbound
+//! `DeliverEnvelope` against it and pushes an `Event` frame into each matching
+//! connection's outbound queue — assigning that connection's per-channel sequence
+//! as it goes (the sequence state lives in the shared [`Connection`]).
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use prost::Message;
+use realtime_api as pb;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+
+use crate::application::DeliverableEvent;
+use crate::domain::{Connection, ConnectionId, DeviceId};
+use crate::infrastructure::codec;
+
+/// A live connection's node-local handle: its shared domain state (for sequencing
+/// + subscription checks) and the bounded sender feeding its socket writer task.
+#[derive(Clone)]
+pub struct ConnHandle {
+    pub connection_id: ConnectionId,
+    pub device_id: DeviceId,
+    pub connection: Arc<Mutex<Connection>>,
+    /// Bounded outbound queue; a full queue means a slow consumer — `try_send`
+    /// drops the frame (the shed) rather than blocking the deliver path.
+    pub sender: mpsc::Sender<Vec<u8>>,
+}
+
+/// Maps a `user_id` to the handles of its live connections on this node.
+#[derive(Default)]
+pub struct ConnectionTable {
+    by_user: DashMap<String, Vec<ConnHandle>>,
+}
+
+impl ConnectionTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, user_id: &str, handle: ConnHandle) {
+        self.by_user.entry(user_id.to_owned()).or_default().push(handle);
+    }
+
+    /// Remove one connection; drops the user's entry entirely when it empties.
+    pub fn remove(&self, user_id: &str, connection_id: &ConnectionId) {
+        if let Some(mut handles) = self.by_user.get_mut(user_id) {
+            handles.retain(|h| &h.connection_id != connection_id);
+        }
+        self.by_user.remove_if(user_id, |_, v| v.is_empty());
+    }
+
+    pub fn connection_count(&self) -> usize {
+        self.by_user.iter().map(|e| e.value().len()).sum()
+    }
+
+    /// Deliver an event to the recipient's matching connections on this node,
+    /// stamping each with that connection's next per-channel sequence. Returns the
+    /// number of sockets the frame was queued onto.
+    ///
+    /// Skips connections not subscribed to the event's channel (a non-error), and
+    /// honours an optional device filter. A full outbound queue sheds the frame
+    /// for that connection (the slow-consumer protection) without affecting others.
+    pub async fn deliver(&self, event: &DeliverableEvent) -> usize {
+        let Some(handles) = self
+            .by_user
+            .get(event.recipient.as_str())
+            .map(|e| e.value().clone())
+        else {
+            return 0;
+        };
+
+        let mut delivered = 0;
+        for handle in handles {
+            if let Some(device) = &event.device_id
+                && &handle.device_id != device
+            {
+                continue;
+            }
+
+            let frame = {
+                let mut conn = handle.connection.lock().await;
+                if !conn.is_subscribed(&event.channel) {
+                    continue;
+                }
+                match conn.issue_seq(&event.channel) {
+                    Ok(seq) => codec::event_frame(&event.channel, seq, event).encode_to_vec(),
+                    Err(_) => continue,
+                }
+            };
+
+            // try_send: a full queue is a slow consumer — shed rather than block.
+            if handle.sender.try_send(frame).is_ok() {
+                delivered += 1;
+            }
+        }
+        delivered
+    }
+
+    /// Graceful drain (rollout): mark every connection `Draining` and push a
+    /// `RECONNECT` control frame carrying the base backoff. The client adds jitter
+    /// on top — mandatory, to spread the reconnect across the fleet instead of
+    /// stampeding the auth handshake path. Returns the number of connections
+    /// signalled. The owning per-socket tasks then close on their own terms.
+    ///
+    /// Handles are snapshotted before any `await` so no DashMap shard guard is held
+    /// across the per-connection lock (a deadlock/`!Send` hazard otherwise).
+    pub async fn broadcast_drain(&self, reconnect_after_ms: u32) -> usize {
+        let handles: Vec<ConnHandle> =
+            self.by_user.iter().flat_map(|e| e.value().clone()).collect();
+        let frame = codec::control_frame(
+            pb::ServerControl::Reconnect,
+            None,
+            "RTM-5003",
+            "node draining; reconnect with backoff",
+            reconnect_after_ms,
+        )
+        .encode_to_vec();
+
+        let mut signalled = 0;
+        for handle in handles {
+            let _ = handle.connection.lock().await.begin_drain();
+            if handle.sender.try_send(frame.clone()).is_ok() {
+                signalled += 1;
+            }
+        }
+        signalled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::domain::{
+        ChannelClass, ChannelKey, ChannelRef, NodeId, Session, UserId,
+    };
+
+    fn deliverable(recipient: &str, device: Option<&str>) -> DeliverableEvent {
+        DeliverableEvent {
+            recipient: UserId::new(recipient).unwrap(),
+            device_id: device.map(|d| DeviceId::new(d).unwrap()),
+            channel: ChannelRef::new(ChannelClass::Dm, ChannelKey::new(recipient).unwrap()),
+            payload: b"x".to_vec(),
+            event_type: "chat.message".to_owned(),
+            emitted_at: Utc::now(),
+            idempotency_key: "e1".to_owned(),
+        }
+    }
+
+    fn handle(user: &str, device: &str, conn: &str) -> (ConnHandle, mpsc::Receiver<Vec<u8>>) {
+        handle_cap(user, device, conn, 8)
+    }
+
+    fn handle_cap(
+        user: &str,
+        device: &str,
+        conn: &str,
+        cap: usize,
+    ) -> (ConnHandle, mpsc::Receiver<Vec<u8>>) {
+        let session = Session::new(
+            UserId::new(user).unwrap(),
+            DeviceId::new(device).unwrap(),
+            Utc::now() + chrono::Duration::hours(1),
+        );
+        let connection = Connection::open(
+            ConnectionId::new(conn).unwrap(),
+            NodeId::new("node-1").unwrap(),
+            session,
+            16,
+            Utc::now(),
+        );
+        let (tx, rx) = mpsc::channel(cap);
+        (
+            ConnHandle {
+                connection_id: ConnectionId::new(conn).unwrap(),
+                device_id: DeviceId::new(device).unwrap(),
+                connection: Arc::new(Mutex::new(connection)),
+                sender: tx,
+            },
+            rx,
+        )
+    }
+
+    async fn subscribe(handle: &ConnHandle, user: &str) {
+        handle
+            .connection
+            .lock()
+            .await
+            .subscribe(ChannelRef::new(
+                ChannelClass::Dm,
+                ChannelKey::new(user).unwrap(),
+            ))
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn delivers_only_to_subscribed_connections() {
+        let table = ConnectionTable::new();
+        let (h, mut rx) = handle("alice", "phone", "c1");
+        // Subscribe the connection to dm:alice first.
+        h.connection
+            .lock()
+            .await
+            .subscribe(ChannelRef::new(
+                ChannelClass::Dm,
+                ChannelKey::new("alice").unwrap(),
+            ))
+            .unwrap();
+        table.insert("alice", h);
+
+        assert_eq!(table.deliver(&deliverable("alice", None)).await, 1);
+        assert!(rx.try_recv().is_ok()); // a frame was queued
+
+        // An unsubscribed second connection receives nothing.
+        let (h2, mut rx2) = handle("alice", "tablet", "c2");
+        table.insert("alice", h2);
+        assert_eq!(table.deliver(&deliverable("alice", None)).await, 1);
+        assert!(rx2.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn offline_user_delivers_to_nobody() {
+        let table = ConnectionTable::new();
+        assert_eq!(table.deliver(&deliverable("ghost", None)).await, 0);
+    }
+
+    #[tokio::test]
+    async fn remove_clears_the_entry() {
+        let table = ConnectionTable::new();
+        let (h, _rx) = handle("alice", "phone", "c1");
+        table.insert("alice", h);
+        assert_eq!(table.connection_count(), 1);
+        table.remove("alice", &ConnectionId::new("c1").unwrap());
+        assert_eq!(table.connection_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn broadcast_drain_marks_draining_and_sends_reconnect() {
+        use prost::Message as _;
+
+        let table = ConnectionTable::new();
+        let (h, mut rx) = handle("alice", "phone", "c1");
+        let conn = Arc::clone(&h.connection);
+        table.insert("alice", h);
+
+        assert_eq!(table.broadcast_drain(500).await, 1);
+
+        // The connection is now Draining …
+        assert_eq!(
+            conn.lock().await.state(),
+            crate::domain::ConnectionState::Draining
+        );
+        // … and a RECONNECT control frame was queued with the base backoff.
+        let frame = rx.try_recv().expect("a reconnect frame was queued");
+        match super::pb::ServerFrame::decode(&frame[..]).unwrap().body.unwrap() {
+            super::pb::server_frame::Body::Control(c) => {
+                assert_eq!(c.control, super::pb::ServerControl::Reconnect as i32);
+                assert_eq!(c.reconnect_after_ms, 500);
+            }
+            _ => panic!("expected a Control frame"),
+        }
+    }
+
+    #[tokio::test]
+    async fn full_queue_sheds_without_blocking_or_affecting_others() {
+        let table = ConnectionTable::new();
+        // A slow consumer with a 1-slot queue that nobody drains.
+        let (slow, _slow_rx) = handle_cap("alice", "phone", "c1", 1);
+        subscribe(&slow, "alice").await;
+        table.insert("alice", slow);
+
+        // First delivery fills the slot; subsequent ones shed (try_send fails) —
+        // deliver still returns promptly and never blocks the hot path.
+        assert_eq!(table.deliver(&deliverable("alice", None)).await, 1);
+        assert_eq!(table.deliver(&deliverable("alice", None)).await, 0);
+        assert_eq!(table.deliver(&deliverable("alice", None)).await, 0);
+    }
+}

--- a/crates/services/realtime/src/infrastructure/runtime/dispatcher.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/dispatcher.rs
@@ -1,0 +1,51 @@
+//! The dispatcher fan-out consumer: the at-least-once runtime around
+//! [`FanOutHandler`].
+//!
+//! Each upstream topic runs on the shared
+//! [`run_consumer`](transport::kafka::consumer::run_consumer) runner (manual commit,
+//! bounded retry + jitter, DLQ on poison/exhaustion). A decoded record is mapped to
+//! a [`DeliverableEvent`](crate::application::DeliverableEvent) and fanned out. An
+//! offline recipient is folded into `Ok` by the handler, so the offset commits;
+//! only a fabric fault (`RTM-4001` / `RTM-4002`) retries.
+
+use std::sync::Arc;
+
+use transport::kafka::consumer::{ProcessOutcome, RetryPolicy, run_consumer, KafkaConsumerHandle};
+use transport::kafka::envelope::ConsumablePayload;
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::{DeliverableEvent, FanOutHandler};
+use crate::error::RealtimeError;
+
+/// Runs a fan-out consumer: decode each record with `map` and fan it out. The
+/// runner owns deserialization, so poison bytes dead-letter before reaching `map`.
+pub async fn run_fanout_consumer<T, M>(
+    label: &'static str,
+    consumer: KafkaConsumerHandle,
+    producer: KafkaProducerHandle,
+    handler: Arc<FanOutHandler>,
+    map: M,
+) where
+    T: ConsumablePayload + Clone,
+    M: Fn(T) -> Result<DeliverableEvent, RealtimeError> + Copy + Send + Sync + 'static,
+{
+    tracing::info!(label, "realtime dispatcher consumer started");
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<T, _>(&consumer, &producer, &policy, move |event| {
+        let handler = Arc::clone(&handler);
+        let event = event.clone();
+        Box::pin(async move {
+            let outcome = async {
+                let deliverable = map(event)?;
+                handler.fan_out(&deliverable).await?;
+                Ok::<(), RealtimeError>(())
+            }
+            .await;
+            ProcessOutcome::from_result(outcome)
+        })
+    })
+    .await;
+    if let Err(error) = result {
+        tracing::error!(label, %error, "realtime dispatcher consumer stopped");
+    }
+}

--- a/crates/services/realtime/src/infrastructure/runtime/gateway.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/gateway.rs
@@ -1,0 +1,268 @@
+//! The gateway edge runtime: the public WebSocket server, the per-socket
+//! lifecycle, and the node-channel subscriber that turns inbound `DeliverEnvelope`s
+//! into `Event` frames on the right sockets.
+//!
+//! This is live networking — its behaviour is exercised by the Phase 6 suite, not
+//! unit tests. The routing it drives ([`ConnectionTable`]) is tested in isolation.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
+use axum::response::Response;
+use axum::routing::get;
+use chrono::Utc;
+use error::AppError;
+use fred::interfaces::{EventInterface, PubsubInterface};
+use futures_util::{SinkExt, StreamExt};
+use prost::Message as _;
+use realtime_api as pb;
+use redis_storage::RedisSubscriber;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::application::handshake::HandshakeHandler;
+use crate::application::lifecycle::ReapHandler;
+use crate::domain::{Connection, ConnectionId};
+use crate::error::RealtimeError;
+use crate::infrastructure::codec::{self, ClientIntent};
+use crate::infrastructure::runtime::connection_table::{ConnHandle, ConnectionTable};
+
+/// Shared state every WebSocket connection is served against.
+#[derive(Clone)]
+pub struct GatewayState {
+    pub handshake: Arc<HandshakeHandler>,
+    pub reap: Arc<ReapHandler>,
+    pub table: Arc<ConnectionTable>,
+    pub send_queue_cap: usize,
+    pub heartbeat_interval: Duration,
+    pub heartbeat_timeout: Duration,
+}
+
+#[derive(Debug, Deserialize)]
+struct WsQuery {
+    /// The edge token, presented as a query parameter on the upgrade request.
+    access_token: String,
+}
+
+/// Bind the public WS listener and serve until shutdown.
+pub async fn serve_ws(state: GatewayState, addr: String) -> anyhow::Result<()> {
+    let app = Router::new().route("/ws", get(ws_upgrade)).with_state(state);
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!(%addr, "realtime gateway WS listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn ws_upgrade(
+    State(state): State<GatewayState>,
+    Query(query): Query<WsQuery>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, state, query.access_token))
+}
+
+/// The per-connection lifecycle: authenticate, register, then pump frames until
+/// close/reap, then tear down the registry + table slot.
+async fn handle_socket(socket: WebSocket, state: GatewayState, token: String) {
+    let now = Utc::now();
+    let Ok(connection_id) = ConnectionId::new(Uuid::now_v7().to_string()) else {
+        return;
+    };
+
+    let connection = match state
+        .handshake
+        .accept(&token, connection_id.clone(), now)
+        .await
+    {
+        Ok(connection) => connection,
+        Err(error) => {
+            tracing::debug!(%error, "ws handshake rejected");
+            return;
+        }
+    };
+
+    let user_id = connection.user_id().clone();
+    let device_id = connection.device_id().clone();
+    let connection = Arc::new(Mutex::new(connection));
+
+    let (tx, mut rx) = mpsc::channel::<Vec<u8>>(state.send_queue_cap);
+    state.table.insert(
+        user_id.as_str(),
+        ConnHandle {
+            connection_id: connection_id.clone(),
+            device_id,
+            connection: Arc::clone(&connection),
+            sender: tx.clone(),
+        },
+    );
+
+    let (mut ws_tx, mut ws_rx) = socket.split();
+
+    // Writer task: drain the bounded mailbox onto the socket.
+    let writer = tokio::spawn(async move {
+        while let Some(bytes) = rx.recv().await {
+            if ws_tx.send(Message::Binary(bytes.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Reader + heartbeat loop.
+    let mut ticker = tokio::time::interval(state.heartbeat_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let timeout = chrono::Duration::from_std(state.heartbeat_timeout)
+        .unwrap_or_else(|_| chrono::Duration::seconds(90));
+    let mut nonce = 0u64;
+
+    loop {
+        tokio::select! {
+            inbound = ws_rx.next() => match inbound {
+                Some(Ok(Message::Binary(data))) => {
+                    connection.lock().await.heartbeat(Utc::now());
+                    if let Err(error) = handle_client_frame(&data, &connection, &tx).await {
+                        tracing::debug!(%error, "client frame rejected");
+                    }
+                }
+                Some(Ok(Message::Pong(_))) => connection.lock().await.heartbeat(Utc::now()),
+                Some(Ok(Message::Close(_))) | None | Some(Err(_)) => break,
+                // Ping (axum auto-pongs) and Text are ignored.
+                Some(Ok(_)) => {}
+            },
+            _ = ticker.tick() => {
+                let now = Utc::now();
+                let (reap, expired) = {
+                    let conn = connection.lock().await;
+                    (conn.should_reap(now, timeout), conn.needs_reauth(now))
+                };
+                if reap {
+                    break;
+                }
+                if expired {
+                    let frame = codec::control_frame(
+                        pb::ServerControl::ReauthRequired, None, "RTM-1002",
+                        "edge token expired; refresh and re-handshake", 0,
+                    ).encode_to_vec();
+                    let _ = tx.try_send(frame);
+                }
+                nonce += 1;
+                let _ = tx.try_send(codec::ping_frame(nonce).encode_to_vec());
+            }
+        }
+    }
+
+    // Teardown: free the routing slots (idempotent) and stop the writer.
+    state.table.remove(user_id.as_str(), &connection_id);
+    if let Err(error) = state.reap.evict(&user_id, &connection_id).await {
+        tracing::warn!(%error, "registry evict failed on teardown");
+    }
+    writer.abort();
+}
+
+/// Decode one client frame and apply its intent to the connection.
+async fn handle_client_frame(
+    data: &[u8],
+    connection: &Arc<Mutex<Connection>>,
+    tx: &mpsc::Sender<Vec<u8>>,
+) -> Result<(), RealtimeError> {
+    let frame = pb::ClientFrame::decode(data).map_err(|e| RealtimeError::MalformedFrame {
+        reason: e.to_string(),
+    })?;
+
+    match codec::decode_client_frame(&frame)? {
+        ClientIntent::Subscribe(channels) => {
+            let mut conn = connection.lock().await;
+            for channel in channels {
+                match conn.subscribe(channel.clone()) {
+                    Ok(_) => send_control(tx, pb::ServerControl::Subscribed, Some(&channel), "", ""),
+                    Err(error) => send_control(
+                        tx,
+                        pb::ServerControl::Error,
+                        Some(&channel),
+                        error.error_code(),
+                        &error.to_string(),
+                    ),
+                }
+            }
+        }
+        ClientIntent::Unsubscribe(channels) => {
+            let mut conn = connection.lock().await;
+            for channel in channels {
+                if conn.unsubscribe(&channel).is_ok() {
+                    send_control(tx, pb::ServerControl::Unsubscribed, Some(&channel), "", "");
+                }
+            }
+        }
+        ClientIntent::Ack { channel, stream_seq } => {
+            let _ = connection.lock().await.ack(&channel, stream_seq);
+        }
+        ClientIntent::Pong { .. } => connection.lock().await.heartbeat(Utc::now()),
+        // A live token refresh is accepted but full re-verification is a follow-up;
+        // the session's existing expiry still governs (RTM-1002 on lapse).
+        ClientIntent::AuthRefresh { .. } => {}
+        // Resume re-subscribes the client's channels; live flow resumes, and any
+        // gap older than what is in flight is the client's re-sync against the SoR.
+        ClientIntent::Resume(cursors) => {
+            let mut conn = connection.lock().await;
+            for (channel, _seq) in cursors {
+                let _ = conn.subscribe(channel);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn send_control(
+    tx: &mpsc::Sender<Vec<u8>>,
+    control: pb::ServerControl,
+    channel: Option<&crate::domain::ChannelRef>,
+    code: &str,
+    message: &str,
+) {
+    let frame = codec::control_frame(control, channel, code, message, 0).encode_to_vec();
+    let _ = tx.try_send(frame);
+}
+
+/// Spawn the node-channel subscriber: `SSUBSCRIBE rt:node:{node_id}`, decode each
+/// `DeliverEnvelope`, and route it to the local connections via the table.
+pub fn spawn_node_subscriber(
+    subscriber: RedisSubscriber,
+    node_id: String,
+    table: Arc<ConnectionTable>,
+) {
+    tokio::spawn(async move {
+        let channel = format!("rt:node:{{{node_id}}}");
+        if let Err(error) = subscriber.inner.ssubscribe(channel.clone()).await {
+            tracing::error!(%error, channel, "failed to subscribe node channel");
+            return;
+        }
+        tracing::info!(channel, "node subscriber listening");
+
+        let mut rx = subscriber.inner.message_rx();
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    let Some(bytes) = msg.value.as_bytes() else {
+                        continue;
+                    };
+                    let Ok(envelope) = pb::DeliverEnvelope::decode(bytes) else {
+                        continue;
+                    };
+                    let Ok(event) = codec::envelope_from_pb(&envelope) else {
+                        continue;
+                    };
+                    table.deliver(&event).await;
+                }
+                Err(RecvError::Lagged(skipped)) => {
+                    tracing::warn!(skipped, "node subscriber lagged")
+                }
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
+}

--- a/crates/services/realtime/src/infrastructure/runtime/mod.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/mod.rs
@@ -1,0 +1,11 @@
+//! The serving runtime: the node-local connection table, the gateway WS edge, and
+//! the dispatcher fan-out consumer. Composed into the two `service_runtime::Service`
+//! impls in [`crate::service`].
+
+pub mod connection_table;
+pub mod dispatcher;
+pub mod gateway;
+
+pub use connection_table::{ConnHandle, ConnectionTable};
+pub use dispatcher::run_fanout_consumer;
+pub use gateway::{GatewayState, serve_ws, spawn_node_subscriber};

--- a/crates/services/realtime/src/lib.rs
+++ b/crates/services/realtime/src/lib.rs
@@ -1,0 +1,58 @@
+//! `realtime` — the platform's **client-facing live delivery plane**: it
+//! terminates millions of multiplexed, long-lived client connections, fans
+//! internal events out to the exact device that should see them, and owns **no**
+//! entity.
+//!
+//! This service is a System-of-**Connection / Delivery**, never a System of
+//! Record. Every byte it forwards is already durable in its owning service —
+//! `chat` persisted the message, `notification` persisted the badge, `counter`
+//! holds the magnitude. If the entire plane vanished, **no data would be lost**:
+//! clients reconnect and re-sync from those SoRs via a sequence token; it just
+//! feels laggy. That single framing sets its boundaries:
+//!
+//! * it answers **"deliver this, live, to this connection"** — never "store
+//!   this", "is this user allowed to read this content" (authorized upstream at
+//!   emit time), or "what did they miss" (re-synced from the SoR on reconnect).
+//! * it exists to **collapse the fleet's ad-hoc client streaming into one plane**:
+//!   `chat` and `notification` each grew their own client-facing fan-out, which
+//!   means multiple sockets and redundant heartbeats on one device. Realtime is
+//!   the single horizontal connection plane — one multiplexed socket per device —
+//!   and reduces those services to mere event *producers*.
+//! * it is a **structural bulkhead**: millions of flaky mobile connections
+//!   terminate here and never propagate into the internal gRPC mesh, which only
+//!   ever sees a bounded set of stable gateway peers. Internal QPS tracks
+//!   *events*, not idle eyeballs.
+//!
+//! The architectural commitment is a deliberate split into **two deployables**:
+//! a **stateful edge gateway** (`realtime-gateway`, holds the WebSocket
+//! connections + the connection registry) and a **stateless fan-out worker**
+//! (`realtime-dispatcher`, consumes the upstream Kafka streams, resolves which
+//! node owns a recipient, and publishes the event to that node). They scale on
+//! different axes — connections-and-memory vs event-throughput — and share no
+//! failure domain. Posture is **best-effort, fail-open**: a delivery miss costs
+//! latency, never data. See `project_realtime_blueprint` for the full design.
+//!
+//! ## Module roadmap (built phase by phase)
+//! Phase 0 (now): [`error`] — the canonical `RTM-XXXX` namespace.
+//! Phase 1: the client-facing transport **envelope** spec + the internal gRPC
+//! contract (`realtime-api`). · Phase 2: `domain` (Connection, identity-pinned
+//! Session, Subscription set + channel-scope authorization, the sequence/ack and
+//! presence state machines — pure). · Phase 3: `application` + ports
+//! (ConnectionRegistry / NodeChannel / TokenVerifier / EventSource + the
+//! handshake, subscribe, deliver, reap and drain handlers + in-memory fakes). ·
+//! Phase 4: `infrastructure` (the WebSocket server with bounded per-connection
+//! mailboxes + shedding, the `fred` Redis registry, the Redis Pub/Sub node-hop,
+//! the `auth-context` token verifier, the `run_consumer` event consumers). ·
+//! Phase 5: `app` (composition roots) + `service` (the two runtime wirings — the
+//! edge gateway and the fan-out dispatcher).
+
+pub mod app;
+pub mod application;
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod infrastructure;
+pub mod service;
+
+pub use error::RealtimeError;
+pub use service::{RealtimeDispatcherService, RealtimeGatewayService};

--- a/crates/services/realtime/src/service.rs
+++ b/crates/services/realtime/src/service.rs
@@ -1,0 +1,227 @@
+//! Adapts the realtime composition roots to the fleet [`service_runtime::Service`]
+//! contract — **twice**, because realtime is two deployables that share a domain
+//! but no process or failure domain:
+//!
+//! * [`RealtimeGatewayService`] (`realtime-gateway`) — the stateful edge. Builds
+//!   the adapters, opens the node-channel subscriber + the public WS server as
+//!   background tasks, and serves only health + reflection on its internal gRPC
+//!   port (:50066). The connections live in the spawned WS server.
+//! * [`RealtimeDispatcherService`] (`realtime-dispatcher`) — the stateless fan-out
+//!   worker. Builds the routing fabric, spawns the supervised `run_consumer`
+//!   loops that decode upstream events and fan them out, and serves only health +
+//!   reflection on its port (:50067). Exposes no domain RPC.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use redis_storage::RedisClient;
+use service_runtime::{FnProbe, HealthProbe, InfraRegistry, Service};
+use tonic::service::RoutesBuilder;
+use tonic_reflection::server::Builder as ReflectionBuilder;
+use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
+use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
+use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
+
+use crate::app::Adapters;
+use crate::application::FanOutHandler;
+use crate::application::handshake::HandshakeHandler;
+use crate::application::lifecycle::ReapHandler;
+use crate::config::RealtimeConfig;
+use crate::domain::NodeId;
+use crate::infrastructure::decode::{NotificationWire, map_notification};
+use crate::infrastructure::runtime::{
+    ConnectionTable, GatewayState, run_fanout_consumer, serve_ws, spawn_node_subscriber,
+};
+
+/// Health-reporting key for both binaries (they serve no domain RPC; this is the
+/// readiness key the runtime marks `SERVING`).
+const HEALTH_KEY: &str = "realtime.v1.RealtimeDispatchService";
+
+const NOTIFICATION_TOPIC: &str = "notification.v1.events";
+const NOTIFICATION_GROUP: &str = "realtime-notif-fanout";
+
+/// Backoff before respawning a consumer after its runner returns.
+const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
+
+// ── Gateway ───────────────────────────────────────────────────────────────────
+
+pub struct RealtimeGatewayService {
+    redis: RedisClient,
+}
+
+#[async_trait]
+impl Service for RealtimeGatewayService {
+    const NAME: &'static str = "realtime-gateway";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = HEALTH_KEY;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let config = RealtimeConfig::from_env();
+        let adapters = Adapters::build(&config).await.context("build adapters")?;
+
+        let node_id = NodeId::new(config.node_id.clone())
+            .map_err(|e| anyhow::anyhow!("invalid REALTIME_NODE_ID: {e}"))?;
+        let table = Arc::new(ConnectionTable::new());
+
+        // The node-channel subscriber turns inbound deliveries into socket frames.
+        spawn_node_subscriber(adapters.subscriber, config.node_id.clone(), Arc::clone(&table));
+
+        let handshake = Arc::new(HandshakeHandler::new(
+            Arc::clone(&adapters.verifier),
+            Arc::clone(&adapters.registry),
+            node_id,
+            config.subscription_cap,
+        ));
+        let reap = Arc::new(ReapHandler::new(Arc::clone(&adapters.registry)));
+
+        let state = GatewayState {
+            handshake,
+            reap,
+            table,
+            send_queue_cap: config.send_queue_cap,
+            heartbeat_interval: config.heartbeat_interval,
+            heartbeat_timeout: config.heartbeat_timeout,
+        };
+
+        let ws_addr = config.ws_addr.clone();
+        tokio::spawn(async move {
+            if let Err(error) = serve_ws(state, ws_addr).await {
+                tracing::error!(%error, "realtime gateway WS server stopped");
+            }
+        });
+
+        Ok(Self {
+            redis: adapters.redis,
+        })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        vec![redis_probe(self.redis.clone())]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(realtime_api::FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+        routes.add_service(reflection);
+        Ok(())
+    }
+}
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+
+pub struct RealtimeDispatcherService {
+    redis: RedisClient,
+}
+
+#[async_trait]
+impl Service for RealtimeDispatcherService {
+    const NAME: &'static str = "realtime-dispatcher";
+    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    const GRPC_SERVICE_NAME: &'static str = HEALTH_KEY;
+
+    async fn build(_infra: Arc<InfraRegistry>) -> anyhow::Result<Self> {
+        let config = RealtimeConfig::from_env();
+        let adapters = Adapters::build(&config).await.context("build adapters")?;
+
+        let handler = Arc::new(FanOutHandler::new(
+            Arc::clone(&adapters.registry),
+            Arc::clone(&adapters.node_channel),
+        ));
+
+        // Supervised fan-out consumer(s). Only the notification stream is wired
+        // today; chat / counter / post follow the same shape as those producers land.
+        spawn_fanout_consumer::<NotificationWire, _>(
+            NOTIFICATION_TOPIC,
+            NOTIFICATION_GROUP,
+            "notification",
+            &handler,
+            map_notification,
+        );
+
+        Ok(Self {
+            redis: adapters.redis,
+        })
+    }
+
+    fn health_probes(&self) -> Vec<Arc<dyn HealthProbe>> {
+        vec![redis_probe(self.redis.clone())]
+    }
+
+    fn register(self, routes: &mut RoutesBuilder) -> anyhow::Result<()> {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(realtime_api::FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+        routes.add_service(reflection);
+        Ok(())
+    }
+}
+
+// ── Shared wiring helpers ─────────────────────────────────────────────────────
+
+/// A hot-tier liveness probe: a trivial `EVAL 'return 1'` round-trip to Redis.
+fn redis_probe(redis: RedisClient) -> Arc<dyn HealthProbe> {
+    use fred::interfaces::LuaInterface;
+    Arc::new(FnProbe::new("redis", move || {
+        let redis = redis.clone();
+        async move {
+            let _: i64 = redis
+                .inner
+                .eval("return 1", Vec::<String>::new(), Vec::<String>::new())
+                .await
+                .map_err(|e: fred::error::Error| anyhow::anyhow!(e.to_string()))?;
+            Ok(())
+        }
+    }))
+}
+
+/// Spawns a supervised fan-out consumer that rebuilds its Kafka handles and
+/// restarts after a backoff whenever the runner returns.
+fn spawn_fanout_consumer<T, M>(
+    topic: &'static str,
+    group: &'static str,
+    label: &'static str,
+    handler: &Arc<FanOutHandler>,
+    map: M,
+) where
+    T: transport::kafka::envelope::ConsumablePayload + Clone,
+    M: Fn(T) -> Result<crate::application::DeliverableEvent, crate::error::RealtimeError>
+        + Copy
+        + Send
+        + Sync
+        + 'static,
+{
+    let handler = Arc::clone(handler);
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(topic, group) {
+                Ok((consumer, producer)) => {
+                    run_fanout_consumer::<T, _>(label, consumer, producer, Arc::clone(&handler), map)
+                        .await;
+                    tracing::warn!(label, "consumer exited; respawning after backoff");
+                }
+                Err(error) => tracing::error!(label, %error, "failed to build consumer; retrying"),
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Builds a manual-commit consumer (subscribed to `topic`) and the dead-letter
+/// producer the runner needs. Kafka config is read fresh per respawn.
+fn build_consumer(
+    topic: &str,
+    group: &str,
+) -> anyhow::Result<(KafkaConsumerHandle, KafkaProducerHandle)> {
+    let kafka = KafkaClientConfig::from_env();
+    let consumer = KafkaConsumerBuilder::new(ConsumerConfig::new(kafka.clone(), group))
+        .subscribe(topic)
+        .build()
+        .with_context(|| format!("build consumer for {topic}"))?;
+    let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+        .build()
+        .with_context(|| format!("build dead-letter producer for {topic}"))?;
+    Ok((consumer, producer))
+}

--- a/crates/services/realtime/tests/integration.rs
+++ b/crates/services/realtime/tests/integration.rs
@@ -1,0 +1,26 @@
+//! Live, container-backed integration suite for the realtime delivery service.
+//!
+//! Realtime's whole point is the internal→external bridge — resolve a recipient,
+//! hop to the owning node over Redis sharded Pub/Sub, and land the event on the
+//! right socket — so this suite boots real **Redis** and drives that bridge over
+//! the production adapters (`RedisConnectionRegistry`, `RedisNodeChannel`) plus the
+//! node-local `ConnectionTable`. It exercises exactly what cannot be unit-tested:
+//! that `HSET`/`HGETALL`/`PEXPIRE` round-trip the registry (and TTL self-heals a
+//! leaked entry), that `SPUBLISH`→`SSUBSCRIBE` carries a prost `DeliverEnvelope`
+//! intact, and that a fanned-out event reaches a subscribed connection's queue
+//! while an unsubscribed/offline one gets nothing.
+//!
+//! The WebSocket accept loop and the auth/JWKS decoder are out of scope here (they
+//! need a live IdP + a browser-grade WS client); their logic is unit-tested over
+//! fakes, and the `spawn_node_subscriber` loop is the thin glue around the tested
+//! `ConnectionTable::deliver` + decode path.
+//!
+//! Gated behind `integration-realtime` so the default `cargo test -p realtime`
+//! stays hermetic and Docker-free:
+//!
+//! ```text
+//! cargo test -p realtime --features integration-realtime -- --nocapture
+//! ```
+#![cfg(feature = "integration-realtime")]
+
+mod realtime_it;

--- a/crates/services/realtime/tests/realtime_it/harness.rs
+++ b/crates/services/realtime/tests/realtime_it/harness.rs
@@ -1,0 +1,152 @@
+//! Integration harness: boots an ephemeral Redis, wires the real realtime routing
+//! adapters against it, and provides builders for scenario-isolated identities.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use redis_storage::{RedisClient, RedisClientBuilder, RedisConfig, RedisSubscriber, RedisSubscriberBuilder};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use realtime::application::port::{ConnectionLocation, NodeChannel};
+use realtime::application::{DeliverableEvent, FanOutHandler};
+use realtime::domain::{
+    ChannelClass, ChannelKey, ChannelRef, Connection, ConnectionId, DeviceId, NodeId, Session,
+    UserId,
+};
+use realtime::infrastructure::redis_connection_registry::RedisConnectionRegistry;
+use realtime::infrastructure::redis_node_channel::RedisNodeChannel;
+use realtime::infrastructure::runtime::{ConnHandle, ConnectionTable};
+
+/// Short registry TTL so the self-heal scenario can observe expiry quickly.
+pub const SHORT_TTL_MS: i64 = 1_000;
+pub const LONG_TTL_MS: i64 = 120_000;
+
+pub struct Harness {
+    pub redis: RedisClient,
+    pub registry: Arc<RedisConnectionRegistry>,
+    pub node_channel: Arc<RedisNodeChannel>,
+    redis_config: RedisConfig,
+}
+
+impl Harness {
+    pub async fn start() -> Self {
+        Self::with_ttl(LONG_TTL_MS).await
+    }
+
+    pub async fn with_ttl(ttl_ms: i64) -> Self {
+        let endpoint = test_support::containers::redis_endpoint().await;
+        let redis_config = RedisConfig {
+            hosts: vec![endpoint],
+            ..RedisConfig::default()
+        };
+        let redis = RedisClientBuilder::new(redis_config.clone())
+            .build()
+            .await
+            .expect("it: redis client");
+
+        let registry = Arc::new(RedisConnectionRegistry::new(redis.clone(), ttl_ms));
+        let node_channel = Arc::new(RedisNodeChannel::new(redis.clone()));
+
+        Self {
+            redis,
+            registry,
+            node_channel,
+            redis_config,
+        }
+    }
+
+    /// A dedicated subscriber connection (for the gateway-side `SSUBSCRIBE` loop).
+    pub async fn subscriber(&self) -> RedisSubscriber {
+        RedisSubscriberBuilder::new(self.redis_config.clone())
+            .build()
+            .await
+            .expect("it: redis subscriber")
+    }
+
+    pub fn fan_out(&self) -> FanOutHandler {
+        FanOutHandler::new(self.registry.clone(), self.node_channel.clone())
+    }
+}
+
+// ── Builders ──────────────────────────────────────────────────────────────────
+
+/// A fresh, scenario-isolated user id.
+pub fn fresh_user() -> UserId {
+    UserId::new(format!("u-{}", Uuid::now_v7())).unwrap()
+}
+
+pub fn dm_channel(user: &UserId) -> ChannelRef {
+    ChannelRef::new(
+        ChannelClass::Dm,
+        ChannelKey::new(user.as_str().to_owned()).unwrap(),
+    )
+}
+
+pub fn location(user: &UserId, device: &str, conn: &str, node: &str) -> ConnectionLocation {
+    ConnectionLocation {
+        user_id: user.clone(),
+        device_id: DeviceId::new(device).unwrap(),
+        connection_id: ConnectionId::new(conn).unwrap(),
+        node_id: NodeId::new(node).unwrap(),
+    }
+}
+
+pub fn dm_event(user: &UserId, payload: &[u8]) -> DeliverableEvent {
+    DeliverableEvent {
+        recipient: user.clone(),
+        device_id: None,
+        channel: dm_channel(user),
+        payload: payload.to_vec(),
+        event_type: "chat.message".to_owned(),
+        emitted_at: Utc::now(),
+        idempotency_key: Uuid::now_v7().to_string(),
+    }
+}
+
+/// Register a connection in `table` subscribed to its `dm:<user>` channel, and
+/// return the receiver standing in for its socket writer.
+pub async fn register_connection(
+    table: &ConnectionTable,
+    user: &UserId,
+    device: &str,
+    conn: &str,
+    node: &str,
+    queue_cap: usize,
+) -> mpsc::Receiver<Vec<u8>> {
+    let session = Session::new(
+        user.clone(),
+        DeviceId::new(device).unwrap(),
+        Utc::now() + chrono::Duration::hours(1),
+    );
+    let mut connection = Connection::open(
+        ConnectionId::new(conn).unwrap(),
+        NodeId::new(node).unwrap(),
+        session,
+        16,
+        Utc::now(),
+    );
+    connection.subscribe(dm_channel(user)).unwrap();
+
+    let (tx, rx) = mpsc::channel(queue_cap);
+    table.insert(
+        user.as_str(),
+        ConnHandle {
+            connection_id: ConnectionId::new(conn).unwrap(),
+            device_id: DeviceId::new(device).unwrap(),
+            connection: Arc::new(Mutex::new(connection)),
+            sender: tx,
+        },
+    );
+    rx
+}
+
+/// Publish to a node's channel directly (test convenience).
+pub async fn publish(channel: &RedisNodeChannel, node: &str, event: &DeliverableEvent) {
+    channel
+        .publish(&NodeId::new(node).unwrap(), event)
+        .await
+        .expect("it: node publish");
+}

--- a/crates/services/realtime/tests/realtime_it/mod.rs
+++ b/crates/services/realtime/tests/realtime_it/mod.rs
@@ -1,0 +1,6 @@
+//! Realtime integration suite: the harness (boots Redis and wires the real
+//! routing adapters) and the bridge scenarios. Isolation is by fresh per-scenario
+//! user ids (UUID); the shared container runs every scenario in parallel.
+
+mod harness;
+mod scenarios;

--- a/crates/services/realtime/tests/realtime_it/scenarios.rs
+++ b/crates/services/realtime/tests/realtime_it/scenarios.rs
@@ -1,0 +1,161 @@
+//! The live bridge scenarios, driven over real Redis.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use fred::interfaces::{EventInterface, PubsubInterface};
+use prost::Message as _;
+use realtime_api as pb;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+use realtime::application::port::ConnectionRegistry;
+use realtime::domain::ConnectionId;
+use realtime::infrastructure::runtime::ConnectionTable;
+use test_support::await_until;
+
+use super::harness::*;
+
+/// `HSET`/`HGETALL`/`HDEL` round-trip: two placements bind, resolve, and evict one.
+#[tokio::test]
+async fn registry_binds_resolves_and_evicts() {
+    let h = Harness::start().await;
+    let user = fresh_user();
+
+    h.registry
+        .bind(&location(&user, "phone", "c1", "node-A"))
+        .await
+        .unwrap();
+    h.registry
+        .bind(&location(&user, "tablet", "c2", "node-B"))
+        .await
+        .unwrap();
+    assert_eq!(h.registry.resolve(&user).await.unwrap().len(), 2);
+
+    h.registry
+        .evict(&user, &ConnectionId::new("c1").unwrap())
+        .await
+        .unwrap();
+    let remaining = h.registry.resolve(&user).await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].connection_id.as_str(), "c2");
+}
+
+/// A connection whose `evict` never ran (a half-open leak) must be reclaimed by
+/// the bind-time TTL — the self-heal that keeps the registry from accreting ghosts.
+#[tokio::test]
+async fn registry_ttl_self_heals_a_leaked_entry() {
+    let h = Harness::with_ttl(SHORT_TTL_MS).await;
+    let user = fresh_user();
+
+    h.registry
+        .bind(&location(&user, "phone", "c1", "node-A"))
+        .await
+        .unwrap();
+    assert_eq!(h.registry.resolve(&user).await.unwrap().len(), 1);
+
+    await_until("leaked registry entry expires", Duration::from_secs(5), || async {
+        h.registry.resolve(&user).await.unwrap().is_empty()
+    })
+    .await;
+}
+
+/// `SPUBLISH`→`SSUBSCRIBE` carries a prost `DeliverEnvelope` intact (the node hop).
+#[tokio::test]
+async fn node_hop_carries_a_deliver_envelope() {
+    let h = Harness::start().await;
+    let user = fresh_user();
+    let node = format!("node-{}", Uuid::now_v7());
+
+    let subscriber = h.subscriber().await;
+    subscriber
+        .inner
+        .ssubscribe(format!("rt:node:{{{node}}}"))
+        .await
+        .unwrap();
+    let mut rx = subscriber.inner.message_rx();
+
+    publish(&h.node_channel, &node, &dm_event(&user, b"hello-bridge")).await;
+
+    let msg = timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("node-hop recv timed out")
+        .expect("recv");
+    let bytes = msg.value.as_bytes().expect("binary payload");
+    let env = pb::DeliverEnvelope::decode(bytes).expect("decode envelope");
+
+    assert_eq!(env.recipient_user_id, user.as_str());
+    assert_eq!(env.payload, b"hello-bridge");
+    assert!(env.ack_required); // DM ⇒ at-least-once
+}
+
+/// The full internal→external bridge over real Redis: fan-out resolves the live
+/// registry, hops to the owning node, and the table lands an `Event` frame on the
+/// subscribed connection's queue.
+#[tokio::test]
+async fn bridge_delivers_event_to_a_subscribed_connection() {
+    let h = Harness::start().await;
+    let user = fresh_user();
+    let node = format!("node-{}", Uuid::now_v7());
+
+    let table = Arc::new(ConnectionTable::new());
+    let mut socket_rx = register_connection(&table, &user, "phone", "c1", &node, 8).await;
+    h.registry
+        .bind(&location(&user, "phone", "c1", &node))
+        .await
+        .unwrap();
+
+    // Subscribe the node channel BEFORE fanning out (pub/sub is fire-and-forget).
+    let subscriber = h.subscriber().await;
+    subscriber
+        .inner
+        .ssubscribe(format!("rt:node:{{{node}}}"))
+        .await
+        .unwrap();
+    let mut node_rx = subscriber.inner.message_rx();
+
+    let outcome = h
+        .fan_out()
+        .fan_out(&dm_event(&user, b"payload-xyz"))
+        .await
+        .unwrap();
+    assert!(!outcome.offline);
+    assert_eq!(outcome.nodes_published, 1);
+
+    // Receive the envelope off the node channel and deliver it via the table.
+    let msg = timeout(Duration::from_secs(5), node_rx.recv())
+        .await
+        .expect("node recv timed out")
+        .expect("recv");
+    let env = pb::DeliverEnvelope::decode(msg.value.as_bytes().expect("bytes")).unwrap();
+    let event = realtime::infrastructure::codec::envelope_from_pb(&env).unwrap();
+    assert_eq!(table.deliver(&event).await, 1);
+
+    // The connection's socket queue received an Event frame for dm:<user>, seq 1.
+    let frame_bytes = timeout(Duration::from_secs(5), socket_rx.recv())
+        .await
+        .expect("socket recv timed out")
+        .expect("frame");
+    match pb::ServerFrame::decode(&frame_bytes[..]).unwrap().body.unwrap() {
+        pb::server_frame::Body::Event(e) => {
+            assert_eq!(e.payload, b"payload-xyz");
+            assert_eq!(e.stream_seq, 1);
+        }
+        _ => panic!("expected an Event frame"),
+    }
+}
+
+/// A recipient with no live placement is a fail-open no-op — nothing is published.
+#[tokio::test]
+async fn offline_recipient_is_a_noop() {
+    let h = Harness::start().await;
+    let user = fresh_user(); // never bound
+
+    let outcome = h
+        .fan_out()
+        .fan_out(&dm_event(&user, b"x"))
+        .await
+        .unwrap();
+    assert!(outcome.offline);
+    assert_eq!(outcome.nodes_published, 0);
+}


### PR DESCRIPTION
## What

A new **TIER-1, fail-open `realtime` service** — the client-facing real-time push/delivery plane. It terminates millions of multiplexed client WebSocket connections and fans internal events out to the exact device, owning no entity.

It is a **System of Connection/Delivery, never a System of Record**: a delivery miss costs latency, never data — durability lives in the owning SoRs (`chat` / `notification` / `counter`) and clients re-sync on reconnect. The point is to collapse the fleet's ad-hoc client streaming (chat, notification each stream their own) into **one multiplexed socket per device**, and to act as a structural bulkhead so millions of flaky mobile connections terminate at the edge and never reach the internal gRPC mesh.

## Shape

Two deployables that share a domain but no process or failure domain, over a Redis routing fabric:

- **`realtime-gateway`** — stateful edge. Holds the WebSocket connections, writes the presence registry, subscribes to its node hop. Internal gRPC health on **:50066**, public **WSS on :8443**. (The fleet's first dual-listener service.)
- **`realtime-dispatcher`** — stateless fan-out worker. `run_consumer` over upstream Kafka → decode → resolve the recipient → publish to the owning node. Health on **:50067**.

The internal→external bridge is three stages: core services emit once to Kafka → the dispatcher resolves the recipient against the registry (targeted, not broadcast) → it publishes to the owning gateway node over Redis sharded Pub/Sub → the node lands the event on the right socket.

## Contents

- **`realtime.v1` contract** — prost `ClientFrame`/`ServerFrame` WSS envelope (not gRPC to the client) + the internal node-hop `DeliverEnvelope` / `RealtimeDispatchService`.
- **Domain** — `Connection` aggregate (`Active → Draining → Closed`), identity-pinned `Session` + the channel-scope authorization rule (the plane's only authz), per-`(connection, channel)` sequencing + ack watermark, derived presence.
- **Application** — `ConnectionRegistry` / `NodeChannel` / `TokenVerifier` / `EventSource` ports; handshake, fan-out (+ `run_dispatch`), and reap handlers; an offline recipient is a fail-open no-op.
- **Infrastructure** — fred Redis registry (Lua single-key writes + TTL self-heal), sharded `SPUBLISH` node hop, `auth-context` ES256 verifier, the proto codec, the bounded drop-oldest mailbox, the node-local `ConnectionTable` (deliver + graceful `broadcast_drain`), the axum WebSocket gateway runtime, and the `run_consumer` fan-out dispatcher.

## Tests & safety

- **52 unit tests** + **5 live integration tests** on a real Redis container (gated behind `integration-realtime`): registry round-trip, TTL self-heal of a leaked entry, `SPUBLISH`/`SSUBSCRIBE` node hop, the end-to-end bridge (fan-out → registry → node hop → socket frame), and the offline no-op.
- **Security-reviewed:** no token or PII in logs, the opaque payload is never logged, and there is no panic in the accept or delivery hot path.
- Clippy clean; README EN + FR with the i18n drift gate passing.

## Explicitly deferred (not gaps)

The live WS-accept-loop + auth/JWKS integration test (needs a live IdP and a WS client — the routing fabric *is* covered live), the live Kafka dispatcher IT (the `run_consumer` runner is covered by `transport`'s own suite), the WebTransport/HTTP-3 lane, presence as a product stream, cross-region routing, the internal-gRPC `NodeChannel` backpressure variant, the `SIGTERM → broadcast_drain` runtime wiring, and the `chat` + `notification` client-streaming consolidation (coexist-first).

## Notes for reviewers

Built phase-by-phase (scaffold → contract → domain → application → adapters → wiring → live IT → hardening), mirroring the counter/media/search service conventions. Upstream producers for `chat` / `counter.v1.popularity` / `post.v1` decode follow the same shape as the wired `notification.v1.events` mapping and land as those streams firm up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3VfarYci2c1BCq29GQLA1
