### PR TITLE
feat(realtime): public-broadcast fan-out — wire counter.v1.popularity + post.v1.events

### DIFF
--- a/crates/contracts/proto/realtime/v1/messages.proto
+++ b/crates/contracts/proto/realtime/v1/messages.proto
@@ -157,6 +157,13 @@ message DeliverEnvelope {
     // dispatcher runs under `run_consumer`, at-least-once) does not double-emit
     // on a reconnected client that already saw it.
     string     idempotency_key     = 8;
+    // Delivery mode. When false (the default), this is a TARGETED delivery to
+    // `recipient_user_id` (identity-scoped channels: dm / notif / presence). When
+    // true, it is a PUBLIC BROADCAST: `recipient_user_id` is empty and every node
+    // delivers it to its local connections subscribed to `channel` (entity
+    // channels: counter / feed). Carried on the fleet broadcast channel, not a
+    // single node's hop channel.
+    bool       broadcast           = 9;
 }
 
 // The result of a node-hop delivery.

--- a/crates/services/realtime/README.fr.md
+++ b/crates/services/realtime/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 474e6e05598cc47a03f4e7b3b44be1e8ca316eda439bf7bef1bf2669c5c9095e
+  source_sha256: e0839b81e1ebf56422362a0c1c7ad638c773c5030d3e6cd4b46e8cd4328fdf14
   translated_at: 2026-06-26
   status: complete
 ---
@@ -21,7 +21,7 @@ i18n:
 > | **Déployable** | **deux** binaires — `crates/apps/realtime-gateway` (bord avec état, détient les connexions) **et** `crates/apps/realtime-dispatcher` (worker de diffusion sans état). Crate bibliothèque : `crates/services/realtime` |
 > | **Écouteurs** | **deux plans** (le premier de la flotte) — un plan client public **WSS** (défaut `:8443`, derrière un LB L4) sur la gateway, et un plan interne **gRPC** de santé/contrôle (`:50066` gateway · `:50067` dispatcher) |
 > | **Datastores** | **Redis** uniquement — le registre de connexion/présence (routage `user → node`) + le tissu de saut inter-nœud Pub/Sub. Ne détient aucune entité, ne persiste aucun message |
-> | **Async** | consomme les événements de message `chat`, `notification.v1.events`, `counter.v1.popularity`, `post.v1.events` (Kafka). Ne publie rien de référence |
+> | **Async** | consomme `notification.v1.events` (ciblé), `counter.v1.popularity` + `post.v1.events` (broadcast public) (Kafka). Ne publie rien de référence. `chat` reste sur son propre plan live (coexistence) |
 > | **Appelants amont** | clients utilisateurs finaux via WSS (mobile / web) — **pas** les services internes |
 > | **Dépendances aval** | Redis, Kafka, et `auth` (vérification du jeton de bord via la bibliothèque `auth-context` — une vérification, pas un appel). La durabilité des messages/notifications reste dans `chat` / `notification` |
 > | **SLO** | `<TODO>` dispo · événement→appareil p99 `< <TODO ~250> ms` pour les utilisateurs en ligne · établissement de connexion p99 `< <TODO> ms` |
@@ -163,10 +163,11 @@ Chaque défaillance implémente `error::AppError` avec un code `RTM-XXXX` stable
 
 | Topic | Groupe de consommateurs | Rôle | En cas de poison/épuisement |
 |---|---|---|---|
-| `<chat message events>` | `realtime-chat-fanout` | livrer les DM / messages aux destinataires en ligne | DLQ `<...>.dlq` |
-| `notification.v1.events` | `realtime-notif-fanout` | livrer les mises à jour notification/badge en live | DLQ `notification.v1.events.dlq` |
-| `counter.v1.popularity` | `realtime-counter-fanout` | livrer les pics d'engagement live aux spectateurs d'une entité | DLQ `counter.v1.popularity.dlq` |
-| `post.v1.events` | `realtime-post-fanout` | livrer les signaux de fil live (sélectif) | DLQ `post.v1.events.dlq` |
+| `notification.v1.events` | `realtime-notif-fanout` | **ciblé** — livrer notification/badge au canal `notif:<user>` du destinataire | DLQ `notification.v1.events.dlq` |
+| `counter.v1.popularity` | `realtime-counter-fanout` | **broadcast** — livrer les pics d'engagement aux spectateurs abonnés à `counter:<entity>` | DLQ `counter.v1.popularity.dlq` |
+| `post.v1.events` | `realtime-post-fanout` | **broadcast** — livrer le cycle de vie du post aux abonnés du `feed:<profile_id>` de l'auteur | DLQ `post.v1.events.dlq` |
+
+> **Deux modes de diffusion.** Les événements *ciblés* (notification — et DM/présence) nomment un utilisateur destinataire ; le dispatcher les résout via le registre et saute vers le(s) nœud(s) propriétaire(s). Les événements *broadcast* (counter / feed) nomment une entité, pas un utilisateur ; le dispatcher les publie une fois sur le canal broadcast de la flotte, et chaque nœud livre à ses connexions locales abonnées à ce canal. `chat.message.sent` n'est **pas** consommé — il ne porte aucune liste de membres et chat exécute déjà son propre plan live (la décision coexistence-d'abord) ; le câbler est une consolidation délibérée, pas un décodage.
 
 > **Contrat d'exécution (obligatoire) :** tous les consommateurs du dispatcher tournent sous `run_consumer` — commit manuel après un résultat terminal, retry borné avec backoff + jitter, DLQ à l'épuisement/poison, reconstruction depuis le dernier offset commité sur erreur broker. **Idempotence :** la diffusion est naturellement idempotente — un événement redélivré ré-résout le registre et re-livre ; les trames live dupliquées sont inoffensives (le client déduplique sur `stream_seq`). Un événement non-routable/inconnu (`RTM-8002` / `RTM-8003`) est replié en `Ok` pour que l'offset commite quand même.
 
@@ -197,7 +198,7 @@ realtime = { path = "crates/services/realtime" }
 
 Bibliothèque uniquement. Implémentera [`service_runtime::Service`](../../platform/service-runtime/README.md) **deux fois** (Phase 5) : `realtime::service::RealtimeGatewayService` (le binaire `realtime-gateway` — la boucle d'acceptation WSS, les écritures de registre, l'abonnement au saut inter-nœud, le hook de drain, la santé gRPC interne) et `realtime::service::RealtimeDispatcherService` (le binaire `realtime-dispatcher` — les boucles de diffusion `run_consumer` supervisées, aucun RPC de domaine). Télémétrie, config + hot-reload, santé et arrêt gracieux sont détenus par le runtime.
 
-> **État de build :** **complet jusqu'à la Phase 7** (les 8 phases : scaffold → contrat → domaine → application+ports → adaptateurs → câblage gateway+dispatcher → IT live → durcissement). 52 tests unitaires plus une suite live `integration-realtime` (Redis réel) couvrent le domaine, le codec proto, la mailbox bornée-à-délestage, la table de routage locale au nœud (avec délestage-sous-pression et `broadcast_drain` gracieux) et le pont de bout en bout (fan-out → résolution registre → saut inter-nœud → trame socket). Revu côté sécurité : aucun jeton ni PII dans les logs, le payload opaque n'est jamais journalisé, et aucun panic dans le chemin chaud d'acceptation ou de livraison.
+> **État de build :** **complet jusqu'à la Phase 7 + le chemin de diffusion publique (broadcast).** 58 tests unitaires plus une suite live `integration-realtime` (Redis réel) couvrent le domaine, le codec proto, la mailbox bornée-à-délestage, la table de routage locale au nœud (livraison ciblée + broadcast, délestage-sous-pression, `broadcast_drain` gracieux), les mappings de décodage amont (notification / counter / post) et les ponts de bout en bout (ciblé : fan-out → registre → saut inter-nœud → socket ; broadcast : fan-out → canal flotte → index de canal → socket). Revu côté sécurité : aucun jeton ni PII dans les logs, le payload opaque n'est jamais journalisé, et aucun panic dans le chemin chaud d'acceptation ou de livraison.
 >
 > **Différé (explicite, pas des lacunes) :** le test d'intégration de la boucle d'acceptation WebSocket + auth/JWKS (nécessite un IdP live et un client WS de qualité navigateur — le tissu de routage *est* couvert en live) ; l'IT live du dispatcher Kafka (le runner `run_consumer` est couvert par la suite de `transport`) ; la voie de transport WebTransport / HTTP-3 ; la présence comme flux orienté produit ; le routage cross-région / multi-PoP ; la variante de contre-pression `NodeChannel` en gRPC interne ; le câblage `SIGTERM` → `broadcast_drain` ; et la consolidation du streaming client `chat` + `notification` (coexistence d'abord).
 >

--- a/crates/services/realtime/README.md
+++ b/crates/services/realtime/README.md
@@ -10,7 +10,7 @@
 > | **Deployable** | **two** binaries — `crates/apps/realtime-gateway` (stateful edge, holds the connections) **and** `crates/apps/realtime-dispatcher` (stateless fan-out worker). Library crate: `crates/services/realtime` |
 > | **Listeners** | **two planes** (the fleet's first) — a public **WSS** client plane (default `:8443`, behind an L4 LB) on the gateway, and an internal **gRPC** health/control plane (`:50066` gateway · `:50067` dispatcher) |
 > | **Datastores** | **Redis** only — the connection/presence registry (`user → node` routing) + the node-hop Pub/Sub fabric. Owns no entity, persists no message |
-> | **Async** | consumes `chat` message events, `notification.v1.events`, `counter.v1.popularity`, `post.v1.events` (Kafka). Publishes nothing of record |
+> | **Async** | consumes `notification.v1.events` (targeted), `counter.v1.popularity` + `post.v1.events` (public broadcast) (Kafka). Publishes nothing of record. `chat` stays on its own live plane (coexist) |
 > | **Upstream callers** | end-user clients over WSS (mobile / web) — **not** internal services |
 > | **Downstream deps** | Redis, Kafka, and `auth` (edge-token verification via the `auth-context` library — a verify, not a call). Message/notification durability stays in `chat` / `notification` |
 > | **SLO** | `<TODO>` avail · event→device p99 `< <TODO ~250> ms` for online users · connection setup p99 `< <TODO> ms` |
@@ -152,10 +152,11 @@ Every fault implements `error::AppError` with a stable `RTM-XXXX` code, mapped t
 
 | Topic | Consumer group | Purpose | On poison/exhaustion |
 |---|---|---|---|
-| `<chat message events>` | `realtime-chat-fanout` | deliver DMs / messages to online recipients | DLQ `<...>.dlq` |
-| `notification.v1.events` | `realtime-notif-fanout` | deliver notification/badge updates live | DLQ `notification.v1.events.dlq` |
-| `counter.v1.popularity` | `realtime-counter-fanout` | deliver live engagement spikes to viewers of an entity | DLQ `counter.v1.popularity.dlq` |
-| `post.v1.events` | `realtime-post-fanout` | deliver live feed signals (selective) | DLQ `post.v1.events.dlq` |
+| `notification.v1.events` | `realtime-notif-fanout` | **targeted** — deliver notification/badge updates to the recipient's `notif:<user>` channel | DLQ `notification.v1.events.dlq` |
+| `counter.v1.popularity` | `realtime-counter-fanout` | **broadcast** — deliver live engagement spikes to viewers subscribed to `counter:<entity>` | DLQ `counter.v1.popularity.dlq` |
+| `post.v1.events` | `realtime-post-fanout` | **broadcast** — deliver post lifecycle to subscribers of the author's `feed:<profile_id>` | DLQ `post.v1.events.dlq` |
+
+> **Two fan-out modes.** *Targeted* events (notification — and DM/presence) name a recipient user; the dispatcher resolves them via the registry and hops to the owning node(s). *Broadcast* events (counter / feed) name an entity, not a user; the dispatcher publishes them once to the fleet broadcast channel, and every node delivers to its local connections subscribed to that channel. `chat.message.sent` is **not** consumed — it carries no member list and chat already runs its own live plane (the coexist-first decision); wiring it is a deliberate consolidation, not a decode.
 
 > **Runtime contract (mandatory):** all dispatcher consumers run under `run_consumer` — manual commit after a terminal outcome, bounded retry with backoff + jitter, DLQ on exhaustion/poison, rebuild-from-last-committed-offset on broker error. **Idempotency:** fan-out is naturally idempotent — a redelivered event re-resolves the registry and re-delivers; duplicate live frames are harmless (the client dedupes on `stream_seq`). An unroutable/unknown event (`RTM-8002` / `RTM-8003`) is folded into `Ok` so the offset still commits.
 
@@ -186,7 +187,7 @@ realtime = { path = "crates/services/realtime" }
 
 Library-only. Will implement [`service_runtime::Service`](../../platform/service-runtime/README.md) **twice** (Phase 5): `realtime::service::RealtimeGatewayService` (the `realtime-gateway` binary — the WSS accept loop, registry writes, node-hop subscription, drain hook, internal gRPC health) and `realtime::service::RealtimeDispatcherService` (the `realtime-dispatcher` binary — the supervised `run_consumer` fan-out loops, no domain RPC). Telemetry, config + hot-reload, health, and graceful shutdown are owned by the runtime.
 
-> **Build status:** **complete through Phase 7** (all 8 phases: scaffold → contract → domain → application+ports → adapters → gateway+dispatcher wiring → live IT → hardening). 52 unit tests plus a live `integration-realtime` suite (real Redis) cover the domain, the proto codec, the bounded-shed mailbox, the node-local routing table (incl. shed-under-pressure and graceful `broadcast_drain`), and the end-to-end bridge (fan-out → registry resolve → node hop → socket frame). Security-reviewed: no token or PII in logs, the opaque payload is never logged, and there is no panic in the accept or delivery hot path.
+> **Build status:** **complete through Phase 7 + the public-broadcast fan-out path.** 58 unit tests plus a live `integration-realtime` suite (real Redis) cover the domain, the proto codec, the bounded-shed mailbox, the node-local routing table (targeted + broadcast delivery, shed-under-pressure, graceful `broadcast_drain`), the upstream decode mappings (notification / counter / post), and the end-to-end bridges (targeted: fan-out → registry → node hop → socket; broadcast: fan-out → fleet channel → channel index → socket). Security-reviewed: no token or PII in logs, the opaque payload is never logged, and there is no panic in the accept or delivery hot path.
 >
 > **Deferred (explicit, not gaps):** the live WebSocket-accept-loop + auth/JWKS integration test (needs a live IdP and a browser-grade WS client — the routing fabric *is* covered live); the live Kafka dispatcher IT (the `run_consumer` runner is covered by `transport`'s own suite); the WebTransport / HTTP-3 transport lane; presence as a product-facing stream; cross-region / multi-PoP routing; the internal-gRPC `NodeChannel` backpressure variant; the `SIGTERM` → `broadcast_drain` runtime wiring; and the `chat` + `notification` client-streaming consolidation (coexist-first).
 >

--- a/crates/services/realtime/src/application/event.rs
+++ b/crates/services/realtime/src/application/event.rs
@@ -12,11 +12,17 @@ use crate::domain::{ChannelRef, DeviceId, UserId};
 /// — it is bytes produced upstream by `chat` / `notification` / `counter`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeliverableEvent {
-    /// The user the event is addressed to. The registry resolves this to the
-    /// node(s) holding the user's live sockets.
-    pub recipient: UserId,
-    /// Restrict delivery to one device; `None` ⇒ all of the recipient's
-    /// connections (the common case).
+    /// The delivery mode, by addressing:
+    /// * `Some(user)` — **targeted**: an identity-scoped event (dm / notif /
+    ///   presence). The registry resolves the user to the node(s) holding its
+    ///   sockets, and the dispatcher hops to those nodes.
+    /// * `None` — **public broadcast**: an entity-channel event (counter / feed)
+    ///   with no single recipient. The dispatcher publishes it to the fleet
+    ///   broadcast channel, and every node delivers it to its local connections
+    ///   subscribed to [`channel`](Self::channel).
+    pub recipient: Option<UserId>,
+    /// Restrict a *targeted* delivery to one device; `None` ⇒ all of the
+    /// recipient's connections. Ignored for a broadcast.
     pub device_id: Option<DeviceId>,
     pub channel: ChannelRef,
     /// Opaque upstream payload, forwarded verbatim — never interpreted or stored.
@@ -30,4 +36,11 @@ pub struct DeliverableEvent {
     /// dispatcher runs at-least-once under `run_consumer`) does not double-emit on
     /// a client that already saw it.
     pub idempotency_key: String,
+}
+
+impl DeliverableEvent {
+    /// Whether this is a public broadcast (no single recipient).
+    pub fn is_broadcast(&self) -> bool {
+        self.recipient.is_none()
+    }
 }

--- a/crates/services/realtime/src/application/fakes.rs
+++ b/crates/services/realtime/src/application/fakes.rs
@@ -125,6 +125,7 @@ impl ConnectionRegistry for InMemoryRegistry {
 #[derive(Default)]
 pub struct FakeNodeChannel {
     published: Mutex<Vec<(NodeId, DeliverableEvent)>>,
+    broadcasts: Mutex<Vec<DeliverableEvent>>,
     unavailable: AtomicBool,
 }
 
@@ -135,6 +136,10 @@ impl FakeNodeChannel {
 
     pub fn publish_count(&self) -> usize {
         self.published.lock().unwrap().len()
+    }
+
+    pub fn broadcast_count(&self) -> usize {
+        self.broadcasts.lock().unwrap().len()
     }
 
     pub fn published_to(&self, node: &str) -> usize {
@@ -161,6 +166,14 @@ impl NodeChannel for FakeNodeChannel {
             .lock()
             .unwrap()
             .push((node_id.clone(), event.clone()));
+        Ok(())
+    }
+
+    async fn broadcast(&self, event: &DeliverableEvent) -> Result<(), RealtimeError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            return Err(RealtimeError::NodeChannelUnavailable);
+        }
+        self.broadcasts.lock().unwrap().push(event.clone());
         Ok(())
     }
 }

--- a/crates/services/realtime/src/application/fanout.rs
+++ b/crates/services/realtime/src/application/fanout.rs
@@ -9,10 +9,12 @@ use crate::error::RealtimeError;
 /// The outcome of fanning one event out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FanOutOutcome {
-    /// How many distinct gateway nodes the event was published to.
+    /// How many distinct gateway nodes a *targeted* event was published to.
     pub nodes_published: usize,
-    /// True when the recipient had no live connection (a fail-open no-op).
+    /// True when a *targeted* recipient had no live connection (a fail-open no-op).
     pub offline: bool,
+    /// True when this was a public broadcast (published once to the fleet channel).
+    pub broadcast: bool,
 }
 
 /// The dispatcher's core use case: resolve a recipient against the registry and
@@ -38,7 +40,20 @@ impl FanOutHandler {
         &self,
         event: &DeliverableEvent,
     ) -> Result<FanOutOutcome, RealtimeError> {
-        let locations = self.registry.resolve(&event.recipient).await?;
+        // Public broadcast (counter / feed): one publish to the fleet channel;
+        // every node delivers to its local subscribers. Never "offline".
+        let Some(recipient) = &event.recipient else {
+            self.channel.broadcast(event).await?;
+            return Ok(FanOutOutcome {
+                nodes_published: 0,
+                offline: false,
+                broadcast: true,
+            });
+        };
+
+        // Targeted (dm / notif / presence): resolve the recipient and hop to its
+        // owning node(s).
+        let locations = self.registry.resolve(recipient).await?;
 
         // Optionally restrict to a single device; otherwise every placement.
         let targets = locations.iter().filter(|loc| match &event.device_id {
@@ -58,11 +73,13 @@ impl FanOutHandler {
             return Ok(FanOutOutcome {
                 nodes_published: 0,
                 offline: true,
+                broadcast: false,
             });
         }
         Ok(FanOutOutcome {
             nodes_published: published_nodes.len(),
             offline: false,
+            broadcast: false,
         })
     }
 }
@@ -92,13 +109,25 @@ mod tests {
 
     fn event_for(recipient: &str, device: Option<&str>) -> DeliverableEvent {
         DeliverableEvent {
-            recipient: UserId::new(recipient).unwrap(),
+            recipient: Some(UserId::new(recipient).unwrap()),
             device_id: device.map(|d| DeviceId::new(d).unwrap()),
             channel: ChannelRef::new(ChannelClass::Dm, ChannelKey::new(recipient).unwrap()),
             payload: b"hello".to_vec(),
             event_type: "chat.message".to_owned(),
             emitted_at: Fixture::fixed_now(),
             idempotency_key: "evt-1".to_owned(),
+        }
+    }
+
+    fn broadcast_event() -> DeliverableEvent {
+        DeliverableEvent {
+            recipient: None,
+            device_id: None,
+            channel: ChannelRef::new(ChannelClass::Counter, ChannelKey::new("post-1").unwrap()),
+            payload: b"{\"score\":9}".to_vec(),
+            event_type: "counter.popularity".to_owned(),
+            emitted_at: Fixture::fixed_now(),
+            idempotency_key: "pop-1".to_owned(),
         }
     }
 
@@ -162,6 +191,17 @@ mod tests {
         assert_eq!(out.nodes_published, 1);
         assert_eq!(fx.channel.published_to("node-2"), 1);
         assert_eq!(fx.channel.published_to("node-1"), 0);
+    }
+
+    #[tokio::test]
+    async fn broadcast_publishes_once_to_the_fleet_channel() {
+        let fx = Fixture::new();
+        let out = fx.fanout().fan_out(&broadcast_event()).await.unwrap();
+
+        assert!(out.broadcast);
+        assert!(!out.offline);
+        assert_eq!(fx.channel.broadcast_count(), 1);
+        assert_eq!(fx.channel.publish_count(), 0); // no targeted node publish
     }
 
     #[tokio::test]

--- a/crates/services/realtime/src/application/port/node_channel.rs
+++ b/crates/services/realtime/src/application/port/node_channel.rs
@@ -20,9 +20,18 @@ use crate::error::RealtimeError;
 /// silently dropped there — a fail-open miss the client recovers from on reconnect.
 #[async_trait]
 pub trait NodeChannel: Send + Sync + 'static {
+    /// Targeted hop: publish to the channel of the one node that owns the
+    /// recipient's socket(s).
     async fn publish(
         &self,
         node_id: &NodeId,
         event: &DeliverableEvent,
     ) -> Result<(), RealtimeError>;
+
+    /// Public broadcast: publish to the fleet broadcast channel, from which
+    /// *every* gateway node delivers the event to its local connections subscribed
+    /// to the event's channel. Used for entity channels (counter / feed) that have
+    /// no single recipient. Same fail-open posture as [`publish`](Self::publish)
+    /// (`RTM-4002` on a transport fault).
+    async fn broadcast(&self, event: &DeliverableEvent) -> Result<(), RealtimeError>;
 }

--- a/crates/services/realtime/src/domain/connection.rs
+++ b/crates/services/realtime/src/domain/connection.rs
@@ -110,6 +110,11 @@ impl Connection {
         self.subscriptions.is_subscribed(channel)
     }
 
+    /// The channels this connection is currently subscribed to.
+    pub fn subscribed_channels(&self) -> Vec<ChannelRef> {
+        self.subscriptions.channels()
+    }
+
     pub fn subscription_count(&self) -> usize {
         self.subscriptions.len()
     }

--- a/crates/services/realtime/src/domain/subscription.rs
+++ b/crates/services/realtime/src/domain/subscription.rs
@@ -38,6 +38,12 @@ impl SubscriptionSet {
         self.channels.contains_key(channel)
     }
 
+    /// The channels currently subscribed — used by the gateway to clean its
+    /// broadcast index on teardown.
+    pub fn channels(&self) -> Vec<ChannelRef> {
+        self.channels.keys().cloned().collect()
+    }
+
     /// Subscribe to `channel`. Idempotent: re-subscribing to an existing channel
     /// is a no-op that preserves its sequence state (so a duplicate Subscribe
     /// never resets a client's ack progress). Returns `true` if newly added.

--- a/crates/services/realtime/src/infrastructure/codec.rs
+++ b/crates/services/realtime/src/infrastructure/codec.rs
@@ -195,7 +195,11 @@ fn require<'a, T>(field: &'a Option<T>, name: &str) -> Result<&'a T, RealtimeErr
 
 pub fn envelope_to_pb(event: &DeliverableEvent) -> pb::DeliverEnvelope {
     pb::DeliverEnvelope {
-        recipient_user_id: event.recipient.as_str().to_owned(),
+        recipient_user_id: event
+            .recipient
+            .as_ref()
+            .map(|u| u.as_str().to_owned())
+            .unwrap_or_default(),
         recipient_device_id: event
             .device_id
             .as_ref()
@@ -207,6 +211,7 @@ pub fn envelope_to_pb(event: &DeliverableEvent) -> pb::DeliverEnvelope {
         event_type: event.event_type.clone(),
         emitted_at: Some(ts_to_pb(event.emitted_at)),
         idempotency_key: event.idempotency_key.clone(),
+        broadcast: event.is_broadcast(),
     }
 }
 
@@ -217,8 +222,14 @@ pub fn envelope_from_pb(env: &pb::DeliverEnvelope) -> Result<DeliverableEvent, R
     } else {
         Some(DeviceId::new(env.recipient_device_id.clone())?)
     };
+    // A broadcast (or an empty recipient) has no targeted user.
+    let recipient = if env.broadcast || env.recipient_user_id.is_empty() {
+        None
+    } else {
+        Some(UserId::new(env.recipient_user_id.clone())?)
+    };
     Ok(DeliverableEvent {
-        recipient: UserId::new(env.recipient_user_id.clone())?,
+        recipient,
         device_id,
         channel,
         payload: env.payload.clone(),
@@ -238,13 +249,25 @@ mod tests {
 
     fn sample_event() -> DeliverableEvent {
         DeliverableEvent {
-            recipient: UserId::new("alice").unwrap(),
+            recipient: Some(UserId::new("alice").unwrap()),
             device_id: Some(DeviceId::new("phone").unwrap()),
             channel: ChannelRef::new(ChannelClass::Dm, ChannelKey::new("alice").unwrap()),
             payload: b"ciphertext".to_vec(),
             event_type: "chat.message".to_owned(),
             emitted_at: DateTime::from_timestamp(1_750_000_000, 0).unwrap(),
             idempotency_key: "evt-1".to_owned(),
+        }
+    }
+
+    fn broadcast_event() -> DeliverableEvent {
+        DeliverableEvent {
+            recipient: None,
+            device_id: None,
+            channel: ChannelRef::new(ChannelClass::Counter, ChannelKey::new("post-42").unwrap()),
+            payload: b"{\"score\":9.0}".to_vec(),
+            event_type: "counter.popularity".to_owned(),
+            emitted_at: DateTime::from_timestamp(1_750_000_000, 0).unwrap(),
+            idempotency_key: "pop-1".to_owned(),
         }
     }
 
@@ -269,7 +292,19 @@ mod tests {
         let event = sample_event();
         let pb = envelope_to_pb(&event);
         assert!(pb.ack_required); // DM ⇒ at-least-once
+        assert!(!pb.broadcast); // targeted
         let back = envelope_from_pb(&pb).unwrap();
+        assert_eq!(back, event);
+    }
+
+    #[test]
+    fn broadcast_envelope_round_trips_with_no_recipient() {
+        let event = broadcast_event();
+        let pb = envelope_to_pb(&event);
+        assert!(pb.broadcast);
+        assert!(pb.recipient_user_id.is_empty());
+        let back = envelope_from_pb(&pb).unwrap();
+        assert!(back.is_broadcast());
         assert_eq!(back, event);
     }
 

--- a/crates/services/realtime/src/infrastructure/decode.rs
+++ b/crates/services/realtime/src/infrastructure/decode.rs
@@ -15,7 +15,7 @@
 //! upstream prerequisite, not a gap in this layer. The realtime plane forwards
 //! `payload` verbatim and never interprets it.
 
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::application::DeliverableEvent;
@@ -24,6 +24,8 @@ use crate::error::RealtimeError;
 use crate::infrastructure::codec::epoch;
 
 const TOPIC_NOTIFICATION: &str = "notification.v1.events";
+const TOPIC_POPULARITY: &str = "counter.v1.popularity";
+const TOPIC_POST: &str = "post.v1.events";
 
 /// A notification destined for one recipient. `payload` is the already-rendered
 /// client view (badge counts / preview) the plane forwards verbatim.
@@ -42,9 +44,13 @@ pub struct NotificationWire {
     pub payload: serde_json::Value,
 }
 
-/// Map a `notification.v1.events` record to a deliverable event on the recipient's
-/// `notif` channel (identity-scoped, at-least-once).
-pub fn map_notification(wire: NotificationWire) -> Result<DeliverableEvent, RealtimeError> {
+/// Map a `notification.v1.events` record to a **targeted** deliverable event on the
+/// recipient's `notif` channel (identity-scoped, at-least-once). `Ok(None)` would
+/// signal a harmless skip; a notification always has a recipient, so this is always
+/// `Some`.
+pub fn map_notification(
+    wire: NotificationWire,
+) -> Result<Option<DeliverableEvent>, RealtimeError> {
     let recipient = UserId::new(wire.recipient_id)?;
     let channel = ChannelRef::new(
         ChannelClass::Notification,
@@ -57,15 +63,103 @@ pub fn map_notification(wire: NotificationWire) -> Result<DeliverableEvent, Real
         })?;
     let device_id = wire.device_id.map(DeviceId::new).transpose()?;
 
-    Ok(DeliverableEvent {
-        recipient,
+    Ok(Some(DeliverableEvent {
+        recipient: Some(recipient),
         device_id,
         channel,
         payload,
         event_type: format!("notif.{}", wire.kind),
         emitted_at: DateTime::from_timestamp_millis(wire.created_at_ms).unwrap_or_else(epoch),
         idempotency_key: wire.notification_id,
-    })
+    }))
+}
+
+// ── counter.v1.popularity → public broadcast on counter:<entity> ──────────────
+
+/// The coarse popularity signal `counter` publishes — entity-addressed, no
+/// recipient. `score` and `entity_type` ride along as the client-facing payload.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PopularityWire {
+    pub entity_type: String,
+    pub entity_id: String,
+    pub score: f64,
+}
+
+/// Map a popularity signal to a **public broadcast** on `counter:<entity_id>` —
+/// delivered to every connection viewing that entity. Fire-and-forget (latest
+/// wins). An empty entity id is unroutable and skipped (`Ok(None)`).
+pub fn map_counter_popularity(
+    wire: PopularityWire,
+) -> Result<Option<DeliverableEvent>, RealtimeError> {
+    if wire.entity_id.trim().is_empty() {
+        return Ok(None);
+    }
+    let channel = ChannelRef::new(
+        ChannelClass::Counter,
+        ChannelKey::new(wire.entity_id.clone())?,
+    );
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "entity_type": wire.entity_type,
+        "entity_id": wire.entity_id,
+        "score": wire.score,
+    }))
+    .map_err(|e| RealtimeError::EventDecodeFailed {
+        topic: TOPIC_POPULARITY.to_owned(),
+        reason: e.to_string(),
+    })?;
+
+    Ok(Some(DeliverableEvent {
+        recipient: None,
+        device_id: None,
+        channel,
+        payload,
+        event_type: "counter.popularity".to_owned(),
+        emitted_at: Utc::now(),
+        idempotency_key: format!("pop:{}:{}", wire.entity_type, wire.entity_id),
+    }))
+}
+
+// ── post.v1.events → public broadcast on feed:<author> ────────────────────────
+
+/// A `post.v1.events` lifecycle record (`{"type": "...", post_id, profile_id}`).
+/// Lenient: extra fields ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PostWire {
+    #[serde(rename = "type", default)]
+    pub event_type: String,
+    #[serde(default)]
+    pub post_id: String,
+    /// The author — the `feed:<profile_id>` channel its viewers subscribe to.
+    #[serde(default)]
+    pub profile_id: String,
+}
+
+/// Map a post lifecycle event to a **public broadcast** on `feed:<profile_id>` —
+/// the author's feed channel. Missing an author is unroutable and skipped.
+pub fn map_post(wire: PostWire) -> Result<Option<DeliverableEvent>, RealtimeError> {
+    if wire.profile_id.trim().is_empty() {
+        return Ok(None);
+    }
+    let channel = ChannelRef::new(ChannelClass::Feed, ChannelKey::new(wire.profile_id.clone())?);
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "type": wire.event_type,
+        "post_id": wire.post_id,
+        "author_id": wire.profile_id,
+    }))
+    .map_err(|e| RealtimeError::EventDecodeFailed {
+        topic: TOPIC_POST.to_owned(),
+        reason: e.to_string(),
+    })?;
+
+    Ok(Some(DeliverableEvent {
+        recipient: None,
+        device_id: None,
+        channel,
+        payload,
+        event_type: format!("post.{}", wire.event_type),
+        emitted_at: Utc::now(),
+        idempotency_key: format!("post:{}:{}", wire.event_type, wire.post_id),
+    }))
 }
 
 #[cfg(test)]
@@ -82,8 +176,8 @@ mod tests {
             created_at_ms: 1_750_000_000_000,
             payload: serde_json::json!({ "unread": 3 }),
         };
-        let ev = map_notification(wire).unwrap();
-        assert_eq!(ev.recipient.as_str(), "alice");
+        let ev = map_notification(wire).unwrap().unwrap();
+        assert_eq!(ev.recipient.unwrap().as_str(), "alice");
         // Identity-scoped: the channel key is the recipient itself.
         assert_eq!(ev.channel.to_string(), "notif:alice");
         assert_eq!(ev.event_type, "notif.follow");
@@ -103,5 +197,49 @@ mod tests {
         };
         let err = map_notification(wire).unwrap_err();
         assert_eq!(<RealtimeError as error::AppError>::error_code(&err), "RTM-9002");
+    }
+
+    #[test]
+    fn maps_popularity_to_a_public_counter_broadcast() {
+        let wire = PopularityWire {
+            entity_type: "post".to_owned(),
+            entity_id: "post-42".to_owned(),
+            score: 9.5,
+        };
+        let ev = map_counter_popularity(wire).unwrap().unwrap();
+        assert!(ev.is_broadcast()); // no recipient
+        assert_eq!(ev.channel.to_string(), "counter:post-42");
+        assert_eq!(ev.event_type, "counter.popularity");
+    }
+
+    #[test]
+    fn maps_post_event_to_a_public_feed_broadcast() {
+        let wire = PostWire {
+            event_type: "PostPublished".to_owned(),
+            post_id: "p-1".to_owned(),
+            profile_id: "author-7".to_owned(),
+        };
+        let ev = map_post(wire).unwrap().unwrap();
+        assert!(ev.is_broadcast());
+        assert_eq!(ev.channel.to_string(), "feed:author-7");
+        assert_eq!(ev.event_type, "post.PostPublished");
+    }
+
+    #[test]
+    fn unroutable_public_events_are_skipped() {
+        // No entity id / no author ⇒ Ok(None), a harmless commit (not a DLQ).
+        let pop = PopularityWire {
+            entity_type: "post".to_owned(),
+            entity_id: "  ".to_owned(),
+            score: 1.0,
+        };
+        assert!(map_counter_popularity(pop).unwrap().is_none());
+
+        let post = PostWire {
+            event_type: "PostPublished".to_owned(),
+            post_id: "p-1".to_owned(),
+            profile_id: String::new(),
+        };
+        assert!(map_post(post).unwrap().is_none());
     }
 }

--- a/crates/services/realtime/src/infrastructure/redis_node_channel.rs
+++ b/crates/services/realtime/src/infrastructure/redis_node_channel.rs
@@ -28,6 +28,11 @@ fn node_channel(node_id: &NodeId) -> String {
     format!("rt:node:{{{}}}", node_id.as_str())
 }
 
+/// The single fleet-wide broadcast channel every gateway subscribes to. Hash-tag
+/// keeps it on one cluster slot; broadcast rate is low (coarse counter/feed
+/// signals), so the single-shard concentration is acceptable.
+pub const BROADCAST_CHANNEL: &str = "rt:broadcast:{0}";
+
 fn channel_err(e: fred::error::Error) -> RealtimeError {
     tracing::warn!(error = %e, "node channel redis error");
     RealtimeError::NodeChannelUnavailable
@@ -57,6 +62,17 @@ impl NodeChannel for RedisNodeChannel {
             .client
             .inner
             .spublish(node_channel(node_id), payload)
+            .await
+            .map_err(channel_err)?;
+        Ok(())
+    }
+
+    async fn broadcast(&self, event: &DeliverableEvent) -> Result<(), RealtimeError> {
+        let payload = codec::envelope_to_pb(event).encode_to_vec();
+        let _: i64 = self
+            .client
+            .inner
+            .spublish(BROADCAST_CHANNEL, payload)
             .await
             .map_err(channel_err)?;
         Ok(())

--- a/crates/services/realtime/src/infrastructure/runtime/connection_table.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/connection_table.rs
@@ -30,10 +30,14 @@ pub struct ConnHandle {
     pub sender: mpsc::Sender<Vec<u8>>,
 }
 
-/// Maps a `user_id` to the handles of its live connections on this node.
+/// Maps a `user_id` to the handles of its live connections on this node (the
+/// targeted index), and a channel string (`class:key`, e.g. `counter:post-42`) to
+/// the handles subscribed to it (the broadcast index). The per-socket task keeps
+/// the channel index in sync as the client subscribes / unsubscribes.
 #[derive(Default)]
 pub struct ConnectionTable {
     by_user: DashMap<String, Vec<ConnHandle>>,
+    by_channel: DashMap<String, Vec<ConnHandle>>,
 }
 
 impl ConnectionTable {
@@ -46,6 +50,8 @@ impl ConnectionTable {
     }
 
     /// Remove one connection; drops the user's entry entirely when it empties.
+    /// The caller (per-socket teardown) also `unsubscribe_channel`s each channel
+    /// the connection held, keeping the broadcast index consistent.
     pub fn remove(&self, user_id: &str, connection_id: &ConnectionId) {
         if let Some(mut handles) = self.by_user.get_mut(user_id) {
             handles.retain(|h| &h.connection_id != connection_id);
@@ -53,29 +59,71 @@ impl ConnectionTable {
         self.by_user.remove_if(user_id, |_, v| v.is_empty());
     }
 
+    /// Index a connection under a channel it just subscribed to (the broadcast
+    /// index). Idempotent on `connection_id`.
+    pub fn subscribe_channel(&self, channel: &str, handle: ConnHandle) {
+        let mut entry = self.by_channel.entry(channel.to_owned()).or_default();
+        if !entry.iter().any(|h| h.connection_id == handle.connection_id) {
+            entry.push(handle);
+        }
+    }
+
+    /// Drop a connection from a channel's broadcast index.
+    pub fn unsubscribe_channel(&self, channel: &str, connection_id: &ConnectionId) {
+        if let Some(mut handles) = self.by_channel.get_mut(channel) {
+            handles.retain(|h| &h.connection_id != connection_id);
+        }
+        self.by_channel.remove_if(channel, |_, v| v.is_empty());
+    }
+
     pub fn connection_count(&self) -> usize {
         self.by_user.iter().map(|e| e.value().len()).sum()
     }
 
-    /// Deliver an event to the recipient's matching connections on this node,
-    /// stamping each with that connection's next per-channel sequence. Returns the
-    /// number of sockets the frame was queued onto.
-    ///
-    /// Skips connections not subscribed to the event's channel (a non-error), and
-    /// honours an optional device filter. A full outbound queue sheds the frame
-    /// for that connection (the slow-consumer protection) without affecting others.
+    /// Deliver a **targeted** event to the recipient's matching connections on this
+    /// node, honouring an optional device filter. Returns the number of sockets the
+    /// frame was queued onto. A broadcast event (no recipient) yields 0 here — use
+    /// [`deliver_broadcast`](Self::deliver_broadcast).
     pub async fn deliver(&self, event: &DeliverableEvent) -> usize {
+        let Some(recipient) = &event.recipient else {
+            return 0;
+        };
         let Some(handles) = self
             .by_user
-            .get(event.recipient.as_str())
+            .get(recipient.as_str())
             .map(|e| e.value().clone())
         else {
             return 0;
         };
+        self.deliver_to(handles, event, event.device_id.as_ref()).await
+    }
 
+    /// Deliver a **public broadcast** event to every local connection subscribed to
+    /// its channel (the broadcast index), stamping each with its own sequence.
+    pub async fn deliver_broadcast(&self, event: &DeliverableEvent) -> usize {
+        let Some(handles) = self
+            .by_channel
+            .get(&event.channel.to_string())
+            .map(|e| e.value().clone())
+        else {
+            return 0;
+        };
+        self.deliver_to(handles, event, None).await
+    }
+
+    /// Shared per-handle delivery: skip connections not subscribed to the event's
+    /// channel (a non-error) and those failing the device filter, stamp each with
+    /// its next per-channel sequence, and `try_send` (a full queue sheds the frame
+    /// for that connection — the slow-consumer protection — without blocking others).
+    async fn deliver_to(
+        &self,
+        handles: Vec<ConnHandle>,
+        event: &DeliverableEvent,
+        device_filter: Option<&DeviceId>,
+    ) -> usize {
         let mut delivered = 0;
         for handle in handles {
-            if let Some(device) = &event.device_id
+            if let Some(device) = device_filter
                 && &handle.device_id != device
             {
                 continue;
@@ -92,7 +140,6 @@ impl ConnectionTable {
                 }
             };
 
-            // try_send: a full queue is a slow consumer — shed rather than block.
             if handle.sender.try_send(frame).is_ok() {
                 delivered += 1;
             }
@@ -142,13 +189,25 @@ mod tests {
 
     fn deliverable(recipient: &str, device: Option<&str>) -> DeliverableEvent {
         DeliverableEvent {
-            recipient: UserId::new(recipient).unwrap(),
+            recipient: Some(UserId::new(recipient).unwrap()),
             device_id: device.map(|d| DeviceId::new(d).unwrap()),
             channel: ChannelRef::new(ChannelClass::Dm, ChannelKey::new(recipient).unwrap()),
             payload: b"x".to_vec(),
             event_type: "chat.message".to_owned(),
             emitted_at: Utc::now(),
             idempotency_key: "e1".to_owned(),
+        }
+    }
+
+    fn counter_event(entity: &str) -> DeliverableEvent {
+        DeliverableEvent {
+            recipient: None,
+            device_id: None,
+            channel: ChannelRef::new(ChannelClass::Counter, ChannelKey::new(entity).unwrap()),
+            payload: b"{\"score\":9}".to_vec(),
+            event_type: "counter.popularity".to_owned(),
+            emitted_at: Utc::now(),
+            idempotency_key: "p1".to_owned(),
         }
     }
 
@@ -227,6 +286,30 @@ mod tests {
     async fn offline_user_delivers_to_nobody() {
         let table = ConnectionTable::new();
         assert_eq!(table.deliver(&deliverable("ghost", None)).await, 0);
+    }
+
+    #[tokio::test]
+    async fn broadcast_delivers_to_channel_subscribers_only() {
+        let table = ConnectionTable::new();
+        let counter = ChannelRef::new(ChannelClass::Counter, ChannelKey::new("post-7").unwrap());
+
+        // A viewer subscribed to counter:post-7 (indexed under the broadcast index).
+        let (viewer, mut viewer_rx) = handle("alice", "phone", "c1");
+        viewer.connection.lock().await.subscribe(counter.clone()).unwrap();
+        table.subscribe_channel(&counter.to_string(), viewer.clone());
+        table.insert("alice", viewer);
+
+        // A non-viewer (subscribed to nothing on this entity) is not indexed.
+        let (other, mut other_rx) = handle("bob", "phone", "c2");
+        table.insert("bob", other);
+
+        assert_eq!(table.deliver_broadcast(&counter_event("post-7")).await, 1);
+        assert!(viewer_rx.try_recv().is_ok());
+        assert!(other_rx.try_recv().is_err());
+
+        // After unsubscribe, the broadcast reaches nobody.
+        table.unsubscribe_channel(&counter.to_string(), &ConnectionId::new("c1").unwrap());
+        assert_eq!(table.deliver_broadcast(&counter_event("post-7")).await, 0);
     }
 
     #[tokio::test]

--- a/crates/services/realtime/src/infrastructure/runtime/dispatcher.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/dispatcher.rs
@@ -27,7 +27,7 @@ pub async fn run_fanout_consumer<T, M>(
     map: M,
 ) where
     T: ConsumablePayload + Clone,
-    M: Fn(T) -> Result<DeliverableEvent, RealtimeError> + Copy + Send + Sync + 'static,
+    M: Fn(T) -> Result<Option<DeliverableEvent>, RealtimeError> + Copy + Send + Sync + 'static,
 {
     tracing::info!(label, "realtime dispatcher consumer started");
     let policy = RetryPolicy::default();
@@ -36,8 +36,11 @@ pub async fn run_fanout_consumer<T, M>(
         let event = event.clone();
         Box::pin(async move {
             let outcome = async {
-                let deliverable = map(event)?;
-                handler.fan_out(&deliverable).await?;
+                // `None` ⇒ an unroutable/unmapped event: a harmless skip that still
+                // commits the offset (never a DLQ).
+                if let Some(deliverable) = map(event)? {
+                    handler.fan_out(&deliverable).await?;
+                }
                 Ok::<(), RealtimeError>(())
             }
             .await;

--- a/crates/services/realtime/src/infrastructure/runtime/gateway.rs
+++ b/crates/services/realtime/src/infrastructure/runtime/gateway.rs
@@ -31,6 +31,7 @@ use crate::application::lifecycle::ReapHandler;
 use crate::domain::{Connection, ConnectionId};
 use crate::error::RealtimeError;
 use crate::infrastructure::codec::{self, ClientIntent};
+use crate::infrastructure::redis_node_channel::BROADCAST_CHANNEL;
 use crate::infrastructure::runtime::connection_table::{ConnHandle, ConnectionTable};
 
 /// Shared state every WebSocket connection is served against.
@@ -92,15 +93,13 @@ async fn handle_socket(socket: WebSocket, state: GatewayState, token: String) {
     let connection = Arc::new(Mutex::new(connection));
 
     let (tx, mut rx) = mpsc::channel::<Vec<u8>>(state.send_queue_cap);
-    state.table.insert(
-        user_id.as_str(),
-        ConnHandle {
-            connection_id: connection_id.clone(),
-            device_id,
-            connection: Arc::clone(&connection),
-            sender: tx.clone(),
-        },
-    );
+    let handle = ConnHandle {
+        connection_id: connection_id.clone(),
+        device_id,
+        connection: Arc::clone(&connection),
+        sender: tx.clone(),
+    };
+    state.table.insert(user_id.as_str(), handle.clone());
 
     let (mut ws_tx, mut ws_rx) = socket.split();
 
@@ -125,7 +124,9 @@ async fn handle_socket(socket: WebSocket, state: GatewayState, token: String) {
             inbound = ws_rx.next() => match inbound {
                 Some(Ok(Message::Binary(data))) => {
                     connection.lock().await.heartbeat(Utc::now());
-                    if let Err(error) = handle_client_frame(&data, &connection, &tx).await {
+                    if let Err(error) =
+                        handle_client_frame(&data, &connection, &tx, &state, &handle).await
+                    {
                         tracing::debug!(%error, "client frame rejected");
                     }
                 }
@@ -156,7 +157,13 @@ async fn handle_socket(socket: WebSocket, state: GatewayState, token: String) {
         }
     }
 
-    // Teardown: free the routing slots (idempotent) and stop the writer.
+    // Teardown: drop the connection from the broadcast index for every channel it
+    // held, free the routing slots (idempotent), and stop the writer.
+    for channel in connection.lock().await.subscribed_channels() {
+        state
+            .table
+            .unsubscribe_channel(&channel.to_string(), &connection_id);
+    }
     state.table.remove(user_id.as_str(), &connection_id);
     if let Err(error) = state.reap.evict(&user_id, &connection_id).await {
         tracing::warn!(%error, "registry evict failed on teardown");
@@ -164,11 +171,14 @@ async fn handle_socket(socket: WebSocket, state: GatewayState, token: String) {
     writer.abort();
 }
 
-/// Decode one client frame and apply its intent to the connection.
+/// Decode one client frame and apply its intent to the connection, keeping the
+/// table's broadcast index in sync with the connection's subscriptions.
 async fn handle_client_frame(
     data: &[u8],
     connection: &Arc<Mutex<Connection>>,
     tx: &mpsc::Sender<Vec<u8>>,
+    state: &GatewayState,
+    handle: &ConnHandle,
 ) -> Result<(), RealtimeError> {
     let frame = pb::ClientFrame::decode(data).map_err(|e| RealtimeError::MalformedFrame {
         reason: e.to_string(),
@@ -179,7 +189,12 @@ async fn handle_client_frame(
             let mut conn = connection.lock().await;
             for channel in channels {
                 match conn.subscribe(channel.clone()) {
-                    Ok(_) => send_control(tx, pb::ServerControl::Subscribed, Some(&channel), "", ""),
+                    Ok(_) => {
+                        state
+                            .table
+                            .subscribe_channel(&channel.to_string(), handle.clone());
+                        send_control(tx, pb::ServerControl::Subscribed, Some(&channel), "", "");
+                    }
                     Err(error) => send_control(
                         tx,
                         pb::ServerControl::Error,
@@ -194,6 +209,9 @@ async fn handle_client_frame(
             let mut conn = connection.lock().await;
             for channel in channels {
                 if conn.unsubscribe(&channel).is_ok() {
+                    state
+                        .table
+                        .unsubscribe_channel(&channel.to_string(), &handle.connection_id);
                     send_control(tx, pb::ServerControl::Unsubscribed, Some(&channel), "", "");
                 }
             }
@@ -210,7 +228,11 @@ async fn handle_client_frame(
         ClientIntent::Resume(cursors) => {
             let mut conn = connection.lock().await;
             for (channel, _seq) in cursors {
-                let _ = conn.subscribe(channel);
+                if conn.subscribe(channel.clone()).is_ok() {
+                    state
+                        .table
+                        .subscribe_channel(&channel.to_string(), handle.clone());
+                }
             }
         }
     }
@@ -236,12 +258,17 @@ pub fn spawn_node_subscriber(
     table: Arc<ConnectionTable>,
 ) {
     tokio::spawn(async move {
-        let channel = format!("rt:node:{{{node_id}}}");
-        if let Err(error) = subscriber.inner.ssubscribe(channel.clone()).await {
-            tracing::error!(%error, channel, "failed to subscribe node channel");
+        // The node's own targeted hop channel, plus the fleet broadcast channel.
+        let node = format!("rt:node:{{{node_id}}}");
+        if let Err(error) = subscriber.inner.ssubscribe(node.clone()).await {
+            tracing::error!(%error, channel = node, "failed to subscribe node channel");
             return;
         }
-        tracing::info!(channel, "node subscriber listening");
+        if let Err(error) = subscriber.inner.ssubscribe(BROADCAST_CHANNEL).await {
+            tracing::error!(%error, "failed to subscribe broadcast channel");
+            return;
+        }
+        tracing::info!(channel = node, "node subscriber listening (targeted + broadcast)");
 
         let mut rx = subscriber.inner.message_rx();
         loop {
@@ -256,7 +283,13 @@ pub fn spawn_node_subscriber(
                     let Ok(event) = codec::envelope_from_pb(&envelope) else {
                         continue;
                     };
-                    table.deliver(&event).await;
+                    // A broadcast (no recipient) goes to local channel subscribers;
+                    // a targeted event goes to the recipient's connections.
+                    if event.is_broadcast() {
+                        table.deliver_broadcast(&event).await;
+                    } else {
+                        table.deliver(&event).await;
+                    }
                 }
                 Err(RecvError::Lagged(skipped)) => {
                     tracing::warn!(skipped, "node subscriber lagged")

--- a/crates/services/realtime/src/service.rs
+++ b/crates/services/realtime/src/service.rs
@@ -30,7 +30,9 @@ use crate::application::handshake::HandshakeHandler;
 use crate::application::lifecycle::ReapHandler;
 use crate::config::RealtimeConfig;
 use crate::domain::NodeId;
-use crate::infrastructure::decode::{NotificationWire, map_notification};
+use crate::infrastructure::decode::{
+    NotificationWire, PopularityWire, PostWire, map_counter_popularity, map_notification, map_post,
+};
 use crate::infrastructure::runtime::{
     ConnectionTable, GatewayState, run_fanout_consumer, serve_ws, spawn_node_subscriber,
 };
@@ -41,6 +43,10 @@ const HEALTH_KEY: &str = "realtime.v1.RealtimeDispatchService";
 
 const NOTIFICATION_TOPIC: &str = "notification.v1.events";
 const NOTIFICATION_GROUP: &str = "realtime-notif-fanout";
+const POPULARITY_TOPIC: &str = "counter.v1.popularity";
+const POPULARITY_GROUP: &str = "realtime-counter-fanout";
+const POST_TOPIC: &str = "post.v1.events";
+const POST_GROUP: &str = "realtime-post-fanout";
 
 /// Backoff before respawning a consumer after its runner returns.
 const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
@@ -131,14 +137,28 @@ impl Service for RealtimeDispatcherService {
             Arc::clone(&adapters.node_channel),
         ));
 
-        // Supervised fan-out consumer(s). Only the notification stream is wired
-        // today; chat / counter / post follow the same shape as those producers land.
+        // Supervised fan-out consumers: notification (targeted), counter popularity
+        // and post (public broadcast). chat stays on its own live plane (coexist).
         spawn_fanout_consumer::<NotificationWire, _>(
             NOTIFICATION_TOPIC,
             NOTIFICATION_GROUP,
             "notification",
             &handler,
             map_notification,
+        );
+        spawn_fanout_consumer::<PopularityWire, _>(
+            POPULARITY_TOPIC,
+            POPULARITY_GROUP,
+            "popularity",
+            &handler,
+            map_counter_popularity,
+        );
+        spawn_fanout_consumer::<PostWire, _>(
+            POST_TOPIC,
+            POST_GROUP,
+            "post",
+            &handler,
+            map_post,
         );
 
         Ok(Self {
@@ -187,7 +207,7 @@ fn spawn_fanout_consumer<T, M>(
     map: M,
 ) where
     T: transport::kafka::envelope::ConsumablePayload + Clone,
-    M: Fn(T) -> Result<crate::application::DeliverableEvent, crate::error::RealtimeError>
+    M: Fn(T) -> Result<Option<crate::application::DeliverableEvent>, crate::error::RealtimeError>
         + Copy
         + Send
         + Sync

--- a/crates/services/realtime/tests/realtime_it/harness.rs
+++ b/crates/services/realtime/tests/realtime_it/harness.rs
@@ -96,7 +96,7 @@ pub fn location(user: &UserId, device: &str, conn: &str, node: &str) -> Connecti
 
 pub fn dm_event(user: &UserId, payload: &[u8]) -> DeliverableEvent {
     DeliverableEvent {
-        recipient: user.clone(),
+        recipient: Some(user.clone()),
         device_id: None,
         channel: dm_channel(user),
         payload: payload.to_vec(),
@@ -104,6 +104,60 @@ pub fn dm_event(user: &UserId, payload: &[u8]) -> DeliverableEvent {
         emitted_at: Utc::now(),
         idempotency_key: Uuid::now_v7().to_string(),
     }
+}
+
+pub fn counter_channel(entity: &str) -> ChannelRef {
+    ChannelRef::new(ChannelClass::Counter, ChannelKey::new(entity.to_owned()).unwrap())
+}
+
+/// A public broadcast event (no recipient) on `counter:<entity>`.
+pub fn counter_event(entity: &str, payload: &[u8]) -> DeliverableEvent {
+    DeliverableEvent {
+        recipient: None,
+        device_id: None,
+        channel: counter_channel(entity),
+        payload: payload.to_vec(),
+        event_type: "counter.popularity".to_owned(),
+        emitted_at: Utc::now(),
+        idempotency_key: Uuid::now_v7().to_string(),
+    }
+}
+
+/// Register a connection subscribed to `counter:<entity>` in both the user index
+/// and the broadcast (channel) index, and return its socket receiver.
+pub async fn register_broadcast_subscriber(
+    table: &ConnectionTable,
+    user: &UserId,
+    entity: &str,
+    conn: &str,
+    node: &str,
+    queue_cap: usize,
+) -> mpsc::Receiver<Vec<u8>> {
+    let session = Session::new(
+        user.clone(),
+        DeviceId::new("phone").unwrap(),
+        Utc::now() + chrono::Duration::hours(1),
+    );
+    let mut connection = Connection::open(
+        ConnectionId::new(conn).unwrap(),
+        NodeId::new(node).unwrap(),
+        session,
+        16,
+        Utc::now(),
+    );
+    let channel = counter_channel(entity);
+    connection.subscribe(channel.clone()).unwrap();
+
+    let (tx, rx) = mpsc::channel(queue_cap);
+    let handle = ConnHandle {
+        connection_id: ConnectionId::new(conn).unwrap(),
+        device_id: DeviceId::new("phone").unwrap(),
+        connection: Arc::new(Mutex::new(connection)),
+        sender: tx,
+    };
+    table.subscribe_channel(&channel.to_string(), handle.clone());
+    table.insert(user.as_str(), handle);
+    rx
 }
 
 /// Register a connection in `table` subscribed to its `dm:<user>` channel, and

--- a/crates/services/realtime/tests/realtime_it/scenarios.rs
+++ b/crates/services/realtime/tests/realtime_it/scenarios.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use realtime::application::port::ConnectionRegistry;
 use realtime::domain::ConnectionId;
+use realtime::infrastructure::redis_node_channel::BROADCAST_CHANNEL;
 use realtime::infrastructure::runtime::ConnectionTable;
 use test_support::await_until;
 
@@ -140,6 +141,55 @@ async fn bridge_delivers_event_to_a_subscribed_connection() {
         pb::server_frame::Body::Event(e) => {
             assert_eq!(e.payload, b"payload-xyz");
             assert_eq!(e.stream_seq, 1);
+        }
+        _ => panic!("expected an Event frame"),
+    }
+}
+
+/// The public broadcast path over real Redis: a counter signal fans out once to
+/// the fleet broadcast channel, and a node delivers it to its local subscribers of
+/// `counter:<entity>` (and to nobody else).
+#[tokio::test]
+async fn broadcast_reaches_local_channel_subscribers() {
+    let h = Harness::start().await;
+    let entity = format!("post-{}", Uuid::now_v7());
+    let node = format!("node-{}", Uuid::now_v7());
+
+    let table = Arc::new(ConnectionTable::new());
+    let mut socket_rx =
+        register_broadcast_subscriber(&table, &fresh_user(), &entity, "c1", &node, 8).await;
+
+    // Subscribe the fleet broadcast channel before fanning out.
+    let subscriber = h.subscriber().await;
+    subscriber.inner.ssubscribe(BROADCAST_CHANNEL).await.unwrap();
+    let mut bc_rx = subscriber.inner.message_rx();
+
+    // Public broadcast fan-out (no recipient) → one SPUBLISH to the fleet channel.
+    let outcome = h
+        .fan_out()
+        .fan_out(&counter_event(&entity, b"{\"score\":9}"))
+        .await
+        .unwrap();
+    assert!(outcome.broadcast);
+
+    // Receive the broadcast envelope and deliver it locally via the channel index.
+    let msg = timeout(Duration::from_secs(5), bc_rx.recv())
+        .await
+        .expect("broadcast recv timed out")
+        .expect("recv");
+    let env = pb::DeliverEnvelope::decode(msg.value.as_bytes().expect("bytes")).unwrap();
+    assert!(env.broadcast);
+    let event = realtime::infrastructure::codec::envelope_from_pb(&env).unwrap();
+    assert_eq!(table.deliver_broadcast(&event).await, 1);
+
+    // The viewer's socket got an Event frame on counter:<entity>.
+    let frame_bytes = timeout(Duration::from_secs(5), socket_rx.recv())
+        .await
+        .expect("socket recv timed out")
+        .expect("frame");
+    match pb::ServerFrame::decode(&frame_bytes[..]).unwrap().body.unwrap() {
+        pb::server_frame::Body::Event(e) => {
+            assert_eq!(e.channel.unwrap().key, entity);
         }
         _ => panic!("expected an Event frame"),
     }


### PR DESCRIPTION
## What

Wires the upstream `counter.v1.popularity` and `post.v1.events` streams into `realtime` — which required building the service's **second fan-out path**, not just three decode functions.

Investigating the producers showed that, unlike `notification.v1.events` (which names a recipient user), these are **entity-addressed with no recipient**:

| Stream | Addressed by | Recipient user? |
|---|---|---|
| `notification.v1.events` | recipient user | ✅ (already wired) |
| `counter.v1.popularity` | entity (`{entity_type, entity_id, score}`) | ❌ public |
| `post.v1.events` | post/author (`{type, post_id, profile_id}`) | ❌ public |
| `chat.message.sent` | conversation (no member list) | ❌ — **kept deferred** |

So this PR adds a **public, broadcast-to-all-nodes fan-out path** alongside the existing targeted (per-recipient) one.

## Decisions (confirmed)

- **Public fan-out = broadcast-to-all-nodes.** The dispatcher publishes a public event once to a fleet broadcast channel; every gateway `SSUBSCRIBE`s it and delivers to its local connections subscribed to the event's channel. No per-subscribe registry writes — the right shape for viral/large subscriber sets, and broadcast rate here is low (coarse signals).
- **`chat` stays deferred (coexist-first).** `chat.message.sent` carries no member list, and `chat` already runs its own live Redis pub/sub plane. Consuming it is a deliberate consolidation migration (needs member addressing), not a decode.

## Changes

- **Model:** `DeliverableEvent.recipient` → `Option<UserId>` (`None` = public broadcast). `DeliverEnvelope` gains an additive `broadcast` flag (`buf breaking` passes — wire-compatible).
- **Path:** `NodeChannel::broadcast` → `SPUBLISH` to the fleet channel; `FanOutHandler` branches targeted vs broadcast; `ConnectionTable` gains a `by_channel` index + `deliver_broadcast`, kept in sync by the gateway's per-socket loop (subscribe / unsubscribe / teardown).
- **Decode:** `map_counter_popularity` → `counter:<entity>`, `map_post` → `feed:<profile_id>`. `map_*` now return `Result<Option<…>>` so an unroutable event (empty entity/author) is a harmless skip that **commits the offset**, never a DLQ.
- **Wiring:** three supervised dispatcher consumers — `notification` (targeted) + `counter` / `post` (broadcast).

## Tests & checks

- **58 unit + 6 live integration tests.** Added `broadcast_reaches_local_channel_subscribers` — proven end-to-end on real Redis: `fan_out → SPUBLISH rt:broadcast → SSUBSCRIBE → deliver_broadcast → Event frame on the subscribed socket` (and nobody else's).
- clippy clean · `buf lint` + `buf breaking` green · README EN/FR updated (two fan-out modes, chat-deferred) + i18n drift gate passing.

## Still deferred

The `chat` consolidation (needs member addressing), and the post→home-feed (followers) fan-out, which is timeline territory — this PR delivers `feed:<author>` (viewers of an author), not follower fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3VfarYci2c1BCq29GQLA1
