### PR TITLE
feat(timeline): consume post.v1.events for home-feed fan-out (migrate off legacy post.published)

### DIFF
--- a/crates/services/timeline/src/config/mod.rs
+++ b/crates/services/timeline/src/config/mod.rs
@@ -57,7 +57,8 @@ pub struct TimelineConfig {
     /// Format: "http://host:port" (no trailing slash).
     pub social_graph_endpoint: String,
 
-    /// Kafka consumer group ID for the post.published worker.
+    /// Kafka consumer group ID for the post-published worker (consumes the unified
+    /// `post.v1.events` stream).
     pub kafka_group_post_published: String,
 
     /// Kafka consumer group ID for the post.deleted worker.

--- a/crates/services/timeline/src/infrastructure/worker/post_published_worker.rs
+++ b/crates/services/timeline/src/infrastructure/worker/post_published_worker.rs
@@ -13,38 +13,50 @@ use cqrs::{CommandBus, CqrsError, Envelope};
 use crate::application::command::ingest_post_published::IngestPostPublishedCommand;
 use crate::infrastructure::worker::{build_dlq_producer, dispatch_outcome};
 
-const TOPIC: &str = "post.published";
+const TOPIC: &str = "post.v1.events";
 
-/// Kafka event schema for `post.published`.
+/// Event schema for the unified `post.v1.events` stream — the internally-tagged
+/// `DomainEvent` from services/post: `{"type": "PostPublished"|"PostUpdated"|
+/// "PostDeleted", ...}`. This worker fans out **PostPublished** and commits the
+/// other variants without work (deletion is handled by `post_deleted_worker`).
 ///
-/// Published by services/post when a post transitions to the Published state.
-/// `author_tier` is denormalized by services/post from services/profile
-/// and propagated forward to avoid synchronous lookups on the timeline write path.
-/// Absent (pre-tier-support) events default to `author_tier = 0` (Standard).
+/// `author_tier` is read with a default of `0` (Standard) for forward
+/// compatibility: services/post does **not** currently denormalize a tier onto any
+/// post topic, so every author is treated as Standard today and the VIP read-path
+/// is dormant. If/when post emits `author_tier` (the documented
+/// profile→geo-discovery→post chain), this worker honours it with no change.
 #[derive(Debug, Deserialize)]
-struct PostPublishedEvent {
-    pub post_id:    String,
-    /// Also called `author_id` in some event versions. Both aliases are accepted.
-    #[serde(alias = "author_id")]
+struct PostV1Event {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub post_id: String,
+    /// Also accepted as `author_id` in some event versions.
+    #[serde(alias = "author_id", default)]
     pub profile_id: String,
-    /// 0=Standard, 1=Premium, 2=Vip. Absent in legacy events → Standard.
+    /// 0=Standard, 1=Premium, 2=Vip. Absent today → Standard.
     #[serde(default)]
     pub author_tier: u8,
+    #[serde(default)]
     pub published_at_ms: i64,
     #[serde(default)]
-    pub audio_id:    Option<String>,
-    #[serde(default)]
-    pub _audio_kind: Option<u8>,
+    pub audio_id: Option<String>,
 }
 
-/// Long-lived Kafka consumer for `post.published`.
+impl PostV1Event {
+    fn is_published(&self) -> bool {
+        self.event_type == "PostPublished"
+    }
+}
+
+/// Long-lived Kafka consumer for the unified `post.v1.events` stream. Each
+/// `PostPublished` event routes to `IngestPostPublishedCommand` via the command
+/// bus, which fans out to Redis + ScyllaDB for Standard/Premium authors or
+/// registers the post in the VIP ZSET for Vip authors. Other event types commit
+/// without work.
 ///
-/// On each event:
-///   - Routes to `IngestPostPublishedCommand` via the command bus.
-///   - The command handler fan-outs to Redis + ScyllaDB for Standard/Premium
-///     authors, or registers in the VIP ZSET for Vip authors.
-///
-/// Delivery semantics: at-least-once. All downstream writes are idempotent.
+/// Delivery semantics: at-least-once. All downstream writes are idempotent, so a
+/// from-earliest replay on cutover safely re-materializes feeds without duplication.
 pub struct PostPublishedWorker<CB> {
     kafka_config: KafkaClientConfig,
     command_bus:  Arc<CB>,
@@ -100,7 +112,7 @@ impl<CB: CommandBus + 'static> PostPublishedWorker<CB> {
         tracing::info!(topic = TOPIC, group = %self.group_id, "consumer started");
 
         let policy = RetryPolicy::default();
-        run_consumer::<PostPublishedEvent, _>(&handle, producer, &policy, move |event| {
+        run_consumer::<PostV1Event, _>(&handle, producer, &policy, move |event| {
             let worker = Arc::clone(&self);
             Box::pin(async move { dispatch_outcome(worker.process(event).await) })
         })
@@ -108,7 +120,12 @@ impl<CB: CommandBus + 'static> PostPublishedWorker<CB> {
         .map_err(|e| e.to_string())
     }
 
-    async fn process(&self, event: &PostPublishedEvent) -> Result<(), CqrsError> {
+    async fn process(&self, event: &PostV1Event) -> Result<(), CqrsError> {
+        // The unified stream carries every post event; this worker only fans out
+        // newly-published posts. Other types (Updated / Deleted) commit unprocessed.
+        if !event.is_published() {
+            return Ok(());
+        }
         let cmd = IngestPostPublishedCommand {
             post_id:         event.post_id.clone(),
             author_id:       event.profile_id.clone(),
@@ -117,5 +134,42 @@ impl<CB: CommandBus + 'static> PostPublishedWorker<CB> {
             audio_id:        event.audio_id.clone(),
         };
         self.command_bus.dispatch(Envelope::new(Uuid::now_v7(), cmd)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_a_v1_post_published_event() {
+        let json = r#"{"type":"PostPublished","post_id":"p1","profile_id":"a1","kind":"image","published_at_ms":1750000000000,"audio_id":"aud1","audio_kind":2}"#;
+        let ev: PostV1Event = serde_json::from_str(json).unwrap();
+        assert!(ev.is_published());
+        assert_eq!(ev.post_id, "p1");
+        assert_eq!(ev.profile_id, "a1");
+        assert_eq!(ev.author_tier, 0); // post emits no tier today → Standard
+        assert_eq!(ev.published_at_ms, 1_750_000_000_000);
+        assert_eq!(ev.audio_id.as_deref(), Some("aud1"));
+    }
+
+    #[test]
+    fn ignores_non_published_v1_events() {
+        for json in [
+            r#"{"type":"PostUpdated","post_id":"p1","profile_id":"a1"}"#,
+            r#"{"type":"PostDeleted","post_id":"p1","profile_id":"a1"}"#,
+        ] {
+            let ev: PostV1Event = serde_json::from_str(json).unwrap();
+            assert!(!ev.is_published());
+        }
+    }
+
+    #[test]
+    fn honors_author_tier_when_present() {
+        // Forward-compat: if/when post denormalizes the tier, the worker reads it
+        // and the VIP read-path activates with no further change.
+        let json = r#"{"type":"PostPublished","post_id":"p1","profile_id":"a1","author_tier":2,"published_at_ms":1}"#;
+        let ev: PostV1Event = serde_json::from_str(json).unwrap();
+        assert_eq!(ev.author_tier, 2);
     }
 }


### PR DESCRIPTION
## What

Migrates timeline's post-published worker from the legacy per-type `post.published` topic to the unified, versioned **`post.v1.events`** stream — the fleet convention that `search` and `realtime` already consume. This is the "wire timeline to the unified topic" half of the home-feed follower fan-out work.

The worker deserializes the internally-tagged `DomainEvent` (`{"type":"PostPublished"|...}`), fans out `PostPublished` into the existing hybrid fan-out (write to followers' feeds for Standard/Premium, VIP ZSET for celebrities), and commits the other variants without work.

## Why home-feed fan-out needed nothing more

Timeline **already implements** the durable home-feed follower fan-out (the hybrid `FanOutMode::Write` / `FanOutMode::Read` in `IngestPostPublishedHandler`), and the **live** delivery to online followers needs no timeline change — clients subscribe to realtime's `feed:<author>` broadcast (already shipped) for each author they follow, which is O(viewers) not O(followers). So the only outstanding wiring was consuming the unified post stream.

## Details

- **Forward-compatible with `author_tier`** — read with a serde default (+ `author_id` alias), so the worker honours a denormalized tier the moment post emits one, with no further change.
- **Cutover is safe** — reuses the existing consumer group with `auto-offset-reset = earliest`; the one-time from-earliest replay re-materializes feeds idempotently (Redis feed push is capped, Scylla insert is keyed).
- **Tests** — 3 unit tests: `PostPublished` deserializes, `PostUpdated`/`PostDeleted` skip, `author_tier` honoured when present.
- `post_deleted_worker` still consumes legacy `post.deleted` — a clean follow-up to migrate alongside.

## ⚠️ Finding (separate follow-up, not in this PR)

While verifying tier-safety I found that **`services/post` emits no `author_tier` on any topic** — the documented profile→geo-discovery→post denormalization was never implemented. So timeline currently treats **every author as Standard**, and the VIP/celebrity read-path is **dormant** (every author, including celebrities, is fanned out on write today). This migration is deliberately **tier-neutral** (both topics lacked the field). Activating the VIP path is a separate multi-service initiative (decide the tier source → post denormalizes → timeline activates automatically) — being scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3VfarYci2c1BCq29GQLA1
