### PR TITLE
feat(social-graph): compute + emit author tier from follower count (author-tier producer, P1)

### DIFF
--- a/crates/services/social-graph/README.fr.md
+++ b/crates/services/social-graph/README.fr.md
@@ -1,8 +1,8 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 717d6564494e96cb95a956df5f6295bde36d63d9f7866106946fc86a0dc5540f
-  translated_at: 2026-06-25
+  source_sha256: 76dbe5c398c64fd84d891df6bb3ba9406fca746559cfaec7777e9c3a8f101e5e
+  translated_at: 2026-06-26
   status: complete
 ---
 > 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
@@ -20,7 +20,7 @@ i18n:
 > | **Palier (Tier)** | **TIER-1** — feeds, notifications et filtrage par blocage en dépendent |
 > | **Binaire déployable** | `crates/apps/social-graph-server` (crate bibliothèque : `crates/services/social-graph`) |
 > | **Bases de données** | ScyllaDB keyspace `social_graph` (4 tables) · Redis (sets + compteurs) |
-> | **Asynchrone** | publie `social-graph.followed` / `.unfollowed` / `.blocked` · ne consomme rien |
+> | **Asynchrone** | publie `social-graph.followed` / `.unfollowed` / `.blocked` / `.author_tier_changed` · ne consomme rien |
 > | **Appelants amont** | `timeline`, `notification`, `<TODO: passerelle>` |
 > | **Dépendances aval** | ScyllaDB, Redis, Kafka |
 > | **SLO** | `<TODO>` dispo · `GetRelationStatus` p99 `<TODO>` · écriture p99 `<TODO>` |
@@ -161,6 +161,7 @@ service SocialGraphService {
 | `social-graph.followed` | `Follow` success | `{actor}:{target}` | `timeline` (fan-out), `notification` |
 | `social-graph.unfollowed` | `Unfollow` success | `{actor}:{target}` | `timeline` (pruning) |
 | `social-graph.blocked` | `Block` success | `{actor}:{target}` | content filtering, notification suppression |
+| `social-graph.author_tier_changed` | un follow/unfollow franchit un seuil de palier (follower count) | `{profile}` | `profile` (persiste le palier → ré-émet sur `profile.v1.events` pour que `post` le dénormalise → routage de fan-out `timeline`/`geo-discovery`). `{profile_id, new_tier, follower_count, changed_at_ms}` |
 
 `ProfileUnblocked` n'est **pas** publié — aucun fan-out aval n'en a besoin.
 

--- a/crates/services/social-graph/README.md
+++ b/crates/services/social-graph/README.md
@@ -9,7 +9,7 @@
 > | **Tier** | **TIER-1** — feeds, notifications, and block-gating depend on it |
 > | **Deployable** | `crates/apps/social-graph-server` (library crate: `crates/services/social-graph`) |
 > | **Datastores** | ScyllaDB keyspace `social_graph` (4 tables) · Redis (sets + counters) |
-> | **Async** | publishes `social-graph.followed` / `.unfollowed` / `.blocked` · consumes nothing |
+> | **Async** | publishes `social-graph.followed` / `.unfollowed` / `.blocked` / `.author_tier_changed` · consumes nothing |
 > | **Upstream callers** | `timeline`, `notification`, `<TODO: gateway>` |
 > | **Downstream deps** | ScyllaDB, Redis, Kafka |
 > | **SLO** | `<TODO>` avail · `GetRelationStatus` p99 `<TODO>` · write p99 `<TODO>` |
@@ -144,6 +144,7 @@ service SocialGraphService {
 | `social-graph.followed` | `Follow` success | `{actor}:{target}` | `timeline` (fan-out), `notification` |
 | `social-graph.unfollowed` | `Unfollow` success | `{actor}:{target}` | `timeline` (pruning) |
 | `social-graph.blocked` | `Block` success | `{actor}:{target}` | content filtering, notification suppression |
+| `social-graph.author_tier_changed` | a follow/unfollow crosses a follower-count tier boundary | `{profile}` | `profile` (persists tier → re-emits on `profile.v1.events` for `post` to denormalize → `timeline`/`geo-discovery` fan-out routing). `{profile_id, new_tier, follower_count, changed_at_ms}` |
 
 `ProfileUnblocked` is **not** published — no downstream fan-out needs it.
 

--- a/crates/services/social-graph/src/app.rs
+++ b/crates/services/social-graph/src/app.rs
@@ -26,6 +26,7 @@ use crate::application::query::{
     GetRelationStatusHandler, GetRelationStatusQuery, ListBlocksHandler, ListBlocksQuery,
     ListFollowersHandler, ListFollowersQuery, ListFollowingHandler, ListFollowingQuery,
 };
+use crate::domain::value_object::TierThresholds;
 use crate::infrastructure::cache::RedisSocialGraphCache;
 use crate::infrastructure::persistence::ScyllaSocialGraphRepository;
 
@@ -53,8 +54,9 @@ impl App {
     /// and Redis cache, and registers every social-graph command and query
     /// against the supplied `publisher`.
     pub async fn build(
-        backends:  Backends,
-        publisher: Arc<dyn EventPublisher>,
+        backends:        Backends,
+        publisher:       Arc<dyn EventPublisher>,
+        tier_thresholds: TierThresholds,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let Backends { scylla, redis } = backends;
 
@@ -72,11 +74,13 @@ impl App {
                     Arc::clone(&repo),
                     Arc::clone(&cache),
                     Arc::clone(&publisher),
+                    tier_thresholds,
                 ))?
                 .register::<UnfollowProfileCommand, _>(UnfollowProfileHandler::new(
                     Arc::clone(&repo),
                     Arc::clone(&cache),
                     Arc::clone(&publisher),
+                    tier_thresholds,
                 ))?
                 .register::<BlockProfileCommand, _>(BlockProfileHandler::new(
                     Arc::clone(&repo),

--- a/crates/services/social-graph/src/application/command/follow_profile.rs
+++ b/crates/services/social-graph/src/application/command/follow_profile.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use chrono::Utc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
 use crate::application::port::{EventPublisher, SocialGraphCache, SocialGraphRepository};
-use crate::domain::value_object::ProfileId;
+use crate::domain::event::{AuthorTierChanged, DomainEvent};
+use crate::domain::value_object::{AuthorTier, ProfileId, TierThresholds};
 use crate::error::SocialGraphError;
 
 #[derive(Debug, Clone)]
@@ -29,18 +31,20 @@ impl Validate for FollowProfileCommand {
 }
 
 pub struct FollowProfileHandler {
-    repo:      Arc<dyn SocialGraphRepository>,
-    cache:     Arc<dyn SocialGraphCache>,
-    publisher: Arc<dyn EventPublisher>,
+    repo:            Arc<dyn SocialGraphRepository>,
+    cache:           Arc<dyn SocialGraphCache>,
+    publisher:       Arc<dyn EventPublisher>,
+    tier_thresholds: TierThresholds,
 }
 
 impl FollowProfileHandler {
     pub fn new(
-        repo:      Arc<dyn SocialGraphRepository>,
-        cache:     Arc<dyn SocialGraphCache>,
-        publisher: Arc<dyn EventPublisher>,
+        repo:            Arc<dyn SocialGraphRepository>,
+        cache:           Arc<dyn SocialGraphCache>,
+        publisher:       Arc<dyn EventPublisher>,
+        tier_thresholds: TierThresholds,
     ) -> Self {
-        Self { repo, cache, publisher }
+        Self { repo, cache, publisher, tier_thresholds }
     }
 }
 
@@ -71,8 +75,26 @@ impl CommandHandler<FollowProfileCommand> for FollowProfileHandler {
 
         // Update Redis side-effects (best-effort; errors are logged, not surfaced).
         let _ = self.cache.add_following(&actor_id, &target_id).await;
-        let _ = self.cache.incr_followers_count(&target_id).await;
         let _ = self.cache.incr_following_count(&actor_id).await;
+
+        // The followee gained a follower: bump the count and, if it crossed a tier
+        // boundary, emit the author-tier signal. INCR returns the new count, so the
+        // crossing check is `tier(new - 1)` vs `tier(new)` — exactly one follow ever
+        // observes a given boundary.
+        if let Ok(new_count) = self.cache.incr_followers_count(&target_id).await
+            && let Some(new_tier) =
+                AuthorTier::crossing(new_count - 1, new_count, self.tier_thresholds)
+        {
+            let _ = self
+                .publisher
+                .publish(&DomainEvent::AuthorTierChanged(AuthorTierChanged {
+                    profile_id: target_id,
+                    new_tier,
+                    follower_count: new_count,
+                    changed_at: Utc::now(),
+                }))
+                .await;
+        }
 
         // Publish domain event to Kafka for downstream timeline fan-out engines.
         for event in relation.take_events() {

--- a/crates/services/social-graph/src/application/command/unfollow_profile.rs
+++ b/crates/services/social-graph/src/application/command/unfollow_profile.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use chrono::Utc;
 use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
 use crate::application::port::{EventPublisher, SocialGraphCache, SocialGraphRepository};
-use crate::domain::value_object::ProfileId;
+use crate::domain::event::{AuthorTierChanged, DomainEvent};
+use crate::domain::value_object::{AuthorTier, ProfileId, TierThresholds};
 use crate::error::SocialGraphError;
 
 #[derive(Debug, Clone)]
@@ -29,18 +31,20 @@ impl Validate for UnfollowProfileCommand {
 }
 
 pub struct UnfollowProfileHandler {
-    repo:      Arc<dyn SocialGraphRepository>,
-    cache:     Arc<dyn SocialGraphCache>,
-    publisher: Arc<dyn EventPublisher>,
+    repo:            Arc<dyn SocialGraphRepository>,
+    cache:           Arc<dyn SocialGraphCache>,
+    publisher:       Arc<dyn EventPublisher>,
+    tier_thresholds: TierThresholds,
 }
 
 impl UnfollowProfileHandler {
     pub fn new(
-        repo:      Arc<dyn SocialGraphRepository>,
-        cache:     Arc<dyn SocialGraphCache>,
-        publisher: Arc<dyn EventPublisher>,
+        repo:            Arc<dyn SocialGraphRepository>,
+        cache:           Arc<dyn SocialGraphCache>,
+        publisher:       Arc<dyn EventPublisher>,
+        tier_thresholds: TierThresholds,
     ) -> Self {
-        Self { repo, cache, publisher }
+        Self { repo, cache, publisher, tier_thresholds }
     }
 }
 
@@ -65,8 +69,25 @@ impl CommandHandler<UnfollowProfileCommand> for UnfollowProfileHandler {
         self.repo.delete_follow(&actor_id, &target_id, followed_at).await?;
 
         let _ = self.cache.remove_following(&actor_id, &target_id).await;
-        let _ = self.cache.decr_followers_count(&target_id).await;
         let _ = self.cache.decr_following_count(&actor_id).await;
+
+        // The followee lost a follower: drop the count and, if it crossed a tier
+        // boundary downward, emit the author-tier signal. DECR returns the new
+        // (clamped) count, so the crossing check is `tier(new + 1)` vs `tier(new)`.
+        if let Ok(new_count) = self.cache.decr_followers_count(&target_id).await
+            && let Some(new_tier) =
+                AuthorTier::crossing(new_count + 1, new_count, self.tier_thresholds)
+        {
+            let _ = self
+                .publisher
+                .publish(&DomainEvent::AuthorTierChanged(AuthorTierChanged {
+                    profile_id: target_id,
+                    new_tier,
+                    follower_count: new_count,
+                    changed_at: Utc::now(),
+                }))
+                .await;
+        }
 
         for event in relation.take_events() {
             let _ = self.publisher.publish(&event).await;

--- a/crates/services/social-graph/src/application/port/social_graph_cache.rs
+++ b/crates/services/social-graph/src/application/port/social_graph_cache.rs
@@ -75,11 +75,13 @@ pub trait SocialGraphCache: Send + Sync + 'static {
 
     // ── Counter operations ────────────────────────────────────────────────────
 
-    /// INCR `sg:followers_count:v1:{profile_id}`.
-    async fn incr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;
+    /// INCR `sg:followers_count:v1:{profile_id}`. Returns the new count, so the
+    /// caller can detect an author-tier boundary crossing.
+    async fn incr_followers_count(&self, profile_id: &ProfileId) -> Result<i64, SocialGraphError>;
 
-    /// DECR `sg:followers_count:v1:{profile_id}` (floor at 0).
-    async fn decr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;
+    /// DECR `sg:followers_count:v1:{profile_id}` (floor at 0). Returns the new
+    /// (clamped) count.
+    async fn decr_followers_count(&self, profile_id: &ProfileId) -> Result<i64, SocialGraphError>;
 
     /// INCR `sg:following_count:v1:{profile_id}`.
     async fn incr_following_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError>;

--- a/crates/services/social-graph/src/domain/event/author_tier_changed.rs
+++ b/crates/services/social-graph/src/domain/event/author_tier_changed.rs
@@ -1,0 +1,17 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::value_object::{AuthorTier, ProfileId};
+
+/// Emitted when a profile's follower count crosses a tier boundary. This is the
+/// fleet's author-tier **signal** — consumed by `profile` (which persists the tier
+/// and re-emits it on `profile.v1.events` for `post` to denormalize). The wire
+/// payload renders `new_tier` as its `u8` taxonomy value (see the Kafka publisher).
+#[derive(Debug, Clone)]
+pub struct AuthorTierChanged {
+    /// The author whose tier changed (the followee whose follower count moved).
+    pub profile_id: ProfileId,
+    pub new_tier: AuthorTier,
+    /// The follower count at the moment of the crossing.
+    pub follower_count: i64,
+    pub changed_at: DateTime<Utc>,
+}

--- a/crates/services/social-graph/src/domain/event/mod.rs
+++ b/crates/services/social-graph/src/domain/event/mod.rs
@@ -1,8 +1,10 @@
+pub mod author_tier_changed;
 pub mod profile_blocked;
 pub mod profile_followed;
 pub mod profile_unblocked;
 pub mod profile_unfollowed;
 
+pub use author_tier_changed::AuthorTierChanged;
 pub use profile_blocked::ProfileBlocked;
 pub use profile_followed::ProfileFollowed;
 pub use profile_unblocked::ProfileUnblocked;
@@ -14,4 +16,6 @@ pub enum DomainEvent {
     ProfileUnfollowed(ProfileUnfollowed),
     ProfileBlocked(ProfileBlocked),
     ProfileUnblocked(ProfileUnblocked),
+    /// The author-tier signal — emitted on a follower-count tier crossing.
+    AuthorTierChanged(AuthorTierChanged),
 }

--- a/crates/services/social-graph/src/domain/value_object/author_tier.rs
+++ b/crates/services/social-graph/src/domain/value_object/author_tier.rs
@@ -1,0 +1,124 @@
+//! Author tier classification, derived from follower count.
+//!
+//! Social-graph is the **producer** of the fleet's author-tier signal: it owns
+//! follower counts (it sees every follow / unfollow), so it is the service that
+//! classifies an author into Standard / Premium / VIP and emits a tier-change
+//! event when a follow crosses a band. Downstream, `profile` persists the tier and
+//! `post` denormalizes it onto its events; `timeline` and `geo-discovery` route on
+//! it. The numeric taxonomy (0/1/2) mirrors those consumers.
+
+/// An author's tier. The numeric value is the wire contract shared with
+/// `timeline` / `geo-discovery` (`0=Standard`, `1=Premium`, `2=Vip`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AuthorTier {
+    Standard = 0,
+    Premium = 1,
+    Vip = 2,
+}
+
+impl AuthorTier {
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Classify a follower count against the thresholds.
+    pub fn from_follower_count(count: i64, thresholds: TierThresholds) -> Self {
+        if count >= thresholds.vip {
+            AuthorTier::Vip
+        } else if count >= thresholds.premium {
+            AuthorTier::Premium
+        } else {
+            AuthorTier::Standard
+        }
+    }
+
+    /// The new tier **iff** a follower-count change from `old_count` to `new_count`
+    /// crossed a tier boundary; `None` when the tier is unchanged.
+    ///
+    /// Stateless — it relies only on the two counts. Because Redis `INCR`/`DECR`
+    /// return distinct sequential values, exactly one follow/unfollow observes any
+    /// given boundary crossing, so this neither misses nor double-emits.
+    pub fn crossing(
+        old_count: i64,
+        new_count: i64,
+        thresholds: TierThresholds,
+    ) -> Option<AuthorTier> {
+        let old = Self::from_follower_count(old_count, thresholds);
+        let new = Self::from_follower_count(new_count, thresholds);
+        (old != new).then_some(new)
+    }
+}
+
+/// Follower-count thresholds for tier classification — the Premium and VIP floors.
+/// These are config-driven (a product decision); the defaults live at the
+/// composition root.
+#[derive(Debug, Clone, Copy)]
+pub struct TierThresholds {
+    pub premium: i64,
+    pub vip: i64,
+}
+
+impl TierThresholds {
+    /// Build thresholds, clamping to the invariant `1 <= premium <= vip` so a
+    /// misconfiguration can never invert or zero the bands.
+    pub fn new(premium: i64, vip: i64) -> Self {
+        let premium = premium.max(1);
+        let vip = vip.max(premium);
+        Self { premium, vip }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thresholds() -> TierThresholds {
+        TierThresholds::new(10_000, 1_000_000)
+    }
+
+    #[test]
+    fn classifies_by_band() {
+        let t = thresholds();
+        assert_eq!(AuthorTier::from_follower_count(0, t), AuthorTier::Standard);
+        assert_eq!(AuthorTier::from_follower_count(9_999, t), AuthorTier::Standard);
+        assert_eq!(AuthorTier::from_follower_count(10_000, t), AuthorTier::Premium);
+        assert_eq!(AuthorTier::from_follower_count(999_999, t), AuthorTier::Premium);
+        assert_eq!(AuthorTier::from_follower_count(1_000_000, t), AuthorTier::Vip);
+    }
+
+    #[test]
+    fn detects_an_upward_crossing_only_at_the_boundary() {
+        let t = thresholds();
+        // 9_999 → 10_000 crosses into Premium.
+        assert_eq!(AuthorTier::crossing(9_999, 10_000, t), Some(AuthorTier::Premium));
+        // 10_000 → 10_001 stays Premium — no emit.
+        assert_eq!(AuthorTier::crossing(10_000, 10_001, t), None);
+        // 999_999 → 1_000_000 crosses into Vip.
+        assert_eq!(AuthorTier::crossing(999_999, 1_000_000, t), Some(AuthorTier::Vip));
+    }
+
+    #[test]
+    fn detects_a_downward_crossing() {
+        let t = thresholds();
+        // 1_000_000 → 999_999 drops back to Premium.
+        assert_eq!(AuthorTier::crossing(1_000_000, 999_999, t), Some(AuthorTier::Premium));
+        // 10_000 → 9_999 drops to Standard.
+        assert_eq!(AuthorTier::crossing(10_000, 9_999, t), Some(AuthorTier::Standard));
+    }
+
+    #[test]
+    fn no_crossing_within_a_band() {
+        let t = thresholds();
+        assert_eq!(AuthorTier::crossing(5, 6, t), None);
+        assert_eq!(AuthorTier::crossing(500_000, 500_001, t), None);
+    }
+
+    #[test]
+    fn thresholds_cannot_invert() {
+        // Misconfigured (vip < premium) is clamped so vip >= premium >= 1.
+        let t = TierThresholds::new(0, -5);
+        assert_eq!(t.premium, 1);
+        assert!(t.vip >= t.premium);
+    }
+}

--- a/crates/services/social-graph/src/domain/value_object/mod.rs
+++ b/crates/services/social-graph/src/domain/value_object/mod.rs
@@ -1,7 +1,9 @@
+pub mod author_tier;
 pub mod profile_id;
 pub mod relation_kind;
 pub mod relation_status;
 
+pub use author_tier::{AuthorTier, TierThresholds};
 pub use profile_id::ProfileId;
 pub use relation_kind::RelationKind;
 pub use relation_status::RelationStatus;

--- a/crates/services/social-graph/src/infrastructure/cache/redis_social_graph_cache.rs
+++ b/crates/services/social-graph/src/infrastructure/cache/redis_social_graph_cache.rs
@@ -109,20 +109,21 @@ impl SocialGraphCache for RedisSocialGraphCache {
 
     // ── Counter operations ────────────────────────────────────────────────────
 
-    async fn incr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {
+    async fn incr_followers_count(&self, profile_id: &ProfileId) -> Result<i64, SocialGraphError> {
         let key = followers_count_key(profile_id);
-        self.client.incr::<i64, _>(&key).await.map_err(redis_err)?;
-        Ok(())
+        let value: i64 = self.client.incr(&key).await.map_err(redis_err)?;
+        Ok(value)
     }
 
-    async fn decr_followers_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {
+    async fn decr_followers_count(&self, profile_id: &ProfileId) -> Result<i64, SocialGraphError> {
         let key   = followers_count_key(profile_id);
         let value: i64 = self.client.decr(&key).await.map_err(redis_err)?;
         // Clamp at zero: a decrement below zero signals a consistency gap.
         if value < 0 {
             let _ = self.client.set::<(), _, _>(&key, 0i64, None, None, false).await;
+            return Ok(0);
         }
-        Ok(())
+        Ok(value)
     }
 
     async fn incr_following_count(&self, profile_id: &ProfileId) -> Result<(), SocialGraphError> {

--- a/crates/services/social-graph/src/infrastructure/publisher/kafka_event_publisher.rs
+++ b/crates/services/social-graph/src/infrastructure/publisher/kafka_event_publisher.rs
@@ -1,16 +1,22 @@
 use async_trait::async_trait;
+use serde::Serialize;
 use transport::{
     error::TransportError,
     kafka::{envelope::EventEnvelope, producer::handle::KafkaProducerHandle},
 };
 
 use crate::application::port::EventPublisher;
-use crate::domain::event::{DomainEvent, ProfileBlocked, ProfileFollowed, ProfileUnfollowed};
+use crate::domain::event::{
+    AuthorTierChanged, DomainEvent, ProfileBlocked, ProfileFollowed, ProfileUnfollowed,
+};
 use crate::error::SocialGraphError;
 
 const TOPIC_FOLLOWED:   &str = "social-graph.followed";
 const TOPIC_UNFOLLOWED: &str = "social-graph.unfollowed";
 const TOPIC_BLOCKED:    &str = "social-graph.blocked";
+/// The author-tier signal `profile` consumes (then persists + re-emits on
+/// `profile.v1.events` for `post` to denormalize). Keyed by profile id.
+const TOPIC_AUTHOR_TIER_CHANGED: &str = "social-graph.author_tier_changed";
 
 fn transport_err(e: TransportError) -> SocialGraphError {
     SocialGraphError::DomainViolation {
@@ -38,8 +44,40 @@ impl EventPublisher for KafkaEventPublisher {
             DomainEvent::ProfileBlocked(e) => publish_blocked(&self.producer, e).await,
             // ProfileUnblocked is not published downstream per the interface contract.
             DomainEvent::ProfileUnblocked(_) => Ok(()),
+            DomainEvent::AuthorTierChanged(e) => {
+                publish_author_tier_changed(&self.producer, e).await
+            }
         }
     }
+}
+
+/// Wire payload for `social-graph.author_tier_changed`. `new_tier` is the shared
+/// `u8` taxonomy (0=Standard, 1=Premium, 2=Vip).
+#[derive(Serialize)]
+struct AuthorTierChangedWire {
+    profile_id:    String,
+    new_tier:      u8,
+    follower_count: i64,
+    changed_at_ms: i64,
+}
+
+async fn publish_author_tier_changed(
+    producer: &KafkaProducerHandle,
+    event:    &AuthorTierChanged,
+) -> Result<(), SocialGraphError> {
+    let key  = event.profile_id.as_str();
+    let wire = AuthorTierChangedWire {
+        profile_id:     event.profile_id.as_str(),
+        new_tier:       event.new_tier.as_u8(),
+        follower_count: event.follower_count,
+        changed_at_ms:  event.changed_at.timestamp_millis(),
+    };
+    let envelope = EventEnvelope::new(TOPIC_AUTHOR_TIER_CHANGED, key, wire)
+        .with_header("event_type", "AuthorTierChanged")
+        .with_header("profile_id", event.profile_id.as_str())
+        .with_header("new_tier",   event.new_tier.as_u8().to_string());
+
+    producer.publish(envelope).await.map_err(transport_err)
 }
 
 async fn publish_followed(

--- a/crates/services/social-graph/src/service.rs
+++ b/crates/services/social-graph/src/service.rs
@@ -18,6 +18,24 @@ use tonic_reflection::server::Builder as ReflectionBuilder;
 use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
 use transport::kafka::producer::KafkaProducerBuilder;
 
+use crate::domain::value_object::TierThresholds;
+
+/// Default follower-count floors for tier classification (a product default; tune
+/// via `SOCIAL_GRAPH_PREMIUM_FOLLOWER_THRESHOLD` / `..._VIP_FOLLOWER_THRESHOLD`).
+const DEFAULT_PREMIUM_FOLLOWERS: i64 = 10_000;
+const DEFAULT_VIP_FOLLOWERS: i64 = 1_000_000;
+
+fn tier_thresholds_from_env() -> TierThresholds {
+    TierThresholds::new(
+        env_i64("SOCIAL_GRAPH_PREMIUM_FOLLOWER_THRESHOLD", DEFAULT_PREMIUM_FOLLOWERS),
+        env_i64("SOCIAL_GRAPH_VIP_FOLLOWER_THRESHOLD", DEFAULT_VIP_FOLLOWERS),
+    )
+}
+
+fn env_i64(key: &str, default: i64) -> i64 {
+    std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
 use crate::app::{App, Backends};
 use crate::application::port::EventPublisher;
 use crate::infrastructure::grpc::handler::social_graph_service_handler::SocialGraphServiceServer;
@@ -52,7 +70,7 @@ impl Service for SocialGraphService {
             .build()?;
         let publisher: Arc<dyn EventPublisher> = Arc::new(KafkaEventPublisher::new(producer));
 
-        let app = App::build(backends, publisher)
+        let app = App::build(backends, publisher, tier_thresholds_from_env())
             .await
             .map_err(|e| anyhow::anyhow!("social-graph app build: {e}"))?;
 

--- a/crates/services/social-graph/tests/social_graph_it/harness/mod.rs
+++ b/crates/services/social-graph/tests/social_graph_it/harness/mod.rs
@@ -68,9 +68,13 @@ impl TestHarness {
             redis: RedisConfig { hosts: vec![redis_endpoint], ..RedisConfig::default() },
         };
 
-        let app = App::build(backends, Arc::new(NoopPublisher) as Arc<dyn EventPublisher>)
-            .await
-            .expect("integration: build social-graph app");
+        let app = App::build(
+            backends,
+            Arc::new(NoopPublisher) as Arc<dyn EventPublisher>,
+            social_graph::domain::value_object::TierThresholds::new(10_000, 1_000_000),
+        )
+        .await
+        .expect("integration: build social-graph app");
 
         Self { command_bus: app.command_bus, query_bus: app.query_bus }
     }


### PR DESCRIPTION
## What

Builds the missing **producer** of the fleet's author-tier signal (P1 of the author-tier initiative).

`geo-discovery` and `timeline` already *consume* `author_tier` / `profile.tier_changed`, but nothing ever *produced* it — so every author was classified Standard and the VIP/celebrity fan-out protection both services built was **dormant** (celebrities were being fanned out on write). social-graph owns follower counts and sees every follow/unfollow, so it's the natural place to classify and emit.

## How

- **`AuthorTier`** {Standard=0, Premium=1, Vip=2} + `from_follower_count` + a stateless `crossing(old, new, thresholds)`.
- **Race-free crossing detection:** `incr/decr_followers_count` now return the new count. Because Redis `INCR`/`DECR` return distinct sequential values, exactly one follow/unfollow ever observes a given boundary — no missed or duplicate emits. (Five unit tests cover the bands and both directions.)
- The follow / unfollow handlers detect a crossing and publish **`AuthorTierChanged`** on the new topic **`social-graph.author_tier_changed`** `{profile_id, new_tier, follower_count, changed_at_ms}`.
- **Thresholds are env-configurable** — `SOCIAL_GRAPH_PREMIUM_FOLLOWER_THRESHOLD` / `SOCIAL_GRAPH_VIP_FOLLOWER_THRESHOLD` (defaults 10K / 1M), read in `service.rs` and threaded through `App::build` (which stays pure). So the product number isn't baked into code.
- README EN/FR + i18n re-stamped. Build + 5 tests + clippy green.

## Deferred / notes

- **Block-induced follower-count drops** (`block_profile` decrements the count) don't recompute tier yet — rare, and self-heals on the next follow/unfollow.
- **Hysteresis:** a follow/unfollow oscillating exactly at a boundary re-emits each way; the downstream consumer should treat tier as latest-wins (a debounce can be added if it's noisy).

## Next in the chain

P2 — `profile` consumes `social-graph.author_tier_changed`, persists `tier`, and re-emits it on `profile.v1.events`; P3 — `post` denormalizes it onto `post.v1.events`, after which `timeline` (already forward-compatible, #469) and `geo-discovery` route on it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3VfarYci2c1BCq29GQLA1
