### PR TITLE
feat(post): denormalize author tier onto published events (author-tier P3)

### DIFF
--- a/crates/services/post/README.fr.md
+++ b/crates/services/post/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 61e22da790d0aa82a96b28409247cbfec94016b3214f7d644198a6518213722a
+  source_sha256: 108236d88c76fe93fc08d03ad5c6f997df7741c14fcc4aba3cc9d6c4f2dc33bc
   translated_at: 2026-06-26
   status: complete
 ---
@@ -20,7 +20,7 @@ i18n:
 > | **Palier (Tier)** | **TIER-0** — le chemin de publication du contenu ; feeds et découverte dérivent de ses événements |
 > | **Binaire déployable** | `crates/apps/post-server` (crate bibliothèque : `crates/services/post`) |
 > | **Bases de données** | ScyllaDB keyspace `post` (2 tables) |
-> | **Asynchrone** | publie `post.v1.events` (unifié) + `post.published` / `post.updated` / `post.deleted` (legacy) · ne consomme rien |
+> | **Asynchrone** | publie `post.v1.events` (unifié) + `post.published` / `post.updated` / `post.deleted` (legacy) · consomme `profile.v1.events` (dénormalisation du palier auteur) |
 > | **Appelants amont** | `<TODO: passerelle>` |
 > | **Dépendances aval** | ScyllaDB, Kafka |
 > | **SLO** | `<TODO>` dispo · `GetPost` p99 `<TODO>` · publication p99 `<TODO>` |
@@ -150,13 +150,17 @@ service PostService {
 | Topic | Déclencheur | Clé | Consommateurs |
 |---|---|---|---|
 | `post.v1.events` | chaque événement de cycle de vie (`PostPublished` / `PostUpdated` / `PostDeleted`) | `post_id` | `search` (indexation des posts) |
-| `post.published` | `PublishPost` success | `post_id` | `timeline`, `geo-discovery`, `notification` |
+| `post.published` | `PublishPost` success — porte le `author_tier` dénormalisé de l'auteur | `post_id` | `timeline`, `geo-discovery`, `notification` |
 | `post.updated` | `UpdatePost` success | `post_id` | `<TODO>` |
 | `post.deleted` | `DeletePost` success | `post_id` | `timeline`, `geo-discovery` |
 
 > **Deux styles d'émission, par conception.** `post.v1.events` est le flux unifié et versionné (la convention de la flotte, comme `moderation.v1.events` / `profile.v1.events`) : le `DomainEvent` entier tagué en interne, clé `post_id`. Les topics legacy par-type (`post.published` / `.updated` / `.deleted`, charges utiles brutes) sont conservés pour leurs consommateurs existants (`timeline` / `geo-discovery` / `notification`) ; chaque événement est publié sur **les deux**. Migrer ces consommateurs vers `post.v1.events` et retirer les topics legacy est un nettoyage futur.
 
-**Consomme :** rien.
+**Consomme :**
+
+| Topic | Consumer group | Purpose | On poison/exhaustion |
+|---|---|---|---|
+| `profile.v1.events` | `post-author-tier` | dénormalise `ProfileTierChanged` dans la projection `author_tiers` (`profile_id → tier`) ; lue sur le chemin de publication pour estampiller `author_tier` sur les posts publiés. Les autres types committent en no-op | DLQ `profile.v1.events.dlq` |
 
 > **Contrat d'exécution :** l'événement est publié après le dual-write durable. Les consommateurs aval
 > gèrent leur propre traitement at-least-once sous `run_consumer` ; tous traitent `post.*` comme

--- a/crates/services/post/README.md
+++ b/crates/services/post/README.md
@@ -9,7 +9,7 @@
 > | **Tier** | **TIER-0** — the content publish path; feeds and discovery derive from its events |
 > | **Deployable** | `crates/apps/post-server` (library crate: `crates/services/post`) |
 > | **Datastores** | ScyllaDB keyspace `post` (2 tables) |
-> | **Async** | publishes `post.v1.events` (unified) + `post.published` / `post.updated` / `post.deleted` (legacy) · consumes nothing |
+> | **Async** | publishes `post.v1.events` (unified) + `post.published` / `post.updated` / `post.deleted` (legacy) · consumes `profile.v1.events` (author-tier denormalization) |
 > | **Upstream callers** | `<TODO: gateway>` |
 > | **Downstream deps** | ScyllaDB, Kafka |
 > | **SLO** | `<TODO>` avail · `GetPost` p99 `<TODO>` · publish p99 `<TODO>` |
@@ -137,13 +137,17 @@ service PostService {
 | Topic | Trigger | Key | Consumers |
 |---|---|---|---|
 | `post.v1.events` | every lifecycle event (`PostPublished` / `PostUpdated` / `PostDeleted`) | `post_id` | `search` (post indexing) |
-| `post.published` | `PublishPost` success | `post_id` | `timeline`, `geo-discovery`, `notification` |
+| `post.published` | `PublishPost` success — carries the author's denormalized `author_tier` | `post_id` | `timeline`, `geo-discovery`, `notification` |
 | `post.updated` | `UpdatePost` success | `post_id` | `<TODO>` |
 | `post.deleted` | `DeletePost` success | `post_id` | `timeline`, `geo-discovery` |
 
 > **Two emission styles, by design.** `post.v1.events` is the unified, versioned stream (the fleet convention, like `moderation.v1.events` / `profile.v1.events`): the whole internally-tagged `DomainEvent`, keyed by `post_id`. The legacy per-type topics (`post.published` / `.updated` / `.deleted`, bare payloads) are retained for their existing consumers (`timeline` / `geo-discovery` / `notification`); every event is published to **both**. Migrating those consumers onto `post.v1.events` and retiring the legacy topics is a future cleanup.
 
-**Consumes:** none.
+**Consumes:**
+
+| Topic | Consumer group | Purpose | On poison/exhaustion |
+|---|---|---|---|
+| `profile.v1.events` | `post-author-tier` | denormalize `ProfileTierChanged` into the `author_tiers` projection (`profile_id → tier`); read on the publish path to stamp `author_tier` onto published posts. Other event types commit as no-ops | DLQ `profile.v1.events.dlq` |
 
 > **Runtime contract:** the event is published after the durable dual-write. Downstream consumers own
 > at-least-once handling under `run_consumer`; all of them treat `post.*` as idempotent by `post_id`.

--- a/crates/services/post/migrations/0005_create_author_tiers_table.cql
+++ b/crates/services/post/migrations/0005_create_author_tiers_table.cql
@@ -1,0 +1,8 @@
+-- Denormalized author tier projection, maintained from profile.v1.events
+-- (ProfileTierChanged). Read on the publish path to stamp `author_tier` onto
+-- post.published / post.v1.events so timeline routes VIP authors to its read path.
+-- 0=Standard, 1=Premium, 2=Vip.
+CREATE TABLE IF NOT EXISTS post.author_tiers (
+    profile_id uuid PRIMARY KEY,
+    tier       tinyint
+) WITH compression = {'sstable_compression': 'LZ4Compressor'};

--- a/crates/services/post/src/app.rs
+++ b/crates/services/post/src/app.rs
@@ -20,12 +20,12 @@ use crate::application::command::create_post::{CreatePostCommand, CreatePostHand
 use crate::application::command::delete_post::{DeletePostCommand, DeletePostHandler};
 use crate::application::command::publish_post::{PublishPostCommand, PublishPostHandler};
 use crate::application::command::update_post::{UpdatePostCommand, UpdatePostHandler};
-use crate::application::port::EventPublisher;
+use crate::application::port::{AuthorTierStore, EventPublisher};
 use crate::application::query::get_post::{GetPostHandler, GetPostQuery};
 use crate::application::query::list_posts_by_profile::{
     ListPostsByProfileHandler, ListPostsByProfileQuery,
 };
-use crate::infrastructure::persistence::ScyllaPostRepository;
+use crate::infrastructure::persistence::{ScyllaAuthorTierStore, ScyllaPostRepository};
 
 /// Storage endpoints the graph is wired against. Post has no Redis and emits its
 /// events through the injected [`EventPublisher`], so only ScyllaDB is needed.
@@ -43,6 +43,9 @@ pub struct App {
     /// Live storage client, retained so the runtime's readiness loop can probe
     /// its liveness (see [`crate::service`]).
     pub scylla:      Arc<ScyllaClient>,
+    /// The author-tier projection, exposed so the serving binary can wire its
+    /// `profile.v1.events` consumer against the same instance.
+    pub author_tier_store: Arc<dyn AuthorTierStore>,
 }
 
 impl App {
@@ -54,6 +57,8 @@ impl App {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let scylla_client = Arc::new(ScyllaSessionBuilder::new(backends.scylla).build().await?);
         let repository = Arc::new(ScyllaPostRepository::new(Arc::clone(&scylla_client)));
+        let author_tier_store: Arc<dyn AuthorTierStore> =
+            Arc::new(ScyllaAuthorTierStore::new(Arc::clone(&scylla_client)));
 
         let command_bus = Arc::new(
             CommandBusBuilder::new()
@@ -62,8 +67,9 @@ impl App {
                     publisher:  Arc::clone(&publisher),
                 })?
                 .register::<PublishPostCommand, _>(PublishPostHandler {
-                    repository: Arc::clone(&repository),
-                    publisher:  Arc::clone(&publisher),
+                    repository:        Arc::clone(&repository),
+                    publisher:         Arc::clone(&publisher),
+                    author_tier_store: Arc::clone(&author_tier_store),
                 })?
                 .register::<UpdatePostCommand, _>(UpdatePostHandler {
                     repository: Arc::clone(&repository),
@@ -87,6 +93,6 @@ impl App {
                 .build(),
         );
 
-        Ok(Self { command_bus, query_bus, scylla: scylla_client })
+        Ok(Self { command_bus, query_bus, scylla: scylla_client, author_tier_store })
     }
 }

--- a/crates/services/post/src/application/command/publish_post.rs
+++ b/crates/services/post/src/application/command/publish_post.rs
@@ -4,8 +4,8 @@ use cqrs::{Command, CommandHandler, Envelope};
 use validate_core::{FieldViolation, Validate};
 
 use crate::{
-    application::port::{EventPublisher, PostRepository},
-    domain::value_object::{PostId, ProfileId},
+    application::port::{AuthorTierStore, EventPublisher, PostRepository},
+    domain::{event::DomainEvent, value_object::{PostId, ProfileId}},
     error::PostError,
 };
 
@@ -30,8 +30,9 @@ impl Validate for PublishPostCommand {
 }
 
 pub struct PublishPostHandler<R, P> {
-    pub repository: Arc<R>,
-    pub publisher:  Arc<P>,
+    pub repository:        Arc<R>,
+    pub publisher:         Arc<P>,
+    pub author_tier_store: Arc<dyn AuthorTierStore>,
 }
 
 impl<R, P> CommandHandler<PublishPostCommand> for PublishPostHandler<R, P>
@@ -60,7 +61,21 @@ where
         post.publish()?;
         self.repository.update_lifecycle(&post).await?;
 
-        for event in post.take_events() {
+        // Stamp the author's current tier (denormalized from profile.v1.events)
+        // onto the published event so timeline routes VIP authors to its read path.
+        // A read failure degrades to Standard rather than blocking the publish.
+        let author_tier = match self.author_tier_store.get_tier(&profile_id).await {
+            Ok(tier) => tier,
+            Err(error) => {
+                tracing::warn!(%error, "author-tier read failed at publish; defaulting to Standard");
+                0
+            }
+        };
+
+        for mut event in post.take_events() {
+            if let DomainEvent::PostPublished(ref mut e) = event {
+                e.author_tier = author_tier;
+            }
             self.publisher.publish(&event).await?;
         }
         Ok(())

--- a/crates/services/post/src/application/port/author_tier_store.rs
+++ b/crates/services/post/src/application/port/author_tier_store.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use crate::domain::value_object::ProfileId;
+use crate::error::PostError;
+
+/// A denormalized `profile_id → author_tier` projection, maintained from
+/// `profile.v1.events` (`ProfileTierChanged`) and read on the publish path to
+/// stamp the author's current tier onto the published event. Keeping this local
+/// avoids a synchronous call to `profile` when publishing.
+#[async_trait]
+pub trait AuthorTierStore: Send + Sync + 'static {
+    /// The author's current tier (0=Standard, 1=Premium, 2=Vip). Defaults to
+    /// `0` (Standard) for an author the projection hasn't seen a tier change for.
+    async fn get_tier(&self, profile_id: &ProfileId) -> Result<u8, PostError>;
+
+    /// Upsert an author's tier (idempotent, last-writer-wins).
+    async fn upsert_tier(&self, profile_id: &ProfileId, tier: u8) -> Result<(), PostError>;
+}

--- a/crates/services/post/src/application/port/mod.rs
+++ b/crates/services/post/src/application/port/mod.rs
@@ -1,5 +1,7 @@
+pub mod author_tier_store;
 pub mod event_publisher;
 pub mod post_repository;
 
+pub use author_tier_store::AuthorTierStore;
 pub use event_publisher::EventPublisher;
 pub use post_repository::{PostRepository, PostSummary};

--- a/crates/services/post/src/domain/aggregate/post.rs
+++ b/crates/services/post/src/domain/aggregate/post.rs
@@ -115,6 +115,9 @@ impl Post {
             profile_id:      self.profile_id.as_str(),
             kind:            self.kind.to_string(),
             published_at_ms: now.timestamp_millis(),
+            // Placeholder; the publish handler stamps the author's current tier from
+            // the projection (the aggregate owns no denormalized profile state).
+            author_tier:     0,
             audio_id:        self.audio_ref.as_ref().map(|a| a.audio_id.as_str()),
             audio_kind:      self.audio_ref.as_ref().map(|a| a.audio_kind.as_tinyint() as u8),
         }));

--- a/crates/services/post/src/domain/event/mod.rs
+++ b/crates/services/post/src/domain/event/mod.rs
@@ -6,6 +6,11 @@ pub struct PostPublishedEvent {
     pub profile_id:      String,
     pub kind:            String,
     pub published_at_ms: i64,
+    /// The author's tier at publish time (0=Standard, 1=Premium, 2=Vip),
+    /// denormalized from `profile.v1.events` and stamped by the publish handler.
+    /// `timeline` routes VIP authors to its read path on this field.
+    #[serde(default)]
+    pub author_tier:     u8,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio_id:        Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/services/post/src/infrastructure/consumer/author_tier_consumer.rs
+++ b/crates/services/post/src/infrastructure/consumer/author_tier_consumer.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tracing::{error, info};
+
+use error::AppError;
+use transport::kafka::consumer::{run_consumer, KafkaConsumerHandle, ProcessOutcome, RetryPolicy};
+use transport::kafka::producer::KafkaProducerHandle;
+
+use crate::application::port::AuthorTierStore;
+use crate::domain::value_object::ProfileId;
+
+/// Lenient read DTO for `profile.v1.events` (the internally-tagged
+/// `{"type": ...}` stream). Only `ProfileTierChanged` is acted on; all other
+/// variants deserialize and are skipped.
+#[derive(Debug, Deserialize)]
+struct ProfileV1Event {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    profile_id: String,
+    #[serde(default)]
+    tier: u8,
+}
+
+/// Runs the author-tier projection consumer on the shared at-least-once runner.
+///
+/// Consumes `profile.v1.events`, upserts the `profile_id → tier` projection on each
+/// `ProfileTierChanged`, and commits everything else as a no-op. The upsert is
+/// last-writer-wins and idempotent, so at-least-once redelivery is harmless. The
+/// publish path reads this projection to stamp `author_tier` onto published posts.
+pub async fn run_author_tier_consumer(
+    consumer: KafkaConsumerHandle,
+    store: Arc<dyn AuthorTierStore>,
+    producer: KafkaProducerHandle,
+) {
+    info!("post author-tier consumer started");
+
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<ProfileV1Event, _>(&consumer, &producer, &policy, move |event| {
+        let store = Arc::clone(&store);
+        Box::pin(async move { process_event(store.as_ref(), event).await })
+    })
+    .await;
+
+    if let Err(e) = result {
+        error!(error = %e, "post author-tier consumer stopped");
+    }
+}
+
+async fn process_event(store: &dyn AuthorTierStore, event: &ProfileV1Event) -> ProcessOutcome {
+    if event.event_type != "ProfileTierChanged" {
+        return ProcessOutcome::Done; // not a tier event — commit and skip
+    }
+
+    let profile_id = match ProfileId::try_from(event.profile_id.as_str()) {
+        Ok(id) => id,
+        Err(e) => return ProcessOutcome::Reject(e.to_string()),
+    };
+
+    match store.upsert_tier(&profile_id, event.tier).await {
+        Ok(())                     => ProcessOutcome::Done,
+        Err(e) if e.is_retryable() => ProcessOutcome::Retry(e.to_string()),
+        Err(e)                     => ProcessOutcome::Reject(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_tier_change_event() {
+        let json = r#"{"type":"ProfileTierChanged","profile_id":"prof-9","tier":2,"occurred_at_ms":1}"#;
+        let ev: ProfileV1Event = serde_json::from_str(json).unwrap();
+        assert_eq!(ev.event_type, "ProfileTierChanged");
+        assert_eq!(ev.profile_id, "prof-9");
+        assert_eq!(ev.tier, 2);
+    }
+
+    #[test]
+    fn other_profile_events_are_not_tier_changes() {
+        // A non-tier event still deserializes (tier defaults to 0) but is skipped
+        // by the `event_type` guard in `process_event`.
+        for json in [
+            r#"{"type":"ProfileUpdated","profile_id":"prof-9","occurred_at_ms":1}"#,
+            r#"{"type":"ProfileVerified","profile_id":"prof-9","occurred_at_ms":1}"#,
+        ] {
+            let ev: ProfileV1Event = serde_json::from_str(json).unwrap();
+            assert_ne!(ev.event_type, "ProfileTierChanged");
+            assert_eq!(ev.tier, 0);
+        }
+    }
+}

--- a/crates/services/post/src/infrastructure/consumer/mod.rs
+++ b/crates/services/post/src/infrastructure/consumer/mod.rs
@@ -1,0 +1,3 @@
+pub mod author_tier_consumer;
+
+pub use author_tier_consumer::run_author_tier_consumer;

--- a/crates/services/post/src/infrastructure/mod.rs
+++ b/crates/services/post/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
+pub mod consumer;
 pub mod grpc;
 pub mod persistence;
 pub mod publisher;

--- a/crates/services/post/src/infrastructure/persistence/mod.rs
+++ b/crates/services/post/src/infrastructure/persistence/mod.rs
@@ -1,4 +1,6 @@
 pub mod model;
+pub mod scylla_author_tier_store;
 pub mod scylla_post_repository;
 
+pub use scylla_author_tier_store::ScyllaAuthorTierStore;
 pub use scylla_post_repository::ScyllaPostRepository;

--- a/crates/services/post/src/infrastructure/persistence/scylla_author_tier_store.rs
+++ b/crates/services/post/src/infrastructure/persistence/scylla_author_tier_store.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use scylla::DeserializeRow;
+use scylla::statement::unprepared::Statement;
+use scylla_storage::{ScyllaClient, ScyllaStorageError};
+
+use crate::application::port::AuthorTierStore;
+use crate::domain::value_object::ProfileId;
+use crate::error::PostError;
+
+fn scylla_err(e: scylla::errors::ExecutionError) -> PostError {
+    PostError::Storage(ScyllaStorageError::from(e))
+}
+
+fn rows_err(ctx: &'static str, e: impl ToString) -> PostError {
+    PostError::DomainViolation {
+        field:   ctx.to_owned(),
+        message: e.to_string(),
+    }
+}
+
+#[derive(DeserializeRow)]
+struct TierRow {
+    tier: Option<i8>,
+}
+
+/// ScyllaDB-backed `profile_id → author_tier` projection (table
+/// `post.author_tiers`, single-column upsert / point read).
+pub struct ScyllaAuthorTierStore {
+    client: Arc<ScyllaClient>,
+}
+
+impl ScyllaAuthorTierStore {
+    pub fn new(client: Arc<ScyllaClient>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl AuthorTierStore for ScyllaAuthorTierStore {
+    async fn get_tier(&self, profile_id: &ProfileId) -> Result<u8, PostError> {
+        let stmt = Statement::new("SELECT tier FROM post.author_tiers WHERE profile_id = ?");
+        let result = self
+            .client
+            .session
+            .execute_unpaged(stmt, (profile_id.as_uuid(),))
+            .await
+            .map_err(scylla_err)?;
+
+        let row = result
+            .into_rows_result()
+            .map_err(|e| rows_err("author_tier_rows", e))?
+            .maybe_first_row::<TierRow>()
+            .map_err(|e| rows_err("author_tier_deser", e))?;
+
+        Ok(row.and_then(|r| r.tier).unwrap_or(0).clamp(0, 2) as u8)
+    }
+
+    async fn upsert_tier(&self, profile_id: &ProfileId, tier: u8) -> Result<(), PostError> {
+        let stmt =
+            Statement::new("INSERT INTO post.author_tiers (profile_id, tier) VALUES (?, ?)");
+        self.client
+            .session
+            .execute_unpaged(stmt, (profile_id.as_uuid(), tier as i8))
+            .await
+            .map_err(scylla_err)?;
+        Ok(())
+    }
+}

--- a/crates/services/post/src/infrastructure/publisher/kafka_event_publisher.rs
+++ b/crates/services/post/src/infrastructure/publisher/kafka_event_publisher.rs
@@ -124,6 +124,7 @@ mod tests {
             profile_id:      "prof-9".to_owned(),
             kind:            "text".to_owned(),
             published_at_ms: 1_700_000_000_000,
+            author_tier:     0,
             audio_id:        None,
             audio_kind:      None,
         });

--- a/crates/services/post/src/service.rs
+++ b/crates/services/post/src/service.rs
@@ -3,6 +3,7 @@
 //! durable Kafka publisher.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use cqrs::command::InMemoryCommandBus;
@@ -11,14 +12,24 @@ use scylla_storage::ScyllaConfig;
 use service_runtime::{HealthProbe, InfraRegistry, Service};
 use tonic::service::RoutesBuilder;
 use tonic_reflection::server::Builder as ReflectionBuilder;
-use transport::kafka::config::{KafkaClientConfig, ProducerConfig};
-use transport::kafka::producer::KafkaProducerBuilder;
+use transport::kafka::config::{ConsumerConfig, KafkaClientConfig, ProducerConfig};
+use transport::kafka::consumer::{KafkaConsumerBuilder, KafkaConsumerHandle};
+use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
 
 use crate::app::{App, Backends};
+use crate::application::port::AuthorTierStore;
+use crate::infrastructure::consumer::run_author_tier_consumer;
 use crate::infrastructure::grpc::handler::post_service_handler::PostServiceServer;
 use crate::infrastructure::grpc::handler::PostServiceHandler;
 use crate::infrastructure::grpc::server::FILE_DESCRIPTOR_SET;
 use crate::infrastructure::publisher::KafkaEventPublisher;
+
+/// The profile event stream post denormalizes author tier from.
+const PROFILE_EVENTS_TOPIC: &str = "profile.v1.events";
+/// Consumer group for post's author-tier projection consumer.
+const AUTHOR_TIER_GROUP: &str = "post-author-tier";
+/// Backoff before respawning the consumer after the runner returns.
+const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
 
 type PostServer =
     PostServiceServer<PostServiceHandler<Arc<InMemoryCommandBus>, Arc<InMemoryQueryBus>>>;
@@ -47,6 +58,10 @@ impl Service for PostService {
             .await
             .map_err(|e| anyhow::anyhow!("post app build: {e}"))?;
 
+        // Inbound integration: profile tier signal → denormalized author-tier
+        // projection (read on the publish path to stamp posts).
+        spawn_author_tier_consumer(Arc::clone(&app.author_tier_store));
+
         Ok(Self { app })
     }
 
@@ -67,4 +82,37 @@ impl Service for PostService {
         routes.add_service(PostServiceServer::new(handler));
         Ok(())
     }
+}
+
+/// Spawns the supervised author-tier projection consumer (profile.v1.events →
+/// `post.author_tiers`), respawning after a backoff whenever the runner returns.
+fn spawn_author_tier_consumer(store: Arc<dyn AuthorTierStore>) {
+    tokio::spawn(async move {
+        loop {
+            match build_author_tier_consumer() {
+                Ok((consumer, producer)) => {
+                    run_author_tier_consumer(consumer, Arc::clone(&store), producer).await;
+                    tracing::warn!("author-tier consumer exited; respawning after backoff");
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build author-tier consumer; retrying");
+                }
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Builds the manual-commit consumer (subscribed to `profile.v1.events`) and the
+/// dead-letter producer the runner needs.
+fn build_author_tier_consumer() -> anyhow::Result<(KafkaConsumerHandle, KafkaProducerHandle)> {
+    let kafka = KafkaClientConfig::from_env();
+    let consumer = KafkaConsumerBuilder::new(ConsumerConfig::new(kafka.clone(), AUTHOR_TIER_GROUP))
+        .subscribe(PROFILE_EVENTS_TOPIC)
+        .build()
+        .map_err(|e| anyhow::anyhow!("build author-tier consumer: {e}"))?;
+    let producer = KafkaProducerBuilder::new(ProducerConfig::new(kafka))
+        .build()
+        .map_err(|e| anyhow::anyhow!("build author-tier dead-letter producer: {e}"))?;
+    Ok((consumer, producer))
 }


### PR DESCRIPTION
## What

Completes the producer chain (P3): post stamps the author's current tier onto `post.published` / `post.v1.events` so timeline routes VIP authors to its **read** path — no fan-out-on-write to millions of followers.

## How

- `PostPublishedEvent` gains `author_tier`. Because both `post.published` (direct) and `post.v1.events` (the tagged `DomainEvent`) serialize this event, the field reaches **both** topics with no publisher change.
- The aggregate stays pure (sets a `0` placeholder); the **publish handler stamps the real tier** read from a local projection. A tier-read failure degrades to Standard rather than blocking the publish.
- New `AuthorTierStore` (Scylla table `post.author_tiers`, migration `0005`), maintained by **post's first Kafka consumer** — `author_tier_consumer` over `profile.v1.events`: upsert on `ProfileTierChanged`, commit everything else (idempotent, last-writer-wins).
- 3 unit tests; README EN/FR + i18n re-stamped.

## The chain is now complete

```
social-graph #470  →  profile #471  →  post (this)  →  timeline #469 (forward-compat)
emits the signal      owns + re-emits    denormalizes     VIP read-path ACTIVATES
```

A VIP author's new post → tier 2 stamped → timeline routes to read-fanout → the celebrity is no longer written to millions of feeds.

## Still open (deferred)

P4 (an end-to-end live verification) and P5 (a one-time backfill so existing authors aren't all-Standard on day one). geo-discovery's separate per-post tier projection stays dormant (different producer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3VfarYci2c1BCq29GQLA1