### PR TITLE
test(timeline): verify VIP author routes to read path, not write fan-out (author-tier P4)

### DIFF
--- a/crates/services/timeline/src/domain/value_object/author_tier.rs
+++ b/crates/services/timeline/src/domain/value_object/author_tier.rs
@@ -71,3 +71,26 @@ pub enum FanOutMode {
     Write,
     Read,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The hard fan-out invariant the author-tier initiative exists to enforce:
+    /// a VIP author routes to the READ path (no write-fan-out to millions of
+    /// feeds); Standard/Premium route to the WRITE path. With the producer chain
+    /// (social-graph → profile → post) now supplying `author_tier` on the event,
+    /// this routing finally fires for real authors instead of always seeing 0.
+    #[test]
+    fn vip_routes_to_read_path_others_to_write() {
+        assert_eq!(AuthorTier::from_u8(2).fan_out_mode(), FanOutMode::Read);
+        assert!(AuthorTier::from_u8(2).is_vip());
+
+        assert_eq!(AuthorTier::from_u8(0).fan_out_mode(), FanOutMode::Write);
+        assert_eq!(AuthorTier::from_u8(1).fan_out_mode(), FanOutMode::Write);
+        assert!(!AuthorTier::from_u8(0).is_vip());
+
+        // Unknown tiers degrade to Standard (write path), never accidentally VIP.
+        assert_eq!(AuthorTier::from_u8(9).fan_out_mode(), FanOutMode::Write);
+    }
+}

--- a/crates/services/timeline/tests/timeline_it/scenarios/mod.rs
+++ b/crates/services/timeline/tests/timeline_it/scenarios/mod.rs
@@ -4,4 +4,5 @@
 
 mod fanout_ordering;
 mod following_cache;
+mod vip_routing;
 mod warmup_lifecycle;

--- a/crates/services/timeline/tests/timeline_it/scenarios/vip_routing.rs
+++ b/crates/services/timeline/tests/timeline_it/scenarios/vip_routing.rs
@@ -1,0 +1,63 @@
+//! Scenario — VIP routing (the author-tier fix, P4).
+//!
+//! The whole point of the author-tier initiative: a VIP author's post must NOT be
+//! fanned out on write to every follower's feed (the celebrity meltdown), but be
+//! served at read time from the per-author VIP registry. This proves the last mile
+//! — given a `post.v1.events` event stamped with the VIP tier (which the
+//! social-graph→profile→post producer chain now supplies), timeline routes to its
+//! read path and writes nothing to follower feeds.
+
+use crate::timeline_it::harness::{self, HarnessOptions, TestHarness};
+
+#[tokio::test]
+async fn vip_post_uses_read_path_not_write_fanout() {
+    let h = TestHarness::start(HarnessOptions::default()).await;
+
+    let reader = harness::random_profile();
+    let vip_author = harness::random_author();
+    h.social_graph.add_follow(reader, vip_author);
+
+    // Ingest a VIP-tier post (the tier post now stamps onto post.v1.events).
+    h.ingest_post(&vip_author, harness::TIER_VIP, 1_000).await;
+
+    // Write path NOT taken: the follower's materialized feed stays empty — a
+    // celebrity is never fanned out to millions of feeds.
+    let materialized = h
+        .feed_store
+        .range_desc(&reader, i64::MAX, 10)
+        .await
+        .expect("range_desc");
+    assert!(
+        materialized.is_empty(),
+        "a VIP author's post must not be fanned out to follower feeds"
+    );
+
+    // Read path DOES surface it: get_following_feed merges the VIP registry.
+    let page = h.get_following_feed(&reader).await;
+    assert!(
+        page.items.iter().any(|e| e.published_at_ms == 1_000),
+        "the VIP post must surface via the read-time VIP merge"
+    );
+}
+
+#[tokio::test]
+async fn standard_post_still_writes_to_follower_feeds() {
+    let h = TestHarness::start(HarnessOptions::default()).await;
+
+    let reader = harness::random_profile();
+    let author = harness::random_author();
+    h.social_graph.add_follow(reader, author);
+
+    // A Standard author keeps the fan-out-on-write path (the contrast to VIP).
+    h.ingest_post(&author, harness::TIER_STANDARD, 2_000).await;
+
+    let materialized = h
+        .feed_store
+        .range_desc(&reader, i64::MAX, 10)
+        .await
+        .expect("range_desc");
+    assert!(
+        materialized.iter().any(|e| e.published_at_ms == 2_000),
+        "a Standard author's post must be fanned out to follower feeds"
+    );
+}


### PR DESCRIPTION
## What

Verifies the payoff of the author-tier initiative (P4): a VIP author's post must route to timeline's **read** path (per-author VIP registry, merged at query time), **not** fan out on write to every follower's feed — the celebrity meltdown the initiative exists to prevent.

- **Unit test** on `AuthorTier::fan_out_mode` — the routing invariant (`Vip→Read`, `Standard/Premium→Write`, unknown→Write). Always runnable, green.
- **Live integration scenario** (`vip_routing`): drives a VIP-tier post through ingest and asserts the follower's materialized feed stays **empty** while the read-time merge **surfaces** it (plus a Standard-author contrast that still write-fans-out).

## Caveat (pre-existing, unrelated)

The timeline live IT suite is **currently broken on develop** — a CQL migration parse error (`line 3:61: Unexpected ''`) that fails **every** scenario, not just this one. It's pre-existing and unrelated to author tier (counter's Scylla IT with the same comment patterns runs green, so it's a subtle timeline-specific issue). The live scenario here compiles but can't run green until that's fixed by the IT's owner. The unit test plus the per-service tests (P1 tier-crossing, P2 `set_tier`, P3 stamp + consumer decode) cover each link of the chain.

## Chain status

P1 #470 → P2 #471 → P3 #472 → timeline #469 (merged). This PR is the end-to-end verification. P5 (backfill) follows, stacked on P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3VfarYci2c1BCq29GQLA1