### PR TITLE
feat(audit+moderation): wire moderation decisions into the audit compliance plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +270,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "audit"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "audit-api",
@@ -245,6 +281,7 @@ dependencies = [
  "postgres",
  "prost 0.14.4",
  "prost-types",
+ "rand 0.9.2",
  "reqwest",
  "rusty-s3",
  "serde",
@@ -830,6 +867,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1167,6 +1215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2027,6 +2084,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3408,6 +3484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3827,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -6586,6 +6680,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ url = "2.5.7"
 dyn-clone = "1.0.17"
 dotenvy = "0.15.7"
 sha2 = "0.11.0"
+aes-gcm = "0.10"
 include_dir = "0.7"
 
 # Observabilité

--- a/crates/services/audit/Cargo.toml
+++ b/crates/services/audit/Cargo.toml
@@ -73,6 +73,12 @@ url              = { workspace = true }
 prost            = { workspace = true }
 prost-types      = { workspace = true }
 tracing          = { workspace = true }
+# Rationale-sealing (Phase 3, audit-adoption): AES-256-GCM envelope encryption —
+# a random per-subject DEK encrypts the PII, wrapped under a service KEK and stored
+# in subject_keys (crypto-shred = delete the wrapped DEK). KMS later takes over KEK
+# custody. `rand`/`OsRng` mints the DEK + nonces.
+aes-gcm          = { workspace = true }
+rand             = { workspace = true }
 
 # ── Error handling ────────────────────────────────────────────────────────────
 thiserror = { workspace = true }

--- a/crates/services/audit/README.fr.md
+++ b/crates/services/audit/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: b522dc35f459f23adda955d4c9bc7126760ec2588255e6d7bd1bba8beef857ac
+  source_sha256: 97f48a4ef2167cd22f8a7f43130a39c5bb64a6134dd69fb4d5a57618678f1fc8
   translated_at: 2026-06-26
   status: complete
 ---
@@ -131,7 +131,7 @@ Chaque faute implémente `error::AppError` avec un code `AUD-XXXX` stable, mapp�
 | Topic | Groupe de consommateurs | But | Sur poison/épuisement |
 |---|---|---|---|
 | `audit.v1.events` | `audit-ingest` | le firehose d'événements de conformité de toute la flotte → dédup → chaîne → persiste → archive | DLQ `audit.v1.events.dlq` |
-| `moderation.v1.events` | `audit-moderation` | décisions d'application + énoncés de motifs DSA | DLQ `moderation.v1.events.dlq` |
+| `moderation.v1.events` ✅ câblé | `audit-moderation` | `decision_recorded` (l'autorité + le motif DSA — scellé dans une enveloppe crypto-effaçable à l'ingestion) et `enforcement_applied` ; les autres variants sont un skip inoffensif | DLQ `moderation.v1.events.dlq` |
 | `<flux de décisions auth / account>` | `audit-<src>` | émission / bris de glace / consentement + cycle de vie PII | DLQ `<topic>.dlq` |
 
 > **Contrat runtime (obligatoire) :** tous les consommateurs tournent sous `run_consumer` — commit manuel uniquement après que l'événement est persisté de façon durable *et* chaîné, retry borné avec backoff + jitter, DLQ sur poison/épuisement. **Aucun offset commité n'avance jamais au-delà d'un événement non persisté → zéro perte.** **Idempotence :** les événements portent un id UUIDv5 déterministe ; une redélivrance est dédupliquée (`AUD-1004`, replié dans `Ok`), donc chaque événement logique apparaît exactement une fois dans la chaîne. Un événement sans rien d'enregistrable (`AUD-8002`) est un skip inoffensif replié dans `Ok`. Les chaînes par partition gardent le chemin d'écriture parallèle (pas de sérialisation globale) ; une racine de Merkle globale périodique recoud les têtes de partition.
@@ -169,7 +169,7 @@ Bibliothèque uniquement. Implémente [`service_runtime::Service`](../../platfor
 >
 > **Différé (explicite, pas des lacunes) :**
 > - **Le provisionnement réel KMS/HSM + Object-Lock + témoin externe** est un engagement IAM / structure organisationnelle — l'intégrité ne vaut que par la séparation entre le principal du registre, le principal de signature et le témoin. Le coffre de clés et l'ancrage v1 sont adossés à Postgres ; la production substitue KMS/HSM et un témoin RFC 3161 / bucket WORM compte-séparé sans changement de domaine ni d'application.
-> - **L'adoption par les producteurs** est une campagne d'instrumentation à l'échelle de la flotte — le service est inerte tant que `moderation` / `auth` / `account` n'émettent pas `audit.v1.events`.
+> - **L'adoption par les producteurs** est une campagne d'instrumentation à l'échelle de la flotte. **`moderation` est câblé** — ses événements `decision_recorded` + `enforcement_applied` sur `moderation.v1.events` sont consommés, scellés et chaînés (le motif dans une enveloppe crypto-effaçable). `auth` et `account` sont encore en attente.
 > - **Le consommateur de crypto-effacement** (nécessite une source de demandes d'effacement) et **le balayage d'expiration-rétention** (nécessite des politiques de rétention résolues) — les handlers existent et sont testés ; seules les boucles worker qui les pilotent attendent leurs sources.
 > - **L'autorisation des lectures + l'auto-audit des lectures** (`AUD-3001`/`AUD-3002` + l'enregistrement de chaque requête comme événement `DATA_ACCESS`) se câblent via l'intercepteur d'ingress `auth-context` au déploiement.
 > - **La pagination** au-delà d'une page bornée ; **l'ancrage blockchain** (excessif — RFC 3161 + WORM compte-séparé suffit) ; **le streaming SIEM temps réel** ; **la génération automatisée de rapports de transparence DSA** ; **la réplication inter-région du registre**.
@@ -184,6 +184,7 @@ Bibliothèque uniquement. Implémente [`service_runtime::Service`](../../platfor
 |---|---|---|---|
 | `AUDIT_SERVER_GRPC_ADDR` | Non | `0.0.0.0:50068` | server : adresse gRPC lectures + `RecordPrivileged` |
 | `AUDIT_WORKER_GRPC_ADDR` | Non | `0.0.0.0:50069` | worker : adresse health/reflection (aucun RPC de domaine) |
+| `AUDIT_KEK_BASE64` | **Oui (prod)** | clé dev | base64 de la clé d'enveloppe (KEK) de 32 octets qui enrobe les DEK par sujet ; **doit être définie en production** (sinon une clé dev fixe est dérivée). KMS reprend la garde ensuite |
 | `<config registre / archive / KMS / témoin>` | **Oui** *(Phase 4)* | — | Postgres append-only, magasin Object-Lock, signataire KMS/HSM + coffre DEK, ancrage externe |
 | `<KAFKA_BROKERS>` | **Oui** *(worker, Phase 4)* | — | ingestion amont de conformité + décisions |
 

--- a/crates/services/audit/README.md
+++ b/crates/services/audit/README.md
@@ -119,7 +119,7 @@ Every fault implements `error::AppError` with a stable `AUD-XXXX` code, mapped t
 | Topic | Consumer group | Purpose | On poison/exhaustion |
 |---|---|---|---|
 | `audit.v1.events` | `audit-ingest` | the fleet-wide compliance event firehose → dedupe → chain → persist → archive | DLQ `audit.v1.events.dlq` |
-| `moderation.v1.events` | `audit-moderation` | enforcement decisions + DSA statements-of-reasons | DLQ `moderation.v1.events.dlq` |
+| `moderation.v1.events` ✅ wired | `audit-moderation` | `decision_recorded` (the authority + the DSA rationale — sealed into a crypto-shreddable envelope at ingest) and `enforcement_applied`; other variants are a benign skip | DLQ `moderation.v1.events.dlq` |
 | `<auth / account decision streams>` | `audit-<src>` | issuance / break-glass / consent + PII lifecycle | DLQ `<topic>.dlq` |
 
 > **Runtime contract (mandatory):** all consumers run under `run_consumer` — manual commit only after the event is durably persisted *and* chained, bounded retry with backoff + jitter, DLQ on poison/exhaustion. **No committed offset ever advances past an un-persisted event → zero loss.** **Idempotency:** events carry a deterministic UUIDv5 id; a redelivery is deduped (`AUD-1004`, folded into `Ok`), so each logical event appears in the chain exactly once. An event with nothing recordable (`AUD-8002`) is a harmless skip folded into `Ok`. Per-partition chains keep the write path parallel (no global serialization); a periodic global Merkle root stitches the partition heads.
@@ -157,7 +157,7 @@ Library-only. Implements [`service_runtime::Service`](../../platform/service-run
 >
 > **Deferred (explicit, not gaps):**
 > - **Real KMS/HSM + Object-Lock + external witness provisioning** is an IAM / org-structure commitment — the integrity story is only as strong as the separation between the ledger principal, the signing principal and the witness. The v1 key vault and checkpoint anchor are Postgres-backed; production swaps in KMS/HSM and an RFC 3161 / cross-account WORM witness with no domain or application change.
-> - **Producer adoption** is a fleet-wide instrumentation campaign — the service is inert until `moderation` / `auth` / `account` emit `audit.v1.events`.
+> - **Producer adoption** is a fleet-wide instrumentation campaign. **`moderation` is wired** — its `decision_recorded` + `enforcement_applied` events on `moderation.v1.events` are consumed, sealed and chained (the rationale into a crypto-shreddable envelope). `auth` and `account` are still pending.
 > - **The crypto-shred consumer** (needs an erasure-request source) and **the retention-expiry sweep** (needs resolved retention policies) — the handlers exist and are tested; only the worker loops that drive them await their input sources.
 > - **Read authorization + read-self-auditing** (`AUD-3001`/`AUD-3002` + recording each query as a `DATA_ACCESS` event) wire via the `auth-context` ingress interceptor at deployment.
 > - **Forward pagination** beyond a single capped page; **blockchain anchoring** (overkill — RFC 3161 + cross-account WORM suffices); **real-time SIEM streaming**; **automated DSA transparency-report generation**; **cross-region ledger replication**.
@@ -172,6 +172,7 @@ Library-only. Implements [`service_runtime::Service`](../../platform/service-run
 |---|---|---|---|
 | `AUDIT_SERVER_GRPC_ADDR` | No | `0.0.0.0:50068` | server: reads + `RecordPrivileged` gRPC address |
 | `AUDIT_WORKER_GRPC_ADDR` | No | `0.0.0.0:50069` | worker: health/reflection address (no domain RPC) |
+| `AUDIT_KEK_BASE64` | **Yes (prod)** | dev key | base64 of the 32-byte key-encryption key that wraps per-subject DEKs; **must be set in production** (a fixed dev key is derived otherwise). KMS takes over custody later |
 | `<ledger / archive / KMS / witness config>` | **Yes** *(Phase 4)* | — | append-only Postgres, Object-Lock store, KMS/HSM signer + DEK vault, external anchor |
 | `<KAFKA_BROKERS>` | **Yes** *(worker, Phase 4)* | — | upstream compliance + decision ingestion |
 

--- a/crates/services/audit/migrations/0002_subject_key_dek.sql
+++ b/crates/services/audit/migrations/0002_subject_key_dek.sql
@@ -1,0 +1,11 @@
+-- Envelope-encryption columns for the per-subject DEK (rationale-sealing). The
+-- DEK is wrapped under the service KEK (which lives in the audit environment, not
+-- here), so the row holds only the wrapped key — a DB operator alone cannot
+-- decrypt. Crypto-shred (DELETE the row, via the key vault) destroys the wrapped
+-- DEK and makes every envelope for that subject permanently undecryptable.
+--
+-- Nullable + additive: existing rows (e.g. bare key references) stay valid; the
+-- cipher fills the columns on first use. Production swaps KEK custody to KMS/HSM
+-- with no further schema change.
+ALTER TABLE subject_keys ADD COLUMN IF NOT EXISTS wrapped_dek BYTEA;
+ALTER TABLE subject_keys ADD COLUMN IF NOT EXISTS wrap_nonce BYTEA;

--- a/crates/services/audit/src/app.rs
+++ b/crates/services/audit/src/app.rs
@@ -14,7 +14,9 @@ use anyhow::Context;
 use postgres_storage::{PgPoolBuilder, PostgresConfig, TransactionManager};
 use sqlx::PgPool;
 
-use crate::application::port::{Clock, CheckpointAnchor, KeyVault, LedgerStore, WormArchive};
+use crate::application::port::{
+    CheckpointAnchor, Clock, KeyVault, LedgerStore, SubjectCipher, WormArchive,
+};
 use crate::application::{
     CheckpointHandler, ExportHandler, IngestHandler, QueryHandler, RecordPrivilegedHandler,
     VerifyHandler,
@@ -22,7 +24,7 @@ use crate::application::{
 use crate::config::AuditConfig;
 use crate::infrastructure::grpc::AuditServiceHandler;
 use crate::infrastructure::{
-    ObjectLockArchive, PgCheckpointAnchor, PgKeyVault, PgLedger, SystemClock,
+    AesGcmSubjectCipher, ObjectLockArchive, PgCheckpointAnchor, PgKeyVault, PgLedger, SystemClock,
 };
 
 /// The shared adapter set both binaries build from. Retains the concrete [`PgPool`]
@@ -33,6 +35,8 @@ pub struct Adapters {
     pub key_vault: Arc<dyn KeyVault>,
     pub anchor: Arc<dyn CheckpointAnchor>,
     pub clock: Arc<dyn Clock>,
+    /// Seals PII (the moderation rationale) into a crypto-shreddable envelope.
+    pub cipher: Arc<dyn SubjectCipher>,
     pub pool: PgPool,
 }
 
@@ -54,6 +58,10 @@ impl Adapters {
                 .map_err(|e| anyhow::anyhow!("build WORM archive: {e}"))?,
         );
         let clock: Arc<dyn Clock> = Arc::new(SystemClock);
+        let cipher: Arc<dyn SubjectCipher> = Arc::new(AesGcmSubjectCipher::new(
+            TransactionManager::new(pool.clone()),
+            config.kek,
+        ));
 
         Ok(Adapters {
             ledger,
@@ -61,6 +69,7 @@ impl Adapters {
             key_vault,
             anchor,
             clock,
+            cipher,
             pool,
         })
     }

--- a/crates/services/audit/src/application/mod.rs
+++ b/crates/services/audit/src/application/mod.rs
@@ -41,7 +41,7 @@ pub use dto::{
 };
 pub use ingest::{IngestHandler, run_ingest};
 pub use port::{
-    CheckpointAnchor, Clock, EventSource, KeyVault, LedgerStore, WormArchive,
+    CheckpointAnchor, Clock, EventSource, KeyVault, LedgerStore, SubjectCipher, WormArchive,
 };
 pub use privileged::RecordPrivilegedHandler;
 pub use query::{ExportHandler, QueryHandler};

--- a/crates/services/audit/src/application/port/mod.rs
+++ b/crates/services/audit/src/application/port/mod.rs
@@ -18,6 +18,7 @@ pub mod clock;
 pub mod event_source;
 pub mod key_vault;
 pub mod ledger_store;
+pub mod subject_cipher;
 pub mod worm_archive;
 
 pub use checkpoint_anchor::CheckpointAnchor;
@@ -25,4 +26,5 @@ pub use clock::Clock;
 pub use event_source::EventSource;
 pub use key_vault::KeyVault;
 pub use ledger_store::LedgerStore;
+pub use subject_cipher::SubjectCipher;
 pub use worm_archive::WormArchive;

--- a/crates/services/audit/src/application/port/subject_cipher.rs
+++ b/crates/services/audit/src/application/port/subject_cipher.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+
+use crate::domain::{PiiEnvelope, SubjectPseudonym};
+use crate::error::AuditError;
+
+/// Seals PII (e.g. a moderation rationale, the DSA statement-of-reasons) into a
+/// crypto-shreddable [`PiiEnvelope`] under the subject's data-encryption key.
+///
+/// The adapter mints-or-fetches the per-subject DEK (wrapped under a service KEK
+/// and persisted in the key vault) and AEAD-encrypts the plaintext. The plane only
+/// ever holds the ciphertext thereafter. Erasure is then
+/// [`KeyVault::destroy_subject_key`](super::KeyVault::destroy_subject_key): once
+/// the wrapped DEK is destroyed, every envelope sealed for that subject is
+/// permanently undecryptable — while the records and the hash chain stay intact.
+///
+/// This is the only seam through which plaintext PII enters the service; keeping it
+/// behind a port means the production KMS adapter swaps in without touching the
+/// ingest path.
+#[async_trait]
+pub trait SubjectCipher: Send + Sync + 'static {
+    async fn seal(
+        &self,
+        subject: &SubjectPseudonym,
+        plaintext: &str,
+    ) -> Result<PiiEnvelope, AuditError>;
+}

--- a/crates/services/audit/src/config.rs
+++ b/crates/services/audit/src/config.rs
@@ -4,7 +4,9 @@
 
 use std::time::Duration;
 
+use base64::Engine as _;
 use postgres_storage::PostgresConfig;
+use sha2::{Digest, Sha256};
 use transport::kafka::config::KafkaClientConfig;
 
 use crate::infrastructure::ObjectLockConfig;
@@ -27,6 +29,10 @@ pub struct AuditConfig {
     /// How often the worker snapshots the partition heads into an anchored
     /// Merkle checkpoint.
     pub checkpoint_interval: Duration,
+    /// The service key-encryption key (32 bytes) that wraps the per-subject DEKs.
+    /// Lives in the environment, never in the database. Production hands custody to
+    /// KMS/HSM. `<TODO: must be set in production>`.
+    pub kek: [u8; 32],
 }
 
 impl AuditConfig {
@@ -43,8 +49,22 @@ impl AuditConfig {
                 "AUDIT_CHECKPOINT_INTERVAL_S",
                 DEFAULT_CHECKPOINT_INTERVAL_S,
             )),
+            kek: kek_from_env(),
         }
     }
+}
+
+/// Resolve the 32-byte KEK from `AUDIT_KEK_BASE64` (base64 of exactly 32 bytes).
+/// Absent or malformed → a deterministic **dev** key derived from a fixed phrase
+/// (sha256), so local/test runs work; this MUST be overridden in production.
+fn kek_from_env() -> [u8; 32] {
+    if let Ok(encoded) = std::env::var("AUDIT_KEK_BASE64")
+        && let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded.trim())
+        && let Ok(key) = <[u8; 32]>::try_from(bytes.as_slice())
+    {
+        return key;
+    }
+    Sha256::digest(b"audit-dev-kek-do-not-use-in-prod").into()
 }
 
 fn object_lock_from_env() -> ObjectLockConfig {

--- a/crates/services/audit/src/infrastructure/aes_gcm_cipher.rs
+++ b/crates/services/audit/src/infrastructure/aes_gcm_cipher.rs
@@ -1,0 +1,119 @@
+//! The AES-256-GCM [`SubjectCipher`] adapter — the audit-side rationale-sealer and
+//! the first concrete piece of the (otherwise deferred) KMS story.
+//!
+//! Envelope encryption: a random per-subject **DEK** encrypts the PII; the DEK is
+//! wrapped under the service **KEK** and the wrapped DEK is stored in
+//! `subject_keys` (one DEK per subject, get-or-create). The KEK lives in audit's
+//! environment, never in the database — so the ledger operator alone cannot
+//! decrypt. Crypto-shred ([`PgKeyVault::destroy_subject_key`] = delete the row)
+//! destroys the wrapped DEK, making every envelope for that subject permanently
+//! undecryptable.
+//!
+//! **v1 / deferral:** the KEK is read from env. Production hands KEK custody (the
+//! wrap/unwrap) to KMS/HSM with no schema change — the wrapped-DEK column and this
+//! port stay as-is.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use postgres_storage::TransactionManager;
+
+use crate::application::port::SubjectCipher;
+use crate::domain::{PiiEnvelope, SubjectKeyRef, SubjectPseudonym};
+use crate::error::AuditError;
+use crate::infrastructure::envelope::{self, KEY_LEN};
+
+/// Get-or-create the wrapped DEK for a subject. Fills a NULL/absent row exactly
+/// once (a lost race keeps the winner's DEK — never overwrites an existing one, so
+/// prior ciphertexts stay decryptable), then the caller re-reads the canonical DEK.
+const UPSERT_DEK_SQL: &str = r#"
+INSERT INTO subject_keys (key_ref, created_at_ms, wrapped_dek, wrap_nonce)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (key_ref) DO UPDATE
+    SET wrapped_dek = EXCLUDED.wrapped_dek, wrap_nonce = EXCLUDED.wrap_nonce
+    WHERE subject_keys.wrapped_dek IS NULL
+"#;
+
+const FETCH_DEK_SQL: &str =
+    "SELECT wrapped_dek, wrap_nonce FROM subject_keys WHERE key_ref = $1";
+
+/// `(wrapped_dek, wrap_nonce)` — both nullable (a row may pre-exist without a DEK).
+type WrappedDekRow = (Option<Vec<u8>>, Option<Vec<u8>>);
+
+pub struct AesGcmSubjectCipher {
+    tx: TransactionManager,
+    kek: [u8; KEY_LEN],
+}
+
+impl AesGcmSubjectCipher {
+    pub fn new(tx: TransactionManager, kek: [u8; KEY_LEN]) -> Self {
+        Self { tx, kek }
+    }
+
+    /// The per-subject key reference — all of a subject's PII shares one DEK, so a
+    /// single shred erases all of it.
+    fn key_ref(subject: &SubjectPseudonym) -> String {
+        format!("dek:{}", subject.as_str())
+    }
+
+    /// Resolve the subject's plaintext DEK, creating + wrapping one on first use.
+    async fn dek_for(&self, key_ref: &str) -> Result<[u8; KEY_LEN], AuditError> {
+        if let Some(dek) = self.fetch_dek(key_ref).await? {
+            return Ok(dek);
+        }
+        // Create + wrap a fresh DEK; the upsert fills a NULL/absent row only.
+        let dek = envelope::random_key()?;
+        let wrapped = envelope::seal(&self.kek, &dek)?;
+        sqlx::query(UPSERT_DEK_SQL)
+            .bind(key_ref)
+            .bind(Utc::now().timestamp_millis())
+            .bind(wrapped.ciphertext)
+            .bind(wrapped.nonce)
+            .execute(self.tx.pool())
+            .await
+            .map_err(|_| AuditError::KeyVaultUnavailable)?;
+        // Re-read the canonical DEK (ours, or a racing writer's that won).
+        self.fetch_dek(key_ref)
+            .await?
+            .ok_or(AuditError::KeyVaultUnavailable)
+    }
+
+    async fn fetch_dek(&self, key_ref: &str) -> Result<Option<[u8; KEY_LEN]>, AuditError> {
+        let row: Option<WrappedDekRow> = sqlx::query_as(FETCH_DEK_SQL)
+            .bind(key_ref)
+            .fetch_optional(self.tx.pool())
+            .await
+            .map_err(|_| AuditError::KeyVaultUnavailable)?;
+
+        match row {
+            Some((Some(wrapped), Some(wrap_nonce))) => {
+                let dek = envelope::open(&self.kek, &wrapped, &wrap_nonce)?;
+                let dek: [u8; KEY_LEN] = dek.try_into().map_err(|_| AuditError::DomainViolation {
+                    field: "dek".to_owned(),
+                    message: "unwrapped DEK has the wrong length".to_owned(),
+                })?;
+                Ok(Some(dek))
+            }
+            // No row, or a row without a wrapped DEK yet (e.g. legacy/seed).
+            _ => Ok(None),
+        }
+    }
+}
+
+#[async_trait]
+impl SubjectCipher for AesGcmSubjectCipher {
+    async fn seal(
+        &self,
+        subject: &SubjectPseudonym,
+        plaintext: &str,
+    ) -> Result<PiiEnvelope, AuditError> {
+        let key_ref = Self::key_ref(subject);
+        let dek = self.dek_for(&key_ref).await?;
+        let sealed = envelope::seal(&dek, plaintext.as_bytes())?;
+        Ok(PiiEnvelope::sealed(
+            SubjectKeyRef::new(key_ref)?,
+            sealed.ciphertext,
+            sealed.nonce,
+            envelope::ALGORITHM,
+        ))
+    }
+}

--- a/crates/services/audit/src/infrastructure/consumer.rs
+++ b/crates/services/audit/src/infrastructure/consumer.rs
@@ -17,8 +17,13 @@ use transport::kafka::consumer::{ProcessOutcome, RetryPolicy, run_consumer, Kafk
 use transport::kafka::producer::KafkaProducerHandle;
 
 use crate::application::IngestHandler;
+use crate::application::port::SubjectCipher;
+use crate::domain::SubjectPseudonym;
 use crate::error::AuditError;
 use crate::infrastructure::decode::{AuditEventWire, map_audit_event};
+use crate::infrastructure::moderation_decode::{
+    ModerationEventWire, map_decision_recorded, map_enforcement_applied,
+};
 
 /// Lets the at-least-once runner classify a failure: delegate to the error's own
 /// retry verdict — transient store faults retry; decode / domain faults are poison
@@ -53,5 +58,53 @@ pub async fn run_audit_ingest_consumer(
     .await;
     if let Err(e) = result {
         tracing::error!(error = %e, "audit ingest consumer stopped");
+    }
+}
+
+/// Run the `moderation.v1.events` ingest consumer until the stream ends.
+///
+/// For a `decision_recorded` it seals the rationale into a crypto-shreddable
+/// envelope (the `cipher`) before mapping + chaining; for an `enforcement_applied`
+/// it maps directly (no PII); every other moderation event is a benign skip that
+/// still commits the offset. The cipher's key-vault faults are retryable (`run_consumer`
+/// retries without committing); a decode/domain fault is poison and dead-letters.
+pub async fn run_moderation_ingest_consumer(
+    consumer: KafkaConsumerHandle,
+    producer: KafkaProducerHandle,
+    handler: Arc<IngestHandler>,
+    cipher: Arc<dyn SubjectCipher>,
+) {
+    tracing::info!("audit moderation ingest consumer started");
+    let policy = RetryPolicy::default();
+    let result = run_consumer::<ModerationEventWire, _>(&consumer, &producer, &policy, move |wire| {
+        let handler = Arc::clone(&handler);
+        let cipher = Arc::clone(&cipher);
+        let wire = wire.clone();
+        Box::pin(async move {
+            let outcome = async {
+                match wire {
+                    ModerationEventWire::DecisionRecorded(decision) => {
+                        let subject = SubjectPseudonym::new(decision.subject.actor_id.clone())?;
+                        // Seal the DSA rationale into a crypto-shreddable envelope.
+                        let sealed = cipher.seal(&subject, &decision.rationale).await?;
+                        let event = map_decision_recorded(&decision, sealed)?;
+                        handler.ingest(event).await?;
+                    }
+                    ModerationEventWire::EnforcementApplied(enforcement) => {
+                        let event = map_enforcement_applied(&enforcement)?;
+                        handler.ingest(event).await?;
+                    }
+                    // Out-of-scope moderation event: a harmless committed skip.
+                    ModerationEventWire::Other => {}
+                }
+                Ok::<(), AuditError>(())
+            }
+            .await;
+            ProcessOutcome::from_result(outcome)
+        })
+    })
+    .await;
+    if let Err(e) = result {
+        tracing::error!(error = %e, "audit moderation ingest consumer stopped");
     }
 }

--- a/crates/services/audit/src/infrastructure/envelope.rs
+++ b/crates/services/audit/src/infrastructure/envelope.rs
@@ -1,0 +1,123 @@
+//! Pure AES-256-GCM envelope-encryption primitives — the crypto behind
+//! rationale-sealing, with no I/O so it is fully unit-testable. The key custody
+//! (the per-subject DEK store + the KEK) lives in the adapter
+//! ([`super::aes_gcm_cipher`]); this module only does the math.
+//!
+//! Scheme: a random 256-bit **data-encryption key (DEK)** encrypts the plaintext;
+//! the DEK is itself encrypted ("wrapped") under a service **key-encryption key
+//! (KEK)**. Storing only the wrapped DEK (in `subject_keys`) while keeping the KEK
+//! out of the database means a DB operator alone cannot decrypt — and destroying
+//! the wrapped DEK row (crypto-shred) renders the data permanently unreadable.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use rand::TryRngCore;
+use rand::rngs::OsRng;
+
+use crate::error::AuditError;
+
+/// AES-256-GCM key length.
+pub const KEY_LEN: usize = 32;
+/// AES-GCM nonce length (96-bit, the standard).
+pub const NONCE_LEN: usize = 12;
+/// Algorithm tag recorded on the envelope (for crypto-agility on read).
+pub const ALGORITHM: &str = "AES-256-GCM";
+
+/// A freshly-encrypted blob: ciphertext (incl. the GCM tag) + its nonce.
+pub struct Sealed {
+    pub ciphertext: Vec<u8>,
+    pub nonce: Vec<u8>,
+}
+
+/// Mint a cryptographically-random 256-bit key (a DEK), via the OS CSPRNG.
+pub fn random_key() -> Result<[u8; KEY_LEN], AuditError> {
+    let mut key = [0u8; KEY_LEN];
+    OsRng
+        .try_fill_bytes(&mut key)
+        .map_err(|e| AuditError::DomainViolation {
+            field: "dek".to_owned(),
+            message: format!("CSPRNG failure: {e}"),
+        })?;
+    Ok(key)
+}
+
+/// Encrypt `plaintext` under `key` with a fresh random nonce.
+pub fn seal(key: &[u8; KEY_LEN], plaintext: &[u8]) -> Result<Sealed, AuditError> {
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    OsRng
+        .try_fill_bytes(&mut nonce_bytes)
+        .map_err(|e| crypto_err(format!("CSPRNG failure: {e}")))?;
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext)
+        .map_err(|_| crypto_err("AEAD seal failed".to_owned()))?;
+
+    Ok(Sealed {
+        ciphertext,
+        nonce: nonce_bytes.to_vec(),
+    })
+}
+
+/// Decrypt under `key`. A wrong key, altered ciphertext, or wrong nonce fails the
+/// GCM tag check — surfaced as the *expected* post-erasure state when the DEK is
+/// gone, `AUD-5004`.
+pub fn open(key: &[u8; KEY_LEN], ciphertext: &[u8], nonce: &[u8]) -> Result<Vec<u8>, AuditError> {
+    if nonce.len() != NONCE_LEN {
+        return Err(AuditError::PiiEnvelopeUndecryptable);
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    cipher
+        .decrypt(Nonce::from_slice(nonce), ciphertext)
+        .map_err(|_| AuditError::PiiEnvelopeUndecryptable)
+}
+
+fn crypto_err(message: String) -> AuditError {
+    AuditError::DomainViolation {
+        field: "pii".to_owned(),
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use error::AppError;
+
+    use super::*;
+
+    #[test]
+    fn seal_open_roundtrips() {
+        let key = random_key().unwrap();
+        let sealed = seal(&key, b"violates harassment policy 3.2").unwrap();
+        let plain = open(&key, &sealed.ciphertext, &sealed.nonce).unwrap();
+        assert_eq!(plain, b"violates harassment policy 3.2");
+        assert_eq!(sealed.nonce.len(), NONCE_LEN);
+        assert_ne!(sealed.ciphertext, b"violates harassment policy 3.2");
+    }
+
+    #[test]
+    fn nonces_differ_per_seal() {
+        let key = random_key().unwrap();
+        let a = seal(&key, b"x").unwrap();
+        let b = seal(&key, b"x").unwrap();
+        assert_ne!(a.nonce, b.nonce, "each seal must use a fresh nonce");
+    }
+
+    #[test]
+    fn wrong_key_cannot_decrypt() {
+        let key = random_key().unwrap();
+        let other = random_key().unwrap();
+        let sealed = seal(&key, b"secret").unwrap();
+        // A destroyed DEK is modelled as "no longer have the right key".
+        let err = open(&other, &sealed.ciphertext, &sealed.nonce).unwrap_err();
+        assert_eq!(err.error_code(), "AUD-5004");
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_the_tag() {
+        let key = random_key().unwrap();
+        let mut sealed = seal(&key, b"secret").unwrap();
+        sealed.ciphertext[0] ^= 0xff;
+        assert!(open(&key, &sealed.ciphertext, &sealed.nonce).is_err());
+    }
+}

--- a/crates/services/audit/src/infrastructure/mod.rs
+++ b/crates/services/audit/src/infrastructure/mod.rs
@@ -26,6 +26,7 @@ pub mod consumer;
 pub mod decode;
 pub mod grpc;
 pub mod loops;
+pub mod moderation_decode;
 pub mod object_lock_archive;
 pub mod pg_anchor;
 pub mod pg_key_vault;
@@ -36,6 +37,9 @@ pub use consumer::run_audit_ingest_consumer;
 pub use decode::{AuditEventWire, map_audit_event};
 pub use grpc::{AuditServiceHandler, AuditServiceServer, FILE_DESCRIPTOR_SET};
 pub use loops::run_checkpoint_loop;
+pub use moderation_decode::{
+    ModerationEventWire, TOPIC_MODERATION_EVENTS, map_decision_recorded, map_enforcement_applied,
+};
 pub use object_lock_archive::{ObjectLockArchive, ObjectLockConfig};
 pub use pg_anchor::PgCheckpointAnchor;
 pub use pg_key_vault::PgKeyVault;

--- a/crates/services/audit/src/infrastructure/mod.rs
+++ b/crates/services/audit/src/infrastructure/mod.rs
@@ -21,9 +21,11 @@
 //! [`KeyVault`]: crate::application::port::KeyVault
 //! [`CheckpointAnchor`]: crate::application::port::CheckpointAnchor
 
+pub mod aes_gcm_cipher;
 pub mod codec;
 pub mod consumer;
 pub mod decode;
+pub mod envelope;
 pub mod grpc;
 pub mod loops;
 pub mod moderation_decode;
@@ -33,7 +35,8 @@ pub mod pg_key_vault;
 pub mod pg_ledger;
 pub mod system_clock;
 
-pub use consumer::run_audit_ingest_consumer;
+pub use aes_gcm_cipher::AesGcmSubjectCipher;
+pub use consumer::{run_audit_ingest_consumer, run_moderation_ingest_consumer};
 pub use decode::{AuditEventWire, map_audit_event};
 pub use grpc::{AuditServiceHandler, AuditServiceServer, FILE_DESCRIPTOR_SET};
 pub use loops::run_checkpoint_loop;

--- a/crates/services/audit/src/infrastructure/moderation_decode.rs
+++ b/crates/services/audit/src/infrastructure/moderation_decode.rs
@@ -1,0 +1,314 @@
+//! Audit-side decode of the moderation compliance feed (`moderation.v1.events`)
+//! into domain [`AuditEvent`]s. Audit owns this read schema (the consumer-owns
+//! -schema tiering rule — it must not depend on the `moderation` crate), so the
+//! wire shapes here are lenient structs hand-matched to moderation's published
+//! JSON (extra fields ignored, so an additive upstream change never breaks us).
+//!
+//! Scope (first cut): `decision_recorded` — the dedicated evidence event carrying
+//! the authority (`DecisionAuthor`) and the DSA `rationale` — and
+//! `enforcement_applied`. Every other moderation event is a benign skip.
+//!
+//! **This layer is pure and does NOT encrypt.** The `rationale` is PII-bearing, so
+//! the caller (the consumer wiring, Phase 3) seals it into a crypto-shreddable
+//! [`PiiEnvelope`] via the audit-side cipher and passes it into
+//! [`map_decision_recorded`]. Keeping the crypto out here keeps the mapping a
+//! total, unit-testable function.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::domain::{
+    Actor, ActorPseudonym, ActorType, AuditEvent, EventCategory, EventId, LawfulBasis,
+    NewAuditEvent, Outcome, PiiEnvelope, ResourceRef, SubjectPseudonym,
+};
+use crate::error::AuditError;
+
+pub const TOPIC_MODERATION_EVENTS: &str = "moderation.v1.events";
+
+/// Fixed namespace for deterministic UUIDv5 audit-event ids derived from a
+/// moderation event's coordinates — so a redelivery maps to the same id and audit
+/// dedupes it. (`b"audit_mod_evt_v5"`.)
+const NS_AUDIT_MODERATION: Uuid = Uuid::from_u128(0x6175_6469_745f_6d6f_645f_6576_745f_7635);
+
+const SOURCE: &str = "moderation";
+
+// ── Wire schema (hand-matched to moderation's published JSON) ──────────────────
+
+/// The moderation events audit consumes. `Other` absorbs every event type outside
+/// the first-cut scope (case_opened/resolved, enforcement_reversed, appeal_resolved)
+/// as a benign skip rather than a poison decode.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ModerationEventWire {
+    DecisionRecorded(DecisionRecordedWire),
+    EnforcementApplied(EnforcementAppliedWire),
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DecisionRecordedWire {
+    pub decision_id: String,
+    pub subject: SubjectRefWire,
+    pub author: DecisionAuthorWire,
+    pub action: String,
+    pub category: String,
+    pub policy_version: String,
+    pub rationale: String,
+    #[serde(default)]
+    pub reverses: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+    #[serde(default)]
+    pub correlation_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EnforcementAppliedWire {
+    pub enforcement_id: String,
+    pub subject: SubjectRefWire,
+    pub action: String,
+    pub version: i64,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    pub occurred_at: DateTime<Utc>,
+    #[serde(default)]
+    pub correlation_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubjectRefWire {
+    #[serde(default)]
+    pub entity_type: String,
+    #[serde(default)]
+    pub entity_id: String,
+    /// The affected actor — moderation's `ActorId` (a UUID string); audit's subject
+    /// pseudonym. Audit never resolves it; the identity↔real mapping lives in
+    /// `account`.
+    pub actor_id: String,
+    #[serde(default)]
+    pub surface: String,
+}
+
+/// Externally-tagged, matching moderation's `DecisionAuthor` JSON
+/// (`{"Reviewer":"id"}` / `{"Rule":"id"}`).
+#[derive(Debug, Clone, Deserialize)]
+pub enum DecisionAuthorWire {
+    Reviewer(String),
+    Rule(String),
+}
+
+// ── Mapping ────────────────────────────────────────────────────────────────────
+
+/// Map a `decision_recorded` event to an `AuditEvent`. `sealed_rationale` is the
+/// crypto-shreddable envelope the caller produced from the wire's `rationale`.
+pub fn map_decision_recorded(
+    wire: &DecisionRecordedWire,
+    sealed_rationale: PiiEnvelope,
+) -> Result<AuditEvent, AuditError> {
+    // A "no action" decision is a dismissal / overturn → the content stands
+    // (Permitted); any enforcing action is Executed.
+    let outcome = if wire.action == "no_action" {
+        Outcome::Permitted
+    } else {
+        Outcome::Executed
+    };
+
+    let (actor_type, author_id, author_kind) = match &wire.author {
+        DecisionAuthorWire::Reviewer(id) => (ActorType::Admin, id.clone(), "reviewer"),
+        DecisionAuthorWire::Rule(id) => (ActorType::System, id.clone(), "rule"),
+    };
+
+    let mut attributes = BTreeMap::new();
+    attributes.insert("decision_id".to_owned(), wire.decision_id.clone());
+    attributes.insert("policy_version".to_owned(), wire.policy_version.clone());
+    attributes.insert("category".to_owned(), wire.category.clone());
+    attributes.insert("author_kind".to_owned(), author_kind.to_owned());
+    if let Some(reverses) = &wire.reverses {
+        attributes.insert("reverses".to_owned(), reverses.clone());
+    }
+    // NB: the rationale is deliberately NOT in attributes — it rides only in the
+    // crypto-shreddable PII envelope.
+
+    AuditEvent::try_new(NewAuditEvent {
+        event_id: EventId::new(derive_id(&["moderation.decision_recorded", &wire.decision_id]))?,
+        category: EventCategory::Moderation,
+        subject: Some(SubjectPseudonym::new(wire.subject.actor_id.clone())?),
+        tenant: None,
+        actor: Actor::new(actor_type, ActorPseudonym::new(author_id)?, String::new()),
+        action: format!("moderation.decide.{}", wire.action),
+        resource: ResourceRef::new(wire.subject.entity_type.clone(), wire.subject.entity_id.clone()),
+        outcome,
+        lawful_basis: LawfulBasis::LegalObligation,
+        source_service: SOURCE.to_owned(),
+        correlation_id: wire.correlation_id.clone(),
+        occurred_at: wire.occurred_at,
+        pii: Some(sealed_rationale),
+        attributes,
+    })
+}
+
+/// Map an `enforcement_applied` event to an `AuditEvent`. No rationale → no PII
+/// envelope. The applying authority is the system (the decision that authorized it
+/// is its own `decision_recorded` event).
+pub fn map_enforcement_applied(wire: &EnforcementAppliedWire) -> Result<AuditEvent, AuditError> {
+    let mut attributes = BTreeMap::new();
+    attributes.insert("enforcement_id".to_owned(), wire.enforcement_id.clone());
+    attributes.insert("version".to_owned(), wire.version.to_string());
+    if let Some(expires_at) = &wire.expires_at {
+        attributes.insert("expires_at".to_owned(), expires_at.to_rfc3339());
+    }
+
+    AuditEvent::try_new(NewAuditEvent {
+        event_id: EventId::new(derive_id(&[
+            "moderation.enforcement_applied",
+            &wire.enforcement_id,
+            &wire.version.to_string(),
+        ]))?,
+        category: EventCategory::Moderation,
+        subject: Some(SubjectPseudonym::new(wire.subject.actor_id.clone())?),
+        tenant: None,
+        actor: Actor::new(ActorType::System, ActorPseudonym::new(SOURCE)?, String::new()),
+        action: format!("moderation.enforce.{}", wire.action),
+        resource: ResourceRef::new(wire.subject.entity_type.clone(), wire.subject.entity_id.clone()),
+        outcome: Outcome::Executed,
+        lawful_basis: LawfulBasis::LegalObligation,
+        source_service: SOURCE.to_owned(),
+        correlation_id: wire.correlation_id.clone(),
+        occurred_at: wire.occurred_at,
+        pii: None,
+        attributes,
+    })
+}
+
+/// Deterministic UUIDv5 over the event's coordinates — the idempotency key audit
+/// dedupes a redelivery on.
+fn derive_id(parts: &[&str]) -> String {
+    Uuid::new_v5(&NS_AUDIT_MODERATION, parts.join(":").as_bytes()).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::SubjectKeyRef;
+
+    fn sealed() -> PiiEnvelope {
+        PiiEnvelope::sealed(
+            SubjectKeyRef::new("dek:test").unwrap(),
+            b"ciphertext".to_vec(),
+            b"nonce".to_vec(),
+            "AES-256-GCM",
+        )
+    }
+
+    fn decision_json(author: serde_json::Value, action: &str) -> ModerationEventWire {
+        serde_json::from_value(serde_json::json!({
+            "type": "decision_recorded",
+            "decision_id": "11111111-1111-1111-1111-111111111111",
+            "subject": {
+                "entity_type": "post",
+                "entity_id": "p1",
+                "actor_id": "22222222-2222-2222-2222-222222222222",
+                "surface": "feed"
+            },
+            "author": author,
+            "action": action,
+            "category": "harassment",
+            "policy_version": "2026.06.1",
+            "rationale": "violates the harassment policy clause 3.2",
+            "reverses": null,
+            "occurred_at": "2026-06-26T12:00:00Z",
+            "correlation_id": "33333333-3333-3333-3333-333333333333"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn decision_recorded_maps_reviewer_to_admin_with_sealed_rationale() {
+        let wire = match decision_json(serde_json::json!({ "Reviewer": "rev-1" }), "remove_content") {
+            ModerationEventWire::DecisionRecorded(d) => d,
+            _ => panic!("expected DecisionRecorded"),
+        };
+        let event = map_decision_recorded(&wire, sealed()).unwrap();
+
+        assert_eq!(event.category(), EventCategory::Moderation);
+        assert_eq!(event.actor().actor_type, ActorType::Admin);
+        assert_eq!(event.actor().pseudonym.as_str(), "rev-1");
+        assert_eq!(event.action(), "moderation.decide.remove_content");
+        assert_eq!(event.outcome(), Outcome::Executed);
+        assert_eq!(event.subject().unwrap().as_str(), "22222222-2222-2222-2222-222222222222");
+        // The rationale rides ONLY in the sealed envelope, never in attributes.
+        assert!(event.has_pii());
+        assert!(!event.attributes().values().any(|v| v.contains("harassment policy clause")));
+        assert_eq!(event.attributes().get("policy_version").unwrap(), "2026.06.1");
+        assert_eq!(event.attributes().get("author_kind").unwrap(), "reviewer");
+    }
+
+    #[test]
+    fn automated_rule_decision_maps_to_system_actor() {
+        let wire = match decision_json(serde_json::json!({ "Rule": "screen:hash-match" }), "remove_content") {
+            ModerationEventWire::DecisionRecorded(d) => d,
+            _ => panic!(),
+        };
+        let event = map_decision_recorded(&wire, sealed()).unwrap();
+        assert_eq!(event.actor().actor_type, ActorType::System);
+        assert_eq!(event.actor().pseudonym.as_str(), "screen:hash-match");
+    }
+
+    #[test]
+    fn dismissal_maps_to_permitted() {
+        let wire = match decision_json(serde_json::json!({ "Reviewer": "rev-1" }), "no_action") {
+            ModerationEventWire::DecisionRecorded(d) => d,
+            _ => panic!(),
+        };
+        let event = map_decision_recorded(&wire, sealed()).unwrap();
+        assert_eq!(event.outcome(), Outcome::Permitted);
+        assert_eq!(event.action(), "moderation.decide.no_action");
+    }
+
+    #[test]
+    fn event_id_is_deterministic_for_the_same_decision() {
+        let mk = || match decision_json(serde_json::json!({ "Reviewer": "rev-1" }), "ban") {
+            ModerationEventWire::DecisionRecorded(d) => map_decision_recorded(&d, sealed()).unwrap(),
+            _ => panic!(),
+        };
+        assert_eq!(mk().event_id(), mk().event_id());
+    }
+
+    #[test]
+    fn enforcement_applied_maps_without_pii() {
+        let wire: ModerationEventWire = serde_json::from_value(serde_json::json!({
+            "type": "enforcement_applied",
+            "enforcement_id": "44444444-4444-4444-4444-444444444444",
+            "subject": { "entity_type": "account", "entity_id": "acc-9", "actor_id": "55555555-5555-5555-5555-555555555555", "surface": "" },
+            "actor_id": "55555555-5555-5555-5555-555555555555",
+            "action": "ban",
+            "version": 7,
+            "expires_at": null,
+            "occurred_at": "2026-06-26T12:00:00Z",
+            "correlation_id": "66666666-6666-6666-6666-666666666666"
+        }))
+        .unwrap();
+        let wire = match wire {
+            ModerationEventWire::EnforcementApplied(e) => e,
+            _ => panic!("expected EnforcementApplied"),
+        };
+        let event = map_enforcement_applied(&wire).unwrap();
+        assert_eq!(event.action(), "moderation.enforce.ban");
+        assert_eq!(event.outcome(), Outcome::Executed);
+        assert!(!event.has_pii());
+        assert_eq!(event.actor().actor_type, ActorType::System);
+        assert_eq!(event.attributes().get("version").unwrap(), "7");
+    }
+
+    #[test]
+    fn out_of_scope_events_decode_to_other() {
+        for ty in ["case_opened", "case_resolved", "enforcement_reversed", "appeal_resolved"] {
+            let wire: ModerationEventWire =
+                serde_json::from_value(serde_json::json!({ "type": ty, "actor_id": "x" })).unwrap();
+            assert!(matches!(wire, ModerationEventWire::Other), "{ty} should be Other");
+        }
+    }
+}

--- a/crates/services/audit/src/service.rs
+++ b/crates/services/audit/src/service.rs
@@ -29,13 +29,17 @@ use transport::kafka::producer::{KafkaProducerBuilder, KafkaProducerHandle};
 
 use crate::app::{Adapters, compose_server};
 use crate::application::IngestHandler;
+use crate::application::port::SubjectCipher;
 use crate::config::AuditConfig;
 use crate::infrastructure::grpc::{AuditServiceHandler, AuditServiceServer, FILE_DESCRIPTOR_SET};
+use crate::infrastructure::moderation_decode::TOPIC_MODERATION_EVENTS;
 use crate::infrastructure::run_audit_ingest_consumer;
 use crate::infrastructure::run_checkpoint_loop;
+use crate::infrastructure::run_moderation_ingest_consumer;
 
 const INGEST_TOPIC: &str = "audit.v1.events";
 const INGEST_GROUP: &str = "audit-ingest";
+const MODERATION_GROUP: &str = "audit-moderation";
 
 /// Backoff before respawning the ingest consumer after its runner returns.
 const CONSUMER_RESPAWN_BACKOFF: Duration = Duration::from_secs(5);
@@ -101,8 +105,10 @@ impl Service for AuditWorkerService {
         let config = AuditConfig::from_env();
         let adapters = Adapters::build(&config).await.context("build audit adapters")?;
 
-        // The supervised async ingest lane: decode → chain → archive.
+        // The supervised async ingest lanes: the generic audit feed, and the
+        // moderation compliance feed (sealing the rationale before chaining).
         spawn_ingest(adapters.ingest_handler());
+        spawn_moderation_ingest(adapters.ingest_handler(), Arc::clone(&adapters.cipher));
 
         // The periodic checkpoint-anchor loop.
         tokio::spawn(run_checkpoint_loop(
@@ -140,6 +146,31 @@ fn spawn_ingest(handler: Arc<IngestHandler>) {
                 }
                 Err(error) => {
                     tracing::error!(%error, "failed to build audit ingest consumer; retrying")
+                }
+            }
+            tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;
+        }
+    });
+}
+
+/// Spawn the supervised moderation-feed consumer (seals the rationale, maps, then
+/// chains). Same respawn discipline as [`spawn_ingest`].
+fn spawn_moderation_ingest(handler: Arc<IngestHandler>, cipher: Arc<dyn SubjectCipher>) {
+    tokio::spawn(async move {
+        loop {
+            match build_consumer(TOPIC_MODERATION_EVENTS, MODERATION_GROUP) {
+                Ok((consumer, producer)) => {
+                    run_moderation_ingest_consumer(
+                        consumer,
+                        producer,
+                        Arc::clone(&handler),
+                        Arc::clone(&cipher),
+                    )
+                    .await;
+                    tracing::warn!("audit moderation consumer exited; respawning after backoff");
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build audit moderation consumer; retrying")
                 }
             }
             tokio::time::sleep(CONSUMER_RESPAWN_BACKOFF).await;

--- a/crates/services/audit/tests/audit_it/harness/mod.rs
+++ b/crates/services/audit/tests/audit_it/harness/mod.rs
@@ -12,7 +12,9 @@ use std::time::Duration;
 use chrono::{DateTime, TimeZone, Utc};
 use uuid::Uuid;
 
-use audit::application::port::{CheckpointAnchor, Clock, KeyVault, LedgerStore, WormArchive};
+use audit::application::port::{
+    CheckpointAnchor, Clock, KeyVault, LedgerStore, SubjectCipher, WormArchive,
+};
 use audit::application::{
     CheckpointHandler, CryptoShredHandler, IngestHandler, QueryHandler, VerifyHandler,
 };
@@ -21,7 +23,8 @@ use audit::domain::{
     PartitionKey, PiiEnvelope, ResourceRef, SubjectKeyRef, SubjectPseudonym, TenantId,
 };
 use audit::infrastructure::{
-    ObjectLockArchive, ObjectLockConfig, PgCheckpointAnchor, PgKeyVault, PgLedger, SystemClock,
+    AesGcmSubjectCipher, ObjectLockArchive, ObjectLockConfig, PgCheckpointAnchor, PgKeyVault,
+    PgLedger, SystemClock,
 };
 
 use postgres_storage::config::StatementLogLevel;
@@ -34,12 +37,16 @@ const PG_MIGRATIONS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations");
 /// tamper scenario can rewrite it via raw SQL.
 pub const LIVE_ACTION: &str = "live.action";
 
+/// A fixed test KEK (production reads a real one from env / KMS).
+const TEST_KEK: [u8; 32] = [42u8; 32];
+
 pub struct Harness {
     pub ledger: Arc<dyn LedgerStore>,
     pub archive: Arc<dyn WormArchive>,
     pub key_vault: Arc<dyn KeyVault>,
     pub anchor: Arc<dyn CheckpointAnchor>,
     pub clock: Arc<dyn Clock>,
+    pub cipher: Arc<dyn SubjectCipher>,
     pub pool: PgPool,
 }
 
@@ -80,6 +87,10 @@ impl Harness {
             Arc::new(PgCheckpointAnchor::new(TransactionManager::new(pool.clone())));
         let archive: Arc<dyn WormArchive> = Arc::new(archive);
         let clock: Arc<dyn Clock> = Arc::new(SystemClock);
+        let cipher: Arc<dyn SubjectCipher> = Arc::new(AesGcmSubjectCipher::new(
+            TransactionManager::new(pool.clone()),
+            TEST_KEK,
+        ));
 
         Self {
             ledger,
@@ -87,6 +98,7 @@ impl Harness {
             key_vault,
             anchor,
             clock,
+            cipher,
             pool,
         }
     }

--- a/crates/services/audit/tests/audit_it/scenarios/mod.rs
+++ b/crates/services/audit/tests/audit_it/scenarios/mod.rs
@@ -5,4 +5,5 @@
 mod anchor;
 mod chain;
 mod idempotency;
+mod moderation;
 mod shred;

--- a/crates/services/audit/tests/audit_it/scenarios/moderation.rs
+++ b/crates/services/audit/tests/audit_it/scenarios/moderation.rs
@@ -74,6 +74,30 @@ async fn moderation_decision_is_sealed_chained_and_shred_preserves_chain() {
 }
 
 #[tokio::test]
+async fn moderation_decision_replay_is_deduped() {
+    let h = Harness::start().await;
+    let actor = Uuid::now_v7().to_string();
+    let subject = SubjectPseudonym::new(actor.clone()).unwrap();
+    let wire = decision_wire(&actor, "violates policy");
+
+    // The audit event id is a deterministic UUIDv5 of the decision id, so a
+    // redelivery maps to the same id and the ledger dedupes it — even though each
+    // seal produces a fresh envelope.
+    let first = {
+        let pii = h.cipher.seal(&subject, &wire.rationale).await.unwrap();
+        h.ingest().ingest(map_decision_recorded(&wire, pii).unwrap()).await.unwrap()
+    };
+    let again = {
+        let pii = h.cipher.seal(&subject, &wire.rationale).await.unwrap();
+        h.ingest().ingest(map_decision_recorded(&wire, pii).unwrap()).await.unwrap()
+    };
+
+    assert!(!first.is_duplicate());
+    assert!(again.is_duplicate());
+    assert_eq!(first.proof(), again.proof());
+}
+
+#[tokio::test]
 async fn cipher_reuses_per_subject_dek_with_fresh_nonces() {
     let h = Harness::start().await;
     let actor = Uuid::now_v7().to_string();

--- a/crates/services/audit/tests/audit_it/scenarios/moderation.rs
+++ b/crates/services/audit/tests/audit_it/scenarios/moderation.rs
@@ -1,0 +1,95 @@
+//! Live moderation→audit path over real Postgres + MinIO: a moderation decision's
+//! rationale is sealed (real AES-GCM + a Postgres-backed wrapped DEK), chained, and
+//! verifiable — and a crypto-shred of the subject leaves the chain intact while the
+//! rationale becomes permanently unreadable.
+//!
+//! Audit's suite boots no Kafka, so the consumer is out of scope here; we drive the
+//! same steps it would (seal → map → ingest) directly over the real adapters.
+
+use audit::application::IntegrityStatus;
+use audit::domain::{EventCategory, PartitionKey, SubjectKeyRef, SubjectPseudonym};
+use audit::infrastructure::map_decision_recorded;
+use audit::infrastructure::moderation_decode::{
+    DecisionAuthorWire, DecisionRecordedWire, SubjectRefWire,
+};
+use uuid::Uuid;
+
+use crate::audit_it::harness::{Harness, at};
+
+fn decision_wire(actor_id: &str, rationale: &str) -> DecisionRecordedWire {
+    DecisionRecordedWire {
+        decision_id: Uuid::now_v7().to_string(),
+        subject: SubjectRefWire {
+            entity_type: "post".to_owned(),
+            entity_id: "p1".to_owned(),
+            actor_id: actor_id.to_owned(),
+            surface: "feed".to_owned(),
+        },
+        author: DecisionAuthorWire::Reviewer("rev-1".to_owned()),
+        action: "remove_content".to_owned(),
+        category: "harassment".to_owned(),
+        policy_version: "2026.06.1".to_owned(),
+        rationale: rationale.to_owned(),
+        reverses: None,
+        occurred_at: at(1_750_000_000_000),
+        correlation_id: Uuid::now_v7().to_string(),
+    }
+}
+
+#[tokio::test]
+async fn moderation_decision_is_sealed_chained_and_shred_preserves_chain() {
+    let h = Harness::start().await;
+    // A fresh subject per run — its DEK is isolated even though moderation records
+    // share the (tenant-less) `_global` Moderation partition.
+    let actor = Uuid::now_v7().to_string();
+    let subject = SubjectPseudonym::new(actor.clone()).unwrap();
+    let key = SubjectKeyRef::new(format!("dek:{actor}")).unwrap();
+
+    let wire = decision_wire(&actor, "violates harassment policy clause 3.2");
+
+    // Seal the rationale over real Postgres (mints + KEK-wraps a per-subject DEK),
+    // map to a domain event, and chain it.
+    let pii = h.cipher.seal(&subject, &wire.rationale).await.unwrap();
+    let event = map_decision_recorded(&wire, pii).unwrap();
+    h.ingest().ingest(event).await.unwrap();
+
+    let partition = PartitionKey::derive(None, EventCategory::Moderation);
+    assert_eq!(
+        h.verify().verify_partition(&partition).await.unwrap().status,
+        IntegrityStatus::Verified
+    );
+    // The DEK exists → an authorized reader could still decrypt the rationale.
+    assert!(h.key_vault.key_exists(&key).await.unwrap());
+
+    // Crypto-shred the subject: the wrapped DEK is destroyed...
+    h.shred().shred(&subject, &key, &[]).await.unwrap();
+    assert!(!h.key_vault.key_exists(&key).await.unwrap());
+
+    // ...the rationale is now permanently undecryptable, yet the chain STILL
+    // verifies — the record's ciphertext (what the chain hashed) never moved.
+    assert_eq!(
+        h.verify().verify_partition(&partition).await.unwrap().status,
+        IntegrityStatus::Verified
+    );
+}
+
+#[tokio::test]
+async fn cipher_reuses_per_subject_dek_with_fresh_nonces() {
+    let h = Harness::start().await;
+    let actor = Uuid::now_v7().to_string();
+    let subject = SubjectPseudonym::new(actor.clone()).unwrap();
+    let key = SubjectKeyRef::new(format!("dek:{actor}")).unwrap();
+
+    let a = h.cipher.seal(&subject, "reason A").await.unwrap();
+    let b = h.cipher.seal(&subject, "reason B").await.unwrap();
+
+    // One DEK per subject (a single shred erases all their PII)...
+    assert_eq!(a.subject_key_ref(), b.subject_key_ref());
+    // ...but a fresh nonce + distinct ciphertext per seal (semantic security).
+    assert_ne!(a.nonce(), b.nonce());
+    assert_ne!(a.ciphertext(), b.ciphertext());
+
+    assert!(h.key_vault.key_exists(&key).await.unwrap());
+    h.shred().shred(&subject, &key, &[]).await.unwrap();
+    assert!(!h.key_vault.key_exists(&key).await.unwrap());
+}

--- a/crates/services/moderation/README.fr.md
+++ b/crates/services/moderation/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 9d684f4ea1ed5851a9165ba14e8c35063cb9dbce3288952c8c8788ba92af32df
+  source_sha256: 5276a8fd821ec8a56401d514440450ebe6679e7e868b9b91b4052b7ff2de94d6
   translated_at: 2026-06-26
   status: complete
 ---
@@ -178,6 +178,9 @@ Chaque faute implémente `error::AppError` avec un code stable `MOD-XXXX` (voir 
 | Topic | Déclencheur | Clé | Consommateurs |
 |---|---|---|---|
 | `moderation.v1.events` | application appliquée/annulée, dossier ouvert/résolu, appel résolu | `actor_id` | `timeline`, `chat`, `account` (dénorm Plan B) |
+| `moderation.v1.events` · `decision_recorded` | une décision est enregistrée (screen automatisé, revue humaine, annulation d'appel) | `actor_id` | `audit` (preuve de conformité) |
+
+> L'événement **`decision_recorded`** est l'enregistrement de preuve de conformité dédié que le plan `audit` consomme — contrairement aux événements Plan-B centrés sur le contrevenant ci-dessus, il porte *qui a décidé* (l'autorité) et *pourquoi* (le motif / énoncé de motifs DSA), issu du registre `Decision` immuable. Le motif est scellé dans une enveloppe crypto-effaçable par `audit` à l'ingestion ; par convention il est référentiel-aux-politiques, non citateur-de-contenu. Les autres consommateurs ignorent ce variant.
 
 **Consomme :**
 

--- a/crates/services/moderation/README.md
+++ b/crates/services/moderation/README.md
@@ -167,6 +167,9 @@ Every fault implements `error::AppError` with a stable `MOD-XXXX` code (see [`sr
 | Topic | Trigger | Key | Consumers |
 |---|---|---|---|
 | `moderation.v1.events` | enforcement applied/reversed, case opened/resolved, appeal resolved | `actor_id` | `timeline`, `chat`, `account` (Plane B denorm) |
+| `moderation.v1.events` · `decision_recorded` | a decision is recorded (automated screen, human review, appeal reversal) | `actor_id` | `audit` (compliance evidence) |
+
+> The **`decision_recorded`** event is the dedicated compliance-evidence record the `audit` plane consumes — unlike the offender-centric Plane-B events above, it carries *who decided* (the authority) and *why* (the rationale / DSA statement-of-reasons), sourced from the immutable `Decision` ledger. The rationale is sealed into a crypto-shreddable envelope by `audit` at ingest; by convention it is policy-referential, not content-quoting. Other consumers ignore this variant.
 
 **Consumes:**
 

--- a/crates/services/moderation/src/application/command/appeal.rs
+++ b/crates/services/moderation/src/application/command/appeal.rs
@@ -147,6 +147,12 @@ impl ResolveAppealHandler {
             )?;
             self.decisions.append(&rev).await?;
 
+            // 1b. Publish the compliance-evidence event (the audit feed) — the
+            // reversal carries `reverses` linking it to the decision it supersedes.
+            self.publisher
+                .publish(&super::decision_recorded(&rev, correlation_id))
+                .await?;
+
             // 2. Reverse the active enforcement(s) the original decision created.
             let actor = original.subject().actor_id();
             for mut enf in self.enforcements.list_active_for_actor(&actor).await? {
@@ -245,11 +251,16 @@ mod tests {
 
         assert!(out.reversal.is_some());
         assert_eq!(out.reversal.unwrap().reverses(), Some(decision_id));
-        // Projection cleared; EnforcementReversed then AppealResolved emitted.
+        // Projection cleared; DecisionRecorded (the reversal), then
+        // EnforcementReversed, then AppealResolved emitted.
         assert!(!fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
         assert_eq!(
             fx.publisher.event_types(),
-            vec!["moderation.enforcement_reversed", "moderation.appeal_resolved"]
+            vec![
+                "moderation.decision_recorded",
+                "moderation.enforcement_reversed",
+                "moderation.appeal_resolved"
+            ]
         );
     }
 

--- a/crates/services/moderation/src/application/command/decide_case.rs
+++ b/crates/services/moderation/src/application/command/decide_case.rs
@@ -189,6 +189,12 @@ impl DecideCaseHandler {
         })?;
         self.decisions.append(&decision).await?;
 
+        // 1b. Publish the compliance-evidence event (the audit feed) — carries the
+        // authority + rationale the offender-centric events omit.
+        self.publisher
+            .publish(&super::decision_recorded(&decision, correlation_id))
+            .await?;
+
         // 2. Apply enforcement (unless the action is a dismissal).
         let mut enforcement = None;
         if cmd.action.is_enforced() {
@@ -321,13 +327,49 @@ mod tests {
         assert_eq!(out.decision.action(), ActionType::RemoveContent);
         assert!(out.enforcement.is_some());
         assert_eq!(fx.decisions.count(), 1);
-        // EnforcementApplied then CaseResolved.
+        // DecisionRecorded (the evidence event), then EnforcementApplied, then
+        // CaseResolved.
         assert_eq!(
             fx.publisher.event_types(),
-            vec!["moderation.enforcement_applied", "moderation.case_resolved"]
+            vec![
+                "moderation.decision_recorded",
+                "moderation.enforcement_applied",
+                "moderation.case_resolved"
+            ]
         );
         // Content action ⇒ no actor restriction.
         assert!(!fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
+    }
+
+    /// The DecisionRecorded evidence event must carry who decided (the authority)
+    /// and why (the rationale) — the fields the offender-centric events omit and
+    /// the whole reason audit consumes this stream.
+    #[tokio::test]
+    async fn decision_recorded_carries_authority_and_reason() {
+        let fx = Fixture::new();
+        let case_id = open_case(&fx).await;
+        fx.publisher.clear();
+
+        fx.decide_handler()
+            .handle(decide_env(case_id, ActionType::RemoveContent), t0())
+            .await
+            .unwrap();
+
+        let recorded = fx
+            .publisher
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                crate::domain::event::DomainEvent::DecisionRecorded(d) => Some(d),
+                _ => None,
+            })
+            .expect("a DecisionRecorded event was published");
+
+        assert_eq!(recorded.author, DecisionAuthor::Reviewer("rev-1".into()));
+        assert_eq!(recorded.rationale, "violates policy");
+        assert_eq!(recorded.policy_version, PolicyVersion::new("2026.06.1").unwrap());
+        assert_eq!(recorded.action, ActionType::RemoveContent);
+        assert!(recorded.reverses.is_none());
     }
 
     #[tokio::test]
@@ -344,7 +386,11 @@ mod tests {
 
         assert!(out.enforcement.is_none());
         assert_eq!(fx.decisions.count(), 1);
-        assert_eq!(fx.publisher.event_types(), vec!["moderation.case_resolved"]);
+        // A dismissal still records + publishes the decision evidence, then resolves.
+        assert_eq!(
+            fx.publisher.event_types(),
+            vec!["moderation.decision_recorded", "moderation.case_resolved"]
+        );
     }
 
     #[tokio::test]

--- a/crates/services/moderation/src/application/command/mod.rs
+++ b/crates/services/moderation/src/application/command/mod.rs
@@ -21,3 +21,27 @@ pub use ingest::{
     IngestReportCommand, IngestReportHandler, IngestSignalCommand, IngestSignalHandler,
 };
 pub use screen::{ScreenCommand, ScreenHandler, ScreenOutcome, ScreenVerdict};
+
+use uuid::Uuid;
+
+use crate::domain::aggregate::Decision;
+use crate::domain::event::{DecisionRecorded, DomainEvent};
+
+/// Build the `DecisionRecorded` compliance-evidence event from a just-recorded
+/// `Decision`, threading the command's `correlation_id`. Used at every site that
+/// appends a decision (automated screen, human review, appeal reversal) so the
+/// `audit` plane captures who decided, under what authority and with what reason.
+pub(crate) fn decision_recorded(decision: &Decision, correlation_id: Uuid) -> DomainEvent {
+    DomainEvent::DecisionRecorded(DecisionRecorded {
+        decision_id: decision.id(),
+        subject: decision.subject().clone(),
+        author: decision.author().clone(),
+        action: decision.action(),
+        category: decision.category(),
+        policy_version: decision.policy_version().clone(),
+        rationale: decision.rationale().to_owned(),
+        reverses: decision.reverses(),
+        occurred_at: decision.decided_at(),
+        correlation_id,
+    })
+}

--- a/crates/services/moderation/src/application/command/screen.rs
+++ b/crates/services/moderation/src/application/command/screen.rs
@@ -118,6 +118,12 @@ impl ScreenHandler {
         })?;
         self.decisions.append(&decision).await?;
 
+        // 1b. Publish the compliance-evidence event (the audit feed) — an automated
+        // (Rule) decision is evidence too.
+        self.publisher
+            .publish(&super::decision_recorded(&decision, correlation_id))
+            .await?;
+
         // 2. Apply the content removal enforcement and publish it.
         let version = self.enforcements.next_version(&cmd.subject).await?;
         let mut enforcement = EnforcementAction::apply(EnforcementParams {
@@ -209,9 +215,13 @@ mod tests {
         assert_eq!(out.matched_categories, vec![PolicyCategory::Csam]);
         assert_eq!(out.match_reference.as_deref(), Some("ncmec:123"));
         assert!(out.enforcement_id.is_some());
-        // One append-only decision + one EnforcementApplied event.
+        // One append-only decision → DecisionRecorded (evidence) then
+        // EnforcementApplied.
         assert_eq!(fx.decisions.count(), 1);
-        assert_eq!(fx.publisher.event_types(), vec!["moderation.enforcement_applied"]);
+        assert_eq!(
+            fx.publisher.event_types(),
+            vec!["moderation.decision_recorded", "moderation.enforcement_applied"]
+        );
         // CSAM weight (6) hits the Ban tier ⇒ actor restricted on the projection.
         assert!(fx.projection.is_actor_restricted(&subject().actor_id()).await.unwrap());
     }

--- a/crates/services/moderation/src/application/fakes.rs
+++ b/crates/services/moderation/src/application/fakes.rs
@@ -403,6 +403,11 @@ impl RecordingEventPublisher {
         self.events.lock().unwrap().len()
     }
 
+    /// A clone of every published event, for asserting on payload content.
+    pub fn events(&self) -> Vec<DomainEvent> {
+        self.events.lock().unwrap().clone()
+    }
+
     /// Resets recorded events — used by tests that assert only on events emitted
     /// after a setup phase (e.g. open-then-decide).
     pub fn clear(&self) {

--- a/crates/services/moderation/src/domain/event.rs
+++ b/crates/services/moderation/src/domain/event.rs
@@ -13,9 +13,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::domain::aggregate::DecisionAuthor;
 use crate::domain::value_object::{
     ActionType, ActorId, AppealId, CaseId, DecisionId, EnforcementId, EnforcementVersion,
-    PolicyCategory, SubjectRef,
+    PolicyCategory, PolicyVersion, SubjectRef,
 };
 
 /// A review case was opened for a subject.
@@ -79,12 +80,43 @@ pub struct AppealResolved {
     pub correlation_id: Uuid,
 }
 
+/// The **compliance evidence** record of a decision — the dedicated event the
+/// `audit` plane consumes (the existing offender-centric events above are the
+/// Plane-B denormalization feed and deliberately omit the authority + reason).
+///
+/// Unlike its siblings it carries *who decided* (`author` — a human reviewer or an
+/// automated rule) and *why* (`rationale`, the DSA statement-of-reasons) alongside
+/// the affected `subject`, so audit can answer "who did what, to whom, under what
+/// authority, with what stated reason". The `rationale` is sealed into a
+/// crypto-shreddable envelope by `audit` at ingest (it may reference content) — by
+/// convention it should be policy-referential, not content-quoting. Emitted at
+/// every site that records a `Decision` (automated screen, human review, appeal
+/// reversal). Partitioned by the affected actor, like its siblings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DecisionRecorded {
+    pub decision_id: DecisionId,
+    pub subject: SubjectRef,
+    /// Who (or what) made the decision — the authority.
+    pub author: DecisionAuthor,
+    pub action: ActionType,
+    pub category: PolicyCategory,
+    pub policy_version: PolicyVersion,
+    /// The DSA statement-of-reasons. Sealed into a crypto-shreddable PII envelope
+    /// downstream in `audit`.
+    pub rationale: String,
+    /// Set when this decision reverses an earlier one (an appeal overturn).
+    pub reverses: Option<DecisionId>,
+    pub occurred_at: DateTime<Utc>,
+    pub correlation_id: Uuid,
+}
+
 /// Sealed sum type of every domain event moderation publishes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum DomainEvent {
     CaseOpened(CaseOpened),
     CaseResolved(CaseResolved),
+    DecisionRecorded(DecisionRecorded),
     EnforcementApplied(EnforcementApplied),
     EnforcementReversed(EnforcementReversed),
     AppealResolved(AppealResolved),
@@ -96,6 +128,7 @@ impl DomainEvent {
         match self {
             Self::CaseOpened(_) => "moderation.case_opened",
             Self::CaseResolved(_) => "moderation.case_resolved",
+            Self::DecisionRecorded(_) => "moderation.decision_recorded",
             Self::EnforcementApplied(_) => "moderation.enforcement_applied",
             Self::EnforcementReversed(_) => "moderation.enforcement_reversed",
             Self::AppealResolved(_) => "moderation.appeal_resolved",
@@ -108,6 +141,7 @@ impl DomainEvent {
         match self {
             Self::CaseOpened(e) => e.actor_id,
             Self::CaseResolved(e) => e.actor_id,
+            Self::DecisionRecorded(e) => e.subject.actor_id(),
             Self::EnforcementApplied(e) => e.actor_id,
             Self::EnforcementReversed(e) => e.actor_id,
             Self::AppealResolved(e) => e.actor_id,

--- a/crates/services/moderation/src/infrastructure/history/scylla_evidence_history.rs
+++ b/crates/services/moderation/src/infrastructure/history/scylla_evidence_history.rs
@@ -65,6 +65,16 @@ fn project(event: &DomainEvent) -> HistoryRow {
             category: e.category.as_str().to_owned(),
             action: e.action.as_str().to_owned(),
         },
+        DomainEvent::DecisionRecorded(e) => {
+            let (et, eid) = subject_cols(&e.subject);
+            HistoryRow {
+                occurred_at: e.occurred_at.timestamp_millis(),
+                entity_type: et,
+                entity_id: eid,
+                category: e.category.as_str().to_owned(),
+                action: e.action.as_str().to_owned(),
+            }
+        }
         DomainEvent::EnforcementApplied(e) => {
             let (et, eid) = subject_cols(&e.subject);
             HistoryRow {


### PR DESCRIPTION
## Summary

The first **producer adoption** for the audit compliance plane (which landed via #476): `moderation`'s integrity decisions now flow into `audit` as tamper-evident, crypto-shreddable evidence. Cross-service feature — moderation (producer) + audit (consumer) — across 5 phases, one commit each.

**Why it was needed:** moderation already published `moderation.v1.events`, but those are offender-centric Plane-B denormalization signals — they omit *who decided* and *why*, even though moderation's immutable `Decision` ledger holds both. Audit needs exactly that to answer "who did what, to whom, under what authority, with what stated reason".

## Design (locked decisions)

- **Topology C** — moderation adds a **dedicated `DecisionRecorded` evidence event**; the existing enforcement events stay untouched. Audit owns the read schema (no cross-service crate dependency).
- **Rationale (DSA statement-of-reasons) sealed in a crypto-shreddable `PiiEnvelope`** — sealing happens **audit-side at ingest** (key custody stays in audit's trust domain). Policy-referential by convention.
- **Scope** — `DecisionRecorded` + `EnforcementApplied`.

## Phases

- **P1 — moderation** (`1f6d1002`): new `DecisionRecorded` event (author / rationale / policy_version / subject / action / reverses?), emitted at all three decision sites (automated screen, human review, appeal reversal).
- **P2 — audit decode** (`88d902d3`): `ModerationEventWire` + `map_decision_recorded` / `map_enforcement_applied` (DecisionAuthor → Admin/System, deterministic UUIDv5 ids, rationale routed to the envelope not cleartext attributes).
- **P3 — audit cipher + consumer** (`51a3d97d`): `SubjectCipher` + `AesGcmSubjectCipher` (AES-256-GCM; a per-subject DEK wrapped under a service KEK and stored in `subject_keys`; KEK in env, never the DB; KMS-upgradeable) + the supervised `moderation.v1.events` consumer. Migration `0002` adds the wrapped-DEK columns. **New dep: `aes-gcm`.**
- **P4 — live IT** (`9d327491`): over real Postgres + MinIO — a decision's rationale is sealed, chained, verified; a crypto-shred makes the rationale permanently unreadable **while the chain still verifies**; per-subject DEK reuse with fresh nonces.
- **P5 — finalize** (`00dc44c4`): replay-dedup live test; READMEs (EN + FR) + `AUDIT_KEK_BASE64`.

## Testing

- **moderation**: 93 unit tests (incl. the evidence-payload + event-ordering assertions).
- **audit**: 88 unit + **8 live-IT** (real Postgres + MinIO) — ran green on Docker.
- `clippy` clean across both services; i18n drift gate green (READMEs EN + FR).

## Notes

- The `aes-gcm` dependency is the only new external crate (`rand`/`sha2` already present).
- The KEK is the first concrete piece of the deferred KMS story: production hands KEK custody (wrap/unwrap) to KMS/HSM with no schema or contract change.
- `auth` and `account` producer adoption remain as follow-ons.

> `develop` is protected — this likely needs an admin-override squash merge, as with #476 / #467 / #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)