### PR TITLE
docs(domain): author DOMAIN.md for audit, moderation, realtime

### DIFF
--- a/crates/services/audit/docs/DOMAIN.md
+++ b/crates/services/audit/docs/DOMAIN.md
@@ -1,0 +1,179 @@
+# `audit` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Compliance Evidence — the tamper-evident audit trail |
+> | **Subdomain class** | **Supporting** — legally non-negotiable but not a user-facing differentiator; bespoke (not Generic) because no off-the-shelf SIEM/audit tool reconciles GDPR Art. 17 erasure with Art. 5(2) accountability |
+> | **System of …** | **Record / Evidence** for "who did what, to whom, when, under what authority, with what outcome" |
+> | **Aggregate root(s)** | `AuditRecord` (`domain::record`), with the per-partition `ChainLink` / `ChainHead` chain (`domain::chain`) and `MerkleCheckpoint` (`domain::checkpoint`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Split** — *fail-open* at producers (audit liveness never browns out the mesh); *fail-closed* on durability and on the synchronous break-glass lane |
+> | **Upstream contexts** | `moderation`, `auth`, `account` via **Conformist + ACL** (audit consumes their event streams and translates each foreign wire shape into `AuditEvent` at `infrastructure/decode.rs`) |
+> | **Downstream contexts** | none of record — audit is a **terminal sink**; it publishes nothing other services consume |
+> | **Decision log** | [`ADR-0001`](../../../../docs/adr/0001-audit-is-a-separate-evidence-plane.md) |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `audit` is the authority for **compliance evidence**: it answers
+**"can we prove this record of who-did-what is complete and was never altered, and would we detect it if it were?"**
+
+**The hard problem.** Telemetry and an audit trail look alike on a screen but are different
+substances: telemetry is best-effort, mutable, sampled and retention-cycled; evidence must be
+zero-loss, append-only, tamper-evident, complete, retained for years, and erasable at the *field*
+level. Conflating them puts PII into uncontrolled log indexes and makes a GDPR Art. 17 erasure
+request directly contradict the Art. 5(2) duty to retain proof.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ General application logging / observability → owned by the telemetry plane (`telemetry` crate).
+- ❌ Making or acting on decisions — audit *records* decisions others make and acts on none.
+- ❌ Holding the identity↔pseudonym mapping → owned by `account`; audit only ever sees pseudonyms.
+- ❌ Publishing events of record → it is a terminal sink.
+
+---
+
+## 2. Ubiquitous Language
+
+> Cross-context terms (subject, lawful basis) live in `docs/domain/UBIQUITOUS_LANGUAGE.md`.
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Audit record | One immutable, hash-linked entry in the evidence ledger | `AuditRecord` |
+| Chain link / head | The `H(prev ‖ canonical(payload) ‖ sequence_no)` link and the current tip of a per-partition chain | `ChainLink`, `ChainHead` |
+| Crypto-shred | Erasure by destroying a subject's key, leaving the record + proof intact | via `PiiEnvelope` + `KeyVault` |
+| PII envelope | A per-subject, crypto-shreddable ciphertext; the chain hashes the *ciphertext*, never cleartext | `PiiEnvelope` |
+| Checkpoint | A signed Merkle root over all partition heads, anchored to an external witness | `MerkleCheckpoint` |
+| Legal hold | A lawful-retention override (Art. 17(3)) that suspends erasure | `LegalHold` |
+| Privileged action | A must-record-before-permitted action recorded on the synchronous fail-closed lane | `PrivilegedActionType` |
+| Partition | The `(tenant, category)` shard a record's chain belongs to; subject is indexed, not the partition key | `EventCategory` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `AuditRecord` | aggregate root | A record, once committed, is immutable and hash-linked to its predecessor |
+| `NewAuditEvent` / `AuditEvent` | entity / VO | A well-formed, deduplicated intake event before/after it is sequenced into the chain |
+| `ChainLink` / `ChainHead` | VO | Per-partition append-only linkage; `sequence_no` is strictly monotonic (gap = truncation signal) |
+| `MerkleCheckpoint` | VO | A signed root binding all partition heads at a point in time |
+| `PiiEnvelope` | VO | PII exists only as crypto-shreddable ciphertext; cleartext never enters the chain |
+| `Actor` / `ResourceRef` | VO | The pseudonymous who and the what-was-acted-on |
+| `LegalHold` / `RetentionPolicy` | VO | When erasure is permitted vs lawfully suspended |
+| `EventCategory` / `ActorType` / `Outcome` / `LawfulBasis` | enum | The closed classification vocabulary |
+
+**Lifecycle of a record:**
+
+```
+intake --(dedupe: UUIDv5)--> sequenced (chain-linked) --(persist+archive)--> committed --(checkpoint)--> witnessed
+                                                                                  └--(erase: destroy DEK)--> pii-shredded (chain still verifies)
+```
+
+> **Legal transitions only.** A committed record is never updated or deleted (`UPDATE`/`DELETE`
+> revoked at the DB role). A hash mismatch or sequence gap on read is not a recoverable state — it
+> raises `AUD-2001` / `AUD-2002` as a tamper alarm.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- The hash-chained compliance ledger — append-only **Postgres** (canonical) mirrored to **Object-Lock WORM** (S3/MinIO, compliance mode). No other service writes it.
+- Per-subject DEKs and the signing key custody record (in KMS/HSM, a separate trust domain).
+
+**This context holds copies it does NOT own (read-model / denormalization):**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Moderation decision facts | `moderation` | `moderation.v1.events` (`decision_recorded`, `enforcement_applied`) | eventually consistent (Kafka lag) |
+| Auth session lifecycle | `auth` | `auth.v1.events` (`session_issued`/`session_revoked`) | eventually consistent |
+| Account lifecycle + GDPR events | `account` | `account.v1.events` | eventually consistent |
+
+**The "do-not-write" list:** audit never mutates upstream state, never resolves a pseudonym to a
+real identity (that mapping lives in `account`), and never emits a record other services depend on.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | PII never enters the chain in cleartext (subjects are pseudonyms; PII is a `PiiEnvelope` ciphertext) | domain + infrastructure | (prevented by construction) |
+| I2 | Erasure is key-destruction, not record-deletion — record, sequence, hash and non-PII metadata survive | application | `AUD-5xxx` |
+| I3 | A subject under an active legal hold is not shredded (Art. 17(3) overrides) | domain | `AUD-5002` |
+| I4 | The most dangerous actions fail closed — `RecordPrivileged` denies unless durably recorded first | application | `AUD-4004` |
+| I5 | Reads are evidence too — every query/export is itself recorded; access is need-to-know | application | `AUD-3001`/`AUD-3002` |
+| I6 | The chain is append-only and complete; any mutation/gap is detectable | domain + DB role (`UPDATE`/`DELETE` revoked) | `AUD-2001`/`AUD-2002` |
+| I7 | A signed checkpoint must reconcile with the external witness | application | `AUD-2004` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Bulk ingestion (async, fail-open).**
+1. A fleet service emits a compliance event to Kafka (`audit.v1.events` or a decision stream) — fire-and-forget.
+2. `audit-worker` consumes under `run_consumer`; dedupes by UUIDv5 (`AUD-1004` → `Ok`).
+3. Decode foreign wire → `AuditEvent`; seal any PII into a `PiiEnvelope`.
+4. Append to the per-partition chain → persist to Postgres → mirror to WORM.
+- **Commit discipline:** the Kafka offset advances **only after** durable persist + chain. No committed offset ever sits past an un-persisted event → zero loss.
+- **Idempotency:** deterministic UUIDv5; redelivery deduped, so each logical event appears once.
+
+**Privileged action (sync, fail-closed).**
+1. A privileged caller invokes `RecordPrivileged` on `:50068`.
+2. Audit attempts durable+chained commit within a hard deadline.
+3. Success → permit; deadline/durability miss → **deny** (`AUD-4004`). The action must not proceed unrecorded.
+
+**Erasure (crypto-shred).** A GDPR Art. 17 request destroys the subject's DEK (unless under legal hold) → all that subject's sealed PII becomes permanently undecryptable while the chain still verifies. *(Driving worker loop awaits an erasure-request source; the handler exists and is tested.)*
+
+**Integrity verification.** A worker loop signs a Merkle root over partition heads, anchors it to the external witness, and a standalone verifier recomputes the chain and compares (`AUD-2004` on divergence).
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `moderation` | upstream | Conformist + ACL | `moderation.v1.events` | a schema change to `decision_recorded` breaks the sealed DSA-rationale chain |
+| `auth` | upstream | Conformist + ACL | `auth.v1.events` | session-lifecycle evidence gaps |
+| `account` | upstream | Conformist + ACL | `account.v1.events` | PII sealing + the Art. 17 crypto-shred trigger break |
+| `account` | dependency | Customer/Supplier | identity↔pseudonym mapping stays in `account` | audit cannot (and must not) resolve subjects |
+| external witness / KMS | dependency | separate trust domain | RFC 3161 TSA / cross-account WORM; KMS SigV4 | the operator-level tamper guarantee weakens |
+
+> **Anti-Corruption Layer:** `infrastructure/decode.rs` maps each foreign event wire shape (and the audit-owned `AuditEventWire` JSON) into the domain `AuditEvent` — upstream schema drift stops at this boundary.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+> Audit **publishes nothing of record** — it is a terminal sink. An integrity alarm on
+> tamper/gap/witness-divergence is operational signal, not a System-of-Record stream.
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| — (none) | audit asserts no business facts outward | — | — |
+
+It **consumes** the compliance facts of `moderation`/`auth`/`account` — their meanings are owned by
+those contexts' `DOMAIN.md §8` and rolled up in `docs/domain/EVENT_CATALOG.md`.
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Audit is a separate tamper-evident evidence plane, not a log aggregator | [`ADR-0001`](../../../../docs/adr/0001-audit-is-a-separate-evidence-plane.md) | Accepted |
+| _(candidate split-out)_ crypto-shred RtbF mechanism; dual-lane fail-open/fail-closed ingest; hash-chain + WORM + external-witness immutability | _to be written_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — invest enough to be legally bulletproof and tamper-evident; do not gold-plate beyond regulatory need.
+- **Volatility:** low. The chain/shred/checkpoint model is stable; change is driven by new *regulatory* obligations (a new event category, a new lawful basis), not feature churn.
+- **Known modeling debt:** the crypto-shred consumer and retention-expiry sweep handlers exist and are tested, but their driving worker loops await input sources (an erasure-request stream; resolved retention policies).
+- **Deferred capabilities:** read-authz + read-self-auditing via the `auth-context` ingress interceptor; DSA transparency-report generation; cross-region ledger replication. KMS/witness *provisioning* is an IAM/org commitment (the code sits behind the ports).

--- a/crates/services/moderation/docs/DOMAIN.md
+++ b/crates/services/moderation/docs/DOMAIN.md
@@ -1,0 +1,181 @@
+# `moderation` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Trust, Safety & Integrity — the integrity *decision of record* |
+> | **Subdomain class** | **Core** — for a UGC network, integrity enforcement is product-differentiating and bespoke; safety *is* part of the product's value |
+> | **System of …** | **Record** for "what action was taken against which entity, under which policy version, with what evidence" |
+> | **Aggregate root(s)** | `Case`, `Decision`, `EnforcementAction`, `Appeal`, `PenaltyLedger` (`domain::aggregate`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Per-category split** — CSAM/NCII/TVEC `Screen` fails **closed**; everything else is async/fail-open |
+> | **Upstream contexts** | `post`, `comment`, `chat`, `media` (content + Screen); classifier services (signals); users (reports) — via **ACL** over Kafka/gRPC |
+> | **Downstream contexts** | `timeline`, `chat`, `account` (Plane-B enforcement denorm); `audit` (`decision_recorded` evidence); `account` (gRPC suspension execution) — via **Open-Host Service / Published Language** |
+> | **Decision log** | [`ADR-0002`](../../../../docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `moderation` is the authority for **integrity decisions and enforcement**: it
+answers **"is this actor restricted / this content actioned, by what authority, and can we prove it
+to a regulator?"**
+
+**The hard problem.** Moderating at the network's *write volume* without becoming a global latency
+bottleneck. A naive design calls a moderation RPC on every post/message/upload, taxing every write
+and coupling content availability to an integrity outage. The resolving pattern is a **three-plane
+split** that decouples the heavy classification/review path from the hot decision path.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Classify content with ML inline → classifiers are upstream signal *producers*; `Screen` is inference-free hash/blocklist lookup only.
+- ❌ Store content → it references content by `SubjectRef`, never holds the bytes (`media`/`post` own those).
+- ❌ Be the review UI → the ops console is a separate caller of the case/appeal API.
+- ❌ Serve enforcement on the hot read path via RPC → the fleet reads **Plane B** (events + Redis projection), not `GetEnforcementState`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Subject | The normalized target of moderation: entity type + id + actor + surface | `SubjectRef` |
+| Case | A unit of review opened on a subject when signals cross a threshold | `Case` |
+| Decision | An append-only, auditable ruling (the legal evidence ledger entry) | `Decision`, `DecisionAuthor` |
+| Enforcement action | The applied consequence, versioned monotonically per subject | `EnforcementAction`, `EnforcementVersion` |
+| Strike / penalty ledger | The graduated-enforcement history that escalates consequences | `Strike`, `PenaltyLedger`, `PenaltyPolicy` |
+| Appeal | A subject's challenge to a decision; resolution is a *new* decision | `Appeal`, `AppealStatus` |
+| Signal / report | A classifier verdict / a user abuse report feeding Plane A | `Signal`, `Report` |
+| Screen | The narrow, synchronous, fail-closed pre-publish gate (Plane C) | (RPC `Screen`) |
+| Policy category / version | The policy under which a decision was made; pinned for auditability | `PolicyCategory`, `PolicyVersion` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Case` | aggregate root | A subject under review; keyed by deterministic UUIDv5 of subject identity (idempotent open) |
+| `Decision` | aggregate root | Append-only ruling; a reversal is a *new* decision, never a mutation |
+| `EnforcementAction` | aggregate root | Carries a per-subject monotonic `EnforcementVersion` — a reversal can never race ahead of a re-application |
+| `Appeal` | aggregate root | Challenge lifecycle; resolution emits a new `Decision` |
+| `PenaltyLedger` | aggregate root | Graduated escalation state per actor |
+| `SubjectRef` / `EntityType` / `ActorId` | VO | The normalized integrity target — never vendor or content-internal fields |
+| `PolicyCategory` / `PolicyVersion` / `Confidence` | VO | The decision's policy basis and certainty |
+
+**Lifecycle (case → enforcement):**
+
+```
+signals/report --(threshold)--> Case opened --(review/decide)--> Decision recorded --> EnforcementAction applied (v+1)
+                                                     ▲                                          │
+                                                 Appeal filed ◄───────────── (reversal = new Decision) ──┘
+```
+
+> **Legal transitions only.** Decisions are never retro-mutated (append-only ledger); a reversal is
+> a new `Decision`. The `EnforcementVersion` and the `Screen` hash scheme must never change after
+> data exists.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Cases, decisions (WORM), appeals, penalty ledger, policy versions — **Postgres** db `moderation`. The decision ledger is append-only.
+- Signal / evidence history — **ScyllaDB** keyspace `moderation` (TWCS).
+- The enforcement projection + Screen hash corpus — **Redis** (derived/rebuildable).
+
+**This context holds copies it does NOT own (read-model / denormalization):**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Content existence / metadata to build a `SubjectRef` | `post`, `comment`, `chat`, `media` | `post.v1.events`, `comment.*`, chat content (Plane A) | post-hoc (optimistic publish) |
+| Classifier verdicts | classifier services | `moderation.signals` | best-effort |
+
+**The "do-not-write" list:** moderation never mutates content (it references it); account
+suspension is *executed* by `account` over gRPC — moderation records the decision and requests
+execution, it does not own account state.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Decisions are append-only — a reversal is a new decision | domain + Postgres | `MOD-2xxx` |
+| I2 | `Screen` is deterministic and inference-free (hash/blocklist only; ML never inline) | infrastructure boundary | — |
+| I3 | Per-category fail policy — CSAM/NCII/TVEC fail **closed**; spam/borderline fail **open** | application | `MOD-7002`/`MOD-7003` |
+| I4 | `EnforcementAction` version is monotonic per subject (reversal can't race re-application) | domain | concurrency `MOD-9xxx` |
+| I5 | Cases are idempotent — keyed by deterministic UUIDv5 of subject identity | domain (consumer) | dedup folds into `Ok` |
+| I6 | Mutating ops RPCs are reviewer-privileged — not self-authorized | deployment edge (auth-context) | `PERMISSION_DENIED` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Plane A — async ingestion (off the write path, fail-open).**
+1. Content `*.created` / reports / classifier signals arrive on Kafka.
+2. `moderation-ingestion-consumer` runs cheap deterministic checks (blocklist, known-bad hash, actor history).
+3. Fan-out to async classifiers; open a `Case` when signals cross a threshold.
+- **Idempotency:** Cases keyed by UUIDv5 of subject; intentional skips (block-gated, self-target, dedup) fold into `Ok`.
+
+**Decision → enforcement (graduated).** A `Decision` is recorded under a pinned `PolicyVersion`; the penalty engine escalates via the `PenaltyLedger`; an `EnforcementAction` is applied at version *v+1* and projected to Redis + emitted on `moderation.v1.events`.
+
+**Plane B — enforcement state (hot read, O(1)).** The fleet reads `mod:enf:{actor:<id>}` from the Redis projection rebuilt by consumers — never a per-item RPC.
+
+**Plane C — Screen gate (sync, fail-closed).** `media`/`post` call `Screen` pre-publish for catastrophic categories. A hard timeout (`MODERATION_SCREEN_TIMEOUT_MS`, default 200ms) + circuit breaker bound it; on elapse/outage the gate returns `MOD-7002` and the caller blocks the upload.
+
+**Appeal.** A subject files an appeal; resolution records a new `Decision` (possibly a reversal) and a corresponding enforcement reversal.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `post`/`comment`/`chat`/`media` | upstream | ACL | content `*.events` → `SubjectRef` (Plane A) | a content schema change breaks subject construction |
+| classifier services | upstream | ACL | `moderation.signals` | lost ML signals → engine degrades to deterministic rules |
+| `media`/`post` | downstream | OHS (sync) | `Screen` RPC | a `Screen` contract change breaks the publish gate |
+| `timeline`/`chat`/`account` | downstream | Published Language | `moderation.v1.events` (Plane B) | enforcement denorm breaks |
+| `audit` | downstream | Published Language | `moderation.v1.events` · `decision_recorded` | the compliance evidence trail breaks |
+| `account` | downstream | Customer/Supplier (gRPC) | suspension/ban execution | lifecycle actions can't apply (decision still recorded, retried) |
+
+> **Anti-Corruption Layer:** the Plane-A ingestion consumers translate each content/signal wire
+> shape into the normalized `SubjectRef` / `Signal` domain types — vendor and content-internal
+> fields never leak into the model.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+> Meaning only; wire schema is owned by the proto/README. Roll-up in `docs/domain/EVENT_CATALOG.md`.
+
+| Event (on `moderation.v1.events`) | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `decision_recorded` | An authoritative integrity ruling was made — carries *who decided* and *why* (DSA statement-of-reasons) | a decision is recorded (auto-screen, human review, appeal reversal) | `audit` — seals the rationale into a crypto-shreddable envelope |
+| `enforcement_applied` / `enforcement_reversed` | A consequence was applied / lifted against an actor (versioned) | enforcement action commits | `timeline`, `chat`, `account` — Plane-B denorm |
+| `case_opened` / `case_resolved` | A review unit was opened / closed | ingestion threshold / reviewer action | Plane-B consumers |
+| `appeal_resolved` | An appeal was decided | appeal resolution | Plane-B consumers |
+
+> All events are keyed by `actor_id` for per-actor ordering. `decision_recorded` is the dedicated
+> compliance-evidence variant; offender-centric consumers ignore it, `audit` consumes only it +
+> `enforcement_applied`.
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Moderation is the decision/enforcement SoR with a narrow fail-closed Screen gate (three-plane split) | [`ADR-0002`](../../../../docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) | Accepted |
+| `decision_recorded` as the audit-facing evidence event (vs. mapping offender-centric events) | _see ADR-0001 context_ | Accepted |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Core — trust & safety is product-differentiating for a UGC platform; the three-plane design and graduated enforcement are bespoke.
+- **Volatility:** medium — policy categories, the penalty engine, and classifier integration evolve with product and regulation; the *ledger* and version discipline are stable.
+- **Known modeling debt:** gateway authorization for mutating ops RPCs is a deployment-time `<TODO>` (the service does not self-authorize).
+- **Deferred capabilities:** richer DSA transparency reporting; `chat` content ingestion depth; cross-surface actor reputation.

--- a/crates/services/realtime/docs/DOMAIN.md
+++ b/crates/services/realtime/docs/DOMAIN.md
@@ -1,0 +1,178 @@
+# `realtime` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Live Delivery — the client-facing System-of-Connection |
+> | **Subdomain class** | **Supporting** — it accelerates delivery but owns none of the value; the SoRs (`chat`/`notification`/`counter`) own every byte it forwards. Bespoke (not Generic) because the C10M edge is hand-built |
+> | **System of …** | **Connection / Delivery** — explicitly **never** a System of Record |
+> | **Aggregate root(s)** | `Connection` (`domain::connection`), with `Session`, `SubscriptionSet`, `SequenceState` |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-open** — a delivery miss costs latency, never data; clients re-sync from the SoRs on reconnect |
+> | **Upstream contexts** | end-user clients over WSS (not internal services); `auth` via `auth-context` (a verify, not a call) |
+> | **Downstream contexts** | none of record; delegates offline delivery to `notification` (APNs/FCM) |
+> | **Decision log** | [`ADR-0003`](../../../../docs/adr/0003-realtime-is-a-fail-open-system-of-connection.md) |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `realtime` is the authority for **live client delivery**: it answers
+**"which of this user's devices are connected right now, and how do I get this already-durable event
+onto the exact device the instant it happens?"**
+
+**The hard problem** is twofold. **Polling's inverted load trap:** at hyperscale, clients polling
+the edge couple core QPS to the count of *idle* users — every empty poll pays full TLS + auth +
+fan-out to deliver nothing, a self-inflicted DDoS on the mesh. **Connection sprawl:** `chat` and
+`notification` each grew their own client streaming, so one device holds multiple sockets with
+redundant heartbeats. Realtime inverts the first (work tracks *events*, not eyeballs) and collapses
+the second into one multiplexed socket per device.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Store any entity or message → durability lives in `chat`/`notification`/`counter`.
+- ❌ Sit in any synchronous write path → it is never in the path of sending a message or persisting a notification.
+- ❌ Re-authenticate per frame → the edge token is verified once at the handshake.
+- ❌ Author content-level authorization → that happened upstream at emit time; realtime only checks channel-scope ownership.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Connection | One live, multiplexed client socket and its lifecycle | `Connection`, `ConnectionState` |
+| Session | The authenticated identity bound to a connection at handshake | `Session` |
+| Channel | A logical stream multiplexed over the one socket (`dm`, `notif`, `presence`, `counter:<id>`, `feed:<id>`) | `ChannelRef`, `ChannelKey`, `ChannelClass` |
+| Subscription set | The channels a connection is subscribed to (capped) | `SubscriptionSet` |
+| Stream sequence | The per-stream monotonic token clients dedupe and re-sync from | `StreamSeq`, `SequenceState` |
+| Presence | Internal liveness (online/offline) derived from connections — not a product stream | `PresenceState` |
+| Targeted vs broadcast | Fan-out that names a *recipient user* vs one that names an *entity* | (dispatcher modes) |
+| Node / registry | A gateway instance and the `user → node` routing map | `ConnectionRegistry` port |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Connection` | aggregate root | Lifecycle + the bounded send queue / shed discipline for one socket |
+| `Session` | entity | The pinned identity authenticated at handshake |
+| `SubscriptionSet` | VO | Channel subscriptions, capped (`RTM-3002`) and scope-checked |
+| `SequenceState` / `StreamSeq` | VO | Monotonic per-stream sequencing for client-side dedupe + re-sync |
+| `ChannelRef` / `ChannelKey` / `ChannelClass` | VO | A channel's identity and its ownership scope |
+| `PresenceState` / `ConnectionState` / `CloseReason` / `DeliveryGuarantee` | enum | The closed lifecycle + delivery vocabulary |
+
+**Connection lifecycle:**
+
+```
+handshake (verify token → bind Session) --> Active --(subscribe within scope)--> delivering
+     │ heartbeat timeout / shed / drain                                              │
+     ▼                                                                               ▼
+   Closed  ◄──────────────── reconnect (jittered backoff) ◄──── drain (control frame) ┘
+```
+
+> **Legal transitions only.** A connection may subscribe only to channels scoped to its pinned
+> identity (Alice → `dm:alice`, never `dm:bob`) — else `RTM-3001`. A slow consumer is **shed**
+> (`RTM-5001`), never buffered unboundedly.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Nothing durable. It owns only **ephemeral Redis routing state** — `presence:{user_id}` → node(s) and the node-hop Pub/Sub fabric. All of it is TTL'd and self-healing.
+
+**Everything it forwards is owned elsewhere:**
+
+| Forwarded data | Owned by | Reaches realtime via | Durability |
+|---|---|---|---|
+| Notifications / badges | `notification` | `notification.v1.events` (targeted) | `notification` persists it |
+| Engagement magnitudes | `counter` | `counter.v1.popularity` (broadcast) | `counter` holds it |
+| Post lifecycle | `post` | `post.v1.events` (broadcast) | `post` persists it |
+| Messages | `chat` | (not consumed — chat runs its own live plane, coexist-first) | `chat` persists it |
+
+**The "do-not-write" list:** realtime writes no SoR; a registry miss (recipient offline) is a
+no-op, with the locked-phone path delegated to `notification`.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | The plane stores nothing of record; a registry miss is a no-op | domain + application | (by design) |
+| I2 | Authenticate once, at the handshake; never re-verify per frame | infrastructure boundary | `RTM-1001` (handshake) |
+| I3 | The only authorization is channel-scope ownership against the pinned identity | domain | `RTM-3001` |
+| I4 | A slow consumer is shed, not buffered (bounded per-connection queue) | infrastructure | `RTM-5001` |
+| I5 | Fail-open — a lost live event is never a lost message; client re-syncs via `StreamSeq` | application | (recovery, not error) |
+| I6 | Subscriptions are capped per connection | domain | `RTM-3002` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Connection (handshake → delivery).**
+1. Client connects over WSS (`:8443`, behind an L4 LB); the edge token is verified once via `auth-context` → a `Session` is bound.
+2. The gateway writes the `user → node` registry entry and subscribes to its node channel.
+3. Client subscribes to channels within its identity scope; frames are not re-authenticated thereafter.
+
+**The internal→external bridge (three stages).**
+1. **Emit once:** a core service publishes to Kafka — no new synchronous call inward.
+2. **Resolve:** `realtime-dispatcher` (under `run_consumer`) resolves the recipient against the registry (targeted) or names a broadcast channel (entity).
+3. **Last hop:** publish to the owning node's Redis channel → the gateway hands it to the connection's bounded mailbox → socket write. Core→device = one Kafka hop + one Redis hop + one socket write.
+- **Idempotency:** fan-out is naturally idempotent; duplicate live frames are harmless (client dedupes on `StreamSeq`); an unroutable event (`RTM-8002`/`RTM-8003`) folds into `Ok`.
+
+**Two fan-out modes.** *Targeted* (notification/DM/presence) names a recipient → registry-resolve → hop to owning node(s). *Broadcast* (counter/feed) names an entity → publish once to the fleet broadcast channel → every node delivers to its local subscribers.
+
+**Degradation & reaping.** Half-open connections are reaped on heartbeat timeout (`RTM-5002`, frees FD + registry slot, flips presence offline). On node drain, stop-accept → reconnect control frame with jittered backoff (`RTM-5003`) → drain.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| end-user clients | upstream | OHS (Published Language) | the WSS multiplexed envelope `{stream_seq, channel, ack_required, payload}` | an envelope change breaks every client |
+| `auth` | dependency | Conformist (verify-only) | `auth-context` ES256 edge-token verification | new handshakes fail if token format changes |
+| `notification` | upstream + delegate | ACL | consumes `notification.v1.events`; delegates offline push | decode breaks / offline path lost |
+| `counter` | upstream | ACL | consumes `counter.v1.popularity` | broadcast decode breaks |
+| `post` | upstream | ACL | consumes `post.v1.events` | broadcast decode breaks |
+| `chat` | peer | Separate Ways (coexist) | not consumed — chat owns its own live plane | — (consolidation is a future decision) |
+
+> **Anti-Corruption Layer:** `infrastructure/decode.rs` maps each upstream wire event into the
+> internal `DeliverableEvent`; the opaque payload is forwarded, never interpreted.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+> Realtime **publishes nothing of record**. Presence, if surfaced, is internal liveness only — not a
+> System-of-Record stream.
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| — (none of record) | realtime asserts no durable business facts | — | — |
+
+It consumes the facts of `notification`/`counter`/`post`; their meanings are owned by those
+contexts' `DOMAIN.md §8` and rolled up in `docs/domain/EVENT_CATALOG.md`.
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Realtime is a fail-open System-of-Connection, never a record store | [`ADR-0003`](../../../../docs/adr/0003-realtime-is-a-fail-open-system-of-connection.md) | Accepted |
+| Coexist-first with `chat`'s live plane (do not consume `chat.message.sent` yet) | _see ADR-0003 consequences_ | Accepted |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — it makes the product *feel* live but owns no truth; the value lives in the SoRs. Investment goes to the bespoke C10M edge, not to data ownership.
+- **Volatility:** low-to-medium — new fan-out sources (channels) are additive; the connection model and envelope are stable.
+- **Known modeling debt:** `SIGTERM` → `broadcast_drain` runtime wiring is not yet connected; the internal-gRPC `NodeChannel` backpressure variant is unbuilt (Redis Pub/Sub fabric is the v1).
+- **Deferred capabilities:** WebTransport/HTTP-3 transport lane; presence as a product-facing stream; cross-region / multi-PoP routing; the `chat` + `notification` client-streaming consolidation (the seam — reducing them to event producers — is left open).

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -43,25 +43,25 @@ The 17 services. Each link will resolve once that service's `docs/DOMAIN.md` lan
 rollout in the strategy). Tier drives depth: TIER-0/1 get the full DEEP sections; TIER-2 keeps
 CORE plus collapsed one-line DEEP sections.
 
-| Service | Bounded context | `DOMAIN.md` |
-|---|---|---|
-| `account` | Account / identity SoR | `crates/services/account/docs/DOMAIN.md` |
-| `audit` | Tamper-evident compliance evidence | `crates/services/audit/docs/DOMAIN.md` |
-| `auth` | Issuance / session / IdP broker | `crates/services/auth/docs/DOMAIN.md` |
-| `chat` | Conversations & messaging | `crates/services/chat/docs/DOMAIN.md` |
-| `comment` | Comment threads | `crates/services/comment/docs/DOMAIN.md` |
-| `counter` | Counter / analytics SoReference | `crates/services/counter/docs/DOMAIN.md` |
-| `engagement` | Reactions & edge state | `crates/services/engagement/docs/DOMAIN.md` |
-| `geo-discovery` | Geo-spatial discovery | `crates/services/geo-discovery/docs/DOMAIN.md` |
-| `media` | Media control plane | `crates/services/media/docs/DOMAIN.md` |
-| `moderation` | Trust & safety decisions | `crates/services/moderation/docs/DOMAIN.md` |
-| `notification` | Notification activity feed | `crates/services/notification/docs/DOMAIN.md` |
-| `post` | Content / posts | `crates/services/post/docs/DOMAIN.md` |
-| `profile` | Public personas | `crates/services/profile/docs/DOMAIN.md` |
-| `realtime` | Connection / delivery plane | `crates/services/realtime/docs/DOMAIN.md` |
-| `search` | Discovery read-model | `crates/services/search/docs/DOMAIN.md` |
-| `social-graph` | Follower / following relations | `crates/services/social-graph/docs/DOMAIN.md` |
-| `timeline` | Timeline fan-out | `crates/services/timeline/docs/DOMAIN.md` |
+| Service | Bounded context | `DOMAIN.md` | Status |
+|---|---|---|---|
+| `account` | Account / identity SoR | `crates/services/account/docs/DOMAIN.md` | ⬜ |
+| `audit` | Tamper-evident compliance evidence | [`crates/services/audit/docs/DOMAIN.md`](../../crates/services/audit/docs/DOMAIN.md) | ✅ |
+| `auth` | Issuance / session / IdP broker | `crates/services/auth/docs/DOMAIN.md` | ⬜ |
+| `chat` | Conversations & messaging | `crates/services/chat/docs/DOMAIN.md` | ⬜ |
+| `comment` | Comment threads | `crates/services/comment/docs/DOMAIN.md` | ⬜ |
+| `counter` | Counter / analytics SoReference | `crates/services/counter/docs/DOMAIN.md` | ⬜ |
+| `engagement` | Reactions & edge state | `crates/services/engagement/docs/DOMAIN.md` | ⬜ |
+| `geo-discovery` | Geo-spatial discovery | `crates/services/geo-discovery/docs/DOMAIN.md` | ⬜ |
+| `media` | Media control plane | `crates/services/media/docs/DOMAIN.md` | ⬜ |
+| `moderation` | Trust & safety decisions | [`crates/services/moderation/docs/DOMAIN.md`](../../crates/services/moderation/docs/DOMAIN.md) | ✅ |
+| `notification` | Notification activity feed | `crates/services/notification/docs/DOMAIN.md` | ⬜ |
+| `post` | Content / posts | `crates/services/post/docs/DOMAIN.md` | ⬜ |
+| `profile` | Public personas | `crates/services/profile/docs/DOMAIN.md` | ⬜ |
+| `realtime` | Connection / delivery plane | [`crates/services/realtime/docs/DOMAIN.md`](../../crates/services/realtime/docs/DOMAIN.md) | ✅ |
+| `search` | Discovery read-model | `crates/services/search/docs/DOMAIN.md` | ⬜ |
+| `social-graph` | Follower / following relations | `crates/services/social-graph/docs/DOMAIN.md` | ⬜ |
+| `timeline` | Timeline fan-out | `crates/services/timeline/docs/DOMAIN.md` | ⬜ |
 
 ## Authoring
 


### PR DESCRIPTION
## Why

Rollout phase 1 of the functional-documentation effort (#490): author the first per-service `DOMAIN.md` contracts. These three TIER-0/1 services are the natural exemplars — their keystone ADRs (0001–0003) already exist.

## What

Three `crates/services/<svc>/docs/DOMAIN.md`, written from the [DOMAIN template](https://github.com/arnaudmaillet/core-platform/blob/develop/docs/templates/DOMAIN.template.md) and grounded in each crate's **actual** domain types, `error.rs` namespaces, and event contracts — not the quarantined C4.

| Service | Context | Class / Tier | Aggregates documented | ADR |
|---|---|---|---|---|
| `audit` | Compliance Evidence | Supporting / TIER-0 | `AuditRecord`, `ChainLink/Head`, `MerkleCheckpoint`, `PiiEnvelope` | [0001](https://github.com/arnaudmaillet/core-platform/blob/develop/docs/adr/0001-audit-is-a-separate-evidence-plane.md) |
| `moderation` | Trust, Safety & Integrity | Core / TIER-0 | `Case`, `Decision`, `EnforcementAction`, `Appeal`, `PenaltyLedger` | [0002](https://github.com/arnaudmaillet/core-platform/blob/develop/docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) |
| `realtime` | Live Delivery (System-of-Connection) | Supporting / TIER-1 | `Connection`, `Session`, `SubscriptionSet`, `SequenceState` | [0003](https://github.com/arnaudmaillet/core-platform/blob/develop/docs/adr/0003-realtime-is-a-fail-open-system-of-connection.md) |

Each fills both CORE and DEEP sections (all three are TIER-0/1): bounded-context purpose + non-goals, ubiquitous language (with code symbols), domain model + lifecycle, **data ownership + the do-not-write list**, invariants mapped to enforcement layer + error code, workflows (inline — no C4 link until it's regenerated), context relationships tagged with DDD patterns (ACL / OHS / Conformist / Customer-Supplier), event semantics, and decision links.

`docs/domain/README.md` index updated to link the three and mark status (✅ × 3, ⬜ × 14).

## Scope boundary respected

These docs own *meaning* — they do **not** restate the README (ports/env/runbook) or the proto (wire schema). Workflow sections describe flows inline and deliberately avoid linking `docs/_legacy/`.

## Verification

- All relative ADR links from each `DOMAIN.md` resolve (checked).
- i18n drift gate: **PASS** (French mirrors + gate extension to `DOMAIN.*.md` remain the governance-phase task).

## Follow-ups

- Remaining 14 services (rollout phases 1–2).
- Extend the i18n gate to `DOMAIN.*.md` + add `DOMAIN.fr.md` mirrors.
- Populate `docs/domain/CONTEXT_MAP.md` / `EVENT_CATALOG.md` from these Domain Cards + the topology guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)