### PR TITLE
docs(domain): author DOMAIN.md for the remaining 14 services (17/17)

### DIFF
--- a/crates/services/account/docs/DOMAIN.md
+++ b/crates/services/account/docs/DOMAIN.md
@@ -1,0 +1,158 @@
+# `account` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Account / Identity — the user account system of record |
+> | **Subdomain class** | **Supporting** — identity lifecycle is necessary infrastructure, not a user-facing differentiator; bespoke because it carries the platform's PII + GDPR obligations |
+> | **System of …** | **Record** for account existence, credentials metadata, KYC, roles, and GDPR state |
+> | **Aggregate root(s)** | `Account` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Fail-closed** — account writes are authoritative; a lifecycle write must durably commit |
+> | **Upstream contexts** | `auth` (federated IdP subject link), internal ops/registration flows |
+> | **Downstream contexts** | `audit` (compliance), `profile` (persona over the account) — via **Open-Host Service / Published Language** (`account.v1.events`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `account` is the authority for **the user account**: it answers
+**"does this account exist, what is its lifecycle state, role, and KYC status, and what is the
+lawful state of its personal data?"**
+
+**The hard problem.** Owning PII as the system of record while honouring GDPR — erasure, export,
+rectification — without other services holding shadow copies of identity that erasure can't reach.
+Account is the *one* place a real identity lives; everyone else holds derived, non-authoritative
+references.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Authenticate / issue sessions or tokens → owned by `auth`.
+- ❌ Hold the public persona (handle, bio, avatar) → owned by `profile`.
+- ❌ Verify tokens → that's the `auth-context` library.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Account | The authoritative user account record | `Account`, `AccountId` |
+| Identity id | The stable cross-system subject identifier | `IdentityId` |
+| Credential metadata | Password hash, MFA enrolment, recovery codes — *metadata*, not auth flow | `PasswordHash`, `MfaState`, `RecoveryCodeHash` |
+| KYC status | Know-your-customer verification state | `KycStatus`, `KycStatusChanged` |
+| Role | Authorization role assigned to the account | `AccountRole`, `RoleAssigned`/`RoleRevoked` |
+| GDPR record | The lawful-data-handling state (export/deletion requests) | `GdprRecord`, `GdprDeletionRequested`, `GdprDataExportRequested` |
+| Encrypted bytes | At-rest-encrypted PII fields | `EncryptedBytes` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Account` | aggregate root | Lifecycle state machine + uniqueness of email/identity |
+| `EmailAddress` / `PhoneNumber` / `CountryCode` | VO | Validity enforced at construction |
+| `PasswordHash` / `MfaState` / `RecoveryCodeHash` | VO | Credential metadata integrity |
+| `GdprRecord` | VO | Erasure/export request state |
+| `AccountStatus` / `AccountRole` / `KycStatus` | enum | Closed lifecycle / authorization / verification vocabularies |
+
+**Lifecycle:**
+
+```
+created --> activated --(suspend)--> suspended --(reactivate)--> activated
+   │            │                                                   │
+   │            └--(deactivate)--> deactivated                      │
+   └────────────────────────── gdpr_deletion_requested ──> deleted (PII erased)
+```
+
+> **Legal transitions only.** Email/phone changes are events, not silent mutations; a GDPR deletion
+> is terminal and triggers downstream crypto-shred in `audit`.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Account records, credentials metadata, roles, KYC, and GDPR state — **Postgres** db `account`. No other service writes these.
+
+**This context holds copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| IdP subject link | `auth` / federated IdP | `auth` linking flow | at link time |
+
+**The "do-not-write" list:** account never issues tokens, never writes profile presentation data,
+and never stores another service's projection.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Email/identity uniqueness | domain + Postgres unique constraint | `ACC-1xxx` |
+| I2 | PII at rest is encrypted (`EncryptedBytes`) | infrastructure | — |
+| I3 | A lifecycle change emits an event (no silent state change) | domain (after-save publish) | — |
+| I4 | GDPR deletion is terminal and propagates erasure downstream | application | `ACC-1xxx` |
+| I5 | Roles are explicit grants/revocations, audited | domain | `ACC-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Registration / lifecycle.** A create/activate/suspend/deactivate command mutates the `Account`
+aggregate, persists to Postgres, and publishes the corresponding `account.v1.events` variant
+**after** the save (the EventPublisher port → Kafka).
+
+**GDPR erasure (Art. 17).** `gdpr_deletion_requested` → account marks the record deleted and emits
+the event; `audit` consumes it and **crypto-shreds the subject's per-subject DEK**, rendering all
+that subject's sealed PII across the fleet permanently unreadable while the chain still verifies —
+closing the erasure loop end to end.
+
+**GDPR export (Art. 15/20).** `gdpr_data_export_requested` → emitted for downstream fulfilment.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `auth` | upstream | Customer/Supplier | IdP `SubjectLink` ↔ `AccountId` | session subject resolution breaks |
+| `audit` | downstream | Published Language | `account.v1.events` (PII sealed; GDPR pair) | compliance evidence + Art. 17 loop break |
+| `profile` | downstream | Published Language | `account.v1.events` | persona provisioning breaks |
+
+> **Anti-Corruption Layer:** consumers (`audit`, `profile`) translate `account.v1.events` into their
+> own models; account exposes a stable published language and owns no consumer's schema.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event (`account.v1.events`) | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `account_created` / `email_changed` / `email_verified` / `phone_changed` | PII-bearing lifecycle facts | the corresponding command commits | `audit` (PII sealed), `profile` |
+| `password_changed` / `mfa_enrolled` / `mfa_revoked` | security facts (no PII) | credential change | `audit` (Authentication) |
+| `activated`/`deactivated`/`suspended`/`deleted`, `kyc_status_changed` | identity lifecycle | lifecycle transition | `audit` (Identity), `profile` |
+| `role_assigned` / `role_revoked` | authorization change | role grant/revoke | `audit` (Authorization) |
+| `gdpr_deletion_requested` / `gdpr_data_export_requested` | a lawful data right was invoked | user/DPO request | `audit` (`gdpr_deletion` → crypto-shred subject) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Account is the identity SoR; built its outbound event lane (was a phantom producer) so `audit`/`profile` can consume | _candidate — not yet recorded_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — invest for correctness, PII safety, and GDPR compliance; not a differentiator.
+- **Volatility:** low — driven by regulatory and IdP-integration change, not feature churn.
+- **Known modeling debt:** none material recorded.
+- **Deferred capabilities:** richer KYC workflows; export fulfilment pipeline downstream of the export event.

--- a/crates/services/auth/docs/DOMAIN.md
+++ b/crates/services/auth/docs/DOMAIN.md
@@ -1,0 +1,152 @@
+# `auth` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Authentication — session issuance, refresh, and IdP brokerage |
+> | **Subdomain class** | **Supporting** — necessary security capability; partly leans on a federated IdP (Keycloak) but the edge-token / session-generation model is bespoke |
+> | **System of …** | **Record** for sessions and refresh tokens (not for the user account — that's `account`) |
+> | **Aggregate root(s)** | `Session`, `RefreshToken` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Fail-closed** — no valid session/token, no access |
+> | **Upstream contexts** | end-user login flows; federated IdP (Keycloak); `account` (subject ↔ account link) |
+> | **Downstream contexts** | every service via the `auth-context` verify library; `realtime` (edge-token verify at handshake); `audit` (`auth.v1.events`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `auth` is the authority for **authentication state**: it answers
+**"is this caller who they claim to be right now, and is this session still valid?"** — issuing
+short-lived ES256 edge tokens and managing the refresh lifecycle.
+
+**The hard problem.** Federating an external IdP while issuing the platform's own fast,
+stateless-to-verify edge tokens — and being able to **revoke** instantly despite statelessness. The
+resolving mechanism is a monotonic per-subject `Generation` that invalidates token families.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own the user account / PII → `account` is the SoR.
+- ❌ Verify tokens in-process for every service → that's the `auth-context` library (a verify, not a call).
+- ❌ Authorize business actions → it authenticates; services authorize via permissions/`auth-context`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Session | An authenticated session of record | `Session`, `SessionId`, `SessionStatus` |
+| Refresh token | The long-lived credential that mints access tokens | `RefreshToken`, `RefreshTokenId`, `RefreshTokenHash` |
+| Access token claims | The ES256 edge-token payload | `AccessTokenClaims` |
+| Generation | Monotonic per-subject counter; bumping it revokes a token family | `Generation` |
+| IdP subject | The federated identity-provider subject id | `IdpSubject`, `SubjectLink` |
+| Device fingerprint | Per-device binding for a session | `DeviceFingerprint` |
+| Permission | An authorization grant carried in claims | `Permission` |
+| Revocation reason | Why a session/token was revoked | `RevocationReason` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Session` | aggregate root | Session validity + revocation via `Generation` |
+| `RefreshToken` | aggregate root | Token rotation; a used refresh token cannot be reused |
+| `AccessTokenClaims` | VO | The signed edge-token contract |
+| `Generation` | VO | Monotonic per-subject; the instant-revocation lever |
+| `SubjectLink` | VO | IdP subject ↔ `AccountId` binding |
+
+**Session lifecycle:**
+
+```
+issued --(refresh: rotate)--> issued' --(revoke / generation-bump / expiry)--> revoked
+```
+
+> **Legal transitions only.** A refresh token rotates (old one invalidated); a `Generation` bump
+> revokes the whole family; expired/revoked sessions never re-activate.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Sessions and refresh tokens — **Postgres** (durable) + **Redis** (hot session/revocation state). No other service writes these.
+
+**This context holds copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Account ↔ IdP subject link | `account` / IdP | linking flow | at link time |
+
+**The "do-not-write" list:** auth never mutates account state and never stores profile/business data.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | A refresh token is single-use (rotation invalidates the prior) | domain | `AUT-7xxx` |
+| I2 | A `Generation` bump revokes all tokens of that subject family | domain | (revocation) |
+| I3 | Access tokens are short-lived and ES256-signed | domain + infrastructure | verify fails downstream |
+| I4 | Revocation is fail-closed and immediate | application | — |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Issuance.** Login (federated IdP verified) → create `Session` + `RefreshToken`, mint an ES256
+access token, persist, and emit `session_issued` on `auth.v1.events`.
+
+**Refresh (rotation).** Present refresh token → validate + rotate (old invalidated) → mint a new
+access token. Reuse of a rotated token is a security signal.
+
+**Revocation.** Explicit logout, security event, or `Generation` bump → mark revoked, emit
+`session_revoked`. Verification downstream (via `auth-context`) fails closed thereafter.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| federated IdP (Keycloak) | upstream | Conformist | OIDC/credentials | login breaks |
+| `account` | peer | Customer/Supplier | `SubjectLink` ↔ `AccountId` | subject resolution breaks |
+| all services | downstream | Open-Host Service (Published Language) | ES256 edge token verified by `auth-context` | every authenticated call breaks |
+| `realtime` | downstream | Conformist (verify-only) | edge-token verify at WS handshake | new connections can't authenticate |
+| `audit` | downstream | Published Language | `auth.v1.events` | session-lifecycle evidence breaks |
+
+> **Anti-Corruption Layer:** the federated-IdP adapter translates external OIDC claims into the
+> internal `Session` / `AccessTokenClaims` model.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event (`auth.v1.events`) | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `session_issued` | An authenticated session was established | login / token issuance | `audit` (Authentication) |
+| `session_revoked` | A session was invalidated | logout / revoke / generation bump | `audit` (Authentication) |
+| `subject_linked` | An IdP subject was bound to an account | account-link flow | (internal) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Federated Keycloak credentials + bespoke ES256 edge tokens; distinct from `account` (SoR) and `auth-context` (verify lib) | _candidate — not yet recorded_ | — |
+| Instant revocation via monotonic per-subject `Generation` despite stateless tokens | _candidate — not yet recorded_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — security-critical, federates a generic IdP, bespoke only at the edge-token/session layer.
+- **Volatility:** low-to-medium — driven by security posture and IdP changes.
+- **Known modeling debt:** none material recorded.
+- **Deferred capabilities:** step-up auth flows; richer device/session management surfaces.

--- a/crates/services/chat/docs/DOMAIN.md
+++ b/crates/services/chat/docs/DOMAIN.md
@@ -1,0 +1,148 @@
+# `chat` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Conversations & Messaging |
+> | **Subdomain class** | **Core** — direct-messaging is a primary product surface; the member/audience shadowing model is bespoke |
+> | **System of …** | **Record** for conversations, membership, and messages |
+> | **Aggregate root(s)** | `Conversation`, `Message` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Fail-closed on writes** (a sent message must persist); live delivery is best-effort over its own plane |
+> | **Upstream contexts** | end-user clients (send/read); `moderation` (content gating) |
+> | **Downstream contexts** | consumers of `chat.*` events; runs its **own** live plane (coexists with `realtime`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `chat` is the authority for **conversations and messages**: it answers
+**"what was said, in which conversation, by whom, and who is allowed to see it?"**
+
+**The hard problem.** Serving both *members* (who read/write) and a broader *audience* (who may
+view a published conversation) without conflating the two visibility planes — the **Shadowing
+Pattern** (a Member plane vs an Audience plane) — and storing a high-volume message log
+cost-effectively via bucketed `(conversation_id, bucket)` partitions.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Be the generic live-delivery plane → `realtime` is that; chat runs its own live plane today (coexist-first).
+- ❌ Classify/decide on content → `moderation` decides; chat enforces gating.
+- ❌ Store media bytes → `media` owns those.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Conversation | A messaging thread with a membership and a policy | `Conversation`, `ConversationId`, `ConversationKind` |
+| Message | A single message in a conversation log | `Message`, `MessageId`, `MessageContent` |
+| Participant | A member of a conversation, with a role | `Participant`, `Role` |
+| Conversation policy | The rules governing the conversation | `ConversationPolicy` |
+| Visibility | Member-plane vs audience-plane visibility (the shadowing) | `Visibility` |
+| Content type | The kind of message content | `ContentType` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Conversation` | aggregate root | Membership + policy + publish/visibility state |
+| `Message` | aggregate root | Message integrity within a conversation bucket |
+| `Participant` / `Role` | VO/enum | Who may read/write and at what authority |
+| `ConversationPolicy` | VO | The conversation's governing rules |
+| `Visibility` / `ConversationKind` / `ContentType` | enum | Closed plane/kind/content vocabularies |
+
+**Conversation lifecycle:**
+
+```
+created --(publish)--> published --(unpublish)--> unpublished (audience plane torn down)
+   │  member join/leave                                   │
+   └──────────────── message.sent (bucketed log) ─────────┘
+```
+
+> **Legal transitions only.** Membership is checked at the gRPC boundary; an unpublish tears down
+> the audience plane via the `VisibilityWorker`; only members write.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Conversations, membership, and the message log — **ScyllaDB** (bucketed `(conversation_id, bucket)` log). No other service writes these.
+- Live routing/presence — **Redis** sharded pub/sub (`RedisSubscriber`), derived/ephemeral.
+
+**The "do-not-write" list:** chat doesn't own media bytes (references `media`), doesn't decide
+moderation, and doesn't write any other service's state.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Only members may write/read the member plane | gRPC boundary | `CHT-3xxx`/`PERMISSION_DENIED` |
+| I2 | Member plane and audience plane are kept distinct (shadowing) | domain | `CHT-2xxx` |
+| I3 | Unpublish tears down the audience plane completely | application (`VisibilityWorker`) | `CHT-4xxx` |
+| I4 | Messages are appended to the correct conversation bucket | domain | `CHT-9xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Send message.** Member-authorized send → append to the `(conversation_id, bucket)` Scylla log →
+publish `chat.message.sent` and push live over chat's own Redis sharded pub/sub plane (dual gRPC
+streaming to connected clients).
+
+**Publish / unpublish (shadowing).** Publishing a conversation opens the audience plane;
+unpublishing triggers the `VisibilityWorker` teardown, consuming `chat.conversation.unpublished`
+(DLQ `chat.conversation.unpublished.dlq`) to dismantle audience-plane state.
+
+**Membership.** Join/leave emit `chat.member.joined` / `chat.member.left`.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| clients | upstream | OHS | gRPC + dual streaming | client messaging breaks |
+| `moderation` | upstream | Customer/Supplier | content gating | gated content path breaks |
+| `realtime` | peer | Separate Ways (coexist) | — (not consumed; chat owns its live plane) | future consolidation deferred |
+| event consumers | downstream | Published Language | `chat.*` topics | downstream reactions break |
+
+> **Anti-Corruption Layer:** the Redis subscriber + visibility worker isolate the live-plane
+> mechanics from the domain.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `chat.conversation.created` / `chat.conversation.published` / `chat.conversation.unpublished` | conversation lifecycle facts | create / publish / unpublish | `VisibilityWorker`, downstream consumers |
+| `chat.member.joined` / `chat.member.left` | membership change | join/leave | downstream consumers |
+| `chat.message.sent` | a message was committed to the log | send commits | (chat live plane; **not** consumed by `realtime` yet) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Shadowing Pattern — distinct Member vs Audience visibility planes | _candidate — not yet recorded_ | — |
+| Coexist-first with `realtime` (chat keeps its own live plane for now) | _see ADR-0003 consequences_ | Accepted |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Core — messaging is a primary product surface.
+- **Volatility:** medium — conversation kinds and visibility rules evolve with product.
+- **Known modeling debt:** chat's own live plane duplicates `realtime` (the consolidation seam is deliberately open).
+- **Deferred capabilities:** consolidation onto `realtime`; richer media-in-chat; reactions.

--- a/crates/services/comment/docs/DOMAIN.md
+++ b/crates/services/comment/docs/DOMAIN.md
@@ -1,0 +1,135 @@
+# `comment` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Comments — threaded replies on posts |
+> | **Subdomain class** | **Core** — comments are primary UGC engagement |
+> | **System of …** | **Record** for comments and their lifecycle |
+> | **Aggregate root(s)** | `Comment` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-closed on writes** (a posted comment must persist) |
+> | **Upstream contexts** | end-user clients; `post` (the commented-on entity) |
+> | **Downstream contexts** | `notification`, `engagement`, `counter` — via **Published Language** (`comment.created` / `comment.deleted`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `comment` is the authority for **comments**: it answers
+**"what was commented on which post, by whom, and is it still present or removed?"**
+
+**The hard problem.** Storing a high-write comment stream with a flat-thread model cheaply, and
+distinguishing *tombstone* (visible "deleted") from *purge* (hard removal) for moderation/GDPR —
+using a **nil-UUID sentinel** for the flat tree and a two-table ScyllaDB layout (LCS for lookups +
+TWCS for the time-ordered stream).
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own the post being commented on → `post`.
+- ❌ Count comments for display → that's `counter` (magnitudes); comment emits the events.
+- ❌ Decide moderation → `moderation` decides; comment applies deletion.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Comment | A reply attached to a post | `Comment`, `CommentId` |
+| Comment body | The textual content | `CommentBody` |
+| GIF attachment | An attached GIF reference | `GifAttachment` |
+| Comment status | Active / tombstoned state | `CommentStatus` |
+| Deletion strategy | Tombstone vs purge | `DeletionStrategy` |
+| Nil-UUID sentinel | The flat-tree root marker (no parent) | (UUID nil) |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Comment` | aggregate root | Comment integrity + status transitions |
+| `CommentBody` / `GifAttachment` | VO | Content validity at construction |
+| `CommentStatus` | enum | Active → tombstoned legality |
+| `DeletionStrategy` | enum | Tombstone (visible) vs purge (hard) |
+| `PostId` / `ProfileId` | VO | The commented-on entity and author references |
+
+**Lifecycle:**
+
+```
+created --(delete: tombstone)--> tombstoned   |   created --(delete: purge)--> purged (hard removed)
+```
+
+> **Legal transitions only.** Deletion strategy is explicit; a tombstone preserves the slot, a
+> purge removes the row (moderation/GDPR).
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Comments — **ScyllaDB** two-table (LCS lookups + TWCS stream). No other service writes them.
+
+**The "do-not-write" list:** comment never writes post state or comment *counts* (those are derived
+in `counter` from comment's events).
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | A comment references a valid post + author | domain | `CMT-1xxx` |
+| I2 | Tombstone vs purge is an explicit, irreversible choice | domain | `CMT-1xxx` |
+| I3 | Flat-tree uses the nil-UUID sentinel for rootless comments | domain | `CMT-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Create.** Authorized create → write to both Scylla tables → publish `comment.created` (consumed by
+`notification`, `engagement`/`counter` for counts).
+
+**Delete.** Tombstone (visible deleted marker) or purge (hard removal for moderation/GDPR) → publish
+`comment.deleted`.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `post` | upstream | Customer/Supplier | references `PostId` | orphaned comments if post semantics change |
+| `notification` | downstream | Published Language | `comment.created` | reply notifications break |
+| `engagement` / `counter` | downstream | Published Language | `comment.created` / `comment.deleted` | comment counts break |
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `comment.created` | a comment was posted on a post | create commits | `notification` (notify author), `counter`/`engagement` (count++) |
+| `comment.deleted` | a comment was tombstoned or purged | delete commits | `counter`/`engagement` (count--), feeds |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Nil-UUID sentinel flat-tree + two-table (LCS+TWCS) Scylla layout | _candidate — not yet recorded_ | — |
+| Tombstone vs purge deletion semantics | _candidate — not yet recorded_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Core — comments are primary UGC.
+- **Volatility:** low-to-medium.
+- **Known modeling debt:** flat-thread only (no nested threading).
+- **Deferred capabilities:** nested threads; richer attachments.

--- a/crates/services/counter/docs/DOMAIN.md
+++ b/crates/services/counter/docs/DOMAIN.md
@@ -1,0 +1,148 @@
+# `counter` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Counter / Analytics — magnitudes ("how many?") |
+> | **Subdomain class** | **Supporting** — a derived measurement plane; valuable but not the product's value origin |
+> | **System of …** | **Reference (SoRef)** for counts/cardinalities/trends — exact-but-reconcilable, never edge state ("who?") |
+> | **Aggregate root(s)** | `Metric` + `WindowAggregator` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-open** — a read degrades to a stale/approximate magnitude, never an error on the hot path |
+> | **Upstream contexts** | view/impression/click producers, `engagement` (reactions) — via **ACL** over Kafka |
+> | **Downstream contexts** | `search` (PopularityScore), `realtime` (broadcast) — via **Published Language** (`counter.v1.popularity`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `counter` is the authority for **magnitudes**: it answers
+**"how many views / likes / followers / trending rank does this entity have?"** — never *who* did
+what (that is edge state, owned elsewhere).
+
+**The hard problem.** Counting a firehose at write-volume without losing accuracy or melting the
+hot path: pure-Kafka ingest with windowed N→1 pre-aggregation, two-stage sharded counters, a
+3-tier store (Redis hot / Postgres warm-SoRef + reconciliation / Scylla TWCS cold), HLL for unique
+views and CMS for trending, exact-but-reconcilable for likes/follows.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Hold edge state (who liked/followed whom) → `engagement` / `social-graph`.
+- ❌ Be a System of Record → it is a reconcilable System of *Reference*.
+- ❌ Serve raw event analytics → it serves aggregated magnitudes.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Metric | A counted quantity with a kind + aggregation | `Metric`, `MetricKind`, `Aggregation` |
+| Window | The idempotency linchpin — a bounded aggregation interval | `WindowId`, `WindowKey`, `WindowSize`, `WindowAggregator` |
+| Observation / delta | A single signal / the folded change to apply | `Observation`, `WindowDelta` |
+| Cardinality | Approximate unique count (HLL) | `Cardinality` |
+| Popularity score | The published engagement magnitude + weights | `PopularityScore`, `PopularityWeights` |
+| Trending | CMS-backed ranked items within a scope | `TrendingItem`, `TrendingScope`, `TrendingQuery` |
+| Time-series bucket | A cold-tier TWCS time bucket | `TimeSeriesBucket`, `TimeGranularity` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Metric` | aggregate root | Orthogonal `MetricKind` (exact/approx) × `Aggregation` (sum/cardinality) |
+| `WindowAggregator` | aggregate root | N→1 fold; `WindowId` makes flushes idempotent |
+| `CounterValue` / `CountSnapshot` / `Cardinality` | VO | A magnitude / point-in-time snapshot / HLL estimate |
+| `PopularityScore` / `PopularityWeights` | VO | The published popularity signal |
+| `EntityRef` / `EntityId` / `EntityKind` | VO | What is being counted |
+
+> **`WindowId` is the linchpin.** It gates all-tier side effects (the delta ledger), so a replayed
+> flush cannot double-count.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth (of *reference*) for:**
+- Magnitudes — **Redis** (hot) + **Postgres** (warm SoRef + reconciliation ledger) + **ScyllaDB** (cold TWCS time-series). Reconcilable against the owning edge SoRs.
+
+**This context holds derived copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Follower/following truth | `social-graph` | reconciliation source (gRPC) | reconciled periodically (drift → `CTR-5002`) |
+| Reaction edge state | `engagement` | `engagement.*` events | eventually consistent |
+
+**The "do-not-write" list:** counter never owns *who* — it derives magnitudes and reconciles to the
+edge SoRs; it supersedes engagement's *raw* view/share counts only.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | A flush is idempotent per `WindowId` (no double-count on replay) | domain + Pg ledger CTE | `CTR-2xxx` |
+| I2 | Magnitudes never claim edge identity ("who") | domain | — |
+| I3 | Hot reads fail open (hard timeout → stale/approx) | application | `CTR-4xxx` |
+| I4 | Reference values reconcile to the owning SoR; drift alarms | application | `CTR-5002` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Ingest → aggregate → flush.** Signals stream in (`view.v1.events`, `impression.v1.events`,
+`click.v1.events`, engagement) → `WindowAggregator` folds N→1 → `DeltaFlusher` writes idempotently
+(gated by the `WindowId` ledger) across the 3 tiers → `PopularityPublisher` emits
+`counter.v1.popularity`.
+
+**Read (fail-open).** Hot reads hit Redis with a hard `tokio::timeout`; on miss/timeout return a
+stale/approximate value rather than erroring.
+
+**Reconcile.** A `Reconciler` periodically heals magnitudes against the owning SoR
+(`set_total`/overwrite); divergence raises `CTR-5002`.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| view/impression/click producers | upstream | ACL | `*.v1.events` | counts stop advancing |
+| `engagement` | upstream | ACL | reaction events | like/share magnitudes break |
+| `social-graph` | reconcile source | Customer/Supplier | gRPC follower/following | follower-count reconciliation breaks |
+| `search` | downstream | Published Language | `counter.v1.popularity` | search's PopularityScore goes stale |
+| `realtime` | downstream | Published Language | `counter.v1.popularity` (broadcast) | live counters stop |
+
+> **Anti-Corruption Layer:** the pure `decode` layer maps each upstream signal wire shape into
+> `Observation`.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `counter.v1.popularity` | an entity's popularity magnitude changed | a window flush updates a popularity score | `search` (ranking), `realtime` (live broadcast) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Magnitudes ("how many") are a separate reconcilable SoRef, distinct from edge state ("who"); supersedes engagement's raw counts | _candidate — not yet recorded_ | — |
+| `WindowId`-gated idempotent flush across a 3-tier store | _candidate — not yet recorded_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — a measurement/reference plane derived from the edge SoRs.
+- **Volatility:** medium — new metric kinds and producers are additive.
+- **Known modeling debt:** like/share/comment reconcile awaits an engagement reaction-count RPC.
+- **Deferred capabilities:** upstream view/impression/click producers; the `social-graph.follows` stream; shard-fan-out producer.

--- a/crates/services/engagement/docs/DOMAIN.md
+++ b/crates/services/engagement/docs/DOMAIN.md
@@ -1,0 +1,133 @@
+# `engagement` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Engagement — reactions and their edge state / scoring |
+> | **Subdomain class** | **Core** — direct user interaction with content; the reaction edge is product fabric |
+> | **System of …** | **Record** for reaction edge state ("who reacted, how"); magnitudes are superseded by `counter` |
+> | **Aggregate root(s)** | `Reaction` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-open-ish** — Redis-primary with Lua atomicity, Kafka write-behind |
+> | **Upstream contexts** | end-user clients; `comment` (counts) |
+> | **Downstream contexts** | `counter` (magnitudes), `notification`, `geo-discovery` (score) — via **Published Language** |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `engagement` is the authority for **reactions**: it answers
+**"who reacted to this content, with what reaction, and what is the weighted engagement score?"**
+
+**The hard problem.** Applying high-frequency, idempotent reaction toggles atomically at the hot
+path — **Redis-primary with Lua atomicity** — while durably recording the edge via **Kafka
+write-behind**, without a per-toggle database round-trip.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Serve display *counts* → `counter` owns magnitudes; engagement emits the edge events.
+- ❌ Own the content reacted to → `post` / `comment`.
+- ❌ Own raw view/share counters → superseded by `counter`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Reaction | A user's reaction edge on a content item | `Reaction`, `ReactionKind` |
+| Reaction weight | The score weight of a reaction kind | `ReactionWeight` |
+| Upsert / remove | Idempotent set/clear of a reaction | `ReactionUpsertedEvent`, `ReactionRemovedEvent` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Reaction` | aggregate root | One reaction edge per (user, content); idempotent toggle |
+| `ReactionKind` | enum | Closed reaction vocabulary |
+| `ReactionWeight` | VO | Scoring contribution per kind |
+| `PostId` / `ProfileId` | VO | The reacted-on content + reactor |
+
+**Lifecycle:**
+
+```
+(none) --(react)--> upserted --(react again, same kind)--> idempotent --(unreact)--> removed
+```
+
+> **Legal transitions only.** Re-applying the same reaction is idempotent (Lua-atomic in Redis); the
+> edge is the truth, the score is derived.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Reaction edge state — **Redis** (primary, Lua-atomic) with **ScyllaDB** durable write-behind.
+
+**The "do-not-write" list:** engagement does not write display counts (emits events; `counter`
+aggregates), and does not own the content.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | One reaction edge per (user, content); toggles are idempotent | domain + Lua-atomic in Redis | `ENG-2xxx` |
+| I2 | The edge is authoritative; the score is derived from weights | domain | `ENG-3xxx` |
+| I3 | Durable record via Kafka write-behind (no per-toggle DB round-trip) | application | `ENG-5xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**React / unreact.** A Lua script atomically sets/clears the reaction edge and updates the
+in-Redis score; a `ReactionUpsertedEvent` / `ReactionRemovedEvent` is emitted (Kafka write-behind)
+for durable recording and downstream consumption.
+
+**Score propagation.** `engagement.score_updated` carries the weighted score to consumers
+(`geo-discovery` virality, `counter`).
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `comment` | upstream | ACL | `comment.created` / `comment.deleted` | comment-driven counts break |
+| `counter` | downstream | Published Language | reaction events | like/reaction magnitudes break |
+| `notification` | downstream | Published Language | `engagement.reactions` | reaction notifications break |
+| `geo-discovery` | downstream | Published Language | `engagement.score_updated` | virality scoring breaks |
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `engagement.reactions` (`ReactionUpserted`/`Removed`) | a reaction edge was set/cleared | react/unreact commits | `notification`, `counter` |
+| `engagement.score_updated` | the weighted engagement score changed | score recompute | `geo-discovery`, `counter` |
+| `engagement.post_reactions` / `post_interaction_counters` | per-post reaction/interaction rollups | aggregation | downstream consumers |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Redis-primary Lua-atomic reactions + Kafka write-behind durability | _candidate — not yet recorded_ | — |
+| Engagement keeps the reaction *edge*; `counter` supersedes raw magnitudes | _see counter §4_ | Accepted |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Core — direct content interaction.
+- **Volatility:** low-to-medium — new reaction kinds are additive.
+- **Known modeling debt:** a reaction-count RPC for `counter` reconciliation is not yet exposed.
+- **Deferred capabilities:** richer reaction analytics; per-kind scoring tuning.

--- a/crates/services/geo-discovery/docs/DOMAIN.md
+++ b/crates/services/geo-discovery/docs/DOMAIN.md
@@ -1,0 +1,140 @@
+# `geo-discovery` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Geo Discovery — spatial discovery of posts on a map |
+> | **Subdomain class** | **Supporting** — a derived spatial read-model; product-distinctive surface but owns no truth |
+> | **System of …** | **Reference (SoRef)** — a queryable spatial index over posts, rebuildable from upstream |
+> | **Aggregate root(s)** | `MapPostCard` (projection) keyed by `H3Index` |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-open** — a degraded index returns fewer/staler cards, never an error |
+> | **Upstream contexts** | `post` (published posts w/ location), `engagement` (virality), `profile`/`social-graph` (author tier) — via **ACL** |
+> | **Downstream contexts** | clients (map viewport queries); publishes none of record |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `geo-discovery` is the authority for **spatial discovery**: it answers
+**"what are the most relevant posts visible in this map viewport right now?"**
+
+**The hard problem.** Serving viewport queries at interactive latency over a constantly-changing
+post population — an **H3 `grid_disk` viewport** mapped to a dual-layer Redis structure (ZSET +
+cardinality), with Lua Top-K / XX / prune scripts and TTL'd retention so the index self-trims.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own posts → `post` is the SoR; geo holds a spatial projection.
+- ❌ Compute engagement scores → consumes them from `engagement`.
+- ❌ Own author tier → consumes `profile.tier_changed`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Map post card | The projected, map-renderable summary of a post | `MapPostCard` |
+| H3 index / resolution | The hexagonal spatial cell id and its resolution | `H3Index`, `H3Resolution` |
+| Geo coordinate | A lat/lng point | `GeoCoordinate` |
+| Virality score | The engagement-derived ranking weight | `ViralityScore` |
+| Author tier | The author's tier (affects ranking/visibility) | `AuthorTier` |
+| Retention TTL | How long a card stays in the spatial index | `RetentionTtl` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `MapPostCard` | projection (aggregate) | The map-renderable post summary in a cell |
+| `H3Index` / `H3Resolution` | VO | Spatial cell identity + zoom granularity |
+| `GeoCoordinate` | VO | Valid lat/lng at construction |
+| `ViralityScore` / `AuthorTier` | VO/enum | Ranking inputs |
+| `RetentionTtl` | VO | Self-trimming lifetime |
+
+> **Invariant.** A card lives in exactly the H3 cell(s) for its coordinate; ranking within a cell is
+> Top-K by virality, pruned and TTL'd.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth (of *reference*) for:**
+- The spatial index — **Redis** (ZSET + cardinality dual-layer) + **ScyllaDB** (`map_post_cards`). Rebuildable from upstream events.
+
+**This context holds derived copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Post content/location | `post` | `post.published` / `post.deleted` | eventually consistent |
+| Virality | `engagement` | `engagement.score_updated` | eventually consistent |
+| Author tier | `profile` | `profile.tier_changed` | eventually consistent |
+
+**The "do-not-write" list:** geo never mutates posts, scores, or tiers — it indexes them.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | A card is indexed in the correct H3 cell for its coordinate | domain | `GEO-1xxx` |
+| I2 | Within a cell, results are Top-K by virality, pruned + TTL'd | domain (Lua) | `GEO-2xxx` |
+| I3 | Viewport queries fail open (degrade, never error) | application | `GEO-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Index maintenance.** Consume `post.published` (add card), `post.deleted` (remove),
+`engagement.score_updated` (re-rank), `profile.tier_changed` (re-weight) → update the dual-layer
+Redis ZSET via Lua Top-K/XX/prune; TTL handles retention.
+
+**Viewport query.** A map viewport → `H3 grid_disk` of covering cells → merge Top-K per cell →
+return `MapPostCard`s. A degraded index returns fewer/staler cards (fail-open).
+
+> **Known payload gap:** `post` currently emits no lat/lng/caption on `post.published`, so the geo
+> projection depends on a product decision to enrich the post event (recorded in the pre-infra audit).
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `post` | upstream | ACL | `post.published` / `post.deleted` | cards stop appearing/clearing |
+| `engagement` | upstream | ACL | `engagement.score_updated` | ranking goes stale |
+| `profile` | upstream | ACL | `profile.tier_changed` | tier weighting breaks |
+| clients | downstream | OHS | viewport gRPC query | map discovery breaks |
+
+> **Anti-Corruption Layer:** the consumers translate each upstream event into `MapPostCard` updates.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+> Publishes **none of record** — it is a read-model. It consumes the facts of `post` / `engagement`
+> / `profile`; their meanings are owned by those contexts.
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| H3 grid_disk viewport + dual-layer Redis (ZSET+cardinality) Top-K spatial index | _candidate — not yet recorded_ | — |
+| Post→geo payload enrichment (lat/lng/caption) needs a product decision | _open — see pre-infra audit_ | Open |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — a distinctive but derived spatial projection.
+- **Volatility:** medium — ranking inputs evolve.
+- **Known modeling debt:** the post→geo payload gap (no lat/lng/caption emitted upstream).
+- **Deferred capabilities:** richer spatial queries; clustering; heatmaps.

--- a/crates/services/media/docs/DOMAIN.md
+++ b/crates/services/media/docs/DOMAIN.md
@@ -1,0 +1,149 @@
+# `media` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Media — asset lifecycle control plane + delivery brokerage |
+> | **Subdomain class** | **Supporting** — necessary media handling; bespoke pipeline, but not the product's value origin |
+> | **System of …** | **Record** for asset *metadata/lifecycle* (the bytes live in object storage, not here) |
+> | **Aggregate root(s)** | `Asset` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Mixed** — *fail-open* delivery resolution; *fail-closed* CSAM `Screen` before an asset goes ready |
+> | **Upstream contexts** | clients (upload tickets); `moderation` (Screen + takedown) |
+> | **Downstream contexts** | `post`, `profile`, `search` — via **Published Language** (`media.v1.events`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `media` is the authority for **the media asset lifecycle**: it answers
+**"is this asset uploaded, screened, transformed, and safe to deliver — and where from?"**
+
+**The hard problem.** Handling large binaries without ever putting bytes on gRPC/Kafka: a
+three-plane design — (A) an upload broker issuing **pre-signed direct-to-object-store** tickets, (B)
+an async Kafka transform pipeline, (C) a delivery-resolution/CDN brokerage — with a **fail-closed
+CSAM Screen** gating readiness.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Move bytes through gRPC/Kafka → uploads go direct to object storage via pre-signed URLs.
+- ❌ Decide moderation policy → `moderation` decides; media enforces Screen/takedown.
+- ❌ Own where the asset is *used* → `post` / `profile` reference it.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Asset | A media asset and its lifecycle | `Asset`, `AssetId`, `AssetState` |
+| Upload ticket | A pre-signed direct-to-store upload grant | `UploadTicket`, `ReserveParams`, `UploadConstraints` |
+| Rendition | A derived variant (size/format) of an asset | `Rendition`, `RenditionKind` |
+| Content hash | The dedup/identity hash of the bytes | `ContentHash` |
+| Storage key | The object-store location | `StorageKey` |
+| Blurhash / dimensions | Perceptual placeholder + size metadata | `Blurhash`, `Dimensions` |
+| Delivery visibility | Whether/how an asset may be served | `DeliveryVisibility` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Asset` | aggregate root | The asset lifecycle state machine |
+| `UploadTicket` / `ReserveParams` / `UploadConstraints` | VO | A bounded, pre-signed upload grant |
+| `Rendition` / `RenditionKind` | VO/enum | Derived variants |
+| `ContentHash` / `StorageKey` / `MimeType` / `Dimensions` / `Blurhash` | VO | Byte identity + placement + metadata |
+| `MediaKind` / `AssetState` / `DeliveryVisibility` | enum | Closed kind/state/delivery vocabularies |
+
+**Asset lifecycle:**
+
+```
+reserved --(upload+finalize)--> uploaded --(Screen: fail-closed)--> ready --(variant)--> variant_ready
+   │                                  │                                │
+   │                                  └--(Screen fail)--> quarantined  └--(takedown)--> deleted --(restore)--> ready
+   └--(timeout)--> failed
+```
+
+> **Legal transitions only.** An asset cannot reach `ready` without passing the CSAM `Screen`; a
+> takedown quarantines/deletes; restore is explicit.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Asset metadata/lifecycle — **Postgres** (asset doc, JSONB) + **Redis** (cache). The **bytes** live in **S3/MinIO** (object store), referenced by `StorageKey` — media owns the control plane, not a bytes-in-database copy.
+
+**The "do-not-write" list:** media never decides moderation policy and never owns where an asset is
+embedded (`post`/`profile` reference it).
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Bytes never traverse gRPC/Kafka — only pre-signed direct-to-store | infrastructure | `MED-1xxx` |
+| I2 | An asset reaches `ready` only after a passing CSAM `Screen` (fail-closed) | application | `MED-7xxx` |
+| I3 | A moderation takedown quarantines/deletes the asset | application (consumer) | `MED-6xxx` |
+| I4 | Delivery resolution fails open (degrade, never block) | application | `MED-5xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Plane A — upload broker.** Client requests an `UploadTicket` → media reserves an `Asset` + issues
+a pre-signed URL → client uploads **direct to object storage** → finalize.
+
+**Plane B — transform (async).** On `media.v1.events` (uploaded) the processor probes the image,
+runs the **fail-closed CSAM Screen** (gRPC to `moderation`, hard timeout), generates renditions +
+blurhash, and transitions the asset to `ready` (or `quarantined`).
+
+**Plane C — delivery (fail-open).** Resolve an asset → CDN URL (CloudFront brokerage). A
+`moderation` takedown consumer quarantines/deletes on demand.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| clients | upstream | OHS | pre-signed upload tickets | uploads break |
+| `moderation` | upstream | Customer/Supplier (sync) + ACL | `Screen` gRPC + takedown consumer | readiness gating / takedowns break |
+| `post` / `profile` / `search` | downstream | Published Language | `media.v1.events` | embeds/indexing break |
+
+> **Anti-Corruption Layer:** the object-store + CDN adapters isolate the byte plane; the moderation
+> takedown decode maps foreign events to asset transitions.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event (`media.v1.events`) | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `asset_uploaded` | bytes landed in the store | finalize | the transform pipeline (Plane B) |
+| `asset_ready` / `asset_variant_ready` | the asset (or a variant) is safe to deliver | Screen passes / rendition done | `post`, `profile`, `search` |
+| `asset_quarantined` / `asset_deleted` / `asset_restored` | safety/lifecycle transitions | Screen fail / takedown / restore | embeds, delivery |
+| `asset_failed` | processing failed | timeout/error | upload UX |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Byte-free control plane — pre-signed direct-to-store uploads, bytes never on gRPC/Kafka | _candidate — not yet recorded_ | — |
+| Fail-open delivery / fail-closed CSAM Screen split | _candidate — not yet recorded_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — necessary media plumbing; bespoke pipeline.
+- **Volatility:** medium — new media kinds/renditions are additive.
+- **Known modeling debt:** images-first; video transcoding deferred.
+- **Deferred capabilities:** video transcoding, real malware sidecar, orphan-GC consumer, WebP/AVIF, CloudFront invalidation, dedup-refcount GDPR purge.

--- a/crates/services/notification/docs/DOMAIN.md
+++ b/crates/services/notification/docs/DOMAIN.md
@@ -1,0 +1,97 @@
+# `notification` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Notifications — the user activity feed + push fan-out |
+> | **Subdomain class** | **Supporting** — a derived delivery/feed plane; owns no source content |
+> | **System of …** | **Record** for the notification activity feed (derived from upstream facts) |
+> | **Aggregate root(s)** | `Notification` (`domain`) |
+> | **Tier** | **TIER-2** — best-effort / derived |
+> | **Failure posture** | **Fail-open** — a missed notification is re-derivable; nothing blocks |
+> | **Upstream contexts** | `comment`, `engagement`, `post`, `social-graph` — via **ACL** over Kafka |
+> | **Downstream contexts** | clients (feed read + gRPC broadcast stream); offline push (APNs/FCM); delegated from `realtime` |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `notification` is the authority for **the activity feed**: it answers
+**"what should this user be told happened, how many are unread, and how do we deliver it?"**
+
+**The hard problem.** Collapsing a high-fan-in event stream into a per-user feed without write
+amplification — a **Redis write-collapse fan-out** (3 layers + an hourly cap) over a TWCS activity
+feed, with deterministic UUIDv5 ids and a claim-gated unread counter.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own the source events → it derives notifications from upstream facts.
+- ❌ Be the live socket → `realtime` delivers live; notification owns the durable feed + offline push.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Notification | A single activity-feed entry | `Notification`, `NotificationId`, `NotificationKind` |
+| Subject | The thing the notification is about | `SubjectId`, `SubjectKind` |
+| Read / created event | Feed lifecycle facts | `NotificationCreatedEvent`, `NotificationReadEvent` |
+| Write-collapse | Coalescing many triggers into one feed entry | (Redis fan-out) |
+| Unread counter | The claim-gated unread badge count | (Redis `SET NX`) |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Notification` | aggregate root | Feed-entry identity + read state |
+| `NotificationKind` / `SubjectKind` | enum | Closed notification/subject vocabularies |
+| `SubjectId` | VO | What the notification references |
+
+> **Invariant.** Ids are deterministic UUIDv5 (idempotent on redelivery); the unread counter is
+> claim-gated (`SET NX`) so a re-delivered event can't double-increment; unique senders collapse
+> via `SADD`. `created_at` is event-time, not ingest-time.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- The per-user notification feed + unread counters — **ScyllaDB** (TWCS activity feed) + **Redis** (write-collapse counters). Derived, but authoritative for the feed view.
+
+**The "do-not-write" list:** notification never mutates the source content; it reacts to events.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Notification ids are deterministic UUIDv5 (idempotent) | domain | `NTF-1xxx` |
+| I2 | The unread counter is claim-gated (no double-count on redelivery) | application (Redis `SET NX`) | `NTF-1xxx` |
+| I3 | `created_at` is event-time, not ingest-time | domain | `NTF-9xxx` |
+
+---
+
+## 6. Workflows & Orchestration &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, collapsed) — consumes upstream events (`comment.created`, `engagement.reactions`, `post.published`, social follows) under `run_consumer`, write-collapses into the per-user feed, increments the claim-gated unread counter, and pushes via the gRPC broadcast stream (live) or APNs/FCM (offline, delegated from `realtime`).
+
+## 7. Context Relationships &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, collapsed) — **upstream (ACL):** `comment`, `engagement`, `post`, `social-graph` event streams. **downstream (OHS):** clients (feed + broadcast stream); offline push providers.
+
+## 8. Domain Events &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, collapsed) — publishes **none of record** (its `NotificationCreated`/`Read` events are internal feed state). Consumes upstream facts whose meanings are owned by their contexts.
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, collapsed) — keystone choice: Redis write-collapse fan-out + claim-gated idempotent unread counter (deterministic UUIDv5 ids, event-time `created_at`, `SET NX` unread claim, `SADD` unique-sender collapse); candidate ADR not yet recorded.
+
+## 10. Subdomain Classification & Evolution &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, collapsed) — **Supporting**, low volatility; deferred: richer notification types, preference center, digest batching.

--- a/crates/services/post/docs/DOMAIN.md
+++ b/crates/services/post/docs/DOMAIN.md
@@ -1,0 +1,144 @@
+# `post` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Posts — the content lifecycle |
+> | **Subdomain class** | **Core** — published content is the platform's primary substance |
+> | **System of …** | **Record** for posts and their lifecycle |
+> | **Aggregate root(s)** | `Post` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Fail-closed on writes** — a published post must persist |
+> | **Upstream contexts** | clients (author); `profile` (author identity); `moderation` (gating); `media` (attachments) |
+> | **Downstream contexts** | `timeline`, `geo-discovery`, `search`, `counter`, `realtime` — via **Published Language** (`post.v1.events`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `post` is the authority for **content**: it answers
+**"what was published by whom, in what state, with what media — and is it still live?"**
+
+**The hard problem.** Owning a high-write content store cheaply and serving it by author, while
+being the fan-out source the whole read side depends on — a two-table ScyllaDB layout
+(`post.posts` by id + `post.posts_by_profile` by author) with `post.v1.events` as the published
+language.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Build feeds/timelines → `timeline` consumes `post.v1.events`.
+- ❌ Index for search/discovery → `search` / `geo-discovery` consume events.
+- ❌ Own media bytes → references `media` attachments; counts → `counter`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Post | A unit of published content | `Post`, `PostId`, `PostKind`, `PostStatus` |
+| Caption | The post's text | `Caption` |
+| Media attachment | A reference to a `media` asset + its CDN URL | `MediaAttachment`, `CdnUrl` |
+| Audio reference | Attached audio track | `AudioReference`, `AudioId`, `AudioKind` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Post` | aggregate root | The content lifecycle state machine |
+| `Caption` / `MediaAttachment` / `AudioReference` | VO | Content validity + media/audio references |
+| `PostKind` / `PostStatus` | enum | Closed kind/status vocabularies (proto maps kind/status +1) |
+
+**Lifecycle:**
+
+```
+published --(update)--> published' --(delete)--> deleted   |   (moderation gate may block/remove)
+```
+
+> **Legal transitions only.** Proto enums map domain tinyint +1 (no UNSPECIFIED sentinel); a delete
+> emits `post.deleted` for downstream teardown.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Posts — **ScyllaDB** two-table (`post.posts` by id, `post.posts_by_profile` by author). No other service writes them.
+
+**This context holds copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Author profile snapshot fields | `profile` | `profile.v1.events` (DLQ `profile.v1.events.dlq`) | eventually consistent |
+| Moderation state | `moderation` | `moderation.v1.events` | eventually consistent |
+
+**The "do-not-write" list:** post never builds feeds, indexes, or counts — it emits the events those derive from.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | A post references a valid author | domain | `PST-1xxx` |
+| I2 | Both tables stay consistent (id + by-profile) | domain/application | `PST-1xxx` |
+| I3 | A lifecycle change emits the matching `post.v1.events` | domain (after-save) | — |
+| I4 | Proto kind/status mapping is +1 with no UNSPECIFIED | infrastructure (codec) | — |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Publish / update / delete.** Authorized command → write both Scylla tables → publish
+`post.published` / `post.updated` / `post.deleted` on `post.v1.events`. Downstream `timeline`
+fans out, `search`/`geo-discovery` index, `counter` counts, `realtime` broadcasts.
+
+**Denormalization.** Consume `profile.v1.events` to keep author snapshot fields fresh; consume
+`moderation.v1.events` to reflect enforcement.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `profile` | upstream | ACL | `profile.v1.events` | author snapshots go stale |
+| `moderation` | upstream | ACL | `moderation.v1.events` | enforcement reflection breaks |
+| `media` | upstream | Customer/Supplier | `MediaAttachment` references | broken media in posts |
+| `timeline`/`search`/`geo-discovery`/`counter`/`realtime` | downstream | Published Language (OHS) | `post.v1.events` | the entire read/discovery side breaks |
+
+> **Anti-Corruption Layer:** the `profile`/`moderation` event consumers translate foreign wire
+> shapes into post's denormalized fields.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event (`post.v1.events`) | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `post.published` | new content went live | publish commits | `timeline` (fan-out), `search`/`geo` (index), `counter`, `realtime` |
+| `post.updated` | content was edited | update commits | `search`/`geo` (re-index) |
+| `post.deleted` | content was removed | delete commits | `timeline`/`search`/`geo` (teardown) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Two-table ScyllaDB layout (by id + by author) with `post.v1.events` as published language | _candidate — not yet recorded_ | — |
+| Post→geo payload enrichment (lat/lng/caption) — open product decision | _open — see geo-discovery §6_ | Open |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Core — content is the primary substance of the platform.
+- **Volatility:** medium — post kinds and attachments evolve.
+- **Known modeling debt:** `post.published` emits no geo payload (blocks geo-discovery enrichment).
+- **Deferred capabilities:** richer media/audio; scheduled posts; edit history.

--- a/crates/services/profile/docs/DOMAIN.md
+++ b/crates/services/profile/docs/DOMAIN.md
@@ -1,0 +1,151 @@
+# `profile` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Profile — the public persona over an account |
+> | **Subdomain class** | **Supporting** — the presentation layer of identity; product-facing but derived from `account` |
+> | **System of …** | **Record** for public persona (handle, display name, bio, avatar, tier, visibility) |
+> | **Aggregate root(s)** | `Profile` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Failure posture** | **Fail-closed on writes** — persona changes (esp. handle) must be consistent |
+> | **Upstream contexts** | `account` (account lifecycle); `social-graph` (author tier source); clients (edits) |
+> | **Downstream contexts** | `post`, `search`, `geo-discovery`, `timeline` — via **Published Language** (`profile.v1.events`) |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `profile` is the authority for **the public persona**: it answers
+**"what is this user's handle, display name, bio, avatar, tier, and visibility?"**
+
+**The hard problem.** Owning a globally-unique, claimable **handle** with no conflicts under
+concurrency, plus dual-axis visibility (owner choice **and** moderation masking), while being the
+denormalization source other read models embed.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own the account/credentials/PII → `account` is the SoR; profile is the public face.
+- ❌ Compute author tier → consumes it (the social-graph→profile tier initiative); profile *owns and emits* it.
+- ❌ Build feeds/search → emits `profile.v1.events` those consume.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Profile | The public persona record | `Profile`, `ProfileId` |
+| Handle | The globally-unique, claimable @name | `Handle`, `HandleChanged` |
+| Display name / bio / avatar / banner | Presentation fields | `DisplayName`, `Bio`, `AvatarUrl`, `BannerUrl` |
+| Visibility | Owner-chosen visibility | `ProfileVisibility` |
+| Masking reason | Why moderation hid a profile | `MaskingReason`, `ProfileHidden` |
+| Verification | Verified-badge state | `VerificationKind`, `ProfileVerified` |
+| Tier | The author tier (denormalized + emitted) | `TierChanged` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Profile` | aggregate root | Persona consistency + handle uniqueness |
+| `Handle` | VO | Global uniqueness; claim under concurrency |
+| `DisplayName` / `Bio` / `AvatarUrl` / `BannerUrl` / `WebsiteUrl` / `Locale` | VO | Field validity at construction |
+| `ProfileVisibility` / `ProfileStatus` / `ProfileKind` / `VerificationKind` | enum | Closed visibility/status/kind/verification vocabularies |
+
+**Lifecycle:**
+
+```
+created --(update / verify)--> active --(hide: owner OR moderation)--> hidden --(restore)--> active --> deleted
+```
+
+> **Legal transitions only.** Visibility is **dual-axis** — a profile is visible only if the owner
+> *and* moderation both allow it; a handle change is an event, not a silent rename.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- The public persona (handle, names, bio, media URLs, tier, visibility) — **ScyllaDB** + **Redis** (entity cache L1). No other service writes persona fields.
+
+**This context holds copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Account lifecycle state | `account` | `account.v1.events` (DLQ `account.v1.events.dlq`) | eventually consistent |
+| Author tier (computed) | `social-graph` (computes) | tier-change flow | eventually consistent |
+
+**The "do-not-write" list:** profile never writes account/PII, and never builds the read models that consume its events.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Handles are globally unique; claims are conflict-free under concurrency | domain + store | `PRF-1xxx` (claim conflict) |
+| I2 | Dual-axis visibility — owner AND moderation must both allow | domain | `PRF-1xxx` |
+| I3 | A persona change emits the matching `profile.v1.events` | domain (after-save) | — |
+| I4 | Concurrent modifications are detected | domain | `PRF-1xxx` (concurrent_modification) |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Provision / update.** Consume `account.v1.events` to provision a persona; client edits mutate the
+`Profile` and emit `profile.v1.events` (incl. `HandleChanged`, `ProfileVerified`, `TierChanged`).
+
+**Handle claim.** A claim checks global uniqueness atomically; conflicts return a claim-conflict
+error (tracked by `profile.handle.claim.conflict_total`).
+
+**Tier.** `social-graph` computes the tier from follower count → profile owns and emits
+`profile.tier_changed` → `geo-discovery`/`timeline` light up (consumer-ready). *(Producer side per the author-tier initiative.)*
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `account` | upstream | ACL | `account.v1.events` | persona provisioning breaks |
+| `social-graph` | upstream | Customer/Supplier | tier computation | tier emission breaks |
+| `post`/`search`/`geo-discovery`/`timeline` | downstream | Published Language (OHS) | `profile.v1.events` | author snapshots / indexing break |
+
+> **Anti-Corruption Layer:** the `account` event consumer translates account lifecycle into persona
+> provisioning.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event (`profile.v1.events`) | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `profile_created` / `profile_updated` | persona created/edited | command commits | `post`/`search` (snapshots) |
+| `handle_changed` | the @handle changed | handle claim | `search` (re-index), embeds |
+| `profile_verified` | verification badge changed | verification | `search`, embeds |
+| `tier_changed` | author tier changed | tier recompute | `geo-discovery`, `timeline` |
+| `profile_hidden` / `profile_restored` / `profile_deleted` | visibility/lifecycle | owner/moderation action | read models (teardown/restore) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Profile is the public persona over the `account` SoR; emits `profile.v1.events` | _candidate — not yet recorded_ | — |
+| Dual-axis visibility (owner AND moderation) | _candidate — not yet recorded_ | — |
+| Author tier: social-graph computes → profile owns + emits | _open — author-tier initiative_ | Scoped |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — the product-facing presentation of identity, derived from `account`.
+- **Volatility:** medium — persona fields and verification evolve.
+- **Known modeling debt:** the author-tier producer side (social-graph→profile) is scoped, not fully built.
+- **Deferred capabilities:** richer verification flows; profile-event indexing rollout to `search`.

--- a/crates/services/search/docs/DOMAIN.md
+++ b/crates/services/search/docs/DOMAIN.md
@@ -1,0 +1,144 @@
+# `search` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Search & Discovery — the inverted-index read model |
+> | **Subdomain class** | **Supporting** — a derived discovery read-model; owns no source content |
+> | **System of …** | **Reference (SoRef)** — eventually-consistent index over profiles/posts/hashtags, rebuildable |
+> | **Aggregate root(s)** | `IndexDocument` (`PostDoc` / `ProfileDoc` / `HashtagDoc`) |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-open** — a degraded index returns fewer/staler hits, never an error |
+> | **Upstream contexts** | `post`, `profile`, `moderation` — via **ACL** over Kafka |
+> | **Downstream contexts** | clients (search/suggest); publishes none of record |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `search` is the authority for **discovery queries**: it answers
+**"which profiles/posts/hashtags match this query, ranked, and respecting visibility?"**
+
+**The hard problem.** Keeping an eventually-consistent inverted index correct under out-of-order
+events and re-indexing — **OpenSearch as the single canonical store with external versioning** (a
+2-version-guard Painless script), a pure-Kafka command side and a stateless read RPC, plus
+blue-green reindexing.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own profiles/posts → it indexes references (SoReference, not SoRecord).
+- ❌ Decide visibility → it *honours* the dual visibility authority (owner + moderation).
+- ❌ Serve magnitudes → consumes `PopularityScore` from `counter`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Index document | A searchable doc (post/profile/hashtag) | `IndexDocument`, `PostDoc`, `ProfileDoc`, `HashtagDoc` |
+| Doc version | The external version guarding out-of-order updates | `DocVersion` |
+| Index mutation | An upsert/delete to apply to the index | `IndexMutation`, `EntityDeletion` |
+| Search hit / results | A ranked match and the result set | `SearchHit`, `SearchResults`, `HitDisplay` |
+| Suggestion | A typeahead suggestion | `Suggestion`, `Suggestions`, `SuggestQuery` |
+| Visibility authority | Who may suppress a doc (owner vs moderation) | `VisibilityAuthority`, `VisibilityChange` |
+| Popularity score | The ranking signal from `counter` | `PopularityScore` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `IndexDocument` | aggregate (per kind) | The searchable projection of a source entity |
+| `DocVersion` | VO | External version → out-of-order writes are rejected (2-version guard) |
+| `IndexMutation` / `EntityDeletion` | VO | The applied index change |
+| `VisibilityAuthority` / `VisibilityChange` | enum/VO | Dual visibility (owner + moderation) honoured in results |
+| `SearchQuery` / `SortStrategy` | VO/enum | Query intent + ranking |
+
+> **Invariant.** An update with a lower `DocVersion` than the indexed one is dropped (external
+> versioning); a doc is returned only if both visibility authorities allow it.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth (of *reference*) for:**
+- The inverted index — **OpenSearch** (single canonical store). Fully rebuildable from upstream via blue-green reindex.
+
+**This context holds derived copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Post/profile/hashtag content | `post` / `profile` | `post.v1.events` / `profile.v1.events` | eventually consistent |
+| Moderation visibility | `moderation` | `moderation.v1.events` | eventually consistent |
+| Popularity | `counter` | `counter.v1.popularity` (deferred wiring) | eventually consistent |
+
+**The "do-not-write" list:** search never mutates source entities; it projects them.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Out-of-order updates rejected by external `DocVersion` (2-version guard) | infrastructure (Painless) | `SCH-2xxx` |
+| I2 | A hit is returned only if owner AND moderation visibility allow | domain | `SCH-3xxx` |
+| I3 | Reads fail open (degrade, never error) | application | `SCH-4xxx` |
+| I4 | Reindex is blue-green (no read downtime) | application | `SCH-5xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Index (command side, pure Kafka).** Consume `post.v1.events` (hydrated) + `profile.v1.events` +
+`moderation.v1.events` → build `IndexMutation` with an external `DocVersion` → upsert/delete in
+OpenSearch under the 2-version Painless guard.
+
+**Query (read side, stateless).** A `SearchQuery` / `SuggestQuery` → ranked OpenSearch query →
+filter by dual visibility → return `SearchResults` / `Suggestions`. Fail-open on a degraded cluster.
+
+**Reindex.** Blue-green `Reindexer` rebuilds into a new index and atomically swaps the alias.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `post` | upstream | ACL | `post.v1.events` (hydrated) | post search goes stale |
+| `profile` | upstream | ACL | `profile.v1.events` | profile search (pending rollout) |
+| `moderation` | upstream | ACL | `moderation.v1.events` | visibility suppression breaks |
+| `counter` | upstream | ACL | `counter.v1.popularity` | popularity ranking (deferred) |
+| clients | downstream | OHS | search/suggest RPC | discovery breaks |
+
+> **Anti-Corruption Layer:** the per-source decode (`PostEvent`/`ProfileEvent`/`ModerationEvent`)
+> maps foreign wire shapes into `IndexMutation`.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+> Publishes **none of record** — it is a read-model. It consumes `post`/`profile`/`moderation`/
+> `counter` facts, whose meanings are owned by those contexts.
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| OpenSearch single canonical store with external 2-version guard; pure-Kafka command side + stateless read RPC | _candidate — not yet recorded_ | — |
+| Dual visibility authority (owner + moderation) honoured at query time | _candidate — not yet recorded_ | — |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — a derived discovery read-model.
+- **Volatility:** medium — ranking and doc schema evolve.
+- **Known modeling debt:** profile indexing pending the `profile.v1.events` rollout; popularity wiring deferred.
+- **Deferred capabilities:** richer ranking; personalized search; cross-entity blended results.

--- a/crates/services/social-graph/docs/DOMAIN.md
+++ b/crates/services/social-graph/docs/DOMAIN.md
@@ -1,0 +1,149 @@
+# `social-graph` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Social Graph — follower/following and block relations |
+> | **Subdomain class** | **Core** — the social graph is the network itself |
+> | **System of …** | **Record** for relations (follows, blocks) and derived author tier |
+> | **Aggregate root(s)** | `Relation` (with `FollowEdge` / `BlockEdge`) |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-closed on writes** — a relation change must be atomic + durable |
+> | **Upstream contexts** | clients (follow/block); `profile` (identity) |
+> | **Downstream contexts** | `timeline` (fan-out, gRPC reads), `counter` (follower counts), `profile` (tier) — via gRPC + events |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `social-graph` is the authority for **relations**: it answers
+**"who follows whom, who blocked whom, and what tier is this author?"**
+
+**The hard problem.** Maintaining a high-fan-out relation graph with consistent reverse indexes and
+hot-set reads — a 4-table ScyllaDB schema with Redis Set hot-relation caching, logged-batch
+atomicity for the dual-write, and tier thresholds derived from follower counts.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Build timelines → `timeline` reads the graph (gRPC) and fans out.
+- ❌ Own author tier *presentation* → `social-graph` computes it; `profile` owns + emits it.
+- ❌ Own profiles → `profile`.
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Relation | A directed edge between two profiles | `Relation`, `RelationKind`, `RelationStatus` |
+| Follow / block edge | The two relation kinds | `FollowEdge`, `BlockEdge` |
+| Relation context | The surrounding metadata of a relation | `RelationContext` |
+| Author tier | The tier derived from follower count | `AuthorTier`, `TierThresholds`, `AuthorTierChanged` |
+| Severed follows | Follows removed when a block is applied | `SeveredFollows` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `Relation` | aggregate root | Edge consistency across forward + reverse indexes |
+| `FollowEdge` / `BlockEdge` | VO | The two directed relation kinds |
+| `RelationStatus` / `RelationKind` | enum | Closed relation vocabularies |
+| `AuthorTier` / `TierThresholds` | VO | Tier derivation from follower count |
+| `SeveredFollows` | VO | The follows a block tears down |
+
+**Relation transitions:**
+
+```
+(none) --(follow)--> following --(unfollow)--> (none)
+(none) --(block)--> blocked (severs existing follows both ways)
+```
+
+> **Legal transitions only.** A block severs existing follows (`SeveredFollows`); forward and reverse
+> indexes are written atomically (logged batch); a follower-count crossing a threshold changes `AuthorTier`.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth for:**
+- Relations (follows, blocks) and their reverse indexes — **ScyllaDB** (4-table) + **Redis** (hot-relation Sets). No other service writes relations.
+
+**This context holds copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Profile existence | `profile` | `profile.v1.events` | eventually consistent |
+
+**The "do-not-write" list:** social-graph never builds feeds and never writes profile presentation
+(it computes tier; `profile` owns + emits it).
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Forward + reverse relation indexes are written atomically | application (logged batch) | `SGR-1xxx` |
+| I2 | A block severs existing follows both directions | domain | `SGR-1xxx` |
+| I3 | Author tier is derived from follower count crossing `TierThresholds` | domain | — |
+| I4 | Hot-relation reads are served from Redis Sets, rebuildable from Scylla | infrastructure | `SGR-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Follow / unfollow / block.** Mutate the `Relation` aggregate → atomic logged-batch write of
+forward + reverse Scylla rows + Redis hot-set update. A block emits `SeveredFollows`.
+
+**Tier computation.** A follower-count change crossing a `TierThresholds` boundary produces
+`AuthorTierChanged`, feeding the profile→tier flow (author-tier initiative; producer side scoped).
+
+**Reads.** `timeline` reads the follower set via gRPC for fan-out; `counter` reconciles follower
+counts via gRPC (the `social-graph.follows` Kafka stream is a deferred producer).
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `profile` | upstream | ACL | `profile.v1.events` | relation validity vs unknown profiles |
+| `timeline` | downstream | Customer/Supplier (gRPC) | follower-set reads for fan-out | feed fan-out breaks |
+| `counter` | downstream | Customer/Supplier (gRPC) | follower-count reconciliation | follower magnitudes drift |
+| `profile` | downstream | Published Language | tier change flow | author-tier emission breaks |
+
+> **Anti-Corruption Layer:** the `profile` event consumer keeps relation validity aligned with
+> profile existence.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+| Event | Means | Emitted when | Who reacts |
+|---|---|---|---|
+| `ProfileFollowed` / `ProfileUnfollowed` | a follow edge was created/removed | follow/unfollow commits | timeline/counter (consumers; follows-stream wiring deferred) |
+| `ProfileBlocked` / `ProfileUnblocked` | a block edge changed (severs follows) | block/unblock commits | feeds |
+| `AuthorTierChanged` | the author's tier changed | follower count crosses a threshold | `profile` (owns + re-emits) |
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| 4-table ScyllaDB schema + Redis hot Sets + logged-batch atomicity for dual-write | _candidate — not yet recorded_ | — |
+| Author tier: social-graph computes → profile owns + emits | _open — author-tier initiative_ | Scoped |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Core — the relation graph is the social network.
+- **Volatility:** low-to-medium — relation kinds are stable; tier policy may tune.
+- **Known modeling debt:** orphan reconciliation (TD-6); the `social-graph.follows` Kafka producer is deferred (counter consumes via gRPC for now).
+- **Deferred capabilities:** NebulaGraph-style recommendation traversals; mutual/second-degree queries.

--- a/crates/services/timeline/docs/DOMAIN.md
+++ b/crates/services/timeline/docs/DOMAIN.md
@@ -1,0 +1,139 @@
+# `timeline` — Domain & Functional Contract
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Timeline — the home-feed read model |
+> | **Subdomain class** | **Supporting** — a derived feed projection; owns no source content |
+> | **System of …** | **Reference (SoRef)** — a materialized per-user feed, rebuildable from upstream |
+> | **Aggregate root(s)** | `FeedEntry` (projection), addressed by `FeedCursor` |
+> | **Tier** | **TIER-1** |
+> | **Failure posture** | **Fail-open** — a degraded feed returns fewer/staler entries, never an error |
+> | **Upstream contexts** | `post` (content), `social-graph` (follower graph) — via events + gRPC |
+> | **Downstream contexts** | clients (feed read); publishes none of record |
+> | **Decision log** | _none yet — see [`docs/adr/`](../../../../docs/adr/README.md)_ |
+
+---
+
+## 1. Business Capability & Non-Goals
+
+**Capability.** `timeline` is the authority for **the home feed**: it answers
+**"what should this user see in their feed right now, in order?"**
+
+**The hard problem.** Feed generation at scale without the fan-out-on-write cost of celebrities or
+the fan-out-on-read cost of everyone — a **hybrid push/pull** model: materialize feeds for normal
+authors (push), pull for high-tier authors at read time, merged via a Lua `ZREVRANGEBYSCORE`.
+
+**Non-goals — what this context deliberately does NOT do:**
+- ❌ Own posts → `post` is the SoR; timeline holds feed references.
+- ❌ Own the follower graph → reads `social-graph` (gRPC) for fan-out.
+- ❌ Rank by popularity magnitudes → that signal comes from `counter` (where wired).
+
+---
+
+## 2. Ubiquitous Language
+
+| Term | Meaning in this context | Code symbol |
+|---|---|---|
+| Feed entry | One materialized item in a user's feed | `FeedEntry` |
+| Feed cursor | The pagination position in a feed | `FeedCursor` |
+| Fan-out mode | Push (materialize) vs pull (read-time) per author | `FanOutMode` |
+| Author tier | The tier that decides push vs pull | `AuthorTier` |
+
+---
+
+## 3. Domain Model
+
+| Element | Kind | Invariant boundary it guards |
+|---|---|---|
+| `FeedEntry` | projection (aggregate) | A feed item's identity + ordering score |
+| `FeedCursor` | VO | Stable pagination position |
+| `FanOutMode` | enum | Push vs pull decision per author |
+| `AuthorTier` | enum | The tier driving the hybrid decision |
+
+> **Invariant.** Feed entries are ordered by score (Lua `ZREVRANGEBYSCORE` via eval); members are
+> encoded compactly; `from_uuid` is infallible. High-tier authors are pulled at read time, not
+> materialized, to bound fan-out cost.
+
+---
+
+## 4. Data Ownership & Boundaries
+
+**This context is the source of truth (of *reference*) for:**
+- The materialized per-user feed — **Redis** (feed ZSETs) + **ScyllaDB** (durable materialization). Rebuildable from `post` + `social-graph`.
+
+**This context holds derived copies it does NOT own:**
+
+| Copied data | Owned by | Kept fresh via | Staleness tolerance |
+|---|---|---|---|
+| Post content/refs | `post` | `post.published` / `post.deleted` | eventually consistent |
+| Follower graph | `social-graph` | gRPC follower-set reads | read-time |
+| Author tier | `profile` (emits) | tier-change consumption | eventually consistent |
+
+**The "do-not-write" list:** timeline never writes posts or the graph — it projects them into feeds.
+
+---
+
+## 5. Invariants & Business Rules
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Hybrid fan-out — normal authors pushed, high-tier pulled at read | domain/application | `TML-1xxx` |
+| I2 | Feed ordering by score via Lua `ZREVRANGEBYSCORE` | infrastructure (Lua) | `TML-1xxx` |
+| I3 | Reads fail open (degrade, never error) | application | `TML-1xxx` |
+| I4 | A deleted post is removed from feeds | application (consumer) | `TML-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> Inline until a corrected C4 is regenerated from `docs/domain/`.
+
+**Fan-out on publish (push).** Consume `post.published` → read the author's follower set from
+`social-graph` (gRPC) → for normal-tier authors, materialize the entry into each follower's feed
+ZSET. High-tier authors are skipped here (pulled at read).
+
+**Read (hybrid merge).** A feed read merges the materialized push entries with a read-time pull of
+the user's high-tier followees, ordered by score via Lua `ZREVRANGEBYSCORE`, paginated by
+`FeedCursor`. Fail-open on a degraded backend.
+
+**Teardown.** Consume `post.deleted` → remove the entry from affected feeds.
+
+---
+
+## 7. Context Relationships (Context-Map slice)
+
+| Neighbour context | Direction | Pattern | Mechanism | What breaks if they change |
+|---|---|---|---|---|
+| `post` | upstream | ACL | `post.published` / `post.deleted` | feed freshness/teardown breaks |
+| `social-graph` | upstream | Customer/Supplier (gRPC) | follower-set reads | fan-out breaks |
+| `profile` | upstream | ACL | `tier_changed` | push/pull decision goes stale |
+| clients | downstream | OHS | feed-read RPC | the home feed breaks |
+
+> **Anti-Corruption Layer:** the `post` event consumer translates post lifecycle into feed mutations.
+
+---
+
+## 8. Domain Events (semantics, not wire)
+
+> Publishes **none of record** — it is a read-model. It consumes `post` (and reads `social-graph`);
+> their meanings are owned by those contexts.
+
+---
+
+## 9. Decisions & Rationale
+
+| Decision | ADR | Status |
+|---|---|---|
+| Hybrid push/pull fan-out (materialize normal authors, pull high-tier at read) | _candidate — not yet recorded_ | — |
+| Forward-compatibility for author-tier-driven fan-out (shipped #469) | _open — author-tier initiative_ | Scoped |
+
+---
+
+## 10. Subdomain Classification & Evolution
+
+- **Classification:** Supporting — a derived feed projection over `post` + `social-graph`.
+- **Volatility:** medium — ranking and the push/pull threshold evolve.
+- **Known modeling debt:** fan-out performance tuning (TD-4); author-tier producer side not yet complete.
+- **Deferred capabilities:** popularity-weighted ranking from `counter`; personalized/ML ranking.

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -45,23 +45,23 @@ CORE plus collapsed one-line DEEP sections.
 
 | Service | Bounded context | `DOMAIN.md` | Status |
 |---|---|---|---|
-| `account` | Account / identity SoR | `crates/services/account/docs/DOMAIN.md` | ⬜ |
+| `account` | Account / Identity SoR | [`crates/services/account/docs/DOMAIN.md`](../../crates/services/account/docs/DOMAIN.md) | ✅ |
 | `audit` | Tamper-evident compliance evidence | [`crates/services/audit/docs/DOMAIN.md`](../../crates/services/audit/docs/DOMAIN.md) | ✅ |
-| `auth` | Issuance / session / IdP broker | `crates/services/auth/docs/DOMAIN.md` | ⬜ |
-| `chat` | Conversations & messaging | `crates/services/chat/docs/DOMAIN.md` | ⬜ |
-| `comment` | Comment threads | `crates/services/comment/docs/DOMAIN.md` | ⬜ |
-| `counter` | Counter / analytics SoReference | `crates/services/counter/docs/DOMAIN.md` | ⬜ |
-| `engagement` | Reactions & edge state | `crates/services/engagement/docs/DOMAIN.md` | ⬜ |
-| `geo-discovery` | Geo-spatial discovery | `crates/services/geo-discovery/docs/DOMAIN.md` | ⬜ |
-| `media` | Media control plane | `crates/services/media/docs/DOMAIN.md` | ⬜ |
-| `moderation` | Trust & safety decisions | [`crates/services/moderation/docs/DOMAIN.md`](../../crates/services/moderation/docs/DOMAIN.md) | ✅ |
-| `notification` | Notification activity feed | `crates/services/notification/docs/DOMAIN.md` | ⬜ |
-| `post` | Content / posts | `crates/services/post/docs/DOMAIN.md` | ⬜ |
-| `profile` | Public personas | `crates/services/profile/docs/DOMAIN.md` | ⬜ |
-| `realtime` | Connection / delivery plane | [`crates/services/realtime/docs/DOMAIN.md`](../../crates/services/realtime/docs/DOMAIN.md) | ✅ |
-| `search` | Discovery read-model | `crates/services/search/docs/DOMAIN.md` | ⬜ |
-| `social-graph` | Follower / following relations | `crates/services/social-graph/docs/DOMAIN.md` | ⬜ |
-| `timeline` | Timeline fan-out | `crates/services/timeline/docs/DOMAIN.md` | ⬜ |
+| `auth` | Authentication / session / IdP broker | [`crates/services/auth/docs/DOMAIN.md`](../../crates/services/auth/docs/DOMAIN.md) | ✅ |
+| `chat` | Conversations & messaging | [`crates/services/chat/docs/DOMAIN.md`](../../crates/services/chat/docs/DOMAIN.md) | ✅ |
+| `comment` | Comment threads | [`crates/services/comment/docs/DOMAIN.md`](../../crates/services/comment/docs/DOMAIN.md) | ✅ |
+| `counter` | Counter / analytics SoReference | [`crates/services/counter/docs/DOMAIN.md`](../../crates/services/counter/docs/DOMAIN.md) | ✅ |
+| `engagement` | Reactions & edge state | [`crates/services/engagement/docs/DOMAIN.md`](../../crates/services/engagement/docs/DOMAIN.md) | ✅ |
+| `geo-discovery` | Geo-spatial discovery | [`crates/services/geo-discovery/docs/DOMAIN.md`](../../crates/services/geo-discovery/docs/DOMAIN.md) | ✅ |
+| `media` | Media control plane | [`crates/services/media/docs/DOMAIN.md`](../../crates/services/media/docs/DOMAIN.md) | ✅ |
+| `moderation` | Trust, safety & integrity | [`crates/services/moderation/docs/DOMAIN.md`](../../crates/services/moderation/docs/DOMAIN.md) | ✅ |
+| `notification` | Notification activity feed | [`crates/services/notification/docs/DOMAIN.md`](../../crates/services/notification/docs/DOMAIN.md) | ✅ |
+| `post` | Content / posts | [`crates/services/post/docs/DOMAIN.md`](../../crates/services/post/docs/DOMAIN.md) | ✅ |
+| `profile` | Public personas | [`crates/services/profile/docs/DOMAIN.md`](../../crates/services/profile/docs/DOMAIN.md) | ✅ |
+| `realtime` | Live delivery / connection plane | [`crates/services/realtime/docs/DOMAIN.md`](../../crates/services/realtime/docs/DOMAIN.md) | ✅ |
+| `search` | Discovery read-model | [`crates/services/search/docs/DOMAIN.md`](../../crates/services/search/docs/DOMAIN.md) | ✅ |
+| `social-graph` | Follower / following relations | [`crates/services/social-graph/docs/DOMAIN.md`](../../crates/services/social-graph/docs/DOMAIN.md) | ✅ |
+| `timeline` | Timeline fan-out | [`crates/services/timeline/docs/DOMAIN.md`](../../crates/services/timeline/docs/DOMAIN.md) | ✅ |
 
 ## Authoring
 


### PR DESCRIPTION
## Why

Completes the per-service functional-documentation rollout: the remaining **14** `DOMAIN.md` files. With this, **17/17** services have a domain contract.

> **Stacked on #491.** Base is `docs/domain-audit-moderation-realtime` (the first 3 exemplars), so this PR's diff is just the 14 new files. GitHub will auto-retarget it to `develop` once #491 merges. Merge #491 first.

## What

Each `crates/services/<svc>/docs/DOMAIN.md` is written from the DOMAIN template and grounded in the crate's **actual** domain types (`src/domain`), error namespaces (`error.rs`), datastores, and event/topic contracts — not the quarantined C4.

| Tier | Services | Depth |
|---|---|---|
| TIER-0 | `account`, `auth`, `chat`, `post`, `profile` | full CORE + DEEP |
| TIER-1 | `comment`, `counter`, `engagement`, `geo-discovery`, `media`, `search`, `social-graph`, `timeline` | full CORE + DEEP |
| TIER-2 | `notification` | CORE + collapsed DEEP (per the tier rule) |

Every file states: bounded context + non-goals, ubiquitous language (each term carrying its `crate::Type`), domain model + lifecycle diagram, **data ownership + do-not-write list**, invariants mapped to enforcement layer + error code, inline workflows (no `docs/_legacy/` C4 link), context relationships tagged with DDD patterns (ACL / OHS / Conformist / Customer-Supplier / Separate Ways), event semantics, and decision links/candidates.

`docs/domain/README.md` index now links all 17 (✅ × 17).

## Reviewable judgement calls

- **Subdomain classification:** Core = `post`, `comment`, `chat`, `social-graph`, `engagement` (the content + social fabric); Supporting = identity/auth/audit, the derived read-models (`search`, `timeline`, `geo-discovery`, `counter`), and the delivery planes (`realtime`, `notification`, `media`). One-line edits if you'd classify differently.
- Several `DOMAIN.md` reference **open initiatives** (author-tier producer side; post→geo payload gap) and **deferred producers** (`social-graph.follows` stream) — captured honestly in §10.

## Verification

- 17/17 `DOMAIN.md` present; all relative ADR/index links resolve (checked).
- i18n drift gate: **PASS**.

## Follow-ups

- Record the per-service keystone decisions as ADRs (most §9 rows are "candidate — not yet recorded").
- Extend the i18n gate to `DOMAIN.*.md` + add `DOMAIN.fr.md` mirrors.
- Populate `CONTEXT_MAP.md` / `EVENT_CATALOG.md` from these Domain Cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)