### PR TITLE
docs(adr): record per-service keystone decisions (ADR-0004..0017)

### DIFF
--- a/crates/services/account/docs/DOMAIN.md
+++ b/crates/services/account/docs/DOMAIN.md
@@ -146,7 +146,7 @@ closing the erasure loop end to end.
 
 | Decision | ADR | Status |
 |---|---|---|
-| Account is the identity SoR; built its outbound event lane (was a phantom producer) so `audit`/`profile` can consume | _candidate — not yet recorded_ | — |
+| Account is the identity SoR; built its outbound event lane (was a phantom producer) so `audit`/`profile` can consume | [`ADR-0004`](../../../../docs/adr/0004-account-is-the-single-identity-sor.md) | Accepted |
 
 ---
 

--- a/crates/services/auth/docs/DOMAIN.md
+++ b/crates/services/auth/docs/DOMAIN.md
@@ -139,8 +139,8 @@ access token. Reuse of a rotated token is a security signal.
 
 | Decision | ADR | Status |
 |---|---|---|
-| Federated Keycloak credentials + bespoke ES256 edge tokens; distinct from `account` (SoR) and `auth-context` (verify lib) | _candidate — not yet recorded_ | — |
-| Instant revocation via monotonic per-subject `Generation` despite stateless tokens | _candidate — not yet recorded_ | — |
+| Federated Keycloak credentials + bespoke ES256 edge tokens; distinct from `account` (SoR) and `auth-context` (verify lib) | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) | Accepted |
+| Instant revocation via monotonic per-subject `Generation` despite stateless tokens | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) | Accepted |
 
 ---
 

--- a/crates/services/chat/docs/DOMAIN.md
+++ b/crates/services/chat/docs/DOMAIN.md
@@ -135,7 +135,7 @@ unpublishing triggers the `VisibilityWorker` teardown, consuming `chat.conversat
 
 | Decision | ADR | Status |
 |---|---|---|
-| Shadowing Pattern — distinct Member vs Audience visibility planes | _candidate — not yet recorded_ | — |
+| Shadowing Pattern — distinct Member vs Audience visibility planes | [`ADR-0006`](../../../../docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md) | Accepted |
 | Coexist-first with `realtime` (chat keeps its own live plane for now) | _see ADR-0003 consequences_ | Accepted |
 
 ---

--- a/crates/services/comment/docs/DOMAIN.md
+++ b/crates/services/comment/docs/DOMAIN.md
@@ -122,8 +122,8 @@ in `counter` from comment's events).
 
 | Decision | ADR | Status |
 |---|---|---|
-| Nil-UUID sentinel flat-tree + two-table (LCS+TWCS) Scylla layout | _candidate — not yet recorded_ | — |
-| Tombstone vs purge deletion semantics | _candidate — not yet recorded_ | — |
+| Nil-UUID sentinel flat-tree + two-table (LCS+TWCS) Scylla layout | [`ADR-0007`](../../../../docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md) | Accepted |
+| Tombstone vs purge deletion semantics | [`ADR-0007`](../../../../docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md) | Accepted |
 
 ---
 

--- a/crates/services/counter/docs/DOMAIN.md
+++ b/crates/services/counter/docs/DOMAIN.md
@@ -135,8 +135,8 @@ stale/approximate value rather than erroring.
 
 | Decision | ADR | Status |
 |---|---|---|
-| Magnitudes ("how many") are a separate reconcilable SoRef, distinct from edge state ("who"); supersedes engagement's raw counts | _candidate — not yet recorded_ | — |
-| `WindowId`-gated idempotent flush across a 3-tier store | _candidate — not yet recorded_ | — |
+| Magnitudes ("how many") are a separate reconcilable SoRef, distinct from edge state ("who"); supersedes engagement's raw counts | [`ADR-0008`](../../../../docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md) | Accepted |
+| `WindowId`-gated idempotent flush across a 3-tier store | [`ADR-0008`](../../../../docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md) | Accepted |
 
 ---
 

--- a/crates/services/engagement/docs/DOMAIN.md
+++ b/crates/services/engagement/docs/DOMAIN.md
@@ -120,7 +120,7 @@ for durable recording and downstream consumption.
 
 | Decision | ADR | Status |
 |---|---|---|
-| Redis-primary Lua-atomic reactions + Kafka write-behind durability | _candidate — not yet recorded_ | — |
+| Redis-primary Lua-atomic reactions + Kafka write-behind durability | [`ADR-0009`](../../../../docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md) | Accepted |
 | Engagement keeps the reaction *edge*; `counter` supersedes raw magnitudes | _see counter §4_ | Accepted |
 
 ---

--- a/crates/services/geo-discovery/docs/DOMAIN.md
+++ b/crates/services/geo-discovery/docs/DOMAIN.md
@@ -127,7 +127,7 @@ return `MapPostCard`s. A degraded index returns fewer/staler cards (fail-open).
 
 | Decision | ADR | Status |
 |---|---|---|
-| H3 grid_disk viewport + dual-layer Redis (ZSET+cardinality) Top-K spatial index | _candidate — not yet recorded_ | — |
+| H3 grid_disk viewport + dual-layer Redis (ZSET+cardinality) Top-K spatial index | [`ADR-0010`](../../../../docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.md) | Accepted |
 | Post→geo payload enrichment (lat/lng/caption) needs a product decision | _open — see pre-infra audit_ | Open |
 
 ---

--- a/crates/services/media/docs/DOMAIN.md
+++ b/crates/services/media/docs/DOMAIN.md
@@ -136,8 +136,8 @@ blurhash, and transitions the asset to `ready` (or `quarantined`).
 
 | Decision | ADR | Status |
 |---|---|---|
-| Byte-free control plane — pre-signed direct-to-store uploads, bytes never on gRPC/Kafka | _candidate — not yet recorded_ | — |
-| Fail-open delivery / fail-closed CSAM Screen split | _candidate — not yet recorded_ | — |
+| Byte-free control plane — pre-signed direct-to-store uploads, bytes never on gRPC/Kafka | [`ADR-0011`](../../../../docs/adr/0011-media-byte-free-control-plane.md) | Accepted |
+| Fail-open delivery / fail-closed CSAM Screen split | [`ADR-0011`](../../../../docs/adr/0011-media-byte-free-control-plane.md) | Accepted |
 
 ---
 

--- a/crates/services/notification/docs/DOMAIN.md
+++ b/crates/services/notification/docs/DOMAIN.md
@@ -90,7 +90,7 @@ N/A (TIER-2, collapsed) — publishes **none of record** (its `NotificationCreat
 
 ## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
 
-N/A (TIER-2, collapsed) — keystone choice: Redis write-collapse fan-out + claim-gated idempotent unread counter (deterministic UUIDv5 ids, event-time `created_at`, `SET NX` unread claim, `SADD` unique-sender collapse); candidate ADR not yet recorded.
+N/A (TIER-2, collapsed) — keystone choice: Redis write-collapse fan-out + claim-gated idempotent unread counter (deterministic UUIDv5 ids, event-time `created_at`, `SET NX` unread claim, `SADD` unique-sender collapse) — [`ADR-0012`](../../../../docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.md) (Accepted).
 
 ## 10. Subdomain Classification & Evolution &nbsp;·&nbsp; DEEP
 

--- a/crates/services/post/docs/DOMAIN.md
+++ b/crates/services/post/docs/DOMAIN.md
@@ -131,7 +131,7 @@ fans out, `search`/`geo-discovery` index, `counter` counts, `realtime` broadcast
 
 | Decision | ADR | Status |
 |---|---|---|
-| Two-table ScyllaDB layout (by id + by author) with `post.v1.events` as published language | _candidate — not yet recorded_ | — |
+| Two-table ScyllaDB layout (by id + by author) with `post.v1.events` as published language | [`ADR-0013`](../../../../docs/adr/0013-post-two-table-scylla-with-published-language.md) | Accepted |
 | Post→geo payload enrichment (lat/lng/caption) — open product decision | _open — see geo-discovery §6_ | Open |
 
 ---

--- a/crates/services/profile/docs/DOMAIN.md
+++ b/crates/services/profile/docs/DOMAIN.md
@@ -137,8 +137,8 @@ error (tracked by `profile.handle.claim.conflict_total`).
 
 | Decision | ADR | Status |
 |---|---|---|
-| Profile is the public persona over the `account` SoR; emits `profile.v1.events` | _candidate — not yet recorded_ | — |
-| Dual-axis visibility (owner AND moderation) | _candidate — not yet recorded_ | — |
+| Profile is the public persona over the `account` SoR; emits `profile.v1.events` | [`ADR-0014`](../../../../docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md) | Accepted |
+| Dual-axis visibility (owner AND moderation) | [`ADR-0014`](../../../../docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md) | Accepted |
 | Author tier: social-graph computes → profile owns + emits | _open — author-tier initiative_ | Scoped |
 
 ---

--- a/crates/services/search/docs/DOMAIN.md
+++ b/crates/services/search/docs/DOMAIN.md
@@ -131,8 +131,8 @@ filter by dual visibility → return `SearchResults` / `Suggestions`. Fail-open 
 
 | Decision | ADR | Status |
 |---|---|---|
-| OpenSearch single canonical store with external 2-version guard; pure-Kafka command side + stateless read RPC | _candidate — not yet recorded_ | — |
-| Dual visibility authority (owner + moderation) honoured at query time | _candidate — not yet recorded_ | — |
+| OpenSearch single canonical store with external 2-version guard; pure-Kafka command side + stateless read RPC | [`ADR-0015`](../../../../docs/adr/0015-search-opensearch-single-store-external-versioning.md) | Accepted |
+| Dual visibility authority (owner + moderation) honoured at query time | [`ADR-0015`](../../../../docs/adr/0015-search-opensearch-single-store-external-versioning.md) | Accepted |
 
 ---
 

--- a/crates/services/social-graph/docs/DOMAIN.md
+++ b/crates/services/social-graph/docs/DOMAIN.md
@@ -136,7 +136,7 @@ counts via gRPC (the `social-graph.follows` Kafka stream is a deferred producer)
 
 | Decision | ADR | Status |
 |---|---|---|
-| 4-table ScyllaDB schema + Redis hot Sets + logged-batch atomicity for dual-write | _candidate — not yet recorded_ | — |
+| 4-table ScyllaDB schema + Redis hot Sets + logged-batch atomicity for dual-write | [`ADR-0016`](../../../../docs/adr/0016-social-graph-four-table-scylla-logged-batch.md) | Accepted |
 | Author tier: social-graph computes → profile owns + emits | _open — author-tier initiative_ | Scoped |
 
 ---

--- a/crates/services/timeline/docs/DOMAIN.md
+++ b/crates/services/timeline/docs/DOMAIN.md
@@ -126,7 +126,7 @@ the user's high-tier followees, ordered by score via Lua `ZREVRANGEBYSCORE`, pag
 
 | Decision | ADR | Status |
 |---|---|---|
-| Hybrid push/pull fan-out (materialize normal authors, pull high-tier at read) | _candidate — not yet recorded_ | — |
+| Hybrid push/pull fan-out (materialize normal authors, pull high-tier at read) | [`ADR-0017`](../../../../docs/adr/0017-timeline-hybrid-push-pull-fanout.md) | Accepted |
 | Forward-compatibility for author-tier-driven fan-out (shipped #469) | _open — author-tier initiative_ | Scoped |
 
 ---

--- a/docs/adr/0004-account-is-the-single-identity-sor.md
+++ b/docs/adr/0004-account-is-the-single-identity-sor.md
@@ -1,0 +1,36 @@
+# ADR-0004: Account is the single identity SoR and owns an outbound event lane
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** account; consumers audit, profile
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+A real identity (email, phone, KYC, roles) must live in exactly one place, or GDPR erasure becomes
+impossible — every shadow copy is an uncontrolled record that Art. 17 can't reach. Account was also
+a **phantom producer**: it owned identity but published nothing, so downstream contexts had no way
+to react to lifecycle changes except by reaching into account's store.
+
+## Decision
+
+Account **is the single System of Record for the user account** — existence, credential metadata,
+KYC, roles, and GDPR state — and **owns an outbound event lane** (`account.v1.events`, published
+after each durable save). Downstream contexts (`audit`, `profile`) consume references; none holds
+authoritative identity. A `gdpr_deletion_requested` event propagates erasure (audit crypto-shreds
+the subject), closing the Art. 17 loop end to end.
+
+## Consequences
+
+- **Positive:** identity has one home; GDPR erasure has a single authoritative trigger that
+  propagates; downstream stays decoupled (events, not store reach-in).
+- **Negative / accepted trade-off:** account must guarantee event emission after save (an outbox/
+  after-save publish discipline), adding write-path responsibility.
+- **Closes:** the phantom-producer gap and the shadow-identity erasure problem.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Let services read account's store directly | Couples every consumer to account's schema; no erasure propagation |
+| Replicate identity into each service | Multiplies PII copies; makes Art. 17 erasure unenforceable |

--- a/docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md
+++ b/docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md
@@ -1,0 +1,40 @@
+# ADR-0005: Auth federates an IdP and issues platform ES256 edge tokens with generation-based revocation
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** auth; account; auth-context (verify lib); realtime; all services
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Authentication is three concerns that are easy to conflate: the **account** (who exists — a SoR),
+**verification** (does this token check out — a per-service concern), and **issuance** (mint a
+credential, manage the session). We also need fast, stateless-to-verify tokens at the edge *and*
+the ability to revoke instantly — two goals that normally fight (stateless tokens can't be
+recalled).
+
+## Decision
+
+`auth` is a distinct context that **federates an external IdP (Keycloak) for credentials** and
+**issues the platform's own short-lived ES256 edge tokens**. It is separate from `account` (the
+identity SoR) and from `auth-context` (the in-process verify library every service uses — a verify,
+not a call). Instant revocation despite stateless verification is achieved with a **monotonic
+per-subject `Generation`**: bumping it invalidates a whole token family; refresh tokens are
+single-use (rotation invalidates the prior).
+
+## Consequences
+
+- **Positive:** verification is cheap and decentralized (`auth-context`, no call to auth per
+  request); credentials reuse a hardened IdP; revocation is immediate via generation bump.
+- **Negative / accepted trade-off:** the generation counter must be checked at verify time
+  (a small lookup) for revocation to be timely; token lifetime tuning trades revocation latency
+  against verification cost.
+- **Closes:** the conflation of account/verify/issuance; the stateless-vs-revocable tension.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Opaque tokens verified by calling auth per request | Reintroduces a synchronous hop on every authenticated call |
+| Long-lived tokens, no generation | No instant revocation; a leaked token stays valid until expiry |
+| Build our own credential store instead of federating | Re-solves a generic, security-sensitive problem an IdP already solves |

--- a/docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md
+++ b/docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md
@@ -1,0 +1,37 @@
+# ADR-0006: Chat uses the Shadowing Pattern — separate Member and Audience visibility planes
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** chat
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+A conversation has two distinct audiences with different rights: **members** who read and write,
+and a broader **audience** who may view a *published* conversation but not participate. Modelling
+both with one visibility flag leaks member-only state to the audience (or hides published content
+from it), and a published conversation that is later unpublished must have its audience view torn
+down cleanly without disturbing the member log.
+
+## Decision
+
+Chat models the two as **separate planes — the Member plane and the Audience plane (the Shadowing
+Pattern)**. Membership is authorized at the gRPC boundary for the member plane; publishing opens the
+audience plane; unpublishing triggers a `VisibilityWorker` that consumes
+`chat.conversation.unpublished` and dismantles audience-plane state. The message log is stored in a
+bucketed `(conversation_id, bucket)` ScyllaDB partition, decoupled from visibility.
+
+## Consequences
+
+- **Positive:** member-only state never leaks to the audience; publish/unpublish is a clean plane
+  toggle, not a per-message rewrite; the high-volume log scales by bucket.
+- **Negative / accepted trade-off:** two planes to keep coherent, and an async teardown worker
+  (with its own DLQ) to operate.
+- **Closes:** the visibility-conflation leak and the unpublish-teardown problem.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Single visibility flag per conversation | Leaks member state to the audience or hides published content |
+| Per-message ACL checks at read | Expensive on a high-volume log; doesn't model the audience plane |

--- a/docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md
+++ b/docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md
@@ -1,0 +1,36 @@
+# ADR-0007: Comment uses a nil-UUID flat thread, a two-table Scylla layout, and tombstone-vs-purge deletion
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** comment
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Comments are a high-write stream that must be read both by id and in time order, and deletion has
+two genuinely different meanings: a user removing their own comment (leave a visible "deleted"
+marker) versus a moderation/GDPR hard removal (the row must be gone). One deletion semantic can't
+serve both, and a single access pattern can't serve both id-lookup and time-ordered reads cheaply.
+
+## Decision
+
+Comment models a **flat thread using a nil-UUID sentinel** for rootless comments, stores them in a
+**two-table ScyllaDB layout** (an LCS table for id lookups + a TWCS table for the time-ordered
+stream), and makes deletion an **explicit `DeletionStrategy` — tombstone (visible marker) vs purge
+(hard removal)**.
+
+## Consequences
+
+- **Positive:** both read patterns are cheap and compaction-appropriate (LCS vs TWCS); deletion
+  semantics match the actual use cases; the nil-UUID sentinel keeps the model flat and simple.
+- **Negative / accepted trade-off:** dual-table writes to keep consistent; no nested threading
+  (a deliberate simplification).
+- **Closes:** the deletion-semantics ambiguity and the read-pattern mismatch.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Single table | Can't serve id-lookup and time-ordered reads with appropriate compaction |
+| One "deleted" flag | Conflates user-delete (tombstone) with moderation/GDPR purge |
+| Nested thread tree now | Premature complexity for the current product |

--- a/docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md
+++ b/docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md
@@ -1,0 +1,41 @@
+# ADR-0008: Counter is a reconcilable System-of-Reference for magnitudes, distinct from edge state
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** counter; supersedes engagement's raw counts; producer for search, realtime
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+"How many views/likes/followers?" (a **magnitude**) and "who liked/followed whom?" (**edge state**)
+look related but have opposite shapes: magnitudes are a firehose-scale aggregate that tolerates
+approximation and reconciliation; edge state is exact relational truth. Storing magnitudes inside
+the edge-state services (engagement, social-graph) couples a high-write counting workload to the
+relational write path and scatters the same count across services.
+
+## Decision
+
+`counter` is a dedicated **System of Reference for magnitudes** — exact-but-reconcilable, never edge
+state. It ingests a pure-Kafka firehose with windowed N→1 pre-aggregation, stores across a 3-tier
+hot/warm/cold layout (Redis / Postgres SoRef+reconciliation / Scylla TWCS), uses HLL for unique
+counts and CMS for trending, and gates all-tier side effects behind a **`WindowId`-keyed
+idempotency ledger** so replays can't double-count. It **supersedes engagement's raw view/share
+counts** and **reconciles** authoritative totals against the owning SoRs (drift → `CTR-5002`).
+Reads **fail open** (hard timeout → stale/approximate).
+
+## Consequences
+
+- **Positive:** counting scales independently of the edge SoRs; one home per magnitude; replay-safe;
+  hot reads never block the product.
+- **Negative / accepted trade-off:** magnitudes are eventually consistent and reconciled, not
+  transactionally exact at the instant of read; reconciliation sources (e.g. follower counts) must
+  be exposed by the edge SoRs.
+- **Closes:** scattered counters and the high-write-counting-on-the-relational-path coupling.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Keep counts in engagement/social-graph | Couples firehose counting to the relational write path; duplicates counts |
+| Exact transactional counters | Doesn't scale to firehose volume; melts the hot path |
+| Approximate-only (no reconciliation) | Drifts unboundedly from the authoritative edge truth |

--- a/docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md
+++ b/docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md
@@ -1,0 +1,37 @@
+# ADR-0009: Engagement is Redis-primary with Lua-atomic edges and Kafka write-behind durability
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** engagement; counter (magnitudes); notification, geo-discovery
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Reactions are extremely high-frequency, idempotent toggles (like/unlike). A per-toggle database
+round-trip can't keep up, and a non-atomic read-modify-write races under concurrency (double-likes,
+lost unlikes). But reactions are still an **edge of record** ("who reacted, how") that must survive
+a cache loss.
+
+## Decision
+
+Engagement is **Redis-primary**: each react/unreact is a **Lua-atomic** set/clear of the reaction
+edge plus an in-Redis score update (idempotent by construction), with **Kafka write-behind** for
+durable recording and downstream propagation (`engagement.reactions`, `engagement.score_updated`).
+Engagement owns the **edge**; `counter` owns the derived **magnitudes** (see ADR-0008). The edge is
+the truth; the score is derived from `ReactionWeight`s.
+
+## Consequences
+
+- **Positive:** hot-path toggles are atomic and fast with no DB round-trip; durability is preserved
+  asynchronously; magnitudes are someone else's job.
+- **Negative / accepted trade-off:** a window of write-behind lag where the durable record trails
+  Redis; reconciliation/replay depends on the Kafka stream.
+- **Closes:** the per-toggle DB bottleneck and reaction race conditions.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Database-primary reactions | Per-toggle round-trip can't sustain reaction volume |
+| Non-atomic Redis read-modify-write | Races under concurrency (double/lost reactions) |
+| Keep magnitudes here too | Counting belongs in `counter` (ADR-0008) |

--- a/docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.md
+++ b/docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.md
@@ -1,0 +1,38 @@
+# ADR-0010: Geo-discovery is an H3 grid_disk + dual-layer Redis Top-K spatial read-model
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** geo-discovery; upstream post, engagement, profile
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Map viewport queries must return the most relevant posts in a moving rectangle at interactive
+latency, over a post population that constantly changes and must self-trim (stale posts shouldn't
+linger). Arbitrary lat/lng range queries don't index well, and an unbounded per-cell list both
+costs memory and returns junk.
+
+## Decision
+
+Geo-discovery is a **fail-open spatial read-model (SoReference)** built on **H3**: a viewport maps
+to an `H3 grid_disk` of covering cells; each cell is a **dual-layer Redis structure (ZSET +
+cardinality)** maintained by Lua **Top-K / XX / prune** scripts with **TTL'd retention** so the
+index self-trims. Cards are projected from upstream events (`post.published`/`post.deleted`,
+`engagement.score_updated`, `profile.tier_changed`); geo owns no source truth and a degraded index
+returns fewer/staler cards rather than erroring.
+
+## Consequences
+
+- **Positive:** viewport queries become a bounded set of cell lookups; per-cell results are ranked
+  and capped; retention is automatic via TTL; the index is fully rebuildable from upstream.
+- **Negative / accepted trade-off:** results are eventually consistent and approximate (Top-K);
+  depends on upstream emitting the needed payload (see the open post→geo enrichment gap).
+- **Closes:** the spatial-indexing and unbounded-cell-list problems.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| lat/lng range queries on a generic store | Poor spatial locality; slow at viewport scale |
+| Unbounded per-cell lists | Memory blowup; returns low-relevance noise |
+| Make geo a SoR | It's a projection; durability lives in `post` |

--- a/docs/adr/0011-media-byte-free-control-plane.md
+++ b/docs/adr/0011-media-byte-free-control-plane.md
@@ -1,0 +1,38 @@
+# ADR-0011: Media is a byte-free control plane with fail-open delivery and a fail-closed CSAM Screen
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** media; moderation; post, profile, search
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Media means large binaries. Pushing bytes through gRPC or Kafka wrecks both (message-size limits,
+broker pressure, memory). Yet the asset *lifecycle* — uploaded → screened → transformed → ready —
+must be tracked authoritatively, must **never** let unsafe content (CSAM) reach `ready`, and must
+keep serving even when a non-safety dependency is degraded.
+
+## Decision
+
+`media` is a **byte-free control plane**: bytes go **direct to object storage via pre-signed URLs**,
+never over gRPC/Kafka; media owns the asset **metadata/lifecycle SoR** (Postgres + Redis), with the
+bytes in S3/MinIO referenced by `StorageKey`. It runs three planes — (A) upload broker, (B) async
+Kafka transform pipeline, (C) delivery/CDN brokerage — with a **per-category failure posture**:
+delivery resolution **fails open**, while the **CSAM `Screen` gating readiness fails closed** (an
+asset cannot reach `ready` without passing it; a moderation takedown quarantines/deletes).
+
+## Consequences
+
+- **Positive:** the byte plane never stresses the mesh; the lifecycle is authoritative; unsafe
+  content can't go live; delivery degrades gracefully.
+- **Negative / accepted trade-off:** clients must handle the pre-signed-upload handshake; the Screen
+  is a synchronous dependency on readiness (bounded by a hard timeout).
+- **Closes:** bytes-on-the-wire pressure and the unsafe-content-goes-live risk.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Stream bytes through the service / Kafka | Size limits, broker pressure, memory blowup |
+| Store bytes in the database | Wrong tool; bloats the SoR; no CDN path |
+| Fail-open Screen | Lets CSAM reach `ready` during an outage — unacceptable |

--- a/docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.md
+++ b/docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.md
@@ -1,0 +1,37 @@
+# ADR-0012: Notification uses write-collapse fan-out and a claim-gated idempotent unread counter
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** notification; upstream comment, engagement, post, social-graph
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+A user's activity feed has high fan-in: many events (likes, comments, follows) target one user, and
+a naive "one feed write per event" amplifies writes and produces noisy per-event spam ("5 people
+liked" should collapse to one entry). At-least-once Kafka delivery also means redelivery must not
+double-count the unread badge.
+
+## Decision
+
+Notification is a **derived TIER-2 feed** that **write-collapses** the high-fan-in stream into the
+per-user feed (3 layers + an hourly cap), backed by a TWCS activity feed. It guarantees idempotency
+with **deterministic UUIDv5 ids**, **event-time `created_at`** (not ingest time), a **claim-gated
+unread counter** (`SET NX` so a redelivery can't double-increment), and **unique-sender collapse**
+(`SADD`). Live push goes over the gRPC broadcast stream; offline delivery is delegated (APNs/FCM).
+
+## Consequences
+
+- **Positive:** bounded write amplification; collapsed, non-spammy entries; redelivery-safe unread
+  counts; missed notifications are re-derivable (fail-open).
+- **Negative / accepted trade-off:** collapse logic adds Redis-side complexity; the feed is a
+  derived view, authoritative only for itself.
+- **Closes:** write amplification and double-counted badges under at-least-once delivery.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| One feed write per source event | Write amplification + noisy per-event spam |
+| Increment unread without a claim | Redelivery double-counts the badge |
+| Ingest-time `created_at` | Misorders the feed under consumer lag/replay |

--- a/docs/adr/0013-post-two-table-scylla-with-published-language.md
+++ b/docs/adr/0013-post-two-table-scylla-with-published-language.md
@@ -1,0 +1,37 @@
+# ADR-0013: Post uses a two-table ScyllaDB layout and is the published-language fan-out source
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** post; downstream timeline, search, geo-discovery, counter, realtime
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Posts are high-write content read two ways — by post id and by author — and the entire read side of
+the platform (feed, search, discovery, counts, live) depends on knowing when content changes. A
+single-access store can't serve both reads cheaply, and if consumers reach into post's store the
+whole fleet couples to its schema.
+
+## Decision
+
+`post` is the **content System of Record** in a **two-table ScyllaDB layout** (`post.posts` by id +
+`post.posts_by_profile` by author), and emits **`post.v1.events`** (`published`/`updated`/`deleted`)
+as its **Open-Host Service / Published Language** — the single fan-out source the read side consumes.
+Proto enums map the domain tinyint **+1 with no UNSPECIFIED sentinel**. Post denormalizes author and
+moderation state by consuming `profile.v1.events` / `moderation.v1.events`.
+
+## Consequences
+
+- **Positive:** both read patterns are cheap; the read side is decoupled (events, not store
+  reach-in); one authoritative content lifecycle drives feed/search/discovery/counts/live.
+- **Negative / accepted trade-off:** dual-table write consistency to maintain; `post.v1.events` is a
+  hard API contract — a schema change breaks every consumer.
+- **Closes:** the read-pattern mismatch and read-side coupling to post's store.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Single posts table | Can't serve by-id and by-author reads efficiently |
+| Let consumers read post's store | Couples the whole read side to post's schema |
+| Synchronous fan-out to consumers | Puts the read side on the write path |

--- a/docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md
+++ b/docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md
@@ -1,0 +1,39 @@
+# ADR-0014: Profile is the public persona over the account SoR with dual-axis visibility
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** profile; account; downstream post, search, geo-discovery, timeline
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+The public face of a user (handle, display name, bio, avatar, tier) is a different concern from the
+private account of record (credentials, PII, KYC). Bundling them puts PII in the read-hot persona
+store. Two separate parties can also legitimately hide a profile — the **owner** (privacy) and
+**moderation** (enforcement) — and a single visibility flag can't represent both without one
+silently overriding the other. Handles must be globally unique under concurrent claims.
+
+## Decision
+
+`profile` is the **public-persona System of Record**, layered over the `account` SoR (provisioned by
+consuming `account.v1.events`) and holding no PII. Visibility is **dual-axis**: a profile is visible
+only if the **owner AND moderation** both allow it. Handles are **globally unique with conflict-free
+claims** under concurrency. Profile **owns and emits** `profile.v1.events` (including
+`handle_changed`, `profile_verified`, and `tier_changed`) for the read side; the author **tier is
+computed by `social-graph`** but owned and published here.
+
+## Consequences
+
+- **Positive:** PII stays in `account`; persona reads are hot and PII-free; both hide-authorities are
+  represented independently; downstream read models react via events.
+- **Negative / accepted trade-off:** persona must stay eventually consistent with account; the
+  handle-claim path needs atomic uniqueness handling.
+- **Closes:** PII-in-the-persona-store and the single-visibility-flag override problem.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| One service for account + profile | Puts PII in the read-hot persona store |
+| Single visibility flag | Owner and moderation hides silently override each other |
+| Compute/own tier in profile | Tier derives from the follower graph (`social-graph`) |

--- a/docs/adr/0015-search-opensearch-single-store-external-versioning.md
+++ b/docs/adr/0015-search-opensearch-single-store-external-versioning.md
@@ -1,0 +1,38 @@
+# ADR-0015: Search is an OpenSearch read-model with external versioning and a fail-open read path
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** search; upstream post, profile, moderation, counter
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Discovery needs an inverted index over profiles/posts/hashtags, fed by an at-least-once,
+**out-of-order** event stream. A late or duplicated event must not clobber a newer document, the
+index must respect both owner and moderation visibility, reindexing must not cause read downtime,
+and a degraded search cluster must not take down the calling surfaces.
+
+## Decision
+
+`search` is an eventually-consistent **read-model (SoReference)** on **OpenSearch as the single
+canonical store**, with a **pure-Kafka command side** and a **stateless read RPC**. Out-of-order
+writes are guarded by **external `DocVersion`** (a 2-version Painless script rejects stale updates).
+Results honour **dual visibility authority** (owner + moderation). Reindexing is **blue-green** (build
+new index, atomically swap the alias — no read downtime). The read path **fails open** (degrade to
+fewer/staler hits, never error).
+
+## Consequences
+
+- **Positive:** out-of-order events can't regress a document; no read downtime on reindex;
+  visibility is enforced at query time; a degraded cluster degrades search, not the product.
+- **Negative / accepted trade-off:** search is eventually consistent; OpenSearch is a single store
+  (no second source of truth — it's rebuildable from upstream instead).
+- **Closes:** stale-overwrite races, reindex downtime, and search-outage blast radius.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Trust event order | At-least-once + reordering corrupts the index |
+| In-place reindex | Read downtime during rebuild |
+| Fail-closed reads | A search outage would break the calling surfaces |

--- a/docs/adr/0016-social-graph-four-table-scylla-logged-batch.md
+++ b/docs/adr/0016-social-graph-four-table-scylla-logged-batch.md
@@ -1,0 +1,39 @@
+# ADR-0016: Social-graph uses a 4-table Scylla schema with logged-batch atomic dual-writes
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** social-graph; downstream timeline, counter; profile (tier)
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+A relation is inherently bidirectional to query — "who do I follow" and "who follows me" — so each
+follow/block needs a forward and a reverse index. If those two writes can diverge, the graph
+corrupts (a follow visible one way but not the other). Hot reads (timeline fan-out) need the
+follower set fast, and a block must atomically sever existing follows both ways. Author tier derives
+from follower count but is *presented* on the profile.
+
+## Decision
+
+`social-graph` is the **relations System of Record** on a **4-table ScyllaDB schema** (forward +
+reverse indexes for follows and blocks) with **Redis hot Sets** for follower reads, and writes the
+forward + reverse rows in a **logged batch** so the dual-write is atomic. A block severs existing
+follows (`SeveredFollows`). **Author tier is computed here** from follower count crossing
+`TierThresholds`, but **owned and emitted by `profile`** (ADR-0014). `timeline`/`counter` read the
+graph over gRPC (the `social-graph.follows` Kafka producer is deferred).
+
+## Consequences
+
+- **Positive:** forward/reverse indexes can't diverge; follower reads are hot; blocks are consistent;
+  tier computation lives where the follower data is.
+- **Negative / accepted trade-off:** logged batches cost more than independent writes; orphan
+  reconciliation is still a tracked debt; consumers read via gRPC until the follows stream lands.
+- **Closes:** the divergent-index corruption risk and slow follower reads.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Single forward-only table | Reverse queries ("who follows me") become full scans |
+| Non-atomic forward/reverse writes | Indexes diverge → graph corruption |
+| Emit tier from social-graph | Tier is *presented* on the profile (ADR-0014) |

--- a/docs/adr/0017-timeline-hybrid-push-pull-fanout.md
+++ b/docs/adr/0017-timeline-hybrid-push-pull-fanout.md
@@ -1,0 +1,37 @@
+# ADR-0017: Timeline uses a hybrid push/pull fan-out
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Context(s) affected:** timeline; upstream post, social-graph, profile
+- **Deciders:** arnaudmaillet (architecture)
+
+## Context and problem
+
+Feed generation has two classic failure modes. **Fan-out on write** (materialize every post into
+every follower's feed) explodes for high-follower authors — one celebrity post writes millions of
+rows. **Fan-out on read** (pull every followee's posts at read time) explodes for users who follow
+many accounts. Neither extreme scales for both author and reader distributions.
+
+## Decision
+
+`timeline` is a **SoReference feed read-model** using a **hybrid push/pull fan-out**: normal-tier
+authors are **pushed** (materialized into follower feed ZSETs on `post.published`); high-tier authors
+are **pulled** at read time, and the two are **merged via a Lua `ZREVRANGEBYSCORE`**, paginated by
+`FeedCursor`. The push/pull boundary is driven by `AuthorTier` (consumed from `profile`). The follower
+set is read from `social-graph` over gRPC; the feed is fail-open and rebuildable.
+
+## Consequences
+
+- **Positive:** bounds both write amplification (no million-row celebrity fan-out) and read
+  amplification (no pull of thousands of followees); ordering is a single Lua merge.
+- **Negative / accepted trade-off:** read-time merge complexity; correctness depends on the
+  author-tier signal; fan-out performance is a tracked tuning debt.
+- **Closes:** the celebrity write-amplification and the heavy-follower read-amplification problems.
+
+## Alternatives rejected
+
+| Option | Why rejected |
+|---|---|
+| Pure fan-out on write | Celebrity posts write millions of feed rows |
+| Pure fan-out on read | Users following many accounts pay huge read cost |
+| Static threshold without tier signal | Misclassifies authors; needs the `profile` tier input |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,13 +30,27 @@ Proposed --> Accepted --> Superseded by ADR-00MM
 | [0001](./0001-audit-is-a-separate-evidence-plane.md) | Audit is a separate tamper-evident evidence plane, not a log aggregator | Accepted | audit |
 | [0002](./0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) | Moderation is the decision/enforcement SoR with a narrow fail-closed Screen gate | Accepted | moderation |
 | [0003](./0003-realtime-is-a-fail-open-system-of-connection.md) | Realtime is a fail-open System-of-Connection, never a record store | Accepted | realtime |
+| [0004](./0004-account-is-the-single-identity-sor.md) | Account is the single identity SoR and owns an outbound event lane | Accepted | account |
+| [0005](./0005-auth-federated-idp-with-platform-edge-tokens.md) | Auth federates an IdP and issues platform ES256 edge tokens with generation-based revocation | Accepted | auth |
+| [0006](./0006-chat-shadowing-pattern-member-vs-audience-plane.md) | Chat uses the Shadowing Pattern — separate Member and Audience visibility planes | Accepted | chat |
+| [0007](./0007-comment-flat-thread-two-table-tombstone-purge.md) | Comment uses a nil-UUID flat thread, two-table Scylla, tombstone-vs-purge deletion | Accepted | comment |
+| [0008](./0008-counter-magnitudes-are-a-reconcilable-soref.md) | Counter is a reconcilable SoReference for magnitudes, distinct from edge state | Accepted | counter |
+| [0009](./0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md) | Engagement is Redis-primary (Lua-atomic) with Kafka write-behind durability | Accepted | engagement |
+| [0010](./0010-geo-discovery-h3-grid-dual-layer-redis-topk.md) | Geo-discovery is an H3 grid_disk + dual-layer Redis Top-K spatial read-model | Accepted | geo-discovery |
+| [0011](./0011-media-byte-free-control-plane.md) | Media is a byte-free control plane (fail-open delivery / fail-closed CSAM Screen) | Accepted | media |
+| [0012](./0012-notification-write-collapse-fanout-claim-gated-counter.md) | Notification uses write-collapse fan-out + a claim-gated idempotent unread counter | Accepted | notification |
+| [0013](./0013-post-two-table-scylla-with-published-language.md) | Post uses a two-table Scylla layout and is the published-language fan-out source | Accepted | post |
+| [0014](./0014-profile-public-persona-with-dual-axis-visibility.md) | Profile is the public persona over the account SoR with dual-axis visibility | Accepted | profile |
+| [0015](./0015-search-opensearch-single-store-external-versioning.md) | Search is an OpenSearch read-model with external versioning and a fail-open read path | Accepted | search |
+| [0016](./0016-social-graph-four-table-scylla-logged-batch.md) | Social-graph uses a 4-table Scylla schema with logged-batch atomic dual-writes | Accepted | social-graph |
+| [0017](./0017-timeline-hybrid-push-pull-fanout.md) | Timeline uses a hybrid push/pull fan-out | Accepted | timeline |
 
 <!-- Add one row per ADR as it lands. -->
 
 ## Backlog
 
-These three exemplars migrate each service's **keystone** decision. The finer-grained locked
-choices behind them are good candidates for their own ADRs as they are next revisited — e.g.
-audit's crypto-shred RtbF mechanism, its dual-lane fail-open/fail-closed split, and the
-hash-chain + WORM + external-witness immutability scheme could each become a standalone ADR that
-this keystone references.
+Every service now has a keystone ADR (0001–0017). The next candidates are the **finer-grained locked
+choices** behind them, to be recorded as their own ADRs when next revisited — e.g. audit's
+crypto-shred RtbF mechanism, its dual-lane fail-open/fail-closed split, and the hash-chain + WORM +
+external-witness immutability scheme; auth's session-`Generation` rotation; profile/social-graph's
+author-tier producer flow.


### PR DESCRIPTION
## Why

Closes the highest-value follow-up from the functional-documentation rollout: every service's `DOMAIN.md §9` listed its keystone decision as _candidate — not yet recorded_. This records all 14 as proper ADRs, so the *why* behind each boundary lives in an immutable, linkable place.

## What

14 new MADR-lean ADRs (one screen each), all **Accepted**, dated 2026-06-26 (the build/decision date):

| ADR | Service | Keystone decision |
|---|---|---|
| 0004 | account | single identity SoR + outbound event lane |
| 0005 | auth | federated IdP + ES256 edge tokens + generation revocation |
| 0006 | chat | Shadowing Pattern (Member vs Audience plane) |
| 0007 | comment | nil-UUID flat thread + two-table Scylla + tombstone/purge |
| 0008 | counter | reconcilable SoReference for magnitudes vs edge state |
| 0009 | engagement | Redis-primary Lua-atomic edges + Kafka write-behind |
| 0010 | geo-discovery | H3 grid_disk + dual-layer Redis Top-K |
| 0011 | media | byte-free control plane (fail-open delivery / fail-closed Screen) |
| 0012 | notification | write-collapse fan-out + claim-gated unread counter |
| 0013 | post | two-table Scylla + `post.v1.events` published language |
| 0014 | profile | public persona over account SoR + dual-axis visibility |
| 0015 | search | OpenSearch single store + external versioning + fail-open reads |
| 0016 | social-graph | 4-table Scylla + logged-batch atomic dual-writes |
| 0017 | timeline | hybrid push/pull fan-out |

Each carries Context/Decision/Consequences (positive + accepted trade-off + what it closes) and a rejected-alternatives table. ADRs cross-reference where decisions interlock (0008↔0009 magnitudes-vs-edge; 0014↔0016 tier ownership).

- ADR index (`docs/adr/README.md`) updated → **0001–0017** listed; backlog now points at finer-grained sub-decisions.
- All 14 `DOMAIN.md §9` rows now link the recorded ADR (**no "candidate" rows remain**).

## Verification

- 18 ADR files (template + 0001–0017); 0 remaining "candidate — not yet recorded".
- Every ADR link in every `DOMAIN.md` resolves; ADR index rows resolve.
- i18n drift gate: **PASS**.

## Remaining follow-ups (unchanged)

- Extend the i18n gate to `DOMAIN.*.md` + add `DOMAIN.fr.md` / ADR French mirrors.
- Populate `CONTEXT_MAP.md` / `EVENT_CATALOG.md`, then regenerate a corrected C4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)