### PR TITLE
docs(domain): populate CONTEXT_MAP and EVENT_CATALOG from the Domain Cards

### DIFF
--- a/docs/domain/CONTEXT_MAP.md
+++ b/docs/domain/CONTEXT_MAP.md
@@ -1,46 +1,103 @@
 # Context Map
 
-> 🟡 **Scaffold.** This file is the cross-context relationship map for the platform. It is
-> **multi-owner** — no single crate can keep it true — so it lives here, owned by the
-> architecture guild. Fill it from ground truth (the crates, their `*.v1` protos, and the
-> event-topology registry guard), **never** from the quarantined legacy C4.
+> Populated from the 17 per-service Domain Cards (`crates/services/<svc>/docs/DOMAIN.md` §1 + §7),
+> grounded in the crates, their `*.v1` protos, and the event-topology registry guard. This file is
+> **multi-owner** (the architecture guild owns it). Do **not** derive it from the quarantined
+> legacy C4 in [`docs/_legacy/`](../_legacy/README.md).
 
 ## What this document is
 
-A [DDD **context map**](https://martinfowler.com/bliki/BoundedContext.html): the bounded
-contexts and the *type of coupling* on every edge between them. The coupling type — not just
-"A talks to B" — is the point, because it tells a reviewer what breaks when a neighbour changes.
+A [DDD **context map**](https://martinfowler.com/bliki/BoundedContext.html): the bounded contexts
+and the *type of coupling* on every edge between them. The coupling type — not just "A talks to B" —
+tells a reviewer what breaks when a neighbour changes.
 
 ## Relationship patterns (the vocabulary)
 
 | Pattern | Meaning in this codebase |
 |---|---|
 | **Open-Host Service / Published Language (OHS/PL)** | A context publishes a stable contract for all comers — our `*.v1` protos and Kafka topics |
-| **Anti-Corruption Layer (ACL)** | A consumer translates a foreign schema into its own model at the edge — e.g. `infrastructure/decode.rs` wire→domain mappers |
+| **Anti-Corruption Layer (ACL)** | A consumer translates a foreign schema into its own model at the edge — the `infrastructure/decode.rs` wire→domain mappers |
 | **Conformist** | A downstream accepts an upstream's model as-is, no translation |
-| **Customer / Supplier** | Downstream's needs are negotiated into the upstream's roadmap |
-| **Shared Kernel** | A shared model both contexts depend on (use sparingly — e.g. shared foundation crates) |
-| **Partnership** | Two contexts succeed or fail together and coordinate releases |
+| **Customer / Supplier** | A synchronous (gRPC) dependency where the downstream's needs shape the upstream |
+| **Separate Ways** | Two contexts deliberately *not* integrated (decoupled on purpose) |
+| **Shared Kernel** | A shared model both contexts depend on (the foundation crates, e.g. `auth-context`) |
 
 ## Subdomain classification
 
-Each context is **Core**, **Supporting**, or **Generic** — this drives investment. Record it in
-each service's Domain Card; this table is the roll-up.
+Drives investment. Rolled up from each Domain Card's class line.
 
-| Context | Subdomain class | Notes |
+| Subdomain class | Contexts | Rationale |
 |---|---|---|
-| `<ctx>` | `<Core \| Supporting \| Generic>` | `<one line>` |
+| **Core** | `post`, `comment`, `chat`, `social-graph`, `engagement` | The content + social fabric — the platform's competitive substance |
+| **Supporting** | `account`, `auth`, `profile`, `audit`, `moderation`*, `media`, `notification`, `realtime`, `search`, `geo-discovery`, `counter`, `timeline` | Necessary capabilities and derived read-models / planes; bespoke but not value-origin |
 
-## The map
+> \* `moderation` is classed **Core** in its own Domain Card (trust & safety is product-differentiating
+> for a UGC network); it is the one judgement call most worth revisiting. All other classifications
+> follow "Core = where truth/value originates; Supporting = derived, infrastructural, or compliance".
 
-> Fill one row per directed edge. Direction is from the perspective of the **owning** context.
+## The map — asynchronous edges (Kafka, Published Language)
 
-| Upstream context | Downstream context | Pattern | Mechanism (topic / RPC) | What breaks downstream if upstream changes |
+> Direction is **producer → consumer**. Every producer topic is part of that context's OHS/PL; every
+> consumer applies an ACL (`decode.rs`) unless noted Conformist.
+
+| Producer | Topic (Published Language) | Consumer | Pattern | What breaks downstream if the producer changes |
 |---|---|---|---|---|
-| `<ctx>` | `<ctx>` | `<OHS/PL \| ACL \| Conformist \| …>` | `<topic.* \| pkg.v1.Rpc>` | `<impact>` |
+| `account` | `account.v1.events` | `audit` | ACL | compliance evidence + GDPR Art. 17 crypto-shred loop |
+| `account` | `account.v1.events` | `profile` | ACL | persona provisioning |
+| `auth` | `auth.v1.events` | `audit` | ACL | session-lifecycle evidence |
+| `profile` | `profile.v1.events` | `post` | ACL | author snapshots on posts |
+| `profile` | `profile.v1.events` | `search` | ACL | profile indexing |
+| `profile` | `profile.v1.events` (`tier_changed`) | `geo-discovery` | ACL | author-tier ranking weight |
+| `profile` | `profile.v1.events` (`tier_changed`) | `timeline` | ACL | push/pull fan-out decision |
+| `profile` | `profile.v1.events` | `social-graph` | ACL | relation validity vs profile existence |
+| `post` | `post.v1.events` | `timeline` | ACL | feed fan-out |
+| `post` | `post.v1.events` | `search` | ACL | post indexing |
+| `post` | `post.v1.events` | `geo-discovery` | ACL | map cards |
+| `post` | `post.v1.events` | `counter` | ACL | post magnitudes |
+| `post` | `post.v1.events` | `realtime` | ACL (broadcast) | live post broadcast |
+| `comment` | `comment.created` / `comment.deleted` | `notification` | ACL | reply notifications |
+| `comment` | `comment.created` / `comment.deleted` | `engagement` / `counter` | ACL | comment counts |
+| `engagement` | `engagement.reactions` | `notification` | ACL | reaction notifications |
+| `engagement` | `engagement.reactions` | `counter` | ACL | reaction magnitudes |
+| `engagement` | `engagement.score_updated` | `geo-discovery` | ACL | virality ranking |
+| `counter` | `counter.v1.popularity` | `search` | ACL | popularity ranking signal |
+| `counter` | `counter.v1.popularity` | `realtime` | ACL (broadcast) | live engagement counters |
+| `moderation` | `moderation.v1.events` (`decision_recorded`) | `audit` | ACL | DSA-rationale compliance evidence |
+| `moderation` | `moderation.v1.events` (Plane B) | `timeline`, `chat`, `account` | ACL | enforcement denormalization |
+| `moderation` | `moderation.v1.events` | `post`, `search` | ACL | content visibility/enforcement reflection |
+| `moderation` | `moderation.v1.events` (takedown) | `media` | ACL | asset takedown |
+| `media` | `media.v1.events` | `post`, `profile`, `search` | ACL | embeds / indexing |
+| `notification` | `notification.v1.events` | `realtime` | ACL (targeted) | live notification delivery |
+| `chat` | `chat.conversation.unpublished` | `chat` `VisibilityWorker` | internal | audience-plane teardown |
+| `social-graph` | relation events (`ProfileFollowed`…) | — | OHS (deferred) | the `social-graph.follows` Kafka producer is **deferred**; consumers read via gRPC today |
+
+## The map — synchronous edges (gRPC + verify)
+
+| Caller | Callee | Pattern | Mechanism | What breaks if the callee changes |
+|---|---|---|---|---|
+| `media` | `moderation` | Customer/Supplier (sync, fail-closed) | `Screen` RPC | catastrophic-category upload gating |
+| `moderation` | `account` | Customer/Supplier | suspension/ban execution | enforcement application |
+| `timeline` | `social-graph` | Customer/Supplier | follower-set reads for fan-out | feed fan-out |
+| `counter` | `social-graph` | Customer/Supplier | follower-count reconciliation | follower-magnitude drift heal |
+| `post` | `media` | Customer/Supplier | `MediaAttachment` references | media in posts |
+| `comment` | `post` | Customer/Supplier | `PostId` references | comment validity |
+| `auth` | `account` | Customer/Supplier | `SubjectLink` ↔ `AccountId` | session subject resolution |
+| `realtime` | `auth` | Conformist (verify-only) | `auth-context` ES256 token verify at handshake | new connection authentication |
+| **all services** | `auth` | Shared Kernel / OHS | edge token verified in-process via `auth-context` | every authenticated call |
+
+## Notable non-integrations (Separate Ways)
+
+| A | B | Why deliberately decoupled |
+|---|---|---|
+| `realtime` | `chat` | `chat.message.sent` is **not** consumed by `realtime`; chat runs its own live plane (coexist-first — see [`ADR-0003`](../adr/0003-realtime-is-a-fail-open-system-of-connection.md) / [`ADR-0006`](../adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md)). Consolidation is a future decision. |
+
+## Terminal sinks (consume, never produce of record)
+
+`audit`, `search`, `timeline`, `geo-discovery`, `realtime` publish **nothing of record** — they are
+read-models or evidence sinks. See each Domain Card §8.
 
 ## Diagram
 
 > A C4 Container/Component view will be **regenerated from this map** (and the per-service Domain
-> Cards) once the scaffold is filled. Until then, this table is authoritative. Do **not** link
-> the legacy C4 in `docs/_legacy/`.
+> Cards) as a derived artifact. Until then, this document is authoritative. Do **not** link the
+> legacy C4 in [`docs/_legacy/`](../_legacy/README.md).

--- a/docs/domain/EVENT_CATALOG.md
+++ b/docs/domain/EVENT_CATALOG.md
@@ -1,25 +1,118 @@
 # Event Catalog (semantic)
 
-> 🟡 **Scaffold — to be generated.** This catalog records the **business meaning** of every
-> domain event on the platform: *what does it mean that this happened, and who reacts?* It does
-> **not** restate the wire/proto schema — that is owned by each producer's contract.
+> Populated from each producer's Domain Card §8 (`crates/services/<svc>/docs/DOMAIN.md`). Records the
+> **business meaning** of every domain event — *what does it mean that this happened, and who
+> reacts?* It does **not** restate the wire/proto schema (owned by each producer's contract).
 
-## Source: the topology guard, not hand-maintenance
+## Source of truth & maintenance
 
-The list of topics, their producers, and their consumers is **machine-checked** by the
-event-topology registry guard (with its contract tests). This catalog must be **generated** from
-that registry so it cannot drift from reality. Hand-editing the topic list here is forbidden;
-only the *semantic* columns (meaning, trigger, reaction) are authored by humans.
+The list of topics, producers, and consumers is **machine-checked** by the event-topology registry
+guard (with its contract tests). The **topic / producer / consumer** columns here should be
+**reconciled with that registry** (ideally generated from it) so they cannot drift; only the
+**semantic** columns (*means* / *trigger*) are authored by humans. Until generation is wired, treat
+the registry guard — not this table — as the authority on *which* edges exist; this table is the
+authority on what they *mean*.
 
-## Per event
+Cross-reference each edge in [`CONTEXT_MAP.md`](./CONTEXT_MAP.md), and the per-event detail in each
+producer's `DOMAIN.md §8`.
 
-| Topic | Means (past-tense business fact) | Emitted when (domain trigger) | Producer | Consumers & why |
-|---|---|---|---|---|
-| `<topic.thing.happened>` | `<the irreversible business fact it asserts>` | `<the domain transition that fires it>` | `<ctx>` | `<ctx>` — `<reaction>` |
+## Identity & Account — `account.v1.events` (producer: `account`)
 
-## Published Language note
+| Event | Means (past-tense business fact) | Emitted when | Consumers & why |
+|---|---|---|---|
+| `account_created` / `email_changed` / `email_verified` / `phone_changed` | a PII-bearing account lifecycle fact occurred | the matching command commits | `audit` (PII sealed in crypto-shred envelope), `profile` (persona) |
+| `password_changed` / `mfa_enrolled` / `mfa_revoked` | a security/credential fact (no PII) | credential change | `audit` (Authentication category) |
+| `activated` / `deactivated` / `suspended` / `deleted` / `kyc_status_changed` | an identity-lifecycle transition | lifecycle change | `audit` (Identity), `profile` |
+| `role_assigned` / `role_revoked` | an authorization grant changed | role grant/revoke | `audit` (Authorization) |
+| `gdpr_deletion_requested` | the right to erasure (Art. 17) was invoked | user/DPO request | `audit` → **crypto-shreds the subject** (closes the Art. 17 loop) |
+| `gdpr_data_export_requested` | the right to access/portability was invoked | user/DPO request | export fulfilment (downstream) |
 
-Every topic in this catalog is part of a context's **Open-Host Service / Published Language**: a
-schema change is a breaking API change for every consumer listed. Cross-reference each topic's
-producer/consumer edge in [`CONTEXT_MAP.md`](./CONTEXT_MAP.md), and the per-event *semantics* in
-each producer's `DOMAIN.md §8`.
+## Authentication — `auth.v1.events` (producer: `auth`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `session_issued` | an authenticated session was established | login / token issuance | `audit` (Authentication) |
+| `session_revoked` | a session was invalidated | logout / revoke / generation bump | `audit` (Authentication) |
+| `subject_linked` | an IdP subject was bound to an account | account-link flow | internal |
+
+## Profile — `profile.v1.events` (producer: `profile`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `profile_created` / `profile_updated` | the public persona was created/edited | command commits | `post`/`search` (snapshots, indexing) |
+| `handle_changed` | the @handle changed | handle claim | `search` (re-index), embeds |
+| `profile_verified` | the verification badge changed | verification | `search`, embeds |
+| `tier_changed` | the author tier changed | tier recompute (from `social-graph`) | `geo-discovery` (weight), `timeline` (push/pull) |
+| `profile_hidden` / `profile_restored` / `profile_deleted` | a visibility/lifecycle transition | owner or moderation action | read models (teardown/restore) |
+
+## Content — `post.v1.events` (producer: `post`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `post.published` | new content went live | publish commits | `timeline` (fan-out), `search`/`geo-discovery` (index), `counter`, `realtime` (broadcast) |
+| `post.updated` | content was edited | update commits | `search`/`geo-discovery` (re-index) |
+| `post.deleted` | content was removed | delete commits | `timeline`/`search`/`geo-discovery` (teardown) |
+
+## Comments — `comment.created` / `comment.deleted` (producer: `comment`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `comment.created` | a comment was posted on a post | create commits | `notification` (notify author), `counter`/`engagement` (count++) |
+| `comment.deleted` | a comment was tombstoned or purged | delete commits | `counter`/`engagement` (count--), feeds |
+
+## Engagement — `engagement.*` (producer: `engagement`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `engagement.reactions` (`ReactionUpserted`/`Removed`) | a reaction edge was set/cleared | react/unreact commits | `notification`, `counter` |
+| `engagement.score_updated` | the weighted engagement score changed | score recompute | `geo-discovery` (virality), `counter` |
+| `engagement.post_reactions` / `engagement.post_interaction_counters` | per-post reaction/interaction rollups | aggregation | downstream consumers |
+
+## Magnitudes — `counter.v1.popularity` (producer: `counter`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `counter.v1.popularity` | an entity's popularity magnitude changed | a window flush updates a popularity score | `search` (ranking), `realtime` (live broadcast) |
+
+## Trust & Safety — `moderation.v1.events` (producer: `moderation`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `decision_recorded` | an authoritative integrity ruling was made — carries *who decided* + *why* (DSA SoR) | a decision is recorded (auto-screen / human review / appeal reversal) | `audit` (seals rationale in crypto-shred envelope) |
+| `enforcement_applied` / `enforcement_reversed` | a consequence was applied/lifted against an actor (versioned) | enforcement commits | `timeline`, `chat`, `account` (Plane-B denorm); `audit` |
+| `case_opened` / `case_resolved` | a review unit opened/closed | ingestion threshold / reviewer action | Plane-B consumers |
+| `appeal_resolved` | an appeal was decided | appeal resolution | Plane-B consumers |
+
+> Keyed by `actor_id` for per-actor ordering. `decision_recorded` is the compliance-evidence variant
+> (offender-centric consumers ignore it; `audit` consumes it + `enforcement_applied`).
+
+## Conversations — `chat.*` (producer: `chat`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `chat.conversation.created` / `chat.conversation.published` / `chat.conversation.unpublished` | conversation lifecycle facts | create / publish / unpublish | `VisibilityWorker` (audience-plane teardown), consumers |
+| `chat.member.joined` / `chat.member.left` | membership changed | join/leave | consumers |
+| `chat.message.sent` | a message was committed to the log | send commits | chat's own live plane (**not** consumed by `realtime` — Separate Ways) |
+
+## Media — `media.v1.events` (producer: `media`)
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `asset_uploaded` | bytes landed in the object store | finalize | the transform pipeline (Plane B) |
+| `asset_ready` / `asset_variant_ready` | the asset (or a variant) is safe to deliver | CSAM Screen passes / rendition done | `post`, `profile`, `search` |
+| `asset_quarantined` / `asset_deleted` / `asset_restored` | a safety/lifecycle transition | Screen fail / takedown / restore | embeds, delivery |
+| `asset_failed` | processing failed | timeout/error | upload UX |
+
+## Social Graph — relation events (producer: `social-graph`) — **Kafka producer deferred**
+
+| Event | Means | Emitted when | Consumers & why |
+|---|---|---|---|
+| `ProfileFollowed` / `ProfileUnfollowed` | a follow edge was created/removed | follow/unfollow commits | `timeline`/`counter` (consume **via gRPC today**; the `social-graph.follows` stream is deferred) |
+| `ProfileBlocked` / `ProfileUnblocked` | a block edge changed (severs follows) | block/unblock commits | feeds |
+| `AuthorTierChanged` | the author's tier changed | follower count crosses a threshold | `profile` (owns + re-emits as `tier_changed`) |
+
+## Terminal sinks — publish nothing of record
+
+`audit`, `search`, `timeline`, `geo-discovery`, `realtime` consume the above and assert no durable
+business facts outward. `notification`'s `NotificationCreated`/`Read` are internal feed state, not a
+System-of-Record stream.

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -33,9 +33,9 @@ will be *regenerated from* the Domain Cards + `CONTEXT_MAP.md`.
 
 | File | What it holds | Status |
 |---|---|---|
-| [`CONTEXT_MAP.md`](./CONTEXT_MAP.md) | DDD context map across all contexts, with relationship patterns (ACL / Conformist / Published Language / OHS) | 🟡 scaffold |
+| [`CONTEXT_MAP.md`](./CONTEXT_MAP.md) | DDD context map across all 17 contexts, with relationship patterns (ACL / Conformist / Published Language / OHS / Customer-Supplier / Separate Ways) | ✅ populated |
 | [`UBIQUITOUS_LANGUAGE.md`](./UBIQUITOUS_LANGUAGE.md) | Terms shared across more than one context (per-context terms stay in each `DOMAIN.md`) | 🟡 scaffold |
-| [`EVENT_CATALOG.md`](./EVENT_CATALOG.md) | Semantic meaning of every domain event; **to be generated** from the topology guard | 🟡 scaffold |
+| [`EVENT_CATALOG.md`](./EVENT_CATALOG.md) | Semantic meaning of every domain event (authored from the Domain Cards; topic/producer/consumer columns to be reconciled with the topology guard) | ✅ populated |
 
 ## Service domain docs (per-crate `DOMAIN.md`)
 


### PR DESCRIPTION
## Why

The two central cross-context documents were scaffolds. This populates them from the 17 per-service Domain Cards — the single multi-owner view of how the contexts relate and what every event means.

## What

**`CONTEXT_MAP.md`** — synthesized from each Domain Card's §1 (subdomain class) + §7 (relationships):
- **Subdomain roll-up:** Core = `post`/`comment`/`chat`/`social-graph`/`engagement`; Supporting = the rest (`moderation` flagged as the one judgement call — Core in its own card).
- **Async edges** (Kafka Published Language → ACL consumers), one row per producer topic with "what breaks downstream".
- **Sync edges** (gRPC Customer/Supplier; `auth-context` verify as Shared Kernel/OHS).
- **Separate Ways** (`realtime` ↔ `chat`) and **terminal sinks** (`audit`/`search`/`timeline`/`geo-discovery`/`realtime`) called out explicitly.

**`EVENT_CATALOG.md`** — semantic meaning of every domain event, grouped by producer, with trigger + consumer rationale. The `social-graph.follows` Kafka producer is marked **deferred** (consumed via gRPC today). Notes that topic/producer/consumer columns should be **reconciled with the event-topology registry guard** (semantics authored by humans; the guard remains the authority on *which* edges exist).

Index (`docs/domain/README.md`) status → ✅ populated for both.

## Verification

- All relative links (incl. ADR cross-links) resolve.
- i18n drift gate: **PASS**.

## Remaining follow-ups

- `UBIQUITOUS_LANGUAGE.md` still a scaffold (cross-context terms).
- Extend the i18n gate to `DOMAIN.*.md` + add French mirrors.
- Wire `EVENT_CATALOG.md` generation from the topology guard; regenerate a corrected C4 from this map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)