### PR TITLE
docs(domain): populate UBIQUITOUS_LANGUAGE cross-context glossary

### DIFF
--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -34,7 +34,7 @@ will be *regenerated from* the Domain Cards + `CONTEXT_MAP.md`.
 | File | What it holds | Status |
 |---|---|---|
 | [`CONTEXT_MAP.md`](./CONTEXT_MAP.md) | DDD context map across all 17 contexts, with relationship patterns (ACL / Conformist / Published Language / OHS / Customer-Supplier / Separate Ways) | ✅ populated |
-| [`UBIQUITOUS_LANGUAGE.md`](./UBIQUITOUS_LANGUAGE.md) | Terms shared across more than one context (per-context terms stay in each `DOMAIN.md`) | 🟡 scaffold |
+| [`UBIQUITOUS_LANGUAGE.md`](./UBIQUITOUS_LANGUAGE.md) | Terms shared across more than one context — shared (one meaning) vs overloaded (per-context); per-context terms stay in each `DOMAIN.md` | ✅ populated |
 | [`EVENT_CATALOG.md`](./EVENT_CATALOG.md) | Semantic meaning of every domain event (authored from the Domain Cards; topic/producer/consumer columns to be reconciled with the topology guard) | ✅ populated |
 
 ## Service domain docs (per-crate `DOMAIN.md`)

--- a/docs/domain/UBIQUITOUS_LANGUAGE.md
+++ b/docs/domain/UBIQUITOUS_LANGUAGE.md
@@ -1,33 +1,70 @@
 # Ubiquitous Language (cross-context)
 
-> 🟡 **Scaffold.** This glossary holds **only** terms used by more than one bounded context.
-> Terms that live inside a single context belong in that service's `DOMAIN.md §2`, not here.
+> Populated from the 17 per-service Domain Cards (`crates/services/<svc>/docs/DOMAIN.md` §2). Holds
+> **only** terms used by more than one bounded context. Terms that live inside a single context stay
+> in that service's `DOMAIN.md §2`, not here.
 
 ## Why a cross-context glossary
 
-The same word often means different things in different contexts ("post," "user," "delivery"),
-and a few words must mean *exactly the same thing everywhere* (identifiers, tier labels). This
+The same word often means different things in different contexts ("subject", "visibility", "score"),
+and a few words must mean *exactly the same thing everywhere* (identifiers, tier, popularity). This
 file pins down the second category and flags the first, so an event or RPC consumed across a
 boundary is not silently misread.
 
 ## Rules
 
-- **Code symbol is mandatory.** A term with no `crate::Type` / proto / topic is aspirational,
-  not ubiquitous — leave it out until it has one.
-- **Contracts stay in English.** Per the [translation standard](../i18n/TRANSLATION.md),
-  identifiers, error codes, topics, env vars, and type names are language-invariant.
-- **Note divergence.** When a word means different things in different contexts, give it a row
-  per context and say so explicitly.
+- **Code symbol is mandatory.** A term with no `crate::Type` / proto / topic is aspirational, not
+  ubiquitous — leave it out until it has one. (Pure architectural *posture* vocabulary is listed
+  separately at the bottom, by reference, since it has no single symbol.)
+- **Contracts stay in English.** Per the [translation standard](../i18n/TRANSLATION.md), identifiers,
+  error codes, topics, env vars, and type names are language-invariant.
+- **Note divergence.** When a word means different things in different contexts, give it a row per
+  context and say so explicitly.
 
 ## Shared terms (one meaning everywhere)
 
 | Term | Meaning | Code symbol / contract | Owning context |
 |---|---|---|---|
-| `<Term>` | `<the single platform-wide meaning>` | `<symbol / topic / proto>` | `<ctx>` |
+| Profile id | The public-persona identifier (a profile / content author) | `ProfileId` — aliased `AuthorId` in `geo-discovery` / `timeline` | `profile` |
+| Account id | The account-of-record identifier (the private identity) | `AccountId` | `account` |
+| Post id | The content (post) identifier | `PostId` | `post` |
+| Author tier | The follower-count-derived tier of an author | `AuthorTier` | `social-graph` computes → `profile` owns + emits (`tier_changed`) |
+| Popularity score | The published popularity magnitude of an entity | `PopularityScore` (topic `counter.v1.popularity`) | `counter` |
+| Stream sequence | The per-stream monotonic token a client dedupes / re-syncs from | `StreamSeq` / `SequenceState` | `realtime` |
+| Consumer runtime | The mandatory Kafka consumer runner: manual commit after a terminal outcome, bounded retry + jitter, DLQ on poison/exhaustion | `run_consumer` | `transport` (shared kernel) |
+| Deterministic event id | A content-addressed `UUIDv5` enabling idempotent dedup on at-least-once redelivery | UUIDv5 id convention | `notification`, `moderation`, `audit` |
+| Monotonic per-subject version | A counter bumped per subject to order / revoke (revocation family; enforcement ordering) | `Generation` (`auth`) · `EnforcementVersion` (`moderation`) | shared pattern |
 
 ## Overloaded terms (different meaning per context)
 
 | Term | Context | Meaning here | Code symbol |
 |---|---|---|---|
-| `<Term>` | `<ctx-A>` | `<meaning in A>` | `<symbol>` |
-| `<Term>` | `<ctx-B>` | `<meaning in B>` | `<symbol>` |
+| **Subject** | `audit` | A pseudonymous **data subject** — the person whose PII is sealed in the chain | pseudonym + `PiiEnvelope` |
+| **Subject** | `moderation` | The **moderated target** — entity type + id + actor + surface | `SubjectRef` |
+| **Subject** | `notification` | The **thing a notification is about** | `SubjectId` / `SubjectKind` |
+| **Visibility** | `chat` | Member-plane vs Audience-plane (the Shadowing Pattern) | `Visibility` |
+| **Visibility** | `profile` | Dual-axis: owner choice **and** moderation masking | `ProfileVisibility` |
+| **Visibility** | `search` | The authority (owner / moderation) honoured at query time | `VisibilityAuthority` |
+| **Visibility** | `media` | Whether / how an asset may be served | `DeliveryVisibility` |
+| **Score** | `engagement` | Reaction-weight-derived engagement score | `ReactionWeight` |
+| **Score** | `geo-discovery` | Virality ranking weight for a map card | `ViralityScore` |
+| **Score** | `counter` | Published popularity magnitude | `PopularityScore` |
+| **Event** | `audit` | An immutable **recorded compliance fact** (the thing stored) | `AuditEvent` / `AuditRecord` |
+| **Event** | fleet-wide | A **published domain fact** on Kafka (the thing emitted) | `DomainEvent` |
+| **Entity kind** | `counter` | The kind of entity being **counted** | `EntityKind` (counter) |
+| **Entity kind** | `search` | The kind of **indexed document** (post / profile / hashtag) | `EntityKind` (search) |
+
+> **Watch-out:** the overloaded terms above are the most common cross-boundary misreads. When an
+> event or RPC crosses contexts, resolve the term against the **producing** context's meaning.
+
+## Cross-cutting posture vocabulary (by reference)
+
+These are pervasive *architectural* terms, not domain types — they have no single code symbol, so
+they live by reference rather than in the tables above:
+
+- **SoR / SoReference / System-of-Connection / Evidence** — a context's authority class; defined per
+  service in each `DOMAIN.md` Domain Card ("System of …").
+- **Fail-open / fail-closed** — a context's failure posture; defined per service in each Domain Card
+  and summarized in `CONTEXT_MAP.md`.
+- **OHS / Published Language / ACL / Conformist / Customer-Supplier / Separate Ways / Shared Kernel**
+  — the DDD coupling vocabulary; defined once in [`CONTEXT_MAP.md`](./CONTEXT_MAP.md#relationship-patterns-the-vocabulary).


### PR DESCRIPTION
## Why

The last `docs/domain/` scaffold. Populates the cross-context glossary so terms that cross a boundary aren't silently misread — the most common source of integration bugs.

## What

Synthesized from the 17 Domain Cards' §2, holding **only** terms used by more than one context (per-context terms stay in each `DOMAIN.md`).

- **Shared terms** (one meaning everywhere, with code symbol): `ProfileId`/`AuthorId`, `AccountId`, `PostId`, `AuthorTier`, `PopularityScore`, `StreamSeq`, `run_consumer`, deterministic `UUIDv5` ids, and the *monotonic per-subject version* pattern (`Generation` in auth / `EnforcementVersion` in moderation).
- **Overloaded terms** (different meaning per context, each with its symbol):
  - **Subject** — audit (data subject / pseudonym) vs moderation (`SubjectRef` target) vs notification (`SubjectId`)
  - **Visibility** — chat (`Visibility` plane) vs profile (`ProfileVisibility` dual-axis) vs search (`VisibilityAuthority`) vs media (`DeliveryVisibility`)
  - **Score** — engagement (`ReactionWeight`) vs geo-discovery (`ViralityScore`) vs counter (`PopularityScore`)
  - **Event** — audit (`AuditEvent`, the recorded fact) vs fleet (`DomainEvent`, the emitted fact)
  - **Entity kind** — counter vs search (`EntityKind` in each, different enums)
  - …with a "resolve against the producing context" watch-out.
- **Cross-cutting posture vocabulary** (SoR/SoRef, fail-open/closed, the DDD coupling patterns) listed **by reference** — they have no single code symbol, per the glossary's own symbol-mandatory rule.

Index (`docs/domain/README.md`) → ✅ populated.

## Verification

- All relative links resolve; the `CONTEXT_MAP.md` anchor target exists.
- i18n drift gate: **PASS**.

## This completes `docs/domain/`

All three central documents are now populated (CONTEXT_MAP, EVENT_CATALOG, UBIQUITOUS_LANGUAGE), atop 17/17 `DOMAIN.md` + 17 keystone ADRs.

Remaining (separate workstreams): extend the i18n gate to `DOMAIN.*.md` + French mirrors; generate `EVENT_CATALOG.md` from the topology guard; regenerate a corrected C4 from the context map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)