### PR TITLE
docs(i18n): generalize drift gate + add docs/domain FR mirrors (PR A)

### DIFF
--- a/docs/domain/CONTEXT_MAP.fr.md
+++ b/docs/domain/CONTEXT_MAP.fr.md
@@ -1,0 +1,115 @@
+---
+i18n:
+  source: ./CONTEXT_MAP.md
+  source_sha256: 78fa1c52c786aafc0762034fcf7a106e368e71555bbeaf6d4d9f9f9d9e1a8f08
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`CONTEXT_MAP.md`](./CONTEXT_MAP.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (topics, noms de types, codes d'erreur,
+> identifiants d'ADR) et les noms de patterns DDD sont volontairement laissés en anglais.
+
+# Context Map
+
+> Rempli depuis les 17 Domain Cards par service (`crates/services/<svc>/docs/DOMAIN.md` §1 + §7),
+> ancré dans les crates, leurs protos `*.v1` et la garde de registre de topologie d'événements. Ce
+> fichier est **multi-propriétaire** (la guilde d'architecture le possède). Ne **pas** le dériver du
+> C4 hérité en quarantaine dans [`docs/_legacy/`](../_legacy/README.md).
+
+## Ce qu'est ce document
+
+Une [**context map** DDD](https://martinfowler.com/bliki/BoundedContext.html) : les bounded contexts
+et le *type de couplage* sur chaque arête entre eux. Le type de couplage — pas seulement « A parle à
+B » — indique au relecteur ce qui casse quand un voisin change.
+
+## Patterns de relation (le vocabulaire)
+
+| Pattern | Sens dans ce codebase |
+|---|---|
+| **Open-Host Service / Published Language (OHS/PL)** | Un contexte publie un contrat stable pour tous — nos protos `*.v1` et topics Kafka |
+| **Anti-Corruption Layer (ACL)** | Un consommateur traduit un schéma étranger vers son propre modèle à la frontière — les mappers `infrastructure/decode.rs` wire→domaine |
+| **Conformist** | Un aval accepte le modèle de l'amont tel quel, sans traduction |
+| **Customer / Supplier** | Une dépendance synchrone (gRPC) où les besoins de l'aval façonnent l'amont |
+| **Separate Ways** | Deux contextes délibérément *non* intégrés (découplés à dessein) |
+| **Shared Kernel** | Un modèle partagé dont les deux contextes dépendent (les crates de fondation, ex. `auth-context`) |
+
+## Classification des sous-domaines
+
+Oriente l'investissement. Consolidé depuis la ligne de classe de chaque Domain Card.
+
+| Classe de sous-domaine | Contextes | Justification |
+|---|---|---|
+| **Core** | `post`, `comment`, `chat`, `social-graph`, `engagement` | Le tissu contenu + social — la substance compétitive de la plateforme |
+| **Supporting** | `account`, `auth`, `profile`, `audit`, `moderation`*, `media`, `notification`, `realtime`, `search`, `geo-discovery`, `counter`, `timeline` | Capacités nécessaires et read-models / plans dérivés ; sur-mesure mais pas origine de valeur |
+
+> \* `moderation` est classé **Core** dans sa propre Domain Card (la confiance & sécurité est
+> différenciante pour un réseau UGC) ; c'est le choix le plus discutable. Toutes les autres
+> classifications suivent « Core = là où la vérité/valeur naît ; Supporting = dérivé,
+> infrastructurel ou de conformité ».
+
+## La carte — arêtes asynchrones (Kafka, Published Language)
+
+> Le sens est **producteur → consommateur**. Chaque topic producteur fait partie de l'OHS/PL de ce
+> contexte ; chaque consommateur applique un ACL (`decode.rs`) sauf mention Conformist.
+
+| Producteur | Topic (Published Language) | Consommateur | Pattern | Ce qui casse en aval si le producteur change |
+|---|---|---|---|---|
+| `account` | `account.v1.events` | `audit` | ACL | preuve de conformité + boucle de crypto-shred RGPD Art. 17 |
+| `account` | `account.v1.events` | `profile` | ACL | provisionnement du persona |
+| `auth` | `auth.v1.events` | `audit` | ACL | preuve du cycle de vie des sessions |
+| `profile` | `profile.v1.events` | `post` | ACL | instantanés d'auteur sur les posts |
+| `profile` | `profile.v1.events` | `search` | ACL | indexation des profils |
+| `profile` | `profile.v1.events` (`tier_changed`) | `geo-discovery` | ACL | pondération de classement par tier d'auteur |
+| `profile` | `profile.v1.events` (`tier_changed`) | `timeline` | ACL | décision de fan-out push/pull |
+| `profile` | `profile.v1.events` | `social-graph` | ACL | validité des relations vs existence du profil |
+| `post` | `post.v1.events` | `timeline` | ACL | fan-out du fil |
+| `post` | `post.v1.events` | `search` | ACL | indexation des posts |
+| `post` | `post.v1.events` | `geo-discovery` | ACL | cartes (map cards) |
+| `post` | `post.v1.events` | `counter` | ACL | magnitudes des posts |
+| `post` | `post.v1.events` | `realtime` | ACL (broadcast) | diffusion live des posts |
+| `comment` | `comment.created` / `comment.deleted` | `notification` | ACL | notifications de réponse |
+| `comment` | `comment.created` / `comment.deleted` | `engagement` / `counter` | ACL | comptes de commentaires |
+| `engagement` | `engagement.reactions` | `notification` | ACL | notifications de réaction |
+| `engagement` | `engagement.reactions` | `counter` | ACL | magnitudes de réactions |
+| `engagement` | `engagement.score_updated` | `geo-discovery` | ACL | classement de viralité |
+| `counter` | `counter.v1.popularity` | `search` | ACL | signal de classement par popularité |
+| `counter` | `counter.v1.popularity` | `realtime` | ACL (broadcast) | compteurs d'engagement live |
+| `moderation` | `moderation.v1.events` (`decision_recorded`) | `audit` | ACL | preuve de conformité (justification DSA) |
+| `moderation` | `moderation.v1.events` (Plane B) | `timeline`, `chat`, `account` | ACL | dénormalisation de l'enforcement |
+| `moderation` | `moderation.v1.events` | `post`, `search` | ACL | reflet de visibilité/enforcement du contenu |
+| `moderation` | `moderation.v1.events` (takedown) | `media` | ACL | retrait d'asset |
+| `media` | `media.v1.events` | `post`, `profile`, `search` | ACL | intégrations / indexation |
+| `notification` | `notification.v1.events` | `realtime` | ACL (targeted) | livraison live des notifications |
+| `chat` | `chat.conversation.unpublished` | `VisibilityWorker` de `chat` | interne | démantèlement du plan audience |
+| `social-graph` | événements de relation (`ProfileFollowed`…) | — | OHS (différé) | le producteur Kafka `social-graph.follows` est **différé** ; les consommateurs lisent via gRPC aujourd'hui |
+
+## La carte — arêtes synchrones (gRPC + vérification)
+
+| Appelant | Appelé | Pattern | Mécanisme | Ce qui casse si l'appelé change |
+|---|---|---|---|---|
+| `media` | `moderation` | Customer/Supplier (sync, fail-closed) | RPC `Screen` | filtrage des uploads en catégories catastrophiques |
+| `moderation` | `account` | Customer/Supplier | exécution de suspension/bannissement | application de l'enforcement |
+| `timeline` | `social-graph` | Customer/Supplier | lecture de l'ensemble des followers pour le fan-out | fan-out du fil |
+| `counter` | `social-graph` | Customer/Supplier | réconciliation du nombre de followers | correction de dérive des magnitudes de followers |
+| `post` | `media` | Customer/Supplier | références `MediaAttachment` | média dans les posts |
+| `comment` | `post` | Customer/Supplier | références `PostId` | validité des commentaires |
+| `auth` | `account` | Customer/Supplier | `SubjectLink` ↔ `AccountId` | résolution du sujet de session |
+| `realtime` | `auth` | Conformist (verify-only) | vérification du token ES256 via `auth-context` au handshake | authentification des nouvelles connexions |
+| **tous les services** | `auth` | Shared Kernel / OHS | token edge vérifié en process via `auth-context` | tout appel authentifié |
+
+## Non-intégrations notables (Separate Ways)
+
+| A | B | Pourquoi découplés à dessein |
+|---|---|---|
+| `realtime` | `chat` | `chat.message.sent` n'est **pas** consommé par `realtime` ; chat fait tourner son propre plan live (coexist-first — voir [`ADR-0003`](../adr/0003-realtime-is-a-fail-open-system-of-connection.md) / [`ADR-0006`](../adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md)). La consolidation est une décision future. |
+
+## Puits terminaux (consomment, ne produisent rien de référence)
+
+`audit`, `search`, `timeline`, `geo-discovery`, `realtime` ne publient **rien de référence** — ce
+sont des read-models ou des puits de preuve. Voir le §8 de chaque Domain Card.
+
+## Diagramme
+
+> Une vue C4 Container/Component sera **régénérée à partir de cette carte** (et des Domain Cards) en
+> tant qu'artefact dérivé. D'ici là, ce document fait autorité. Ne **pas** lier le C4 hérité dans
+> [`docs/_legacy/`](../_legacy/README.md).

--- a/docs/domain/EVENT_CATALOG.fr.md
+++ b/docs/domain/EVENT_CATALOG.fr.md
@@ -1,0 +1,132 @@
+---
+i18n:
+  source: ./EVENT_CATALOG.md
+  source_sha256: 4124a4f580517b57ac43551aa1a2a121a00d30f522efe102a04d242f2659d237
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`EVENT_CATALOG.md`](./EVENT_CATALOG.md) fait foi.
+> En cas de divergence, l'anglais prime. Les noms d'événements, topics, types et identifiants sont
+> volontairement laissés en anglais.
+
+# Catalogue d'événements (sémantique)
+
+> Rempli depuis le §8 de chaque Domain Card producteur (`crates/services/<svc>/docs/DOMAIN.md`).
+> Consigne le **sens métier** de chaque événement de domaine — *qu'est-ce que ça signifie que ceci
+> soit arrivé, et qui réagit ?* Il ne **reformule pas** le schéma wire/proto (possédé par le contrat
+> de chaque producteur).
+
+## Source de vérité & maintenance
+
+La liste des topics, producteurs et consommateurs est **vérifiée par machine** par la garde de
+registre de topologie d'événements (avec ses tests de contrat). Les colonnes **topic / producteur /
+consommateur** ici devraient être **réconciliées avec ce registre** (idéalement générées depuis lui)
+afin de ne pas dériver ; seules les colonnes **sémantiques** (*signifie* / *déclencheur*) sont
+rédigées à la main. Tant que la génération n'est pas câblée, considérer la garde de topologie — et
+non cette table — comme l'autorité sur *quelles* arêtes existent ; cette table fait autorité sur leur
+*sens*.
+
+Croiser chaque arête dans [`CONTEXT_MAP.md`](./CONTEXT_MAP.md), et le détail par événement dans le
+§8 de chaque producteur.
+
+## Identité & Compte — `account.v1.events` (producteur : `account`)
+
+| Événement | Signifie (fait métier au passé) | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `account_created` / `email_changed` / `email_verified` / `phone_changed` | un fait de cycle de vie de compte porteur de PII s'est produit | la commande correspondante commite | `audit` (PII scellée en enveloppe crypto-shred), `profile` (persona) |
+| `password_changed` / `mfa_enrolled` / `mfa_revoked` | un fait sécurité/identifiant (sans PII) | changement d'identifiant | `audit` (catégorie Authentication) |
+| `activated` / `deactivated` / `suspended` / `deleted` / `kyc_status_changed` | une transition du cycle de vie de l'identité | changement de cycle de vie | `audit` (Identity), `profile` |
+| `role_assigned` / `role_revoked` | un octroi d'autorisation a changé | octroi/révocation de rôle | `audit` (Authorization) |
+| `gdpr_deletion_requested` | le droit à l'effacement (Art. 17) a été invoqué | demande utilisateur/DPO | `audit` → **crypto-shred du sujet** (ferme la boucle Art. 17) |
+| `gdpr_data_export_requested` | le droit d'accès/portabilité a été invoqué | demande utilisateur/DPO | exécution de l'export (en aval) |
+
+## Authentification — `auth.v1.events` (producteur : `auth`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `session_issued` | une session authentifiée a été établie | connexion / émission de token | `audit` (Authentication) |
+| `session_revoked` | une session a été invalidée | déconnexion / révocation / bump de génération | `audit` (Authentication) |
+| `subject_linked` | un sujet IdP a été lié à un compte | flux de liaison de compte | interne |
+
+## Profil — `profile.v1.events` (producteur : `profile`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `profile_created` / `profile_updated` | le persona public a été créé/édité | la commande commite | `post`/`search` (instantanés, indexation) |
+| `handle_changed` | le @handle a changé | revendication de handle | `search` (ré-indexation), intégrations |
+| `profile_verified` | le badge de vérification a changé | vérification | `search`, intégrations |
+| `tier_changed` | le tier d'auteur a changé | recalcul de tier (depuis `social-graph`) | `geo-discovery` (pondération), `timeline` (push/pull) |
+| `profile_hidden` / `profile_restored` / `profile_deleted` | une transition de visibilité/cycle de vie | action propriétaire ou modération | read-models (démantèlement/restauration) |
+
+## Contenu — `post.v1.events` (producteur : `post`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `post.published` | un nouveau contenu est en ligne | la publication commite | `timeline` (fan-out), `search`/`geo-discovery` (index), `counter`, `realtime` (broadcast) |
+| `post.updated` | le contenu a été édité | l'édition commite | `search`/`geo-discovery` (ré-indexation) |
+| `post.deleted` | le contenu a été retiré | la suppression commite | `timeline`/`search`/`geo-discovery` (démantèlement) |
+
+## Commentaires — `comment.created` / `comment.deleted` (producteur : `comment`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `comment.created` | un commentaire a été posté sur un post | la création commite | `notification` (notifier l'auteur), `counter`/`engagement` (compte++) |
+| `comment.deleted` | un commentaire a été tombstoné ou purgé | la suppression commite | `counter`/`engagement` (compte--), fils |
+
+## Engagement — `engagement.*` (producteur : `engagement`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `engagement.reactions` (`ReactionUpserted`/`Removed`) | une arête de réaction a été posée/retirée | react/unreact commite | `notification`, `counter` |
+| `engagement.score_updated` | le score d'engagement pondéré a changé | recalcul du score | `geo-discovery` (viralité), `counter` |
+| `engagement.post_reactions` / `engagement.post_interaction_counters` | agrégats de réactions/interactions par post | agrégation | consommateurs aval |
+
+## Magnitudes — `counter.v1.popularity` (producteur : `counter`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `counter.v1.popularity` | la magnitude de popularité d'une entité a changé | un flush de fenêtre met à jour un score de popularité | `search` (classement), `realtime` (broadcast live) |
+
+## Confiance & Sécurité — `moderation.v1.events` (producteur : `moderation`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `decision_recorded` | une décision d'intégrité faisant autorité a été prise — porte *qui a décidé* + *pourquoi* (SoR DSA) | une décision est enregistrée (auto-screen / revue humaine / réversion d'appel) | `audit` (scelle la justification en enveloppe crypto-shred) |
+| `enforcement_applied` / `enforcement_reversed` | une conséquence a été appliquée/levée contre un acteur (versionnée) | l'enforcement commite | `timeline`, `chat`, `account` (dénorm Plane-B) ; `audit` |
+| `case_opened` / `case_resolved` | une unité de revue a été ouverte/fermée | seuil d'ingestion / action du relecteur | consommateurs Plane-B |
+| `appeal_resolved` | un appel a été tranché | résolution de l'appel | consommateurs Plane-B |
+
+> Clé `actor_id` pour l'ordonnancement par acteur. `decision_recorded` est la variante preuve de
+> conformité (les consommateurs offender-centric l'ignorent ; `audit` consomme celui-ci +
+> `enforcement_applied`).
+
+## Conversations — `chat.*` (producteur : `chat`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `chat.conversation.created` / `chat.conversation.published` / `chat.conversation.unpublished` | faits de cycle de vie de conversation | création / publication / dépublication | `VisibilityWorker` (démantèlement du plan audience), consommateurs |
+| `chat.member.joined` / `chat.member.left` | l'appartenance a changé | join/leave | consommateurs |
+| `chat.message.sent` | un message a été commité dans le journal | l'envoi commite | plan live propre de chat (**non** consommé par `realtime` — Separate Ways) |
+
+## Média — `media.v1.events` (producteur : `media`)
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `asset_uploaded` | les octets ont atterri dans le store objet | finalize | le pipeline de transformation (Plane B) |
+| `asset_ready` / `asset_variant_ready` | l'asset (ou une variante) est sûr à livrer | le Screen CSAM passe / rendition terminée | `post`, `profile`, `search` |
+| `asset_quarantined` / `asset_deleted` / `asset_restored` | une transition sécurité/cycle de vie | échec Screen / takedown / restauration | intégrations, livraison |
+| `asset_failed` | le traitement a échoué | timeout/erreur | UX d'upload |
+
+## Social Graph — événements de relation (producteur : `social-graph`) — **producteur Kafka différé**
+
+| Événement | Signifie | Émis quand | Consommateurs & pourquoi |
+|---|---|---|---|
+| `ProfileFollowed` / `ProfileUnfollowed` | une arête de follow a été créée/retirée | follow/unfollow commite | `timeline`/`counter` (consomment **via gRPC aujourd'hui** ; le stream `social-graph.follows` est différé) |
+| `ProfileBlocked` / `ProfileUnblocked` | une arête de block a changé (sectionne les follows) | block/unblock commite | fils |
+| `AuthorTierChanged` | le tier de l'auteur a changé | le nombre de followers franchit un seuil | `profile` (possède + ré-émet en `tier_changed`) |
+
+## Puits terminaux — ne publient rien de référence
+
+`audit`, `search`, `timeline`, `geo-discovery`, `realtime` consomment ce qui précède et n'affirment
+aucun fait métier durable vers l'extérieur. Les `NotificationCreated`/`Read` de `notification` sont
+un état de fil interne, pas un stream System-of-Record.

--- a/docs/domain/README.fr.md
+++ b/docs/domain/README.fr.md
@@ -1,0 +1,87 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: 1e51acfcac71c9d01929176c1891ba9cc2a8bd67dfd8adc8e940ed89501671e0
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, variables
+> d'environnement, topics Kafka, identifiants, noms de types) sont volontairement laissés en anglais.
+
+# Documentation Domaine & Fonctionnelle
+
+> **Objet.** Ce répertoire contient la documentation fonctionnelle **inter-contexte** de la
+> plateforme — les faits qu'*aucun service ne peut maintenir vrais à lui seul*. La documentation
+> domaine par service vit **avec son crate**, dans `crates/services/<svc>/docs/DOMAIN.md` ; ce
+> répertoire ne contient que ce qui traverse les contextes et indexe le reste.
+
+## La règle de séparation
+
+> **Documenter chaque fait là où il peut devenir faux.** Si exactement un bounded context peut
+> rendre une affirmation fausse, elle vit dans le `DOMAIN.md` de ce crate. Si deux contextes ou
+> plus doivent s'accorder pour qu'elle soit vraie, elle vit ici.
+
+| Vit **avec le crate** (`crates/services/<svc>/docs/DOMAIN.md`) | Vit **ici** (`docs/domain/`) |
+|---|---|
+| Objet du bounded context, non-objectifs | La **context map** (relations entre contextes) |
+| Agrégats, invariants, machines à états | Le **langage omniprésent** inter-contexte |
+| Propriété des données (ce dont ce contexte est SoR) | Le **catalogue d'événements** sémantique |
+| Glossaire par contexte, workflows | Cet index |
+
+## Vérité de référence (ground truth)
+
+La source de vérité sur *ce qui existe* est **le code**, jamais un diagramme :
+- les crates — `crates/services/*`, `crates/apps/*` ;
+- leurs contrats proto `*.v1` ;
+- la **garde de registre de topologie d'événements** (vérifiée par machine, donc fiable).
+
+Toute la documentation ici en *dérive*. Le modèle C4 hérité a été mis en quarantaine dans
+[`docs/_legacy/`](../_legacy/README.md) et **ne doit pas être référencé** ; un modèle C4 corrigé
+sera *régénéré à partir* des Domain Cards + `CONTEXT_MAP.md`.
+
+## Contenu
+
+| Fichier | Ce qu'il contient | Statut |
+|---|---|---|
+| [`CONTEXT_MAP.md`](./CONTEXT_MAP.md) | Context map DDD couvrant les 17 contextes, avec les patterns de relation (ACL / Conformist / Published Language / OHS / Customer-Supplier / Separate Ways) | ✅ rempli |
+| [`UBIQUITOUS_LANGUAGE.md`](./UBIQUITOUS_LANGUAGE.md) | Termes partagés par plus d'un contexte — partagés (un seul sens) vs surchargés (sens par contexte) ; les termes propres à un contexte restent dans chaque `DOMAIN.md` | ✅ rempli |
+| [`EVENT_CATALOG.md`](./EVENT_CATALOG.md) | Sens sémantique de chaque événement de domaine (rédigé depuis les Domain Cards ; colonnes topic/producteur/consommateur à réconcilier avec la garde de topologie) | ✅ rempli |
+
+## Documents domaine par service (`DOMAIN.md` par crate)
+
+Les 17 services. La profondeur dépend du tier : TIER-0/1 reçoivent les sections DEEP complètes ;
+TIER-2 conserve CORE plus des sections DEEP réduites à une ligne.
+
+| Service | Bounded context | `DOMAIN.md` | Statut |
+|---|---|---|---|
+| `account` | Account / Identity SoR | [`crates/services/account/docs/DOMAIN.md`](../../crates/services/account/docs/DOMAIN.md) | ✅ |
+| `audit` | Preuve de conformité infalsifiable | [`crates/services/audit/docs/DOMAIN.md`](../../crates/services/audit/docs/DOMAIN.md) | ✅ |
+| `auth` | Authentification / session / courtier IdP | [`crates/services/auth/docs/DOMAIN.md`](../../crates/services/auth/docs/DOMAIN.md) | ✅ |
+| `chat` | Conversations & messagerie | [`crates/services/chat/docs/DOMAIN.md`](../../crates/services/chat/docs/DOMAIN.md) | ✅ |
+| `comment` | Fils de commentaires | [`crates/services/comment/docs/DOMAIN.md`](../../crates/services/comment/docs/DOMAIN.md) | ✅ |
+| `counter` | Compteurs / SoReference analytique | [`crates/services/counter/docs/DOMAIN.md`](../../crates/services/counter/docs/DOMAIN.md) | ✅ |
+| `engagement` | Réactions & état d'arête | [`crates/services/engagement/docs/DOMAIN.md`](../../crates/services/engagement/docs/DOMAIN.md) | ✅ |
+| `geo-discovery` | Découverte géo-spatiale | [`crates/services/geo-discovery/docs/DOMAIN.md`](../../crates/services/geo-discovery/docs/DOMAIN.md) | ✅ |
+| `media` | Plan de contrôle média | [`crates/services/media/docs/DOMAIN.md`](../../crates/services/media/docs/DOMAIN.md) | ✅ |
+| `moderation` | Confiance, sécurité & intégrité | [`crates/services/moderation/docs/DOMAIN.md`](../../crates/services/moderation/docs/DOMAIN.md) | ✅ |
+| `notification` | Fil d'activité de notifications | [`crates/services/notification/docs/DOMAIN.md`](../../crates/services/notification/docs/DOMAIN.md) | ✅ |
+| `post` | Contenu / publications | [`crates/services/post/docs/DOMAIN.md`](../../crates/services/post/docs/DOMAIN.md) | ✅ |
+| `profile` | Personas publics | [`crates/services/profile/docs/DOMAIN.md`](../../crates/services/profile/docs/DOMAIN.md) | ✅ |
+| `realtime` | Plan de livraison temps réel / connexion | [`crates/services/realtime/docs/DOMAIN.md`](../../crates/services/realtime/docs/DOMAIN.md) | ✅ |
+| `search` | Read-model de découverte | [`crates/services/search/docs/DOMAIN.md`](../../crates/services/search/docs/DOMAIN.md) | ✅ |
+| `social-graph` | Relations followers / following | [`crates/services/social-graph/docs/DOMAIN.md`](../../crates/services/social-graph/docs/DOMAIN.md) | ✅ |
+| `timeline` | Fan-out de timeline | [`crates/services/timeline/docs/DOMAIN.md`](../../crates/services/timeline/docs/DOMAIN.md) | ✅ |
+
+## Rédaction
+
+- Modèle : [`docs/templates/DOMAIN.template.md`](../templates/DOMAIN.template.md) — copier vers
+  `crates/services/<svc>/docs/DOMAIN.md` et le remplir.
+- Décisions : consigner la justification dans des ADR immuables sous [`docs/adr/`](../adr/README.md)
+  et les relier depuis `DOMAIN.md §9` — ne jamais intégrer le *pourquoi* en ligne.
+- i18n : l'anglais est canonique ; un miroir `DOMAIN.fr.md` suit le
+  [standard de traduction](../i18n/TRANSLATION.md). La garde de dérive (`tools/i18n/i18n-drift.sh`)
+  couvre **tout** `<name>.<lang>.md`, donc `DOMAIN.fr.md`, `CONTEXT_MAP.fr.md`, etc. sont vérifiés
+  comme les README.
+
+> 🇬🇧 Source anglaise : [`README.md`](./README.md).

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -70,8 +70,8 @@ CORE plus collapsed one-line DEEP sections.
 - Decisions: capture rationale as immutable ADRs under [`docs/adr/`](../adr/README.md) and link
   them from `DOMAIN.md §9` — never inline the *why*.
 - i18n: English is canonical; a `DOMAIN.fr.md` mirror follows the
-  [translation standard](../i18n/TRANSLATION.md). The drift gate currently scans `README.*.md`
-  only; extending it to `DOMAIN.*.md` is part of the rollout's governance phase.
+  [translation standard](../i18n/TRANSLATION.md). The drift gate (`tools/i18n/i18n-drift.sh`)
+  covers **any** `<name>.<lang>.md`, so `DOMAIN.fr.md`, `CONTEXT_MAP.fr.md`, etc. are checked the
+  same way as READMEs.
 
-> 🇫🇷 A French mirror (`README.fr.md`) of this index will be added once the scaffold is filled
-> with real content, per the translation standard.
+> 🇫🇷 French mirror: [`README.fr.md`](./README.fr.md).

--- a/docs/domain/UBIQUITOUS_LANGUAGE.fr.md
+++ b/docs/domain/UBIQUITOUS_LANGUAGE.fr.md
@@ -1,0 +1,85 @@
+---
+i18n:
+  source: ./UBIQUITOUS_LANGUAGE.md
+  source_sha256: 72c3cda3c3efed20a6e51e0fa7a695686d41fdd9c58c390f262b5e34668ca64e
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`UBIQUITOUS_LANGUAGE.md`](./UBIQUITOUS_LANGUAGE.md) fait foi.
+> En cas de divergence, l'anglais prime. Les termes du langage omniprésent, les noms de types et les
+> identifiants restent en anglais (ce sont les mots réellement employés dans le code et les contrats).
+
+# Langage omniprésent (inter-contexte)
+
+> Rempli depuis le §2 des 17 Domain Cards par service (`crates/services/<svc>/docs/DOMAIN.md`).
+> Contient **uniquement** les termes employés par plus d'un bounded context. Les termes propres à un
+> seul contexte restent dans le `DOMAIN.md §2` de ce service.
+
+## Pourquoi un glossaire inter-contexte
+
+Le même mot signifie souvent des choses différentes selon le contexte (« Subject », « Visibility »,
+« Score »), et quelques mots doivent signifier *exactement la même chose partout* (identifiants,
+tier, popularité). Ce fichier fige la seconde catégorie et signale la première, pour qu'un événement
+ou un RPC consommé au-delà d'une frontière ne soit pas silencieusement mal interprété.
+
+## Règles
+
+- **Le symbole de code est obligatoire.** Un terme sans `crate::Type` / proto / topic est une
+  aspiration, pas un langage omniprésent — l'omettre tant qu'il n'en a pas. (Le vocabulaire de
+  *posture* purement architectural est listé séparément en bas, par référence, car il n'a pas de
+  symbole unique.)
+- **Les contrats restent en anglais.** Selon le [standard de traduction](../i18n/TRANSLATION.md), les
+  identifiants, codes d'erreur, topics, variables d'environnement et noms de types sont invariants de
+  langue.
+- **Signaler la divergence.** Quand un mot signifie des choses différentes selon le contexte, lui
+  donner une ligne par contexte et le dire explicitement.
+
+## Termes partagés (un seul sens partout)
+
+| Terme | Sens | Symbole de code / contrat | Contexte propriétaire |
+|---|---|---|---|
+| Profile id | L'identifiant de persona public (un profil / auteur de contenu) | `ProfileId` — aliasé `AuthorId` dans `geo-discovery` / `timeline` | `profile` |
+| Account id | L'identifiant de compte de référence (l'identité privée) | `AccountId` | `account` |
+| Post id | L'identifiant de contenu (post) | `PostId` | `post` |
+| Author tier | Le tier d'un auteur dérivé du nombre de followers | `AuthorTier` | `social-graph` calcule → `profile` possède + émet (`tier_changed`) |
+| Popularity score | La magnitude de popularité publiée d'une entité | `PopularityScore` (topic `counter.v1.popularity`) | `counter` |
+| Stream sequence | Le token monotone par flux qu'un client déduplique / re-synchronise | `StreamSeq` / `SequenceState` | `realtime` |
+| Consumer runtime | Le runner de consommateur Kafka obligatoire : commit manuel après un résultat terminal, retry borné + jitter, DLQ sur poison/épuisement | `run_consumer` | `transport` (shared kernel) |
+| Deterministic event id | Un `UUIDv5` adressé-par-contenu permettant la déduplication idempotente en redelivery at-least-once | convention d'id UUIDv5 | `notification`, `moderation`, `audit` |
+| Monotonic per-subject version | Un compteur incrémenté par sujet pour ordonner / révoquer (famille de révocation ; ordonnancement d'enforcement) | `Generation` (`auth`) · `EnforcementVersion` (`moderation`) | pattern partagé |
+
+## Termes surchargés (sens différent selon le contexte)
+
+| Terme | Contexte | Sens ici | Symbole de code |
+|---|---|---|---|
+| **Subject** | `audit` | Un **sujet de données** pseudonymisé — la personne dont la PII est scellée dans la chaîne | pseudonyme + `PiiEnvelope` |
+| **Subject** | `moderation` | La **cible de modération** — type d'entité + id + acteur + surface | `SubjectRef` |
+| **Subject** | `notification` | Le **sujet d'une notification** | `SubjectId` / `SubjectKind` |
+| **Visibility** | `chat` | Plan Membre vs plan Audience (le Shadowing Pattern) | `Visibility` |
+| **Visibility** | `profile` | Bi-axiale : choix du propriétaire **et** masquage par modération | `ProfileVisibility` |
+| **Visibility** | `search` | L'autorité (propriétaire / modération) honorée au moment de la requête | `VisibilityAuthority` |
+| **Visibility** | `media` | Si / comment un asset peut être servi | `DeliveryVisibility` |
+| **Score** | `engagement` | Score d'engagement dérivé du poids des réactions | `ReactionWeight` |
+| **Score** | `geo-discovery` | Pondération de classement par viralité pour une map card | `ViralityScore` |
+| **Score** | `counter` | Magnitude de popularité publiée | `PopularityScore` |
+| **Event** | `audit` | Un **fait de conformité enregistré** immuable (la chose stockée) | `AuditEvent` / `AuditRecord` |
+| **Event** | toute la flotte | Un **fait de domaine publié** sur Kafka (la chose émise) | `DomainEvent` |
+| **Entity kind** | `counter` | Le type d'entité **comptée** | `EntityKind` (counter) |
+| **Entity kind** | `search` | Le type de **document indexé** (post / profile / hashtag) | `EntityKind` (search) |
+
+> **Attention :** les termes surchargés ci-dessus sont les erreurs de lecture inter-frontières les
+> plus fréquentes. Quand un événement ou un RPC traverse des contextes, résoudre le terme selon le
+> sens du contexte **producteur**.
+
+## Vocabulaire de posture transverse (par référence)
+
+Ce sont des termes *architecturaux* omniprésents, pas des types de domaine — ils n'ont pas de symbole
+de code unique, donc ils vivent par référence plutôt que dans les tables ci-dessus :
+
+- **SoR / SoReference / System-of-Connection / Evidence** — la classe d'autorité d'un contexte ;
+  définie par service dans la Domain Card de chaque `DOMAIN.md` (« System of … »).
+- **Fail-open / fail-closed** — la posture de défaillance d'un contexte ; définie par service dans
+  chaque Domain Card et résumée dans `CONTEXT_MAP.md`.
+- **OHS / Published Language / ACL / Conformist / Customer-Supplier / Separate Ways / Shared Kernel**
+  — le vocabulaire de couplage DDD ; défini une fois dans
+  [`CONTEXT_MAP.md`](./CONTEXT_MAP.fr.md#patterns-de-relation-le-vocabulaire).

--- a/tools/i18n/i18n-drift.sh
+++ b/tools/i18n/i18n-drift.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 #
-# i18n-drift.sh — detect drift between canonical README.md files and their translations.
+# i18n-drift.sh — detect drift between canonical docs and their translations.
 #
-# A translation (README.<lang>.md) records, in its YAML frontmatter, the SHA-256 of the
-# sibling README.md it was translated from. This script recomputes that hash and flags any
-# translation whose recorded hash no longer matches — unless it is explicitly `status: stale`.
+# A translation (<name>.<lang>.md, e.g. README.fr.md, DOMAIN.fr.md, CONTEXT_MAP.fr.md) records,
+# in its YAML frontmatter, the SHA-256 of the canonical <name>.md it was translated from. This
+# script recomputes that hash and flags any translation whose recorded hash no longer matches —
+# unless it is explicitly `status: stale`.
 #
 # Usage:
-#   tools/i18n/i18n-drift.sh check                 # verify all translations (CI gate)
-#   tools/i18n/i18n-drift.sh stamp <README.fr.md>  # record current source hash into a translation
+#   tools/i18n/i18n-drift.sh check               # verify all translations (CI gate)
+#   tools/i18n/i18n-drift.sh stamp <name>.fr.md  # record current source hash into a translation
 #
 # See docs/i18n/TRANSLATION.md for the full standard.
 
@@ -33,20 +34,24 @@ frontmatter_get() {
   ' "$1"
 }
 
-# --- discover all translation files (README.<lang>.md, excluding plain README.md) ----------
+# --- discover all translation files (<name>.<lang>.md, two-letter lang code) ----------------
+# Matches README.fr.md, DOMAIN.fr.md, CONTEXT_MAP.fr.md, … but never a canonical <name>.md
+# (which has no .<lang>. segment). The canonical sibling is derived by stripping .<lang>.md.
 find_translations() {
-  find . -path ./target -prune -o -type f \
-    \( -name 'README.*.md' -a ! -name 'README.md' \) -print | sort
+  find . -path ./target -prune -o -type f -name '*.[a-z][a-z].md' -print | sort
 }
+
+# --- canonical source for a translation: strip the .<lang>.md suffix, append .md -----------
+canonical_for() { printf '%s.md\n' "${1%.[a-z][a-z].md}"; }
 
 check() {
   local fail=0 found=0 fr src want status got
   while IFS= read -r fr; do
     [ -n "$fr" ] || continue
     found=1
-    src="$(dirname "$fr")/README.md"
+    src="$(canonical_for "$fr")"
     if [ ! -f "$src" ]; then
-      printf 'FAIL  %s\n        no sibling README.md\n' "$fr"; fail=1; continue
+      printf 'FAIL  %s\n        no canonical source %s\n' "$fr" "$src"; fail=1; continue
     fi
     want="$(frontmatter_get "$fr" source_sha256 || true)"
     status="$(frontmatter_get "$fr" status || true)"
@@ -72,8 +77,8 @@ stamp() {
   local fr="${1:-}"
   [ -n "$fr" ] && [ -f "$fr" ] || { echo "usage: $0 stamp <README.<lang>.md>" >&2; exit 2; }
   local src want today tmp
-  src="$(dirname "$fr")/README.md"
-  [ -f "$src" ] || { echo "no sibling README.md for $fr" >&2; exit 2; }
+  src="$(canonical_for "$fr")"
+  [ -f "$src" ] || { echo "no canonical source $src for $fr" >&2; exit 2; }
   want="$(sha "$src")"; today="$(date +%F)"; tmp="$(mktemp)"
   awk -v h="$want" -v d="$today" '
     /^---[[:space:]]*$/ { blk++ }


### PR DESCRIPTION
First of three phased PRs adding French mirrors to the functional documentation. **The gate extension ships here**; subsequent PRs add `DOMAIN.fr.md` ×17 (PR B) and `docs/adr/*.fr.md` ×19 (PR C).

## Gate extension (`tools/i18n/i18n-drift.sh`)

- `find_translations` now matches **`*.[a-z][a-z].md`** (any `<name>.<lang>.md`) instead of `README.*.md` only — so `DOMAIN.fr.md`, `CONTEXT_MAP.fr.md`, etc. are checked identically.
- New `canonical_for()` derives the source by stripping the `.<lang>.md` suffix (no longer hardcoded to a sibling `README.md`); used in both `check` and `stamp`.
- Header/usage comments updated.
- **No regression:** all 35 existing `README.fr.md` still pass.

## French mirrors (the 4 central `docs/domain/` docs)

`README.fr.md`, `CONTEXT_MAP.fr.md`, `EVENT_CATALOG.fr.md`, `UBIQUITOUS_LANGUAGE.fr.md` — each with provenance frontmatter (stamped) + the standard banner.

**DNT honored:** code symbols, topics (`*.v1.events`), error codes, type names, ADR ids, and the DDD pattern names (OHS/ACL/Conformist/…) stay verbatim English; only prose and descriptive cells are translated.

EN index note updated to link `README.fr.md` and describe the generalized gate.

## Verification

- `tools/i18n/i18n-drift.sh check` → **39/39 OK** (35 existing + 4 new).
- All relative links resolve (FR docs link FR siblings; the `CONTEXT_MAP.fr.md` anchor matches).

## Next

- **PR B:** 17 × `DOMAIN.fr.md`.
- **PR C:** 19 × `docs/adr/*.fr.md`.
- CI wiring of `i18n-drift.sh check` (if not already a step) so the gate is enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)