### PR TITLE
docs(i18n): French mirrors for all 17 DOMAIN.md (PR B)

### DIFF
--- a/crates/services/account/docs/DOMAIN.fr.md
+++ b/crates/services/account/docs/DOMAIN.fr.md
@@ -1,0 +1,172 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 5c64e6c4176491a870fa3f9505d73057f318e859eed6734da1f858b7129623ad
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `account` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Account / Identity — le système de référence du compte utilisateur |
+> | **Classe de sous-domaine** | **Supporting** — le cycle de vie de l'identité est une infrastructure nécessaire, pas un différenciateur visible ; sur-mesure car il porte la PII et les obligations RGPD de la plateforme |
+> | **System of …** | **Record** pour l'existence du compte, les métadonnées d'identifiants, le KYC, les rôles et l'état RGPD |
+> | **Racine(s) d'agrégat** | `Account` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Fail-closed** — les écritures de compte font autorité ; une écriture de cycle de vie doit commiter durablement |
+> | **Contextes amont** | `auth` (lien de sujet IdP fédéré), flux internes d'ops/inscription |
+> | **Contextes aval** | `audit` (conformité), `profile` (persona sur le compte) — via **Open-Host Service / Published Language** (`account.v1.events`) |
+> | **Journal de décisions** | [`ADR-0004`](../../../../docs/adr/0004-account-is-the-single-identity-sor.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `account` est l'autorité pour **le compte utilisateur** : il répond à
+**« ce compte existe-t-il, quel est son état de cycle de vie, son rôle et son statut KYC, et quel est
+l'état licite de ses données personnelles ? »**
+
+**Le problème difficile.** Posséder la PII en tant que système de référence tout en honorant le
+RGPD — effacement, export, rectification — sans que d'autres services détiennent des copies fantômes
+d'identité que l'effacement ne peut atteindre. Account est le *seul* endroit où vit une identité
+réelle ; tous les autres détiennent des références dérivées, non faisant-autorité.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Authentifier / émettre sessions ou tokens → possédé par `auth`.
+- ❌ Détenir le persona public (handle, bio, avatar) → possédé par `profile`.
+- ❌ Vérifier les tokens → c'est la bibliothèque `auth-context`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Account | L'enregistrement de compte utilisateur faisant autorité | `Account`, `AccountId` |
+| Identity id | L'identifiant de sujet stable inter-systèmes | `IdentityId` |
+| Credential metadata | Hash de mot de passe, enrôlement MFA, codes de récupération — *métadonnées*, pas le flux d'auth | `PasswordHash`, `MfaState`, `RecoveryCodeHash` |
+| KYC status | L'état de vérification know-your-customer | `KycStatus`, `KycStatusChanged` |
+| Role | Le rôle d'autorisation assigné au compte | `AccountRole`, `RoleAssigned`/`RoleRevoked` |
+| GDPR record | L'état de traitement licite des données (demandes export/suppression) | `GdprRecord`, `GdprDeletionRequested`, `GdprDataExportRequested` |
+| Encrypted bytes | Les champs PII chiffrés au repos | `EncryptedBytes` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Account` | racine d'agrégat | Machine à états du cycle de vie + unicité email/identité |
+| `EmailAddress` / `PhoneNumber` / `CountryCode` | VO | Validité imposée à la construction |
+| `PasswordHash` / `MfaState` / `RecoveryCodeHash` | VO | Intégrité des métadonnées d'identifiants |
+| `GdprRecord` | VO | État des demandes d'effacement/export |
+| `AccountStatus` / `AccountRole` / `KycStatus` | enum | Vocabulaires fermés cycle de vie / autorisation / vérification |
+
+**Cycle de vie :**
+
+```
+created --> activated --(suspend)--> suspended --(reactivate)--> activated
+   │            │                                                   │
+   │            └--(deactivate)--> deactivated                      │
+   └────────────────────────── gdpr_deletion_requested ──> deleted (PII erased)
+```
+
+> **Transitions légales uniquement.** Les changements d'email/téléphone sont des événements, pas des
+> mutations silencieuses ; une suppression RGPD est terminale et déclenche le crypto-shred aval dans
+> `audit`.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Les enregistrements de compte, métadonnées d'identifiants, rôles, KYC et état RGPD — **Postgres**
+  db `account`. Aucun autre service ne les écrit.
+
+**Ce contexte détient des copies qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Lien sujet IdP | `auth` / IdP fédéré | flux de liaison `auth` | au moment de la liaison |
+
+**La liste « ne-pas-écrire » :** account n'émet jamais de tokens, n'écrit jamais de données de
+présentation de profil, et ne stocke la projection d'aucun autre service.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Unicité email/identité | domaine + contrainte unique Postgres | `ACC-1xxx` |
+| I2 | La PII au repos est chiffrée (`EncryptedBytes`) | infrastructure | — |
+| I3 | Un changement de cycle de vie émet un événement (pas de changement d'état silencieux) | domaine (publish après-save) | — |
+| I4 | La suppression RGPD est terminale et propage l'effacement en aval | application | `ACC-1xxx` |
+| I5 | Les rôles sont des octrois/révocations explicites, audités | domaine | `ACC-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Inscription / cycle de vie.** Une commande create/activate/suspend/deactivate mute l'agrégat
+`Account`, persiste vers Postgres, et publie la variante `account.v1.events` correspondante **après**
+la sauvegarde (le port EventPublisher → Kafka).
+
+**Effacement RGPD (Art. 17).** `gdpr_deletion_requested` → account marque l'enregistrement supprimé
+et émet l'événement ; `audit` le consomme et **crypto-shred le DEK par-sujet**, rendant toute la PII
+scellée de ce sujet à travers la flotte définitivement illisible alors que la chaîne se vérifie
+toujours — fermant la boucle d'effacement de bout en bout.
+
+**Export RGPD (Art. 15/20).** `gdpr_data_export_requested` → émis pour exécution en aval.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `auth` | amont | Customer/Supplier | `SubjectLink` IdP ↔ `AccountId` | résolution du sujet de session |
+| `audit` | aval | Published Language | `account.v1.events` (PII scellée ; paire RGPD) | preuve de conformité + boucle Art. 17 |
+| `profile` | aval | Published Language | `account.v1.events` | provisionnement du persona |
+
+> **Anti-Corruption Layer :** les consommateurs (`audit`, `profile`) traduisent `account.v1.events`
+> vers leurs propres modèles ; account expose un langage publié stable et ne possède le schéma
+> d'aucun consommateur.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement (`account.v1.events`) | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `account_created` / `email_changed` / `email_verified` / `phone_changed` | faits de cycle de vie porteurs de PII | la commande correspondante commite | `audit` (PII scellée), `profile` |
+| `password_changed` / `mfa_enrolled` / `mfa_revoked` | faits de sécurité (sans PII) | changement d'identifiant | `audit` (Authentication) |
+| `activated`/`deactivated`/`suspended`/`deleted`, `kyc_status_changed` | cycle de vie de l'identité | transition de cycle de vie | `audit` (Identity), `profile` |
+| `role_assigned` / `role_revoked` | changement d'autorisation | octroi/révocation de rôle | `audit` (Authorization) |
+| `gdpr_deletion_requested` / `gdpr_data_export_requested` | un droit licite sur les données a été invoqué | demande utilisateur/DPO | `audit` (`gdpr_deletion` → crypto-shred du sujet) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Account est le SoR d'identité ; a construit sa voie d'événements sortante (était un producteur fantôme) pour que `audit`/`profile` consomment | [`ADR-0004`](../../../../docs/adr/0004-account-is-the-single-identity-sor.md) | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — investir pour la correction, la sûreté de la PII et la conformité RGPD ; pas un différenciateur.
+- **Volatilité :** faible — guidée par le changement réglementaire et l'intégration IdP, pas par le churn de features.
+- **Dette de modélisation connue :** rien de matériel consigné.
+- **Capacités différées :** workflows KYC plus riches ; pipeline d'exécution d'export en aval de l'événement d'export.

--- a/crates/services/audit/docs/DOMAIN.fr.md
+++ b/crates/services/audit/docs/DOMAIN.fr.md
@@ -1,0 +1,198 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: cc401a87035497686aeb395a03b0ced190a39a52cff4f979e88157065cfb6db4
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `audit` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Compliance Evidence — la piste d'audit infalsifiable |
+> | **Classe de sous-domaine** | **Supporting** — légalement non négociable mais pas un différenciateur visible ; sur-mesure (pas Generic) car aucun outil SIEM/audit sur étagère ne réconcilie l'effacement RGPD Art. 17 avec la responsabilité Art. 5(2) |
+> | **System of …** | **Record / Evidence** pour « qui a fait quoi, à qui, quand, sous quelle autorité, avec quel résultat » |
+> | **Racine(s) d'agrégat** | `AuditRecord` (`domain::record`), avec la chaîne par-partition `ChainLink` / `ChainHead` (`domain::chain`) et `MerkleCheckpoint` (`domain::checkpoint`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Mixte** — *fail-open* chez les producteurs (la vivacité d'audit ne fait jamais brownout du mesh) ; *fail-closed* sur la durabilité et sur la voie synchrone de break-glass |
+> | **Contextes amont** | `moderation`, `auth`, `account` via **Conformist + ACL** (audit consomme leurs streams et traduit chaque forme wire étrangère en `AuditEvent` dans `infrastructure/decode.rs`) |
+> | **Contextes aval** | aucun de référence — audit est un **puits terminal** ; il ne publie rien que d'autres consomment |
+> | **Journal de décisions** | [`ADR-0001`](../../../../docs/adr/0001-audit-is-a-separate-evidence-plane.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `audit` est l'autorité pour **la preuve de conformité** : il répond à
+**« peut-on prouver que cet enregistrement de qui-a-fait-quoi est complet et n'a jamais été altéré, et
+le détecterions-nous s'il l'était ? »**
+
+**Le problème difficile.** La télémétrie et une piste d'audit se ressemblent à l'écran mais sont des
+substances différentes : la télémétrie est best-effort, mutable, échantillonnée et à rétention
+cyclique ; la preuve doit être zéro-perte, append-only, infalsifiable, complète, conservée des
+années, et effaçable au niveau *champ*. Les confondre place la PII dans des index de logs
+incontrôlés et fait qu'une demande d'effacement RGPD Art. 17 contredit directement le devoir de
+responsabilité Art. 5(2).
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Le logging applicatif général / l'observabilité → possédés par le plan de télémétrie (crate `telemetry`).
+- ❌ Prendre des décisions ou agir — audit *enregistre* les décisions des autres et n'agit sur aucune.
+- ❌ Détenir le mapping identité↔pseudonyme → possédé par `account` ; audit ne voit que des pseudonymes.
+- ❌ Publier des événements de référence → c'est un puits terminal.
+
+---
+
+## 2. Langage Omniprésent
+
+> Les termes inter-contexte (subject, lawful basis) vivent dans `docs/domain/UBIQUITOUS_LANGUAGE.md`.
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Audit record | Une entrée immuable, chaînée par hash, du registre de preuve | `AuditRecord` |
+| Chain link / head | Le lien `H(prev ‖ canonical(payload) ‖ sequence_no)` et la tête courante d'une chaîne par-partition | `ChainLink`, `ChainHead` |
+| Crypto-shred | Effacement par destruction de la clé d'un sujet, laissant l'enregistrement + la preuve intacts | via `PiiEnvelope` + `KeyVault` |
+| PII envelope | Un ciphertext crypto-shreddable par-sujet ; la chaîne hashe le *ciphertext*, jamais le clair | `PiiEnvelope` |
+| Checkpoint | Une racine de Merkle signée sur toutes les têtes de partition, ancrée à un témoin externe | `MerkleCheckpoint` |
+| Legal hold | Une dérogation de rétention licite (Art. 17(3)) qui suspend l'effacement | `LegalHold` |
+| Privileged action | Une action must-record-before-permitted enregistrée sur la voie synchrone fail-closed | `PrivilegedActionType` |
+| Partition | Le shard `(tenant, category)` auquel appartient la chaîne d'un enregistrement ; le sujet est indexé, pas la clé de partition | `EventCategory` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `AuditRecord` | racine d'agrégat | Un enregistrement, une fois commité, est immuable et chaîné par hash à son prédécesseur |
+| `NewAuditEvent` / `AuditEvent` | entité / VO | Un événement d'admission bien formé et dédupliqué avant/après son séquencement dans la chaîne |
+| `ChainLink` / `ChainHead` | VO | Lien append-only par-partition ; `sequence_no` strictement monotone (un trou = signal de troncature) |
+| `MerkleCheckpoint` | VO | Une racine signée liant toutes les têtes de partition à un instant donné |
+| `PiiEnvelope` | VO | La PII n'existe que comme ciphertext crypto-shreddable ; le clair n'entre jamais dans la chaîne |
+| `Actor` / `ResourceRef` | VO | Le qui pseudonyme et le sur-quoi on a agi |
+| `LegalHold` / `RetentionPolicy` | VO | Quand l'effacement est permis vs suspendu licitement |
+| `EventCategory` / `ActorType` / `Outcome` / `LawfulBasis` | enum | Le vocabulaire de classification fermé |
+
+**Cycle de vie d'un enregistrement :**
+
+```
+intake --(dedupe: UUIDv5)--> sequenced (chain-linked) --(persist+archive)--> committed --(checkpoint)--> witnessed
+                                                                                  └--(erase: destroy DEK)--> pii-shredded (chain still verifies)
+```
+
+> **Transitions légales uniquement.** Un enregistrement commité n'est jamais mis à jour ni supprimé
+> (`UPDATE`/`DELETE` révoqués au niveau rôle DB). Une non-concordance de hash ou un trou de séquence
+> à la lecture n'est pas un état récupérable — il lève `AUD-2001` / `AUD-2002` comme alarme de
+> falsification.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Le registre de conformité chaîné par hash — **Postgres** append-only (canonique) répliqué vers
+  **Object-Lock WORM** (S3/MinIO, mode compliance). Aucun autre service ne l'écrit.
+- Les DEK par-sujet et l'enregistrement de custody de la clé de signature (dans KMS/HSM, un domaine
+  de confiance séparé).
+
+**Ce contexte détient des copies qu'il ne possède PAS (read-model / dénormalisation) :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Faits de décision de modération | `moderation` | `moderation.v1.events` (`decision_recorded`, `enforcement_applied`) | cohérence à terme (lag Kafka) |
+| Cycle de vie de session auth | `auth` | `auth.v1.events` (`session_issued`/`session_revoked`) | cohérence à terme |
+| Cycle de vie compte + événements RGPD | `account` | `account.v1.events` | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** audit ne mute jamais l'état amont, ne résout jamais un pseudonyme en
+identité réelle (ce mapping vit dans `account`), et n'émet jamais d'enregistrement dont d'autres
+services dépendent.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | La PII n'entre jamais en clair dans la chaîne (sujets = pseudonymes ; PII = ciphertext `PiiEnvelope`) | domaine + infrastructure | (empêché par construction) |
+| I2 | L'effacement est destruction de clé, pas suppression d'enregistrement — enregistrement, séquence, hash et métadonnées non-PII survivent | application | `AUD-5xxx` |
+| I3 | Un sujet sous legal hold actif n'est pas shreddé (Art. 17(3) prime) | domaine | `AUD-5002` |
+| I4 | Les actions les plus dangereuses échouent fermées — `RecordPrivileged` refuse sauf si enregistré durablement d'abord | application | `AUD-4004` |
+| I5 | Les lectures sont aussi des preuves — chaque query/export est lui-même enregistré ; accès need-to-know | application | `AUD-3001`/`AUD-3002` |
+| I6 | La chaîne est append-only et complète ; toute mutation/trou est détectable | domaine + rôle DB (`UPDATE`/`DELETE` révoqués) | `AUD-2001`/`AUD-2002` |
+| I7 | Un checkpoint signé doit se réconcilier avec le témoin externe | application | `AUD-2004` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Ingestion en masse (async, fail-open).**
+1. Un service de la flotte émet un événement de conformité vers Kafka (`audit.v1.events` ou un stream de décision) — fire-and-forget.
+2. `audit-worker` consomme sous `run_consumer` ; déduplique par UUIDv5 (`AUD-1004` → `Ok`).
+3. Décode le wire étranger → `AuditEvent` ; scelle toute PII dans une `PiiEnvelope`.
+4. Ajoute à la chaîne par-partition → persiste vers Postgres → réplique vers WORM.
+- **Discipline de commit :** l'offset Kafka n'avance **qu'après** persist durable + chaînage. Aucun offset commité ne dépasse un événement non persisté → zéro perte.
+- **Idempotence :** UUIDv5 déterministe ; redelivery dédupliquée, donc chaque événement logique apparaît une fois.
+
+**Action privilégiée (sync, fail-closed).**
+1. Un appelant privilégié invoque `RecordPrivileged` sur `:50068`.
+2. Audit tente un commit durable+chaîné dans un délai dur.
+3. Succès → permet ; échéance/durabilité ratée → **refuse** (`AUD-4004`). L'action ne doit pas procéder non enregistrée.
+
+**Effacement (crypto-shred).** Une demande RGPD Art. 17 détruit le DEK du sujet (sauf sous legal hold) → toute la PII scellée de ce sujet devient définitivement indéchiffrable alors que la chaîne se vérifie toujours. *(La boucle worker qui le pilote attend une source de demandes d'effacement ; le handler existe et est testé.)*
+
+**Vérification d'intégrité.** Une boucle worker signe une racine de Merkle sur les têtes de partition, l'ancre au témoin externe, et un vérificateur autonome recalcule la chaîne et compare (`AUD-2004` en cas de divergence).
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `moderation` | amont | Conformist + ACL | `moderation.v1.events` | un changement de schéma de `decision_recorded` casse la chaîne de justification DSA scellée |
+| `auth` | amont | Conformist + ACL | `auth.v1.events` | trous de preuve du cycle de vie des sessions |
+| `account` | amont | Conformist + ACL | `account.v1.events` | le scellement PII + le déclencheur crypto-shred Art. 17 cassent |
+| `account` | dépendance | Customer/Supplier | le mapping identité↔pseudonyme reste dans `account` | audit ne peut (et ne doit) pas résoudre les sujets |
+| témoin externe / KMS | dépendance | domaine de confiance séparé | RFC 3161 TSA / WORM cross-compte ; KMS SigV4 | la garantie anti-falsification niveau opérateur s'affaiblit |
+
+> **Anti-Corruption Layer :** `infrastructure/decode.rs` mappe chaque forme wire d'événement étranger
+> (et le JSON `AuditEventWire` possédé par audit) vers le domaine `AuditEvent` — la dérive de schéma
+> amont s'arrête à cette frontière.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+> Audit **ne publie rien de référence** — c'est un puits terminal. Une alarme d'intégrité sur
+> falsification/trou/divergence-de-témoin est un signal opérationnel, pas un stream System-of-Record.
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| — (aucun) | audit n'affirme aucun fait métier vers l'extérieur | — | — |
+
+Il **consomme** les faits de conformité de `moderation`/`auth`/`account` — leurs sens sont possédés
+par le §8 des Domain Cards de ces contextes et consolidés dans `docs/domain/EVENT_CATALOG.md`.
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Audit est un plan de preuve infalsifiable séparé, pas un agrégateur de logs | [`ADR-0001`](../../../../docs/adr/0001-audit-is-a-separate-evidence-plane.md) | Accepté |
+| _(candidat à scinder)_ mécanisme crypto-shred RtbF ; split dual-lane fail-open/fail-closed ; schéma d'immuabilité hash-chain + WORM + témoin externe | _à rédiger_ | — |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — investir assez pour être juridiquement blindé et infalsifiable ; ne pas sur-dimensionner au-delà du besoin réglementaire.
+- **Volatilité :** faible. Le modèle chaîne/shred/checkpoint est stable ; le changement est piloté par de nouvelles obligations *réglementaires* (nouvelle catégorie d'événement, nouvelle base licite), pas par le churn de features.
+- **Dette de modélisation connue :** le consumer crypto-shred et le balayage d'expiration de rétention existent et sont testés, mais leurs boucles worker pilotes attendent des sources d'entrée (un stream de demandes d'effacement ; des politiques de rétention résolues).
+- **Capacités différées :** authz de lecture + auto-audit des lectures via l'intercepteur d'ingress `auth-context` ; génération de rapports de transparence DSA ; réplication cross-région du registre. Le *provisionnement* KMS/témoin est un engagement IAM/org (le code est en place derrière les ports).

--- a/crates/services/auth/docs/DOMAIN.fr.md
+++ b/crates/services/auth/docs/DOMAIN.fr.md
@@ -1,0 +1,165 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 88bce43771b6b12fcfe91c9375185ec5b5bcae1d43d1d5e616e0b965bcc80def
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `auth` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Authentication — émission de sessions, refresh et courtage IdP |
+> | **Classe de sous-domaine** | **Supporting** — capacité de sécurité nécessaire ; s'appuie en partie sur un IdP fédéré (Keycloak) mais le modèle edge-token / génération de session est sur-mesure |
+> | **System of …** | **Record** pour les sessions et refresh tokens (pas pour le compte utilisateur — c'est `account`) |
+> | **Racine(s) d'agrégat** | `Session`, `RefreshToken` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Fail-closed** — pas de session/token valide, pas d'accès |
+> | **Contextes amont** | flux de connexion utilisateur ; IdP fédéré (Keycloak) ; `account` (lien sujet ↔ compte) |
+> | **Contextes aval** | chaque service via la bibliothèque de vérification `auth-context` ; `realtime` (vérif edge-token au handshake) ; `audit` (`auth.v1.events`) |
+> | **Journal de décisions** | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `auth` est l'autorité pour **l'état d'authentification** : il répond à
+**« cet appelant est-il bien celui qu'il prétend être en ce moment, et cette session est-elle encore
+valide ? »** — en émettant des edge tokens ES256 courts et en gérant le cycle de refresh.
+
+**Le problème difficile.** Fédérer un IdP externe tout en émettant les propres edge tokens rapides
+(stateless-à-vérifier) de la plateforme — et pouvoir **révoquer** instantanément malgré l'absence
+d'état. Le mécanisme de résolution est une `Generation` monotone par-sujet qui invalide les familles
+de tokens.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder le compte utilisateur / la PII → `account` est le SoR.
+- ❌ Vérifier les tokens en process pour chaque service → c'est la bibliothèque `auth-context` (une vérification, pas un appel).
+- ❌ Autoriser les actions métier → il authentifie ; les services autorisent via permissions/`auth-context`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Session | Une session authentifiée de référence | `Session`, `SessionId`, `SessionStatus` |
+| Refresh token | L'identifiant longue durée qui frappe des access tokens | `RefreshToken`, `RefreshTokenId`, `RefreshTokenHash` |
+| Access token claims | La charge utile de l'edge token ES256 | `AccessTokenClaims` |
+| Generation | Compteur monotone par-sujet ; l'incrémenter révoque une famille de tokens | `Generation` |
+| IdP subject | L'identifiant de sujet du fournisseur d'identité fédéré | `IdpSubject`, `SubjectLink` |
+| Device fingerprint | Liaison par-appareil pour une session | `DeviceFingerprint` |
+| Permission | Un octroi d'autorisation porté dans les claims | `Permission` |
+| Revocation reason | Pourquoi une session/token a été révoquée | `RevocationReason` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Session` | racine d'agrégat | Validité de session + révocation via `Generation` |
+| `RefreshToken` | racine d'agrégat | Rotation de token ; un refresh token utilisé ne peut être réutilisé |
+| `AccessTokenClaims` | VO | Le contrat de l'edge token signé |
+| `Generation` | VO | Monotone par-sujet ; le levier de révocation instantanée |
+| `SubjectLink` | VO | Liaison sujet IdP ↔ `AccountId` |
+
+**Cycle de vie de session :**
+
+```
+issued --(refresh: rotate)--> issued' --(revoke / generation-bump / expiry)--> revoked
+```
+
+> **Transitions légales uniquement.** Un refresh token tourne (l'ancien invalidé) ; un bump de
+> `Generation` révoque toute la famille ; les sessions expirées/révoquées ne se ré-activent jamais.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Sessions et refresh tokens — **Postgres** (durable) + **Redis** (état hot de session/révocation). Aucun autre service ne les écrit.
+
+**Ce contexte détient des copies qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Lien compte ↔ sujet IdP | `account` / IdP | flux de liaison | au moment de la liaison |
+
+**La liste « ne-pas-écrire » :** auth ne mute jamais l'état du compte et ne stocke aucune donnée de profil/métier.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Un refresh token est à usage unique (la rotation invalide le précédent) | domaine | `AUT-7xxx` |
+| I2 | Un bump de `Generation` révoque tous les tokens de cette famille de sujet | domaine | (révocation) |
+| I3 | Les access tokens sont courts et signés ES256 | domaine + infrastructure | la vérif échoue en aval |
+| I4 | La révocation est fail-closed et immédiate | application | — |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Émission.** Connexion (IdP fédéré vérifié) → créer `Session` + `RefreshToken`, frapper un access
+token ES256, persister, et émettre `session_issued` sur `auth.v1.events`.
+
+**Refresh (rotation).** Présenter le refresh token → valider + tourner (l'ancien invalidé) → frapper
+un nouvel access token. La réutilisation d'un token tourné est un signal de sécurité.
+
+**Révocation.** Déconnexion explicite, événement de sécurité, ou bump de `Generation` → marquer
+révoqué, émettre `session_revoked`. La vérification en aval (via `auth-context`) échoue fermée
+ensuite.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| IdP fédéré (Keycloak) | amont | Conformist | OIDC/identifiants | la connexion casse |
+| `account` | pair | Customer/Supplier | `SubjectLink` ↔ `AccountId` | résolution du sujet |
+| tous les services | aval | Open-Host Service (Published Language) | edge token ES256 vérifié par `auth-context` | tout appel authentifié casse |
+| `realtime` | aval | Conformist (verify-only) | vérif edge-token au handshake WS | les nouvelles connexions ne peuvent s'authentifier |
+| `audit` | aval | Published Language | `auth.v1.events` | la preuve du cycle de vie des sessions casse |
+
+> **Anti-Corruption Layer :** l'adaptateur IdP-fédéré traduit les claims OIDC externes vers le modèle
+> interne `Session` / `AccessTokenClaims`.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement (`auth.v1.events`) | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `session_issued` | une session authentifiée a été établie | connexion / émission de token | `audit` (Authentication) |
+| `session_revoked` | une session a été invalidée | déconnexion / révocation / bump de génération | `audit` (Authentication) |
+| `subject_linked` | un sujet IdP a été lié à un compte | flux de liaison de compte | (interne) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Identifiants Keycloak fédérés + edge tokens ES256 sur-mesure ; distinct de `account` (SoR) et `auth-context` (lib de vérif) | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) | Accepté |
+| Révocation instantanée via `Generation` monotone par-sujet malgré des tokens stateless | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — critique pour la sécurité, fédère un IdP générique, sur-mesure seulement à la couche edge-token/session.
+- **Volatilité :** faible-à-moyenne — guidée par la posture de sécurité et les changements d'IdP.
+- **Dette de modélisation connue :** rien de matériel consigné.
+- **Capacités différées :** flux d'auth step-up ; surfaces de gestion d'appareils/sessions plus riches.

--- a/crates/services/chat/docs/DOMAIN.fr.md
+++ b/crates/services/chat/docs/DOMAIN.fr.md
@@ -1,0 +1,159 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: a52bf3a7daf639818dc1beb72de8509a44b7f4cd0483a1150f16ee7d27d0c60d
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `chat` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Conversations & Messagerie |
+> | **Classe de sous-domaine** | **Core** — la messagerie directe est une surface produit primaire ; le modèle de shadowing membre/audience est sur-mesure |
+> | **System of …** | **Record** pour les conversations, l'appartenance et les messages |
+> | **Racine(s) d'agrégat** | `Conversation`, `Message` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Fail-closed en écriture** (un message envoyé doit persister) ; la livraison live est best-effort sur son propre plan |
+> | **Contextes amont** | clients utilisateur (envoi/lecture) ; `moderation` (filtrage de contenu) |
+> | **Contextes aval** | consommateurs des événements `chat.*` ; fait tourner son **propre** plan live (coexiste avec `realtime`) |
+> | **Journal de décisions** | [`ADR-0006`](../../../../docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `chat` est l'autorité pour **les conversations et messages** : il répond à
+**« qu'a-t-il été dit, dans quelle conversation, par qui, et qui a le droit de le voir ? »**
+
+**Le problème difficile.** Servir à la fois les *membres* (qui lisent/écrivent) et une *audience* plus
+large (qui peut voir une conversation publiée) sans confondre les deux plans de visibilité — le
+**Shadowing Pattern** (un plan Membre vs un plan Audience) — et stocker un journal de messages à fort
+volume à coût maîtrisé via des partitions bucketées `(conversation_id, bucket)`.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Être le plan générique de livraison live → `realtime` l'est ; chat fait tourner son propre plan live aujourd'hui (coexist-first).
+- ❌ Classer/décider sur le contenu → `moderation` décide ; chat applique le filtrage.
+- ❌ Stocker les octets média → `media` les possède.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Conversation | Un fil de messagerie avec une appartenance et une politique | `Conversation`, `ConversationId`, `ConversationKind` |
+| Message | Un message unique dans un journal de conversation | `Message`, `MessageId`, `MessageContent` |
+| Participant | Un membre d'une conversation, avec un rôle | `Participant`, `Role` |
+| Conversation policy | Les règles régissant la conversation | `ConversationPolicy` |
+| Visibility | Visibilité plan-membre vs plan-audience (le shadowing) | `Visibility` |
+| Content type | Le type de contenu du message | `ContentType` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Conversation` | racine d'agrégat | Appartenance + politique + état de publication/visibilité |
+| `Message` | racine d'agrégat | Intégrité du message dans un bucket de conversation |
+| `Participant` / `Role` | VO/enum | Qui peut lire/écrire et à quelle autorité |
+| `ConversationPolicy` | VO | Les règles régissant la conversation |
+| `Visibility` / `ConversationKind` / `ContentType` | enum | Vocabulaires fermés plan/type/contenu |
+
+**Cycle de vie de conversation :**
+
+```
+created --(publish)--> published --(unpublish)--> unpublished (audience plane torn down)
+   │  member join/leave                                   │
+   └──────────────── message.sent (bucketed log) ─────────┘
+```
+
+> **Transitions légales uniquement.** L'appartenance est vérifiée à la frontière gRPC ; une
+> dépublication démantèle le plan audience via le `VisibilityWorker` ; seuls les membres écrivent.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Conversations, appartenance et journal de messages — **ScyllaDB** (journal bucketé `(conversation_id, bucket)`). Aucun autre service ne les écrit.
+- Routage/présence live — **Redis** pub/sub shardé (`RedisSubscriber`), dérivé/éphémère.
+
+**La liste « ne-pas-écrire » :** chat ne possède pas les octets média (référence `media`), ne décide
+pas la modération, et n'écrit l'état d'aucun autre service.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Seuls les membres peuvent écrire/lire le plan membre | frontière gRPC | `CHT-3xxx`/`PERMISSION_DENIED` |
+| I2 | Le plan membre et le plan audience restent distincts (shadowing) | domaine | `CHT-2xxx` |
+| I3 | La dépublication démantèle entièrement le plan audience | application (`VisibilityWorker`) | `CHT-4xxx` |
+| I4 | Les messages sont ajoutés au bon bucket de conversation | domaine | `CHT-9xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Envoyer un message.** Envoi autorisé-membre → ajout au journal Scylla `(conversation_id, bucket)`
+→ publier `chat.message.sent` et pousser live via le plan pub/sub shardé Redis propre à chat
+(streaming gRPC dual vers les clients connectés).
+
+**Publier / dépublier (shadowing).** Publier une conversation ouvre le plan audience ; dépublier
+déclenche le démantèlement par le `VisibilityWorker`, consommant `chat.conversation.unpublished`
+(DLQ `chat.conversation.unpublished.dlq`) pour démonter l'état du plan audience.
+
+**Appartenance.** Join/leave émettent `chat.member.joined` / `chat.member.left`.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| clients | amont | OHS | gRPC + dual streaming | la messagerie client casse |
+| `moderation` | amont | Customer/Supplier | filtrage de contenu | la voie de contenu filtré casse |
+| `realtime` | pair | Separate Ways (coexist) | — (non consommé ; chat possède son plan live) | consolidation future différée |
+| consommateurs d'événements | aval | Published Language | topics `chat.*` | les réactions aval cassent |
+
+> **Anti-Corruption Layer :** le subscriber Redis + le visibility worker isolent la mécanique du plan
+> live du domaine.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `chat.conversation.created` / `chat.conversation.published` / `chat.conversation.unpublished` | faits de cycle de vie de conversation | création / publication / dépublication | `VisibilityWorker`, consommateurs aval |
+| `chat.member.joined` / `chat.member.left` | changement d'appartenance | join/leave | consommateurs aval |
+| `chat.message.sent` | un message a été commité dans le journal | l'envoi commite | (plan live de chat ; **non** consommé par `realtime` pour l'instant) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Shadowing Pattern — plans de visibilité Membre vs Audience distincts | [`ADR-0006`](../../../../docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.md) | Accepté |
+| Coexist-first avec `realtime` (chat garde son propre plan live pour l'instant) | _voir conséquences ADR-0003_ | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Core — la messagerie est une surface produit primaire.
+- **Volatilité :** moyenne — les types de conversation et règles de visibilité évoluent avec le produit.
+- **Dette de modélisation connue :** le plan live propre de chat duplique `realtime` (la couture de consolidation est délibérément ouverte).
+- **Capacités différées :** consolidation sur `realtime` ; média-en-chat plus riche ; réactions.

--- a/crates/services/comment/docs/DOMAIN.fr.md
+++ b/crates/services/comment/docs/DOMAIN.fr.md
@@ -1,0 +1,146 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 7bd89c4524acfa76a8d354ca4ae4a9f1ab76d2145e7a96aa746398bc106be668
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `comment` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Comments — réponses en fil sur les posts |
+> | **Classe de sous-domaine** | **Core** — les commentaires sont un engagement UGC primaire |
+> | **System of …** | **Record** pour les commentaires et leur cycle de vie |
+> | **Racine(s) d'agrégat** | `Comment` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-closed en écriture** (un commentaire posté doit persister) |
+> | **Contextes amont** | clients utilisateur ; `post` (l'entité commentée) |
+> | **Contextes aval** | `notification`, `engagement`, `counter` — via **Published Language** (`comment.created` / `comment.deleted`) |
+> | **Journal de décisions** | [`ADR-0007`](../../../../docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `comment` est l'autorité pour **les commentaires** : il répond à
+**« qu'a-t-on commenté sur quel post, par qui, et est-ce encore présent ou retiré ? »**
+
+**Le problème difficile.** Stocker un flux de commentaires à forte écriture avec un modèle de fil
+plat à bas coût, et distinguer le *tombstone* (« supprimé » visible) du *purge* (retrait dur) pour
+modération/RGPD — via un **sentinelle nil-UUID** pour l'arbre plat et un layout ScyllaDB à deux
+tables (LCS pour les lookups + TWCS pour le flux temporel).
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder le post commenté → `post`.
+- ❌ Compter les commentaires pour l'affichage → c'est `counter` (magnitudes) ; comment émet les événements.
+- ❌ Décider la modération → `moderation` décide ; comment applique la suppression.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Comment | Une réponse attachée à un post | `Comment`, `CommentId` |
+| Comment body | Le contenu textuel | `CommentBody` |
+| GIF attachment | Une référence GIF attachée | `GifAttachment` |
+| Comment status | État actif / tombstoné | `CommentStatus` |
+| Deletion strategy | Tombstone vs purge | `DeletionStrategy` |
+| Nil-UUID sentinel | Le marqueur de racine de l'arbre plat (sans parent) | (UUID nil) |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Comment` | racine d'agrégat | Intégrité du commentaire + transitions d'état |
+| `CommentBody` / `GifAttachment` | VO | Validité du contenu à la construction |
+| `CommentStatus` | enum | Légalité actif → tombstoné |
+| `DeletionStrategy` | enum | Tombstone (visible) vs purge (dur) |
+| `PostId` / `ProfileId` | VO | Références entité commentée et auteur |
+
+**Cycle de vie :**
+
+```
+created --(delete: tombstone)--> tombstoned   |   created --(delete: purge)--> purged (hard removed)
+```
+
+> **Transitions légales uniquement.** La stratégie de suppression est explicite ; un tombstone
+> préserve l'emplacement, un purge retire la ligne (modération/RGPD).
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Les commentaires — **ScyllaDB** deux tables (lookups LCS + flux TWCS). Aucun autre service ne les écrit.
+
+**La liste « ne-pas-écrire » :** comment n'écrit jamais l'état du post ni les *comptes* de commentaires
+(ceux-ci sont dérivés dans `counter` depuis les événements de comment).
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Un commentaire référence un post + un auteur valides | domaine | `CMT-1xxx` |
+| I2 | Tombstone vs purge est un choix explicite, irréversible | domaine | `CMT-1xxx` |
+| I3 | L'arbre plat utilise le sentinelle nil-UUID pour les commentaires sans racine | domaine | `CMT-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Créer.** Création autorisée → écriture dans les deux tables Scylla → publier `comment.created`
+(consommé par `notification`, `engagement`/`counter` pour les comptes).
+
+**Supprimer.** Tombstone (marqueur supprimé visible) ou purge (retrait dur pour modération/RGPD) →
+publier `comment.deleted`.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `post` | amont | Customer/Supplier | référence `PostId` | commentaires orphelins si la sémantique du post change |
+| `notification` | aval | Published Language | `comment.created` | notifications de réponse |
+| `engagement` / `counter` | aval | Published Language | `comment.created` / `comment.deleted` | comptes de commentaires |
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `comment.created` | un commentaire a été posté sur un post | la création commite | `notification` (notifier l'auteur), `counter`/`engagement` (compte++) |
+| `comment.deleted` | un commentaire a été tombstoné ou purgé | la suppression commite | `counter`/`engagement` (compte--), fils |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Arbre plat sentinelle nil-UUID + layout Scylla deux tables (LCS+TWCS) | [`ADR-0007`](../../../../docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md) | Accepté |
+| Sémantique de suppression tombstone vs purge | [`ADR-0007`](../../../../docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.md) | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Core — les commentaires sont du UGC primaire.
+- **Volatilité :** faible-à-moyenne.
+- **Dette de modélisation connue :** fil plat uniquement (pas de threading imbriqué).
+- **Capacités différées :** fils imbriqués ; pièces jointes plus riches.

--- a/crates/services/counter/docs/DOMAIN.fr.md
+++ b/crates/services/counter/docs/DOMAIN.fr.md
@@ -1,0 +1,160 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 7d7422a3f3e4efa04b1e32c3f1fa0b0eac92f29b163c39cf64c2652269e1a830
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `counter` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Counter / Analytics — les magnitudes (« combien ? ») |
+> | **Classe de sous-domaine** | **Supporting** — un plan de mesure dérivé ; précieux mais pas l'origine de la valeur produit |
+> | **System of …** | **Reference (SoRef)** pour comptes/cardinalités/tendances — exact-mais-réconciliable, jamais l'état d'arête (« qui ? ») |
+> | **Racine(s) d'agrégat** | `Metric` + `WindowAggregator` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-open** — une lecture dégrade vers une magnitude périmée/approximative, jamais une erreur sur le hot path |
+> | **Contextes amont** | producteurs view/impression/click, `engagement` (réactions) — via **ACL** sur Kafka |
+> | **Contextes aval** | `search` (PopularityScore), `realtime` (broadcast) — via **Published Language** (`counter.v1.popularity`) |
+> | **Journal de décisions** | [`ADR-0008`](../../../../docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `counter` est l'autorité pour **les magnitudes** : il répond à
+**« combien de vues / likes / followers / rang de tendance cette entité a-t-elle ? »** — jamais *qui*
+a fait quoi (c'est l'état d'arête, possédé ailleurs).
+
+**Le problème difficile.** Compter un firehose au volume d'écriture sans perdre en exactitude ni faire
+fondre le hot path : ingestion pure-Kafka avec pré-agrégation fenêtrée N→1, compteurs shardés à deux
+étages, un store 3-tiers (Redis hot / Postgres warm-SoRef + réconciliation / Scylla TWCS cold), HLL
+pour les vues uniques et CMS pour les tendances, exact-mais-réconciliable pour likes/follows.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Détenir l'état d'arête (qui a liké/suivi qui) → `engagement` / `social-graph`.
+- ❌ Être un System of Record → c'est un System of *Reference* réconciliable.
+- ❌ Servir de l'analytics d'événements bruts → il sert des magnitudes agrégées.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Metric | Une quantité comptée avec un kind + une agrégation | `Metric`, `MetricKind`, `Aggregation` |
+| Window | Le pivot d'idempotence — un intervalle d'agrégation borné | `WindowId`, `WindowKey`, `WindowSize`, `WindowAggregator` |
+| Observation / delta | Un signal unique / le changement plié à appliquer | `Observation`, `WindowDelta` |
+| Cardinality | Compte unique approximatif (HLL) | `Cardinality` |
+| Popularity score | La magnitude de popularité publiée + poids | `PopularityScore`, `PopularityWeights` |
+| Trending | Items classés adossés au CMS dans un scope | `TrendingItem`, `TrendingScope`, `TrendingQuery` |
+| Time-series bucket | Un bucket temporel TWCS du tier cold | `TimeSeriesBucket`, `TimeGranularity` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Metric` | racine d'agrégat | `MetricKind` (exact/approx) × `Aggregation` (sum/cardinality) orthogonaux |
+| `WindowAggregator` | racine d'agrégat | Pli N→1 ; `WindowId` rend les flushes idempotents |
+| `CounterValue` / `CountSnapshot` / `Cardinality` | VO | Une magnitude / un instantané ponctuel / une estimation HLL |
+| `PopularityScore` / `PopularityWeights` | VO | Le signal de popularité publié |
+| `EntityRef` / `EntityId` / `EntityKind` | VO | Ce qui est compté |
+
+> **`WindowId` est le pivot.** Il garde tous les effets de bord multi-tiers (le ledger de deltas),
+> donc un flush rejoué ne peut double-compter.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité (de *référence*) pour :**
+- Les magnitudes — **Redis** (hot) + **Postgres** (warm-SoRef + ledger de réconciliation) + **ScyllaDB** (cold TWCS séries temporelles). Réconciliable face aux SoR d'arête propriétaires.
+
+**Ce contexte détient des copies dérivées qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Vérité follower/following | `social-graph` | source de réconciliation (gRPC) | réconcilié périodiquement (dérive → `CTR-5002`) |
+| État d'arête de réaction | `engagement` | événements `engagement.*` | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** counter ne possède jamais le *qui* — il dérive les magnitudes et
+réconcilie face aux SoR d'arête ; il supersède seulement les comptes *bruts* de vues/partages
+d'engagement.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Un flush est idempotent par `WindowId` (pas de double-compte au rejeu) | domaine + CTE ledger Pg | `CTR-2xxx` |
+| I2 | Les magnitudes ne revendiquent jamais une identité d'arête (« qui ») | domaine | — |
+| I3 | Les lectures hot échouent ouvertes (timeout dur → périmé/approx) | application | `CTR-4xxx` |
+| I4 | Les valeurs de référence se réconcilient au SoR propriétaire ; la dérive alarme | application | `CTR-5002` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Ingest → agréger → flush.** Les signaux affluent (`view.v1.events`, `impression.v1.events`,
+`click.v1.events`, engagement) → `WindowAggregator` plie N→1 → `DeltaFlusher` écrit idempotemment
+(gardé par le ledger `WindowId`) à travers les 3 tiers → `PopularityPublisher` émet
+`counter.v1.popularity`.
+
+**Lecture (fail-open).** Les lectures hot frappent Redis avec un `tokio::timeout` dur ; en cas de
+miss/timeout, retourner une valeur périmée/approximative plutôt qu'une erreur.
+
+**Réconcilier.** Un `Reconciler` répare périodiquement les magnitudes face au SoR propriétaire
+(`set_total`/overwrite) ; la divergence lève `CTR-5002`.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| producteurs view/impression/click | amont | ACL | `*.v1.events` | les comptes cessent d'avancer |
+| `engagement` | amont | ACL | événements de réaction | les magnitudes like/share cassent |
+| `social-graph` | source de réconciliation | Customer/Supplier | gRPC follower/following | la réconciliation du compte de followers casse |
+| `search` | aval | Published Language | `counter.v1.popularity` | le PopularityScore de search devient périmé |
+| `realtime` | aval | Published Language | `counter.v1.popularity` (broadcast) | les compteurs live s'arrêtent |
+
+> **Anti-Corruption Layer :** la couche `decode` pure mappe chaque forme wire de signal amont vers
+> `Observation`.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `counter.v1.popularity` | la magnitude de popularité d'une entité a changé | un flush de fenêtre met à jour un score de popularité | `search` (classement), `realtime` (broadcast live) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Les magnitudes (« combien ») sont un SoRef réconciliable séparé, distinct de l'état d'arête (« qui ») ; supersède les comptes bruts d'engagement | [`ADR-0008`](../../../../docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md) | Accepté |
+| Flush idempotent gardé par `WindowId` à travers un store 3-tiers | [`ADR-0008`](../../../../docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.md) | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — un plan de mesure/référence dérivé des SoR d'arête.
+- **Volatilité :** moyenne — les nouveaux types de métrique et producteurs sont additifs.
+- **Dette de modélisation connue :** la réconciliation like/share/comment attend un RPC de compte de réactions d'engagement.
+- **Capacités différées :** producteurs amont view/impression/click ; le stream `social-graph.follows` ; producteur de shard-fan-out.

--- a/crates/services/engagement/docs/DOMAIN.fr.md
+++ b/crates/services/engagement/docs/DOMAIN.fr.md
@@ -1,0 +1,144 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: c3a6f05972f81abda4eec79aebd5b7bf10ef456803138a1227b5c2b6562c00c0
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `engagement` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Engagement — réactions et leur état d'arête / scoring |
+> | **Classe de sous-domaine** | **Core** — interaction directe de l'utilisateur avec le contenu ; l'arête de réaction est du tissu produit |
+> | **System of …** | **Record** pour l'état d'arête de réaction (« qui a réagi, comment ») ; les magnitudes sont superseded par `counter` |
+> | **Racine(s) d'agrégat** | `Reaction` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-open-ish** — Redis-primary avec atomicité Lua, Kafka write-behind |
+> | **Contextes amont** | clients utilisateur ; `comment` (comptes) |
+> | **Contextes aval** | `counter` (magnitudes), `notification`, `geo-discovery` (score) — via **Published Language** |
+> | **Journal de décisions** | [`ADR-0009`](../../../../docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `engagement` est l'autorité pour **les réactions** : il répond à
+**« qui a réagi à ce contenu, avec quelle réaction, et quel est le score d'engagement pondéré ? »**
+
+**Le problème difficile.** Appliquer atomiquement des bascules de réaction idempotentes à haute
+fréquence sur le hot path — **Redis-primary avec atomicité Lua** — tout en enregistrant durablement
+l'arête via **Kafka write-behind**, sans aller-retour base par bascule.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Servir des *comptes* d'affichage → `counter` possède les magnitudes ; engagement émet les événements d'arête.
+- ❌ Posséder le contenu réagi → `post` / `comment`.
+- ❌ Posséder les compteurs bruts de vues/partages → superseded par `counter`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Reaction | L'arête de réaction d'un utilisateur sur un item de contenu | `Reaction`, `ReactionKind` |
+| Reaction weight | Le poids de score d'un type de réaction | `ReactionWeight` |
+| Upsert / remove | Pose/effacement idempotent d'une réaction | `ReactionUpsertedEvent`, `ReactionRemovedEvent` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Reaction` | racine d'agrégat | Une arête de réaction par (utilisateur, contenu) ; bascule idempotente |
+| `ReactionKind` | enum | Vocabulaire de réaction fermé |
+| `ReactionWeight` | VO | Contribution au scoring par type |
+| `PostId` / `ProfileId` | VO | Le contenu réagi + le réacteur |
+
+**Cycle de vie :**
+
+```
+(none) --(react)--> upserted --(react again, same kind)--> idempotent --(unreact)--> removed
+```
+
+> **Transitions légales uniquement.** Réappliquer la même réaction est idempotent (Lua-atomique dans
+> Redis) ; l'arête est la vérité, le score est dérivé.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- L'état d'arête de réaction — **Redis** (primary, Lua-atomique) avec **ScyllaDB** write-behind durable.
+
+**La liste « ne-pas-écrire » :** engagement n'écrit pas les comptes d'affichage (émet des événements ;
+`counter` agrège), et ne possède pas le contenu.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Une arête de réaction par (utilisateur, contenu) ; les bascules sont idempotentes | domaine + Lua-atomique dans Redis | `ENG-2xxx` |
+| I2 | L'arête fait autorité ; le score est dérivé des poids | domaine | `ENG-3xxx` |
+| I3 | Enregistrement durable via Kafka write-behind (pas d'aller-retour base par bascule) | application | `ENG-5xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**React / unreact.** Un script Lua pose/efface atomiquement l'arête de réaction et met à jour le score
+in-Redis ; un `ReactionUpsertedEvent` / `ReactionRemovedEvent` est émis (Kafka write-behind) pour
+l'enregistrement durable et la consommation aval.
+
+**Propagation du score.** `engagement.score_updated` porte le score pondéré vers les consommateurs
+(`geo-discovery` viralité, `counter`).
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `comment` | amont | ACL | `comment.created` / `comment.deleted` | les comptes pilotés par commentaire cassent |
+| `counter` | aval | Published Language | événements de réaction | les magnitudes like/réaction cassent |
+| `notification` | aval | Published Language | `engagement.reactions` | les notifications de réaction cassent |
+| `geo-discovery` | aval | Published Language | `engagement.score_updated` | le scoring de viralité casse |
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `engagement.reactions` (`ReactionUpserted`/`Removed`) | une arête de réaction a été posée/effacée | react/unreact commite | `notification`, `counter` |
+| `engagement.score_updated` | le score d'engagement pondéré a changé | recalcul du score | `geo-discovery`, `counter` |
+| `engagement.post_reactions` / `post_interaction_counters` | agrégats de réactions/interactions par post | agrégation | consommateurs aval |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Réactions Redis-primary Lua-atomiques + durabilité Kafka write-behind | [`ADR-0009`](../../../../docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md) | Accepté |
+| Engagement garde l'*arête* de réaction ; `counter` supersède les magnitudes brutes | _voir counter §4_ | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Core — interaction directe avec le contenu.
+- **Volatilité :** faible-à-moyenne — les nouveaux types de réaction sont additifs.
+- **Dette de modélisation connue :** un RPC de compte de réactions pour la réconciliation `counter` n'est pas encore exposé.
+- **Capacités différées :** analytics de réactions plus riches ; réglage du scoring par type.

--- a/crates/services/geo-discovery/docs/DOMAIN.fr.md
+++ b/crates/services/geo-discovery/docs/DOMAIN.fr.md
@@ -1,0 +1,154 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: a6e2a078fb92f1501144b2359efb68cc8308b5831f084c675f281a9b71e4f3e2
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `geo-discovery` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Geo Discovery — découverte spatiale de posts sur une carte |
+> | **Classe de sous-domaine** | **Supporting** — un read-model spatial dérivé ; surface produit distinctive mais ne possède aucune vérité |
+> | **System of …** | **Reference (SoRef)** — un index spatial requêtable sur les posts, reconstructible depuis l'amont |
+> | **Racine(s) d'agrégat** | `MapPostCard` (projection) clé par `H3Index` |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-open** — un index dégradé retourne moins/des cartes plus périmées, jamais une erreur |
+> | **Contextes amont** | `post` (posts publiés avec localisation), `engagement` (viralité), `profile`/`social-graph` (tier d'auteur) — via **ACL** |
+> | **Contextes aval** | clients (requêtes de viewport carte) ; ne publie rien de référence |
+> | **Journal de décisions** | [`ADR-0010`](../../../../docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `geo-discovery` est l'autorité pour **la découverte spatiale** : il répond à
+**« quels sont les posts les plus pertinents visibles dans ce viewport de carte en ce moment ? »**
+
+**Le problème difficile.** Servir des requêtes de viewport à latence interactive sur une population de
+posts en changement constant — un **viewport H3 `grid_disk`** mappé vers une structure Redis
+double-couche (ZSET + cardinalité), avec des scripts Lua Top-K / XX / prune et une rétention TTL pour
+que l'index s'auto-élague.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder les posts → `post` est le SoR ; geo détient une projection spatiale.
+- ❌ Calculer les scores d'engagement → les consomme depuis `engagement`.
+- ❌ Posséder le tier d'auteur → consomme `profile.tier_changed`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Map post card | Le résumé projeté, rendable sur carte, d'un post | `MapPostCard` |
+| H3 index / resolution | L'id de cellule spatiale hexagonale et sa résolution | `H3Index`, `H3Resolution` |
+| Geo coordinate | Un point lat/lng | `GeoCoordinate` |
+| Virality score | Le poids de classement dérivé de l'engagement | `ViralityScore` |
+| Author tier | Le tier de l'auteur (affecte classement/visibilité) | `AuthorTier` |
+| Retention TTL | Combien de temps une carte reste dans l'index spatial | `RetentionTtl` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `MapPostCard` | projection (agrégat) | Le résumé de post rendable sur carte dans une cellule |
+| `H3Index` / `H3Resolution` | VO | Identité de cellule spatiale + granularité de zoom |
+| `GeoCoordinate` | VO | lat/lng valides à la construction |
+| `ViralityScore` / `AuthorTier` | VO/enum | Entrées de classement |
+| `RetentionTtl` | VO | Durée de vie auto-élaguante |
+
+> **Invariant.** Une carte vit dans exactement la/les cellule(s) H3 de sa coordonnée ; le classement
+> dans une cellule est Top-K par viralité, élagué et TTL'd.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité (de *référence*) pour :**
+- L'index spatial — **Redis** (double-couche ZSET + cardinalité) + **ScyllaDB** (`map_post_cards`). Reconstructible depuis les événements amont.
+
+**Ce contexte détient des copies dérivées qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Contenu/localisation du post | `post` | `post.published` / `post.deleted` | cohérence à terme |
+| Viralité | `engagement` | `engagement.score_updated` | cohérence à terme |
+| Tier d'auteur | `profile` | `profile.tier_changed` | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** geo ne mute jamais les posts, scores ou tiers — il les indexe.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Une carte est indexée dans la bonne cellule H3 pour sa coordonnée | domaine | `GEO-1xxx` |
+| I2 | Dans une cellule, les résultats sont Top-K par viralité, élagués + TTL'd | domaine (Lua) | `GEO-2xxx` |
+| I3 | Les requêtes de viewport échouent ouvertes (dégradent, jamais d'erreur) | application | `GEO-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Maintenance de l'index.** Consommer `post.published` (ajouter carte), `post.deleted` (retirer),
+`engagement.score_updated` (re-classer), `profile.tier_changed` (re-pondérer) → mettre à jour le ZSET
+Redis double-couche via Lua Top-K/XX/prune ; le TTL gère la rétention.
+
+**Requête de viewport.** Un viewport de carte → `H3 grid_disk` des cellules couvrantes → fusionner
+Top-K par cellule → retourner des `MapPostCard`. Un index dégradé retourne moins/des cartes plus
+périmées (fail-open).
+
+> **Lacune de payload connue :** `post` n'émet actuellement ni lat/lng ni caption sur
+> `post.published`, donc la projection geo dépend d'une décision produit pour enrichir l'événement de
+> post (consignée dans l'audit pré-infra).
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `post` | amont | ACL | `post.published` / `post.deleted` | les cartes cessent d'apparaître/de se purger |
+| `engagement` | amont | ACL | `engagement.score_updated` | le classement devient périmé |
+| `profile` | amont | ACL | `profile.tier_changed` | la pondération par tier casse |
+| clients | aval | OHS | requête gRPC de viewport | la découverte sur carte casse |
+
+> **Anti-Corruption Layer :** les consommateurs traduisent chaque événement amont en mises à jour de `MapPostCard`.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+> Ne publie **rien de référence** — c'est un read-model. Il consomme les faits de `post` /
+> `engagement` / `profile` ; leurs sens sont possédés par ces contextes.
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Viewport H3 grid_disk + index spatial Top-K Redis double-couche (ZSET+cardinalité) | [`ADR-0010`](../../../../docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.md) | Accepté |
+| Enrichissement de payload post→geo (lat/lng/caption) nécessite une décision produit | _ouvert — voir audit pré-infra_ | Ouvert |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — une projection spatiale distinctive mais dérivée.
+- **Volatilité :** moyenne — les entrées de classement évoluent.
+- **Dette de modélisation connue :** la lacune de payload post→geo (pas de lat/lng/caption émis en amont).
+- **Capacités différées :** requêtes spatiales plus riches ; clustering ; heatmaps.

--- a/crates/services/media/docs/DOMAIN.fr.md
+++ b/crates/services/media/docs/DOMAIN.fr.md
@@ -1,0 +1,162 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: d705a417c3e25bbd1a83d11640eeb99b2ed028d1a26792cc9903783651bc94a9
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `media` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Media — plan de contrôle du cycle de vie d'asset + courtage de livraison |
+> | **Classe de sous-domaine** | **Supporting** — gestion média nécessaire ; pipeline sur-mesure, mais pas l'origine de la valeur produit |
+> | **System of …** | **Record** pour les *métadonnées/cycle de vie* d'asset (les octets vivent dans le store objet, pas ici) |
+> | **Racine(s) d'agrégat** | `Asset` (`domain`) |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Mixte** — *fail-open* sur la résolution de livraison ; *fail-closed* sur le `Screen` CSAM avant qu'un asset ne devienne ready |
+> | **Contextes amont** | clients (tickets d'upload) ; `moderation` (Screen + takedown) |
+> | **Contextes aval** | `post`, `profile`, `search` — via **Published Language** (`media.v1.events`) |
+> | **Journal de décisions** | [`ADR-0011`](../../../../docs/adr/0011-media-byte-free-control-plane.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `media` est l'autorité pour **le cycle de vie de l'asset média** : il répond à
+**« cet asset est-il uploadé, screené, transformé et sûr à livrer — et depuis où ? »**
+
+**Le problème difficile.** Gérer de gros binaires sans jamais mettre d'octets sur gRPC/Kafka : un
+design à trois plans — (A) un courtier d'upload émettant des tickets **pré-signés direct-vers-store**,
+(B) un pipeline de transformation Kafka async, (C) un courtage de résolution-de-livraison/CDN — avec
+un **Screen CSAM fail-closed** gardant la mise en ready.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Faire transiter des octets par gRPC/Kafka → les uploads vont direct au store objet via URL pré-signées.
+- ❌ Décider la politique de modération → `moderation` décide ; media applique Screen/takedown.
+- ❌ Posséder l'endroit où l'asset est *utilisé* → `post` / `profile` le référencent.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Asset | Un asset média et son cycle de vie | `Asset`, `AssetId`, `AssetState` |
+| Upload ticket | Un octroi d'upload pré-signé direct-vers-store | `UploadTicket`, `ReserveParams`, `UploadConstraints` |
+| Rendition | Une variante dérivée (taille/format) d'un asset | `Rendition`, `RenditionKind` |
+| Content hash | Le hash de dédup/identité des octets | `ContentHash` |
+| Storage key | L'emplacement dans le store objet | `StorageKey` |
+| Blurhash / dimensions | Placeholder perceptuel + métadonnées de taille | `Blurhash`, `Dimensions` |
+| Delivery visibility | Si/comment un asset peut être servi | `DeliveryVisibility` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Asset` | racine d'agrégat | La machine à états du cycle de vie de l'asset |
+| `UploadTicket` / `ReserveParams` / `UploadConstraints` | VO | Un octroi d'upload borné, pré-signé |
+| `Rendition` / `RenditionKind` | VO/enum | Variantes dérivées |
+| `ContentHash` / `StorageKey` / `MimeType` / `Dimensions` / `Blurhash` | VO | Identité des octets + emplacement + métadonnées |
+| `MediaKind` / `AssetState` / `DeliveryVisibility` | enum | Vocabulaires fermés kind/état/livraison |
+
+**Cycle de vie de l'asset :**
+
+```
+reserved --(upload+finalize)--> uploaded --(Screen: fail-closed)--> ready --(variant)--> variant_ready
+   │                                  │                                │
+   │                                  └--(Screen fail)--> quarantined  └--(takedown)--> deleted --(restore)--> ready
+   └--(timeout)--> failed
+```
+
+> **Transitions légales uniquement.** Un asset ne peut atteindre `ready` sans passer le `Screen`
+> CSAM ; un takedown met en quarantaine/supprime ; la restauration est explicite.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Les métadonnées/cycle de vie d'asset — **Postgres** (doc asset, JSONB) + **Redis** (cache). Les
+  **octets** vivent dans **S3/MinIO** (store objet), référencés par `StorageKey` — media possède le
+  plan de contrôle, pas une copie octets-en-base.
+
+**La liste « ne-pas-écrire » :** media ne décide jamais la politique de modération et ne possède pas
+l'endroit où un asset est intégré (`post`/`profile` le référencent).
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Les octets ne traversent jamais gRPC/Kafka — seulement pré-signé direct-vers-store | infrastructure | `MED-1xxx` |
+| I2 | Un asset atteint `ready` seulement après un `Screen` CSAM réussi (fail-closed) | application | `MED-7xxx` |
+| I3 | Un takedown de modération met en quarantaine/supprime l'asset | application (consumer) | `MED-6xxx` |
+| I4 | La résolution de livraison échoue ouverte (dégrade, jamais ne bloque) | application | `MED-5xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Plan A — courtier d'upload.** Le client demande un `UploadTicket` → media réserve un `Asset` +
+émet une URL pré-signée → le client upload **direct vers le store objet** → finalize.
+
+**Plan B — transformation (async).** Sur `media.v1.events` (uploaded), le processor sonde l'image,
+exécute le **Screen CSAM fail-closed** (gRPC vers `moderation`, timeout dur), génère les renditions +
+blurhash, et transitionne l'asset vers `ready` (ou `quarantined`).
+
+**Plan C — livraison (fail-open).** Résoudre un asset → URL CDN (courtage CloudFront). Un consumer de
+takedown `moderation` met en quarantaine/supprime à la demande.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| clients | amont | OHS | tickets d'upload pré-signés | les uploads cassent |
+| `moderation` | amont | Customer/Supplier (sync) + ACL | gRPC `Screen` + consumer de takedown | filtrage de mise-en-ready / takedowns cassent |
+| `post` / `profile` / `search` | aval | Published Language | `media.v1.events` | intégrations/indexation cassent |
+
+> **Anti-Corruption Layer :** les adaptateurs store-objet + CDN isolent le plan octets ; le décodage
+> de takedown de modération mappe les événements étrangers vers des transitions d'asset.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement (`media.v1.events`) | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `asset_uploaded` | les octets ont atterri dans le store | finalize | le pipeline de transformation (Plan B) |
+| `asset_ready` / `asset_variant_ready` | l'asset (ou une variante) est sûr à livrer | Screen passe / rendition terminée | `post`, `profile`, `search` |
+| `asset_quarantined` / `asset_deleted` / `asset_restored` | transitions sécurité/cycle de vie | échec Screen / takedown / restauration | intégrations, livraison |
+| `asset_failed` | le traitement a échoué | timeout/erreur | UX d'upload |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Plan de contrôle sans-octets — uploads pré-signés direct-vers-store, octets jamais sur gRPC/Kafka | [`ADR-0011`](../../../../docs/adr/0011-media-byte-free-control-plane.md) | Accepté |
+| Split livraison fail-open / Screen CSAM fail-closed | [`ADR-0011`](../../../../docs/adr/0011-media-byte-free-control-plane.md) | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — plomberie média nécessaire ; pipeline sur-mesure.
+- **Volatilité :** moyenne — les nouveaux types média/renditions sont additifs.
+- **Dette de modélisation connue :** images d'abord ; transcodage vidéo différé.
+- **Capacités différées :** transcodage vidéo, sidecar anti-malware réel, consumer orphan-GC, WebP/AVIF, invalidation CloudFront, purge RGPD dédup-refcount.

--- a/crates/services/moderation/docs/DOMAIN.fr.md
+++ b/crates/services/moderation/docs/DOMAIN.fr.md
@@ -1,0 +1,200 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 244c371e01bc70b363f63978185fbc7c3de4617161e27b2b1ab3f7c712d5db77
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `moderation` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Confiance, Sécurité & Intégrité — la *décision d'intégrité de référence* |
+> | **Classe de sous-domaine** | **Core** — pour un réseau UGC, l'enforcement d'intégrité est différenciant et sur-mesure ; la sécurité *fait* partie de la valeur produit |
+> | **System of …** | **Record** pour « quelle action a été prise contre quelle entité, sous quelle version de politique, avec quelle preuve » |
+> | **Racine(s) d'agrégat** | `Case`, `Decision`, `EnforcementAction`, `Appeal`, `PenaltyLedger` (`domain::aggregate`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Split par catégorie** — le `Screen` CSAM/NCII/TVEC échoue **fermé** ; tout le reste est async/fail-open |
+> | **Contextes amont** | `post`, `comment`, `chat`, `media` (contenu + Screen) ; services de classifieurs (signaux) ; utilisateurs (signalements) — via **ACL** sur Kafka/gRPC |
+> | **Contextes aval** | `timeline`, `chat`, `account` (dénorm enforcement Plane-B) ; `audit` (preuve `decision_recorded`) ; `account` (exécution de suspension gRPC) — via **Open-Host Service / Published Language** |
+> | **Journal de décisions** | [`ADR-0002`](../../../../docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `moderation` est l'autorité pour **les décisions d'intégrité et l'enforcement** : il
+répond à **« cet acteur est-il restreint / ce contenu est-il actionné, par quelle autorité, et
+peut-on le prouver à un régulateur ? »**
+
+**Le problème difficile.** Modérer au *volume d'écriture* du réseau sans devenir un goulot de latence
+global. Un design naïf appelle un RPC de modération à chaque post/message/upload, taxant chaque
+écriture et couplant la disponibilité du contenu à une panne d'intégrité. Le pattern résolvant est un
+**split à trois plans** qui découple la voie lourde de classification/revue de la voie chaude de
+décision.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Classer le contenu par ML en ligne → les classifieurs sont des *producteurs* de signaux amont ; `Screen` est un lookup hash/blocklist sans inférence.
+- ❌ Stocker le contenu → il référence le contenu par `SubjectRef`, ne détient jamais les octets (`media`/`post` les possèdent).
+- ❌ Être l'UI de revue → la console d'ops est un appelant séparé de l'API case/appeal.
+- ❌ Servir l'enforcement sur le hot read path via RPC → la flotte lit le **Plane B** (événements + projection Redis), pas `GetEnforcementState`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Subject | La cible normalisée de modération : type d'entité + id + acteur + surface | `SubjectRef` |
+| Case | Une unité de revue ouverte sur un sujet quand des signaux franchissent un seuil | `Case` |
+| Decision | Une décision append-only, auditable (l'entrée du registre de preuve légale) | `Decision`, `DecisionAuthor` |
+| Enforcement action | La conséquence appliquée, versionnée monotone par sujet | `EnforcementAction`, `EnforcementVersion` |
+| Strike / penalty ledger | L'historique d'enforcement gradué qui escalade les conséquences | `Strike`, `PenaltyLedger`, `PenaltyPolicy` |
+| Appeal | Le recours d'un sujet contre une décision ; la résolution est une *nouvelle* décision | `Appeal`, `AppealStatus` |
+| Signal / report | Un verdict de classifieur / un signalement d'abus utilisateur alimentant le Plane A | `Signal`, `Report` |
+| Screen | La porte étroite, synchrone, fail-closed de pré-publication (Plane C) | (RPC `Screen`) |
+| Policy category / version | La politique sous laquelle une décision a été prise ; épinglée pour l'auditabilité | `PolicyCategory`, `PolicyVersion` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Case` | racine d'agrégat | Un sujet en revue ; clé par UUIDv5 déterministe de l'identité du sujet (ouverture idempotente) |
+| `Decision` | racine d'agrégat | Décision append-only ; une réversion est une *nouvelle* décision, jamais une mutation |
+| `EnforcementAction` | racine d'agrégat | Porte une `EnforcementVersion` monotone par-sujet — une réversion ne peut devancer une ré-application |
+| `Appeal` | racine d'agrégat | Cycle de vie du recours ; la résolution émet une nouvelle `Decision` |
+| `PenaltyLedger` | racine d'agrégat | État d'escalade gradué par acteur |
+| `SubjectRef` / `EntityType` / `ActorId` | VO | La cible d'intégrité normalisée — jamais de champs vendeur ou internes au contenu |
+| `PolicyCategory` / `PolicyVersion` / `Confidence` | VO | La base de politique de la décision et sa certitude |
+
+**Cycle de vie (case → enforcement) :**
+
+```
+signals/report --(threshold)--> Case opened --(review/decide)--> Decision recorded --> EnforcementAction applied (v+1)
+                                                     ▲                                          │
+                                                 Appeal filed ◄───────────── (reversal = new Decision) ──┘
+```
+
+> **Transitions légales uniquement.** Les décisions ne sont jamais rétro-mutées (registre
+> append-only) ; une réversion est une nouvelle `Decision`. L'`EnforcementVersion` et le schéma de
+> hash `Screen` ne doivent jamais changer après l'existence de données.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Cases, decisions (WORM), appeals, penalty ledger, policy versions — **Postgres** db `moderation`. Le registre de décisions est append-only.
+- Historique de signaux / preuves — **ScyllaDB** keyspace `moderation` (TWCS).
+- La projection d'enforcement + le corpus de hash Screen — **Redis** (dérivé/reconstructible).
+
+**Ce contexte détient des copies qu'il ne possède PAS (read-model / dénormalisation) :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Existence/métadonnées de contenu pour construire un `SubjectRef` | `post`, `comment`, `chat`, `media` | `post.v1.events`, `comment.*`, contenu chat (Plane A) | post-hoc (publication optimiste) |
+| Verdicts de classifieur | services de classifieurs | `moderation.signals` | best-effort |
+
+**La liste « ne-pas-écrire » :** moderation ne mute jamais le contenu (il le référence) ; la
+suspension de compte est *exécutée* par `account` via gRPC — moderation enregistre la décision et
+demande l'exécution, il ne possède pas l'état du compte.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Les décisions sont append-only — une réversion est une nouvelle décision | domaine + Postgres | `MOD-2xxx` |
+| I2 | `Screen` est déterministe et sans inférence (hash/blocklist seulement ; ML jamais en ligne) | frontière infrastructure | — |
+| I3 | Politique de défaillance par catégorie — CSAM/NCII/TVEC échouent **fermé** ; spam/borderline échouent **ouvert** | application | `MOD-7002`/`MOD-7003` |
+| I4 | La version `EnforcementAction` est monotone par sujet (la réversion ne peut devancer la ré-application) | domaine | concurrence `MOD-9xxx` |
+| I5 | Les Cases sont idempotents — clé par UUIDv5 déterministe de l'identité du sujet | domaine (consumer) | la dédup se replie en `Ok` |
+| I6 | Les RPC d'ops mutants sont privilégiés-relecteur — pas auto-autorisés | frontière de déploiement (auth-context) | `PERMISSION_DENIED` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Plane A — ingestion async (hors du write path, fail-open).**
+1. Le contenu `*.created` / les signalements / les signaux de classifieurs arrivent sur Kafka.
+2. `moderation-ingestion-consumer` exécute des vérifications déterministes bon marché (blocklist, hash known-bad, historique d'acteur).
+3. Fan-out vers les classifieurs async ; ouvre un `Case` quand les signaux franchissent un seuil.
+- **Idempotence :** Cases clé par UUIDv5 du sujet ; les skips intentionnels (block-gated, self-target, dédup) se replient en `Ok`.
+
+**Décision → enforcement (gradué).** Une `Decision` est enregistrée sous une `PolicyVersion`
+épinglée ; le moteur de pénalités escalade via le `PenaltyLedger` ; une `EnforcementAction` est
+appliquée à la version *v+1* et projetée vers Redis + émise sur `moderation.v1.events`.
+
+**Plane B — état d'enforcement (lecture chaude, O(1)).** La flotte lit `mod:enf:{actor:<id>}` depuis
+la projection Redis reconstruite par les consumers — jamais un RPC par-item.
+
+**Plane C — porte Screen (sync, fail-closed).** `media`/`post` appellent `Screen` en pré-publication
+pour les catégories catastrophiques. Un timeout dur (`MODERATION_SCREEN_TIMEOUT_MS`, défaut 200ms) +
+disjoncteur le bornent ; à l'échéance/panne la porte retourne `MOD-7002` et l'appelant bloque
+l'upload.
+
+**Appel.** Un sujet dépose un recours ; la résolution enregistre une nouvelle `Decision`
+(éventuellement une réversion) et une réversion d'enforcement correspondante.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `post`/`comment`/`chat`/`media` | amont | ACL | `*.events` de contenu → `SubjectRef` (Plane A) | un changement de schéma de contenu casse la construction du sujet |
+| services de classifieurs | amont | ACL | `moderation.signals` | perte des signaux ML → le moteur dégrade vers les règles déterministes |
+| `media`/`post` | aval | OHS (sync) | RPC `Screen` | un changement du contrat `Screen` casse la porte de publication |
+| `timeline`/`chat`/`account` | aval | Published Language | `moderation.v1.events` (Plane B) | la dénorm d'enforcement casse |
+| `audit` | aval | Published Language | `moderation.v1.events` · `decision_recorded` | la piste de preuve de conformité casse |
+| `account` | aval | Customer/Supplier (gRPC) | exécution de suspension/bannissement | les actions de cycle de vie ne peuvent s'appliquer (décision quand même enregistrée, retryée) |
+
+> **Anti-Corruption Layer :** les consumers d'ingestion Plane-A traduisent chaque forme wire de
+> contenu/signal vers les types domaine normalisés `SubjectRef` / `Signal` — les champs vendeur et
+> internes au contenu ne fuient jamais dans le modèle.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+> Sens seulement ; le schéma wire est possédé par le proto/README. Consolidation dans `docs/domain/EVENT_CATALOG.md`.
+
+| Événement (sur `moderation.v1.events`) | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `decision_recorded` | une décision d'intégrité faisant autorité a été prise — porte *qui a décidé* et *pourquoi* (statement-of-reasons DSA) | une décision est enregistrée (auto-screen, revue humaine, réversion d'appel) | `audit` — scelle la justification en enveloppe crypto-shreddable |
+| `enforcement_applied` / `enforcement_reversed` | une conséquence a été appliquée / levée contre un acteur (versionnée) | l'action d'enforcement commite | `timeline`, `chat`, `account` — dénorm Plane-B |
+| `case_opened` / `case_resolved` | une unité de revue a été ouverte / fermée | seuil d'ingestion / action du relecteur | consommateurs Plane-B |
+| `appeal_resolved` | un appel a été tranché | résolution d'appel | consommateurs Plane-B |
+
+> Tous les événements sont clé par `actor_id` pour l'ordonnancement par acteur. `decision_recorded`
+> est la variante de preuve de conformité ; les consommateurs offender-centric l'ignorent, `audit`
+> consomme seulement celui-ci + `enforcement_applied`.
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Moderation est le SoR décision/enforcement avec une porte Screen étroite fail-closed (split à trois plans) | [`ADR-0002`](../../../../docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) | Accepté |
+| `decision_recorded` comme événement de preuve face à audit (vs mapper les événements offender-centric) | _voir contexte ADR-0001_ | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Core — la confiance & sécurité est différenciante pour une plateforme UGC ; le design à trois plans et l'enforcement gradué sont sur-mesure.
+- **Volatilité :** moyenne — les catégories de politique, le moteur de pénalités et l'intégration de classifieurs évoluent avec le produit et la réglementation ; le *registre* et la discipline de version sont stables.
+- **Dette de modélisation connue :** l'autorisation de gateway pour les RPC d'ops mutants est un `<TODO>` de déploiement (le service ne s'auto-autorise pas).
+- **Capacités différées :** reporting de transparence DSA plus riche ; profondeur d'ingestion de contenu `chat` ; réputation d'acteur inter-surfaces.

--- a/crates/services/notification/docs/DOMAIN.fr.md
+++ b/crates/services/notification/docs/DOMAIN.fr.md
@@ -1,0 +1,109 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: ea18057b12c6645e194ee8f42b74ad7505573f1acbb3292f9e2f76a2d48c53de
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `notification` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Notifications — le fil d'activité utilisateur + fan-out push |
+> | **Classe de sous-domaine** | **Supporting** — un plan de livraison/fil dérivé ; ne possède aucun contenu source |
+> | **System of …** | **Record** pour le fil d'activité de notifications (dérivé de faits amont) |
+> | **Racine(s) d'agrégat** | `Notification` (`domain`) |
+> | **Tier** | **TIER-2** — best-effort / dérivé |
+> | **Posture de défaillance** | **Fail-open** — une notification manquée est re-dérivable ; rien ne bloque |
+> | **Contextes amont** | `comment`, `engagement`, `post`, `social-graph` — via **ACL** sur Kafka |
+> | **Contextes aval** | clients (lecture du fil + stream broadcast gRPC) ; push offline (APNs/FCM) ; délégué depuis `realtime` |
+> | **Journal de décisions** | [`ADR-0012`](../../../../docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `notification` est l'autorité pour **le fil d'activité** : il répond à
+**« qu'est-ce qu'on doit dire à cet utilisateur qui s'est passé, combien de non-lus, et comment le
+livrer ? »**
+
+**Le problème difficile.** Réduire un flux d'événements à fort fan-in en un fil par-utilisateur sans
+amplification d'écriture — un **fan-out write-collapse Redis** (3 couches + un plafond horaire) sur un
+fil d'activité TWCS, avec des ids UUIDv5 déterministes et un compteur de non-lus claim-gated.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder les événements source → il dérive les notifications de faits amont.
+- ❌ Être le socket live → `realtime` livre le live ; notification possède le fil durable + le push offline.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Notification | Une entrée unique du fil d'activité | `Notification`, `NotificationId`, `NotificationKind` |
+| Subject | La chose dont parle la notification | `SubjectId`, `SubjectKind` |
+| Read / created event | Faits de cycle de vie du fil | `NotificationCreatedEvent`, `NotificationReadEvent` |
+| Write-collapse | Coalescer de nombreux déclencheurs en une entrée de fil | (fan-out Redis) |
+| Unread counter | Le compteur de badge de non-lus claim-gated | (Redis `SET NX`) |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Notification` | racine d'agrégat | Identité d'entrée de fil + état de lecture |
+| `NotificationKind` / `SubjectKind` | enum | Vocabulaires fermés notification/sujet |
+| `SubjectId` | VO | Ce que la notification référence |
+
+> **Invariant.** Les ids sont des UUIDv5 déterministes (idempotents au redelivery) ; le compteur de
+> non-lus est claim-gated (`SET NX`) pour qu'un événement re-livré ne puisse double-incrémenter ; les
+> expéditeurs uniques se coalescent via `SADD`. `created_at` est l'heure d'événement, pas d'ingestion.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Le fil de notifications par-utilisateur + les compteurs de non-lus — **ScyllaDB** (fil d'activité TWCS) + **Redis** (compteurs write-collapse). Dérivé, mais faisant autorité pour la vue de fil.
+
+**La liste « ne-pas-écrire » :** notification ne mute jamais le contenu source ; il réagit aux événements.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Les ids de notification sont des UUIDv5 déterministes (idempotents) | domaine | `NTF-1xxx` |
+| I2 | Le compteur de non-lus est claim-gated (pas de double-compte au redelivery) | application (Redis `SET NX`) | `NTF-1xxx` |
+| I3 | `created_at` est l'heure d'événement, pas d'ingestion | domaine | `NTF-9xxx` |
+
+---
+
+## 6. Workflows & Orchestration &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, réduit) — consomme les événements amont (`comment.created`, `engagement.reactions`, `post.published`, follows sociaux) sous `run_consumer`, write-collapse vers le fil par-utilisateur, incrémente le compteur de non-lus claim-gated, et pousse via le stream broadcast gRPC (live) ou APNs/FCM (offline, délégué depuis `realtime`).
+
+## 7. Relations de Contexte &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, réduit) — **amont (ACL) :** streams d'événements `comment`, `engagement`, `post`, `social-graph`. **aval (OHS) :** clients (fil + stream broadcast) ; fournisseurs de push offline.
+
+## 8. Événements de Domaine &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, réduit) — ne publie **rien de référence** (ses événements `NotificationCreated`/`Read` sont un état de fil interne). Consomme des faits amont dont les sens sont possédés par leurs contextes.
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, réduit) — choix clé : fan-out write-collapse Redis + compteur de non-lus claim-gated idempotent (ids UUIDv5 déterministes, `created_at` heure-d'événement, claim de non-lus `SET NX`, coalescence d'expéditeur unique `SADD`) — [`ADR-0012`](../../../../docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.md) (Accepté).
+
+## 10. Classification de Sous-domaine & Évolution &nbsp;·&nbsp; DEEP
+
+N/A (TIER-2, réduit) — **Supporting**, faible volatilité ; différé : types de notification plus riches, centre de préférences, batching de digests.

--- a/crates/services/post/docs/DOMAIN.fr.md
+++ b/crates/services/post/docs/DOMAIN.fr.md
@@ -1,0 +1,155 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 8ff00a279c556291a43e769038a3fd74ef897c3768d3509ad085a1a8dbd3b995
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `post` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Posts — le cycle de vie du contenu |
+> | **Classe de sous-domaine** | **Core** — le contenu publié est la substance primaire de la plateforme |
+> | **System of …** | **Record** pour les posts et leur cycle de vie |
+> | **Racine(s) d'agrégat** | `Post` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Fail-closed en écriture** — un post publié doit persister |
+> | **Contextes amont** | clients (auteur) ; `profile` (identité auteur) ; `moderation` (filtrage) ; `media` (pièces jointes) |
+> | **Contextes aval** | `timeline`, `geo-discovery`, `search`, `counter`, `realtime` — via **Published Language** (`post.v1.events`) |
+> | **Journal de décisions** | [`ADR-0013`](../../../../docs/adr/0013-post-two-table-scylla-with-published-language.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `post` est l'autorité pour **le contenu** : il répond à
+**« qu'a été publié par qui, dans quel état, avec quel média — et est-ce encore en ligne ? »**
+
+**Le problème difficile.** Posséder un store de contenu à forte écriture à bas coût et le servir par
+auteur, tout en étant la source de fan-out dont dépend tout le côté lecture — un layout ScyllaDB à
+deux tables (`post.posts` par id + `post.posts_by_profile` par auteur) avec `post.v1.events` comme
+langage publié.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Construire des feeds/timelines → `timeline` consomme `post.v1.events`.
+- ❌ Indexer pour la recherche/découverte → `search` / `geo-discovery` consomment les événements.
+- ❌ Posséder les octets média → référence les pièces jointes `media` ; les comptes → `counter`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Post | Une unité de contenu publié | `Post`, `PostId`, `PostKind`, `PostStatus` |
+| Caption | Le texte du post | `Caption` |
+| Media attachment | Une référence à un asset `media` + son URL CDN | `MediaAttachment`, `CdnUrl` |
+| Audio reference | Piste audio attachée | `AudioReference`, `AudioId`, `AudioKind` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Post` | racine d'agrégat | La machine à états du cycle de vie du contenu |
+| `Caption` / `MediaAttachment` / `AudioReference` | VO | Validité du contenu + références média/audio |
+| `PostKind` / `PostStatus` | enum | Vocabulaires fermés kind/status (le proto mappe kind/status +1) |
+
+**Cycle de vie :**
+
+```
+published --(update)--> published' --(delete)--> deleted   |   (la porte de modération peut bloquer/retirer)
+```
+
+> **Transitions légales uniquement.** Les enums proto mappent le tinyint domaine +1 (pas de
+> sentinelle UNSPECIFIED) ; une suppression émet `post.deleted` pour le démantèlement aval.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Les posts — **ScyllaDB** deux tables (`post.posts` par id, `post.posts_by_profile` par auteur). Aucun autre service ne les écrit.
+
+**Ce contexte détient des copies qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Champs d'instantané de profil auteur | `profile` | `profile.v1.events` (DLQ `profile.v1.events.dlq`) | cohérence à terme |
+| État de modération | `moderation` | `moderation.v1.events` | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** post ne construit jamais de feeds, index ou comptes — il émet les événements dont ceux-ci dérivent.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Un post référence un auteur valide | domaine | `PST-1xxx` |
+| I2 | Les deux tables restent cohérentes (id + by-profile) | domaine/application | `PST-1xxx` |
+| I3 | Un changement de cycle de vie émet le `post.v1.events` correspondant | domaine (après-save) | — |
+| I4 | Le mapping proto kind/status est +1 sans UNSPECIFIED | infrastructure (codec) | — |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Publier / mettre à jour / supprimer.** Commande autorisée → écrire les deux tables Scylla →
+publier `post.published` / `post.updated` / `post.deleted` sur `post.v1.events`. En aval, `timeline`
+fan-out, `search`/`geo-discovery` indexent, `counter` compte, `realtime` broadcast.
+
+**Dénormalisation.** Consommer `profile.v1.events` pour garder frais les champs d'instantané auteur ;
+consommer `moderation.v1.events` pour refléter l'enforcement.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `profile` | amont | ACL | `profile.v1.events` | les instantanés d'auteur deviennent périmés |
+| `moderation` | amont | ACL | `moderation.v1.events` | le reflet de l'enforcement casse |
+| `media` | amont | Customer/Supplier | références `MediaAttachment` | média cassé dans les posts |
+| `timeline`/`search`/`geo-discovery`/`counter`/`realtime` | aval | Published Language (OHS) | `post.v1.events` | tout le côté lecture/découverte casse |
+
+> **Anti-Corruption Layer :** les consumers d'événements `profile`/`moderation` traduisent les formes
+> wire étrangères vers les champs dénormalisés de post.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement (`post.v1.events`) | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `post.published` | un nouveau contenu est en ligne | la publication commite | `timeline` (fan-out), `search`/`geo` (index), `counter`, `realtime` |
+| `post.updated` | le contenu a été édité | l'édition commite | `search`/`geo` (ré-indexation) |
+| `post.deleted` | le contenu a été retiré | la suppression commite | `timeline`/`search`/`geo` (démantèlement) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Layout ScyllaDB deux tables (par id + par auteur) avec `post.v1.events` comme langage publié | [`ADR-0013`](../../../../docs/adr/0013-post-two-table-scylla-with-published-language.md) | Accepté |
+| Enrichissement de payload post→geo (lat/lng/caption) — décision produit ouverte | _ouvert — voir geo-discovery §6_ | Ouvert |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Core — le contenu est la substance primaire de la plateforme.
+- **Volatilité :** moyenne — les types de post et pièces jointes évoluent.
+- **Dette de modélisation connue :** `post.published` n'émet pas de payload geo (bloque l'enrichissement geo-discovery).
+- **Capacités différées :** média/audio plus riches ; posts programmés ; historique d'édition.

--- a/crates/services/profile/docs/DOMAIN.fr.md
+++ b/crates/services/profile/docs/DOMAIN.fr.md
@@ -1,0 +1,166 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 5a3681e03ed848d96039cfa5ab9145886826d8de5dbfa1b525b388318b7dd660
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `profile` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Profile — le persona public au-dessus d'un compte |
+> | **Classe de sous-domaine** | **Supporting** — la couche de présentation de l'identité ; visible côté produit mais dérivée de `account` |
+> | **System of …** | **Record** pour le persona public (handle, display name, bio, avatar, tier, visibilité) |
+> | **Racine(s) d'agrégat** | `Profile` (`domain`) |
+> | **Tier** | **TIER-0** |
+> | **Posture de défaillance** | **Fail-closed en écriture** — les changements de persona (surtout le handle) doivent être cohérents |
+> | **Contextes amont** | `account` (cycle de vie du compte) ; `social-graph` (source du tier d'auteur) ; clients (éditions) |
+> | **Contextes aval** | `post`, `search`, `geo-discovery`, `timeline` — via **Published Language** (`profile.v1.events`) |
+> | **Journal de décisions** | [`ADR-0014`](../../../../docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `profile` est l'autorité pour **le persona public** : il répond à
+**« quel est le handle, display name, bio, avatar, tier et visibilité de cet utilisateur ? »**
+
+**Le problème difficile.** Posséder un **handle** globalement unique et revendicable sans conflit sous
+concurrence, plus une visibilité bi-axiale (choix du propriétaire **et** masquage de modération), tout
+en étant la source de dénormalisation que d'autres read-models intègrent.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder le compte/identifiants/PII → `account` est le SoR ; profile est la face publique.
+- ❌ Calculer le tier d'auteur → le consomme (l'initiative tier social-graph→profile) ; profile *possède et émet* le tier.
+- ❌ Construire feeds/recherche → émet `profile.v1.events` que ceux-ci consomment.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Profile | L'enregistrement de persona public | `Profile`, `ProfileId` |
+| Handle | Le @nom globalement unique et revendicable | `Handle`, `HandleChanged` |
+| Display name / bio / avatar / banner | Champs de présentation | `DisplayName`, `Bio`, `AvatarUrl`, `BannerUrl` |
+| Visibility | Visibilité choisie par le propriétaire | `ProfileVisibility` |
+| Masking reason | Pourquoi la modération a masqué un profil | `MaskingReason`, `ProfileHidden` |
+| Verification | État du badge vérifié | `VerificationKind`, `ProfileVerified` |
+| Tier | Le tier d'auteur (dénormalisé + émis) | `TierChanged` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Profile` | racine d'agrégat | Cohérence du persona + unicité du handle |
+| `Handle` | VO | Unicité globale ; revendication sous concurrence |
+| `DisplayName` / `Bio` / `AvatarUrl` / `BannerUrl` / `WebsiteUrl` / `Locale` | VO | Validité des champs à la construction |
+| `ProfileVisibility` / `ProfileStatus` / `ProfileKind` / `VerificationKind` | enum | Vocabulaires fermés visibilité/status/kind/vérification |
+
+**Cycle de vie :**
+
+```
+created --(update / verify)--> active --(hide: owner OR moderation)--> hidden --(restore)--> active --> deleted
+```
+
+> **Transitions légales uniquement.** La visibilité est **bi-axiale** — un profil n'est visible que si
+> le propriétaire *et* la modération l'autorisent ; un changement de handle est un événement, pas un
+> renommage silencieux.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Le persona public (handle, noms, bio, URL média, tier, visibilité) — **ScyllaDB** + **Redis** (cache d'entité L1). Aucun autre service n'écrit les champs de persona.
+
+**Ce contexte détient des copies qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| État du cycle de vie du compte | `account` | `account.v1.events` (DLQ `account.v1.events.dlq`) | cohérence à terme |
+| Tier d'auteur (calculé) | `social-graph` (calcule) | flux de changement de tier | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** profile n'écrit jamais le compte/la PII, et ne construit jamais les read-models qui consomment ses événements.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Les handles sont globalement uniques ; les revendications sont sans conflit sous concurrence | domaine + store | `PRF-1xxx` (conflit de revendication) |
+| I2 | Visibilité bi-axiale — propriétaire ET modération doivent tous deux autoriser | domaine | `PRF-1xxx` |
+| I3 | Un changement de persona émet le `profile.v1.events` correspondant | domaine (après-save) | — |
+| I4 | Les modifications concurrentes sont détectées | domaine | `PRF-1xxx` (concurrent_modification) |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Provisionner / mettre à jour.** Consommer `account.v1.events` pour provisionner un persona ; les
+éditions client mutent le `Profile` et émettent `profile.v1.events` (incl. `HandleChanged`,
+`ProfileVerified`, `TierChanged`).
+
+**Revendication de handle.** Une revendication vérifie l'unicité globale atomiquement ; les conflits
+retournent une erreur de conflit de revendication (suivie par
+`profile.handle.claim.conflict_total`).
+
+**Tier.** `social-graph` calcule le tier depuis le nombre de followers → profile possède et émet
+`profile.tier_changed` → `geo-discovery`/`timeline` s'allument (consommateurs prêts). *(Côté
+producteur selon l'initiative author-tier.)*
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `account` | amont | ACL | `account.v1.events` | le provisionnement du persona casse |
+| `social-graph` | amont | Customer/Supplier | calcul du tier | l'émission du tier casse |
+| `post`/`search`/`geo-discovery`/`timeline` | aval | Published Language (OHS) | `profile.v1.events` | instantanés d'auteur / indexation cassent |
+
+> **Anti-Corruption Layer :** le consumer d'événements `account` traduit le cycle de vie du compte en
+> provisionnement de persona.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement (`profile.v1.events`) | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `profile_created` / `profile_updated` | persona créé/édité | la commande commite | `post`/`search` (instantanés) |
+| `handle_changed` | le @handle a changé | revendication de handle | `search` (ré-indexation), intégrations |
+| `profile_verified` | le badge de vérification a changé | vérification | `search`, intégrations |
+| `tier_changed` | le tier d'auteur a changé | recalcul du tier | `geo-discovery`, `timeline` |
+| `profile_hidden` / `profile_restored` / `profile_deleted` | visibilité/cycle de vie | action propriétaire/modération | read-models (démantèlement/restauration) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Profile est le persona public au-dessus du SoR `account` ; émet `profile.v1.events` | [`ADR-0014`](../../../../docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md) | Accepté |
+| Visibilité bi-axiale (propriétaire ET modération) | [`ADR-0014`](../../../../docs/adr/0014-profile-public-persona-with-dual-axis-visibility.md) | Accepté |
+| Tier d'auteur : social-graph calcule → profile possède + émet | _ouvert — initiative author-tier_ | Cadré |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — la présentation côté produit de l'identité, dérivée de `account`.
+- **Volatilité :** moyenne — les champs de persona et la vérification évoluent.
+- **Dette de modélisation connue :** le côté producteur du tier d'auteur (social-graph→profile) est cadré, pas entièrement construit.
+- **Capacités différées :** flux de vérification plus riches ; déploiement d'indexation d'événements de profil vers `search`.

--- a/crates/services/realtime/docs/DOMAIN.fr.md
+++ b/crates/services/realtime/docs/DOMAIN.fr.md
@@ -1,0 +1,194 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 7d2d402ecc06cf7dc45753cafa8e2e1bf5c96f01369888d517003dba8d4e1722
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `realtime` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Live Delivery — le System-of-Connection côté client |
+> | **Classe de sous-domaine** | **Supporting** — il accélère la livraison mais ne possède aucune valeur ; les SoR (`chat`/`notification`/`counter`) possèdent chaque octet qu'il relaie. Sur-mesure (pas Generic) car l'edge C10M est fait main |
+> | **System of …** | **Connection / Delivery** — explicitement **jamais** un System of Record |
+> | **Racine(s) d'agrégat** | `Connection` (`domain::connection`), avec `Session`, `SubscriptionSet`, `SequenceState` |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-open** — un raté de livraison coûte de la latence, jamais des données ; les clients re-synchronisent depuis les SoR à la reconnexion |
+> | **Contextes amont** | clients utilisateur via WSS (pas les services internes) ; `auth` via `auth-context` (une vérification, pas un appel) |
+> | **Contextes aval** | aucun de référence ; délègue la livraison offline à `notification` (APNs/FCM) |
+> | **Journal de décisions** | [`ADR-0003`](../../../../docs/adr/0003-realtime-is-a-fail-open-system-of-connection.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `realtime` est l'autorité pour **la livraison live côté client** : il répond à
+**« quels appareils de cet utilisateur sont connectés maintenant, et comment amener cet événement déjà
+durable sur l'appareil exact à l'instant où il arrive ? »**
+
+**Le problème difficile** est double. **Le piège de charge inversée du polling :** à très grande
+échelle, des clients qui pollent l'edge couplent le QPS cœur au nombre d'utilisateurs *inactifs* —
+chaque poll vide paye TLS + auth + fan-out complets pour ne rien livrer, un DDoS auto-infligé sur le
+mesh. **La prolifération de connexions :** `chat` et `notification` ont chacun développé leur propre
+streaming client, donc un appareil tient plusieurs sockets avec des heartbeats redondants. Realtime
+inverse le premier (le travail suit les *événements*, pas les yeux) et réduit le second à une seule
+socket multiplexée par appareil.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Stocker une entité ou un message → la durabilité vit dans `chat`/`notification`/`counter`.
+- ❌ Se placer sur un write path synchrone → il n'est jamais sur la voie d'envoi d'un message ou de persistance d'une notification.
+- ❌ Ré-authentifier par frame → l'edge token est vérifié une fois au handshake.
+- ❌ Écrire l'autorisation niveau-contenu → faite en amont au moment de l'émission ; realtime ne vérifie que la propriété de scope de canal.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Connection | Une socket client live, multiplexée, et son cycle de vie | `Connection`, `ConnectionState` |
+| Session | L'identité authentifiée liée à une connexion au handshake | `Session` |
+| Channel | Un flux logique multiplexé sur l'unique socket (`dm`, `notif`, `presence`, `counter:<id>`, `feed:<id>`) | `ChannelRef`, `ChannelKey`, `ChannelClass` |
+| Subscription set | Les canaux auxquels une connexion est abonnée (plafonnés) | `SubscriptionSet` |
+| Stream sequence | Le token monotone par-flux que les clients dédupliquent et re-synchronisent | `StreamSeq`, `SequenceState` |
+| Presence | Vivacité interne (online/offline) dérivée des connexions — pas un stream produit | `PresenceState` |
+| Targeted vs broadcast | Un fan-out qui nomme un *utilisateur destinataire* vs un qui nomme une *entité* | (modes du dispatcher) |
+| Node / registry | Une instance gateway et la carte de routage `user → node` | port `ConnectionRegistry` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Connection` | racine d'agrégat | Cycle de vie + la discipline de file d'envoi bornée / shed pour une socket |
+| `Session` | entité | L'identité épinglée authentifiée au handshake |
+| `SubscriptionSet` | VO | Abonnements de canaux, plafonnés (`RTM-3002`) et scope-vérifiés |
+| `SequenceState` / `StreamSeq` | VO | Séquencement monotone par-flux pour dédup + re-sync côté client |
+| `ChannelRef` / `ChannelKey` / `ChannelClass` | VO | L'identité d'un canal et son scope de propriété |
+| `PresenceState` / `ConnectionState` / `CloseReason` / `DeliveryGuarantee` | enum | Le vocabulaire fermé cycle-de-vie + livraison |
+
+**Cycle de vie de connexion :**
+
+```
+handshake (verify token → bind Session) --> Active --(subscribe within scope)--> delivering
+     │ heartbeat timeout / shed / drain                                              │
+     ▼                                                                               ▼
+   Closed  ◄──────────────── reconnect (jittered backoff) ◄──── drain (control frame) ┘
+```
+
+> **Transitions légales uniquement.** Une connexion ne peut s'abonner qu'aux canaux scoped à son
+> identité épinglée (Alice → `dm:alice`, jamais `dm:bob`) — sinon `RTM-3001`. Un consommateur lent est
+> **shed** (`RTM-5001`), jamais bufferisé sans borne.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Rien de durable. Il ne possède que l'**état de routage Redis éphémère** — `presence:{user_id}` → node(s) et le tissu Pub/Sub de saut-de-node. Tout est TTL'd et auto-réparant.
+
+**Tout ce qu'il relaie est possédé ailleurs :**
+
+| Donnée relayée | Possédée par | Atteint realtime via | Durabilité |
+|---|---|---|---|
+| Notifications / badges | `notification` | `notification.v1.events` (targeted) | `notification` le persiste |
+| Magnitudes d'engagement | `counter` | `counter.v1.popularity` (broadcast) | `counter` le détient |
+| Cycle de vie des posts | `post` | `post.v1.events` (broadcast) | `post` le persiste |
+| Messages | `chat` | (non consommé — chat fait tourner son propre plan live, coexist-first) | `chat` le persiste |
+
+**La liste « ne-pas-écrire » :** realtime n'écrit aucun SoR ; un miss de registry (destinataire
+offline) est un no-op, la voie téléphone-verrouillé étant déléguée à `notification`.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Le plan ne stocke rien de référence ; un miss de registry est un no-op | domaine + application | (par conception) |
+| I2 | Authentifier une fois, au handshake ; jamais ré-vérifier par frame | frontière infrastructure | `RTM-1001` (handshake) |
+| I3 | La seule autorisation est la propriété de scope de canal face à l'identité épinglée | domaine | `RTM-3001` |
+| I4 | Un consommateur lent est shed, pas bufferisé (file par-connexion bornée) | infrastructure | `RTM-5001` |
+| I5 | Fail-open — un événement live perdu n'est jamais un message perdu ; le client re-sync via `StreamSeq` | application | (récupération, pas erreur) |
+| I6 | Les abonnements sont plafonnés par connexion | domaine | `RTM-3002` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Connexion (handshake → livraison).**
+1. Le client se connecte via WSS (`:8443`, derrière un LB L4) ; l'edge token est vérifié une fois via `auth-context` → une `Session` est liée.
+2. La gateway écrit l'entrée de registry `user → node` et s'abonne à son canal de node.
+3. Le client s'abonne aux canaux dans le scope de son identité ; les frames ne sont pas ré-authentifiées ensuite.
+
+**Le pont interne→externe (trois étapes).**
+1. **Émettre une fois :** un service cœur publie vers Kafka — aucun nouvel appel synchrone vers l'intérieur.
+2. **Résoudre :** `realtime-dispatcher` (sous `run_consumer`) résout le destinataire face au registry (targeted) ou nomme un canal de broadcast (entité).
+3. **Dernier saut :** publier vers le canal Redis du node propriétaire → la gateway le remet à la mailbox bornée de la connexion → écriture socket. Cœur→appareil = un saut Kafka + un saut Redis + une écriture socket.
+- **Idempotence :** le fan-out est naturellement idempotent ; les frames live dupliquées sont inoffensives (le client déduplique sur `StreamSeq`) ; un événement non-routable (`RTM-8002`/`RTM-8003`) se replie en `Ok`.
+
+**Deux modes de fan-out.** *Targeted* (notification/DM/presence) nomme un destinataire → résolution
+registry → saut vers le(s) node(s) propriétaire(s). *Broadcast* (counter/feed) nomme une entité →
+publier une fois vers le canal de broadcast de la flotte → chaque node livre à ses abonnés locaux.
+
+**Dégradation & reaping.** Les connexions semi-ouvertes sont reapées au timeout de heartbeat
+(`RTM-5002`, libère FD + slot de registry, bascule la présence offline). Au drain de node,
+stop-accept → frame de contrôle de reconnexion avec backoff jitter (`RTM-5003`) → drain.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| clients utilisateur | amont | OHS (Published Language) | l'enveloppe multiplexée WSS `{stream_seq, channel, ack_required, payload}` | un changement d'enveloppe casse chaque client |
+| `auth` | dépendance | Conformist (verify-only) | vérif edge-token ES256 via `auth-context` | les nouveaux handshakes échouent si le format de token change |
+| `notification` | amont + délégué | ACL | consomme `notification.v1.events` ; délègue le push offline | le décodage casse / la voie offline perdue |
+| `counter` | amont | ACL | consomme `counter.v1.popularity` | le décodage broadcast casse |
+| `post` | amont | ACL | consomme `post.v1.events` | le décodage broadcast casse |
+| `chat` | pair | Separate Ways (coexist) | non consommé — chat possède son propre plan live | — (la consolidation est une décision future) |
+
+> **Anti-Corruption Layer :** `infrastructure/decode.rs` mappe chaque événement wire amont vers le
+> `DeliverableEvent` interne ; la charge utile opaque est relayée, jamais interprétée.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+> Realtime **ne publie rien de référence**. La présence, si exposée, est de la vivacité interne
+> seulement — pas un stream System-of-Record.
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| — (aucun de référence) | realtime n'affirme aucun fait métier durable | — | — |
+
+Il consomme les faits de `notification`/`counter`/`post` ; leurs sens sont possédés par le §8 des
+Domain Cards de ces contextes et consolidés dans `docs/domain/EVENT_CATALOG.md`.
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Realtime est un System-of-Connection fail-open, jamais un record store | [`ADR-0003`](../../../../docs/adr/0003-realtime-is-a-fail-open-system-of-connection.md) | Accepté |
+| Coexist-first avec le plan live de `chat` (ne pas consommer `chat.message.sent` pour l'instant) | _voir conséquences ADR-0003_ | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — il fait *sentir* le produit live mais ne possède aucune vérité ; la valeur vit dans les SoR. L'investissement va à l'edge C10M sur-mesure, pas à la propriété des données.
+- **Volatilité :** faible-à-moyenne — les nouvelles sources de fan-out (canaux) sont additives ; le modèle de connexion et l'enveloppe sont stables.
+- **Dette de modélisation connue :** le câblage runtime `SIGTERM` → `broadcast_drain` n'est pas encore connecté ; la variante de backpressure `NodeChannel` en gRPC interne n'est pas construite (le tissu Redis Pub/Sub est la v1).
+- **Capacités différées :** voie de transport WebTransport/HTTP-3 ; présence comme stream produit ; routage cross-région / multi-PoP ; consolidation du streaming client `chat` + `notification` (la couture — les réduire à des producteurs d'événements — est laissée ouverte).

--- a/crates/services/search/docs/DOMAIN.fr.md
+++ b/crates/services/search/docs/DOMAIN.fr.md
@@ -1,0 +1,158 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 5601ef65a66972fb9e34c5dfe6ae0d972f1ca7bd36bd933effbef7bb8136d21e
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `search` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Search & Discovery — le read-model d'index inversé |
+> | **Classe de sous-domaine** | **Supporting** — un read-model de découverte dérivé ; ne possède aucun contenu source |
+> | **System of …** | **Reference (SoRef)** — index cohérent-à-terme sur profils/posts/hashtags, reconstructible |
+> | **Racine(s) d'agrégat** | `IndexDocument` (`PostDoc` / `ProfileDoc` / `HashtagDoc`) |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-open** — un index dégradé retourne moins/des hits plus périmés, jamais une erreur |
+> | **Contextes amont** | `post`, `profile`, `moderation` — via **ACL** sur Kafka |
+> | **Contextes aval** | clients (search/suggest) ; ne publie rien de référence |
+> | **Journal de décisions** | [`ADR-0015`](../../../../docs/adr/0015-search-opensearch-single-store-external-versioning.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `search` est l'autorité pour **les requêtes de découverte** : il répond à
+**« quels profils/posts/hashtags correspondent à cette requête, classés, en respectant la
+visibilité ? »**
+
+**Le problème difficile.** Garder un index inversé cohérent-à-terme correct sous des événements
+désordonnés et de la ré-indexation — **OpenSearch comme store canonique unique avec versioning
+externe** (un script Painless à garde 2-versions), un côté commande pur-Kafka et un RPC de lecture
+stateless, plus de la ré-indexation blue-green.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder profils/posts → il indexe des références (SoReference, pas SoRecord).
+- ❌ Décider la visibilité → il *honore* l'autorité de visibilité duale (propriétaire + modération).
+- ❌ Servir des magnitudes → consomme `PopularityScore` depuis `counter`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Index document | Un doc cherchable (post/profile/hashtag) | `IndexDocument`, `PostDoc`, `ProfileDoc`, `HashtagDoc` |
+| Doc version | La version externe gardant les updates désordonnés | `DocVersion` |
+| Index mutation | Un upsert/delete à appliquer à l'index | `IndexMutation`, `EntityDeletion` |
+| Search hit / results | Une correspondance classée et l'ensemble de résultats | `SearchHit`, `SearchResults`, `HitDisplay` |
+| Suggestion | Une suggestion typeahead | `Suggestion`, `Suggestions`, `SuggestQuery` |
+| Visibility authority | Qui peut supprimer un doc (propriétaire vs modération) | `VisibilityAuthority`, `VisibilityChange` |
+| Popularity score | Le signal de classement depuis `counter` | `PopularityScore` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `IndexDocument` | agrégat (par type) | La projection cherchable d'une entité source |
+| `DocVersion` | VO | Version externe → les écritures désordonnées sont rejetées (garde 2-versions) |
+| `IndexMutation` / `EntityDeletion` | VO | Le changement d'index appliqué |
+| `VisibilityAuthority` / `VisibilityChange` | enum/VO | Visibilité duale (propriétaire + modération) honorée dans les résultats |
+| `SearchQuery` / `SortStrategy` | VO/enum | Intention de requête + classement |
+
+> **Invariant.** Une update avec une `DocVersion` inférieure à celle indexée est rejetée (versioning
+> externe) ; un doc n'est retourné que si les deux autorités de visibilité l'autorisent.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité (de *référence*) pour :**
+- L'index inversé — **OpenSearch** (store canonique unique). Entièrement reconstructible depuis l'amont via ré-indexation blue-green.
+
+**Ce contexte détient des copies dérivées qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Contenu post/profile/hashtag | `post` / `profile` | `post.v1.events` / `profile.v1.events` | cohérence à terme |
+| Visibilité de modération | `moderation` | `moderation.v1.events` | cohérence à terme |
+| Popularité | `counter` | `counter.v1.popularity` (câblage différé) | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** search ne mute jamais les entités source ; il les projette.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Les updates désordonnées sont rejetées par la `DocVersion` externe (garde 2-versions) | infrastructure (Painless) | `SCH-2xxx` |
+| I2 | Un hit n'est retourné que si la visibilité propriétaire ET modération l'autorise | domaine | `SCH-3xxx` |
+| I3 | Les lectures échouent ouvertes (dégradent, jamais d'erreur) | application | `SCH-4xxx` |
+| I4 | La ré-indexation est blue-green (pas de downtime de lecture) | application | `SCH-5xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Indexer (côté commande, pur Kafka).** Consommer `post.v1.events` (hydraté) + `profile.v1.events` +
+`moderation.v1.events` → construire `IndexMutation` avec une `DocVersion` externe → upsert/delete dans
+OpenSearch sous la garde Painless 2-versions.
+
+**Requête (côté lecture, stateless).** Un `SearchQuery` / `SuggestQuery` → requête OpenSearch classée
+→ filtrer par visibilité duale → retourner `SearchResults` / `Suggestions`. Fail-open sur un cluster
+dégradé.
+
+**Ré-indexation.** Le `Reindexer` blue-green reconstruit dans un nouvel index et bascule l'alias
+atomiquement.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `post` | amont | ACL | `post.v1.events` (hydraté) | la recherche de posts devient périmée |
+| `profile` | amont | ACL | `profile.v1.events` | la recherche de profils (déploiement en attente) |
+| `moderation` | amont | ACL | `moderation.v1.events` | la suppression de visibilité casse |
+| `counter` | amont | ACL | `counter.v1.popularity` | le classement par popularité (différé) |
+| clients | aval | OHS | RPC search/suggest | la découverte casse |
+
+> **Anti-Corruption Layer :** le décodage par-source (`PostEvent`/`ProfileEvent`/`ModerationEvent`)
+> mappe les formes wire étrangères vers `IndexMutation`.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+> Ne publie **rien de référence** — c'est un read-model. Il consomme les faits de
+> `post`/`profile`/`moderation`/`counter`, dont les sens sont possédés par ces contextes.
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| OpenSearch store canonique unique avec garde externe 2-versions ; côté commande pur-Kafka + RPC de lecture stateless | [`ADR-0015`](../../../../docs/adr/0015-search-opensearch-single-store-external-versioning.md) | Accepté |
+| Autorité de visibilité duale (propriétaire + modération) honorée au moment de la requête | [`ADR-0015`](../../../../docs/adr/0015-search-opensearch-single-store-external-versioning.md) | Accepté |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — un read-model de découverte dérivé.
+- **Volatilité :** moyenne — le classement et le schéma de doc évoluent.
+- **Dette de modélisation connue :** l'indexation de profils en attente du déploiement `profile.v1.events` ; le câblage de popularité différé.
+- **Capacités différées :** classement plus riche ; recherche personnalisée ; résultats mixtes inter-entités.

--- a/crates/services/social-graph/docs/DOMAIN.fr.md
+++ b/crates/services/social-graph/docs/DOMAIN.fr.md
@@ -1,0 +1,163 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: a5a89dda0397525a5b1982954fed2851ab869e675ed6e2451a8b948a3a544974
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `social-graph` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Social Graph — relations follower/following et block |
+> | **Classe de sous-domaine** | **Core** — le graphe social est le réseau lui-même |
+> | **System of …** | **Record** pour les relations (follows, blocks) et le tier d'auteur dérivé |
+> | **Racine(s) d'agrégat** | `Relation` (avec `FollowEdge` / `BlockEdge`) |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-closed en écriture** — un changement de relation doit être atomique + durable |
+> | **Contextes amont** | clients (follow/block) ; `profile` (identité) |
+> | **Contextes aval** | `timeline` (fan-out, lectures gRPC), `counter` (comptes de followers), `profile` (tier) — via gRPC + événements |
+> | **Journal de décisions** | [`ADR-0016`](../../../../docs/adr/0016-social-graph-four-table-scylla-logged-batch.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `social-graph` est l'autorité pour **les relations** : il répond à
+**« qui suit qui, qui a bloqué qui, et quel tier est cet auteur ? »**
+
+**Le problème difficile.** Maintenir un graphe de relations à fort fan-out avec des index inverses
+cohérents et des lectures de hot-set — un schéma ScyllaDB à 4 tables avec mise en cache des
+relations chaudes en Redis Set, atomicité logged-batch pour la double-écriture, et des seuils de tier
+dérivés du nombre de followers.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Construire des timelines → `timeline` lit le graphe (gRPC) et fan-out.
+- ❌ Posséder la *présentation* du tier d'auteur → `social-graph` le calcule ; `profile` le possède + émet.
+- ❌ Posséder les profils → `profile`.
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Relation | Une arête dirigée entre deux profils | `Relation`, `RelationKind`, `RelationStatus` |
+| Follow / block edge | Les deux types de relation | `FollowEdge`, `BlockEdge` |
+| Relation context | Les métadonnées entourant une relation | `RelationContext` |
+| Author tier | Le tier dérivé du nombre de followers | `AuthorTier`, `TierThresholds`, `AuthorTierChanged` |
+| Severed follows | Les follows retirés quand un block est appliqué | `SeveredFollows` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `Relation` | racine d'agrégat | Cohérence d'arête à travers les index avant + inverse |
+| `FollowEdge` / `BlockEdge` | VO | Les deux types de relation dirigée |
+| `RelationStatus` / `RelationKind` | enum | Vocabulaires de relation fermés |
+| `AuthorTier` / `TierThresholds` | VO | Dérivation du tier depuis le nombre de followers |
+| `SeveredFollows` | VO | Les follows qu'un block démantèle |
+
+**Transitions de relation :**
+
+```
+(none) --(follow)--> following --(unfollow)--> (none)
+(none) --(block)--> blocked (sectionne les follows existants des deux côtés)
+```
+
+> **Transitions légales uniquement.** Un block sectionne les follows existants (`SeveredFollows`) ;
+> les index avant et inverse sont écrits atomiquement (logged batch) ; un nombre de followers
+> franchissant un seuil change l'`AuthorTier`.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité pour :**
+- Les relations (follows, blocks) et leurs index inverses — **ScyllaDB** (4 tables) + **Redis** (Sets de relations chaudes). Aucun autre service n'écrit les relations.
+
+**Ce contexte détient des copies qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Existence de profil | `profile` | `profile.v1.events` | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** social-graph ne construit jamais de feeds et n'écrit jamais la
+présentation de profil (il calcule le tier ; `profile` le possède + émet).
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Les index de relation avant + inverse sont écrits atomiquement | application (logged batch) | `SGR-1xxx` |
+| I2 | Un block sectionne les follows existants des deux directions | domaine | `SGR-1xxx` |
+| I3 | Le tier d'auteur est dérivé du nombre de followers franchissant `TierThresholds` | domaine | — |
+| I4 | Les lectures de relations chaudes sont servies depuis les Redis Sets, reconstructibles depuis Scylla | infrastructure | `SGR-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Follow / unfollow / block.** Muter l'agrégat `Relation` → écriture logged-batch atomique des lignes
+Scylla avant + inverse + mise à jour du hot-set Redis. Un block émet `SeveredFollows`.
+
+**Calcul du tier.** Un changement de nombre de followers franchissant une frontière `TierThresholds`
+produit `AuthorTierChanged`, alimentant le flux profile→tier (initiative author-tier ; côté
+producteur cadré).
+
+**Lectures.** `timeline` lit l'ensemble des followers via gRPC pour le fan-out ; `counter` réconcilie
+les comptes de followers via gRPC (le stream Kafka `social-graph.follows` est un producteur différé).
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `profile` | amont | ACL | `profile.v1.events` | validité des relations vs profils inconnus |
+| `timeline` | aval | Customer/Supplier (gRPC) | lectures de l'ensemble des followers pour le fan-out | le fan-out du fil casse |
+| `counter` | aval | Customer/Supplier (gRPC) | réconciliation du nombre de followers | les magnitudes de followers dérivent |
+| `profile` | aval | Published Language | flux de changement de tier | l'émission du tier d'auteur casse |
+
+> **Anti-Corruption Layer :** le consumer d'événements `profile` garde la validité des relations
+> alignée avec l'existence des profils.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+| Événement | Signifie | Émis quand | Qui réagit |
+|---|---|---|---|
+| `ProfileFollowed` / `ProfileUnfollowed` | une arête de follow a été créée/retirée | follow/unfollow commite | timeline/counter (consommateurs ; câblage du stream de follows différé) |
+| `ProfileBlocked` / `ProfileUnblocked` | une arête de block a changé (sectionne les follows) | block/unblock commite | fils |
+| `AuthorTierChanged` | le tier de l'auteur a changé | le nombre de followers franchit un seuil | `profile` (possède + ré-émet) |
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Schéma ScyllaDB 4 tables + Redis hot Sets + atomicité logged-batch pour la double-écriture | [`ADR-0016`](../../../../docs/adr/0016-social-graph-four-table-scylla-logged-batch.md) | Accepté |
+| Tier d'auteur : social-graph calcule → profile possède + émet | _ouvert — initiative author-tier_ | Cadré |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Core — le graphe de relations est le réseau social.
+- **Volatilité :** faible-à-moyenne — les types de relation sont stables ; la politique de tier peut se régler.
+- **Dette de modélisation connue :** réconciliation des orphelins (TD-6) ; le producteur Kafka `social-graph.follows` est différé (counter consomme via gRPC pour l'instant).
+- **Capacités différées :** traversées de recommandation type NebulaGraph ; requêtes mutuelles/second-degré.

--- a/crates/services/timeline/docs/DOMAIN.fr.md
+++ b/crates/services/timeline/docs/DOMAIN.fr.md
@@ -1,0 +1,151 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: b2f2e11b276b879b57f25d03c6f44da4b614c675d52e4342f01424bf76a321ec
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `timeline` — Contrat de Domaine & Fonctionnel
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Bounded Context** | Timeline — le read-model du fil d'accueil |
+> | **Classe de sous-domaine** | **Supporting** — une projection de fil dérivée ; ne possède aucun contenu source |
+> | **System of …** | **Reference (SoRef)** — un fil par-utilisateur matérialisé, reconstructible depuis l'amont |
+> | **Racine(s) d'agrégat** | `FeedEntry` (projection), adressé par `FeedCursor` |
+> | **Tier** | **TIER-1** |
+> | **Posture de défaillance** | **Fail-open** — un fil dégradé retourne moins/des entrées plus périmées, jamais une erreur |
+> | **Contextes amont** | `post` (contenu), `social-graph` (graphe de followers) — via événements + gRPC |
+> | **Contextes aval** | clients (lecture du fil) ; ne publie rien de référence |
+> | **Journal de décisions** | [`ADR-0017`](../../../../docs/adr/0017-timeline-hybrid-push-pull-fanout.md) |
+
+---
+
+## 1. Capacité Métier & Non-Objectifs
+
+**Capacité.** `timeline` est l'autorité pour **le fil d'accueil** : il répond à
+**« que doit voir cet utilisateur dans son fil en ce moment, et dans quel ordre ? »**
+
+**Le problème difficile.** La génération de fil à l'échelle sans le coût fan-out-on-write des
+célébrités ni le coût fan-out-on-read de tout le monde — un modèle **hybride push/pull** : matérialiser
+les fils pour les auteurs normaux (push), tirer pour les auteurs haut-tier au moment de la lecture,
+fusionnés via un Lua `ZREVRANGEBYSCORE`.
+
+**Non-objectifs — ce que ce contexte ne fait délibérément PAS :**
+- ❌ Posséder les posts → `post` est le SoR ; timeline détient des références de fil.
+- ❌ Posséder le graphe de followers → lit `social-graph` (gRPC) pour le fan-out.
+- ❌ Classer par magnitudes de popularité → ce signal vient de `counter` (là où câblé).
+
+---
+
+## 2. Langage Omniprésent
+
+| Terme | Sens dans ce contexte | Symbole de code |
+|---|---|---|
+| Feed entry | Un item matérialisé dans le fil d'un utilisateur | `FeedEntry` |
+| Feed cursor | La position de pagination dans un fil | `FeedCursor` |
+| Fan-out mode | Push (matérialiser) vs pull (au moment de la lecture) par auteur | `FanOutMode` |
+| Author tier | Le tier qui décide push vs pull | `AuthorTier` |
+
+---
+
+## 3. Modèle de Domaine
+
+| Élément | Type | Frontière d'invariant gardée |
+|---|---|---|
+| `FeedEntry` | projection (agrégat) | L'identité d'un item de fil + son score d'ordonnancement |
+| `FeedCursor` | VO | Position de pagination stable |
+| `FanOutMode` | enum | Décision push vs pull par auteur |
+| `AuthorTier` | enum | Le tier pilotant la décision hybride |
+
+> **Invariant.** Les entrées de fil sont ordonnées par score (Lua `ZREVRANGEBYSCORE` via eval) ; les
+> membres sont encodés de façon compacte ; `from_uuid` est infaillible. Les auteurs haut-tier sont
+> tirés au moment de la lecture, pas matérialisés, pour borner le coût de fan-out.
+
+---
+
+## 4. Propriété des Données & Frontières
+
+**Ce contexte est la source de vérité (de *référence*) pour :**
+- Le fil par-utilisateur matérialisé — **Redis** (ZSETs de fil) + **ScyllaDB** (matérialisation durable). Reconstructible depuis `post` + `social-graph`.
+
+**Ce contexte détient des copies dérivées qu'il ne possède PAS :**
+
+| Donnée copiée | Possédée par | Maintenue fraîche via | Tolérance d'obsolescence |
+|---|---|---|---|
+| Contenu/refs de post | `post` | `post.published` / `post.deleted` | cohérence à terme |
+| Graphe de followers | `social-graph` | lectures gRPC de l'ensemble des followers | au moment de la lecture |
+| Tier d'auteur | `profile` (émet) | consommation du changement de tier | cohérence à terme |
+
+**La liste « ne-pas-écrire » :** timeline n'écrit jamais les posts ni le graphe — il les projette en fils.
+
+---
+
+## 5. Invariants & Règles Métier
+
+| # | Invariant | Imposé à | En cas de violation |
+|---|---|---|---|
+| I1 | Fan-out hybride — auteurs normaux poussés, haut-tier tirés à la lecture | domaine/application | `TML-1xxx` |
+| I2 | Ordonnancement du fil par score via Lua `ZREVRANGEBYSCORE` | infrastructure (Lua) | `TML-1xxx` |
+| I3 | Les lectures échouent ouvertes (dégradent, jamais d'erreur) | application | `TML-1xxx` |
+| I4 | Un post supprimé est retiré des fils | application (consumer) | `TML-1xxx` |
+
+---
+
+## 6. Workflows & Orchestration
+
+> En ligne jusqu'à ce qu'un C4 corrigé soit régénéré depuis `docs/domain/`.
+
+**Fan-out à la publication (push).** Consommer `post.published` → lire l'ensemble des followers de
+l'auteur depuis `social-graph` (gRPC) → pour les auteurs tier-normal, matérialiser l'entrée dans le
+ZSET de fil de chaque follower. Les auteurs haut-tier sont ignorés ici (tirés à la lecture).
+
+**Lecture (fusion hybride).** Une lecture de fil fusionne les entrées push matérialisées avec un pull
+au moment de la lecture des followees haut-tier de l'utilisateur, ordonnés par score via Lua
+`ZREVRANGEBYSCORE`, paginés par `FeedCursor`. Fail-open sur un backend dégradé.
+
+**Démantèlement.** Consommer `post.deleted` → retirer l'entrée des fils affectés.
+
+---
+
+## 7. Relations de Contexte (extrait de Context-Map)
+
+| Contexte voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `post` | amont | ACL | `post.published` / `post.deleted` | la fraîcheur/le démantèlement du fil casse |
+| `social-graph` | amont | Customer/Supplier (gRPC) | lectures de l'ensemble des followers | le fan-out casse |
+| `profile` | amont | ACL | `tier_changed` | la décision push/pull devient périmée |
+| clients | aval | OHS | RPC de lecture du fil | le fil d'accueil casse |
+
+> **Anti-Corruption Layer :** le consumer d'événements `post` traduit le cycle de vie des posts en mutations de fil.
+
+---
+
+## 8. Événements de Domaine (sémantique, pas wire)
+
+> Ne publie **rien de référence** — c'est un read-model. Il consomme `post` (et lit `social-graph`) ;
+> leurs sens sont possédés par ces contextes.
+
+---
+
+## 9. Décisions & Justification
+
+| Décision | ADR | Statut |
+|---|---|---|
+| Fan-out hybride push/pull (matérialiser les auteurs normaux, tirer le haut-tier à la lecture) | [`ADR-0017`](../../../../docs/adr/0017-timeline-hybrid-push-pull-fanout.md) | Accepté |
+| Compatibilité ascendante pour le fan-out piloté par tier d'auteur (livré #469) | _ouvert — initiative author-tier_ | Cadré |
+
+---
+
+## 10. Classification de Sous-domaine & Évolution
+
+- **Classification :** Supporting — une projection de fil dérivée de `post` + `social-graph`.
+- **Volatilité :** moyenne — le classement et le seuil push/pull évoluent.
+- **Dette de modélisation connue :** réglage de performance du fan-out (TD-4) ; le côté producteur du tier d'auteur pas encore complet.
+- **Capacités différées :** classement pondéré par popularité depuis `counter` ; classement personnalisé/ML.


### PR DESCRIPTION
Second of three phased PRs adding French mirrors (after #497 gate + docs/domain). This adds **`DOMAIN.fr.md` for all 17 services**.

## What

A `DOMAIN.fr.md` beside every `DOMAIN.md`, each with provenance frontmatter (stamped via `i18n-drift.sh`) + the standard "anglais fait foi" banner.

**DNT honored** — code symbols, topics (`*.v1.events`), error codes (`ACC-`/`AUT-`/`CHT-`/…), type names, ADR ids, and DDD pattern names (OHS/ACL/Conformist/Customer-Supplier/Separate Ways) stay verbatim English; only prose, section bodies, and descriptive table cells are translated. Tier depth is mirrored (notification's collapsed DEEP stays collapsed).

## Verification

- `tools/i18n/i18n-drift.sh check` → **56/56 OK** (35 README + 4 docs/domain + 17 DOMAIN).
- Each `DOMAIN.fr.md` source hash bound to its sibling `DOMAIN.md`.

## Next

- **PR C:** 19 × `docs/adr/*.fr.md`.
- CI wiring of `i18n-drift.sh check` if not already enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)