### PR TITLE
docs(i18n): French mirrors for all ADRs (PR C) — completes FR rollout

### DIFF
--- a/docs/adr/0000-template.fr.md
+++ b/docs/adr/0000-template.fr.md
@@ -1,0 +1,47 @@
+---
+i18n:
+  source: ./0000-template.md
+  source_sha256: 2758b239613114431c6f9f634d80098756f1d58f33ecc15ed4db08e9094b20fd
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0000-template.md`](./0000-template.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants d'ADR et statuts restent en anglais.
+
+# ADR-00NN : <titre court de décision>
+
+<!--
+ Copier vers docs/adr/00NN-<kebab-title>.md (prochain numéro libre, paddé à 4 chiffres).
+ Les ADR sont IMMUABLES une fois Accepted : pour en inverser un, écrire un NOUVEL ADR qui le remplace
+ et basculer le statut de celui-ci en « Superseded by ADR-00MM ». Ne jamais réécrire la décision en
+ place — la valeur d'un ADR est la piste préservée du POURQUOI.
+ Format : MADR allégé. Le garder à un écran. Le relier depuis le §9 du DOMAIN.md concerné.
+-->
+
+- **Statut :** Proposed | Accepted | Superseded by ADR-00MM | Deprecated
+- **Date :** <AAAA-MM-JJ>
+- **Contexte(s) affecté(s) :** <bounded contexts, ex. audit, moderation>
+- **Décideurs :** <noms / guilde>
+
+## Contexte et problème
+
+<Les forces en tension : la pression de domaine, la forme de charge, la contrainte, la contradiction à
+résoudre. 3–6 phrases. Énoncer le problème si bien que la décision se lise comme inévitable.>
+
+## Décision
+
+<Le choix, énoncé en règle au présent : « Nous … ». Un paragraphe. Assez spécifique pour qu'un
+relecteur puisse dire si une future PR le viole.>
+
+## Conséquences
+
+- **Positives :** <ce que cela nous apporte>
+- **Négatives / compromis accepté :** <ce qu'on abandonne sciemment>
+- **Clôt :** <la contradiction ou le risque spécifique que ceci supprime>
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| `<l'alternative évidente>` | `<la raison disqualifiante>` |
+| `<…>` | `<…>` |

--- a/docs/adr/0001-audit-is-a-separate-evidence-plane.fr.md
+++ b/docs/adr/0001-audit-is-a-separate-evidence-plane.fr.md
@@ -1,0 +1,73 @@
+---
+i18n:
+  source: ./0001-audit-is-a-separate-evidence-plane.md
+  source_sha256: 2e86ba3dc484c255b8542daf27ded5201d60f958e46aa2fa3a46715ba263fc0d
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0001-audit-is-a-separate-evidence-plane.md`](./0001-audit-is-a-separate-evidence-plane.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0001 : Audit est un plan de preuve infalsifiable séparé, pas un agrégateur de logs
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** audit (nouveau contexte TIER-0) ; producteurs moderation, auth, account
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Il nous faut un enregistrement faisant autorité de **qui a fait quoi, à qui, quand et sous quelle
+autorité** — pour SOC2, le DSA et la responsabilité RGPD (Art. 5(2)). L'instinct est de le dériver de
+la télémétrie (logs/traces). Cet instinct est faux, et démontrablement : **la télémétrie est mutable,
+échantillonnée et à rétention plafonnée, alors que la preuve doit être infalsifiable, complète et
+non-répudiable.**
+
+Pire, confondre les deux fabrique une contradiction juridique directe. Le RGPD Art. 17 (droit à
+l'effacement) exige de pouvoir supprimer les données d'un sujet ; l'Art. 5(2) (responsabilité) exige
+de pouvoir prouver ce qui leur est arrivé. Si la preuve *est* la donnée, satisfaire l'un viole
+l'autre. Un agrégateur de logs ou des tables d'audit par-service ne peuvent résoudre cela — ils n'ont
+pas de chaîne globale, et supprimer une ligne pour honorer l'effacement détruit silencieusement
+l'enregistrement de responsabilité.
+
+## Décision
+
+Nous construisons **`audit` comme un plan de preuve dédié, TIER-0, append-only et chaîné par hash** —
+un puits terminal qui *enregistre les décisions et n'agit jamais*, distinct du plan de télémétrie.
+Règles constituantes :
+
+1. **Immuabilité = quatre domaines de confiance indépendants à forger.** Une chaîne de hash à 3
+   couches sur les événements, stockée INSERT-only en Postgres **et** répliquée en WORM Object-Lock,
+   avec un checkpoint Merkle signé ancré à un témoin externe. Forger l'histoire requiert de
+   compromettre les quatre.
+2. **RtbF RGPD par crypto-shred, pas par suppression.** La PII de chaque sujet est scellée sous un DEK
+   par-sujet avec un pseudonyme ; la chaîne hashe le *ciphertext*. L'effacement = détruire la clé —
+   l'enregistrement et sa preuve survivent, la PII devient irrécupérable. Le legal-hold prime sur
+   l'effacement.
+3. **Ingestion dual-lane.** Kafka async (`run_consumer`, producteur **fail-open**) porte ~99% du
+   volume et absorbe les pics ; une voie gRPC synchrone `RecordPrivileged` est **fail-closed** — une
+   action de break-glass est *refusée* si elle ne peut être enregistrée d'abord.
+4. **Partitionnement hybride** par tenant + catégorie, avec le sujet indexé pour les lookups
+   d'effacement.
+5. Réalisé en deux binaires : `audit-server` (`:50068`) et `audit-worker` (`:50069`) ; namespace
+   d'erreur `AUD-XXXX`.
+
+## Conséquences
+
+- **Positives :** l'effacement (Art. 17) et la responsabilité (Art. 5(2)) coexistent sans
+  contradiction ; la falsification requiert de percer quatre domaines de confiance ; une action de
+  break-glass ne peut jamais procéder non enregistrée ; les exigences de preuve SOC2/DSA sont
+  satisfaites par construction.
+- **Négatives / compromis accepté :** un nouveau service TIER-0 à opérer ; la voie synchrone ajoute
+  une dépendance dure sur le chemin break-glass ; la custody des clés en prod (KMS/HSM) et le témoin
+  externe (RFC3161 / WORM cross-compte) sont différés au provisionnement IAM/org ; les consumers
+  crypto-shred et de balayage de rétention attendent des sources amont.
+- **Clôt :** la contradiction RGPD Art. 17 ⇄ Art. 5(2), et la lacune probatoire SOC2/DSA.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Dériver l'audit des logs / d'un SIEM | Mutable, échantillonné, rétention plafonnée — ne peut prouver la non-répudiation ni la complétude |
+| Tables d'audit par-service | Pas de chaîne globale ; honorer l'effacement en supprimant des lignes détruit l'enregistrement de responsabilité |
+| Stocker la PII en clair, supprimer sur demande | La suppression casse la chaîne de hash ; effacement et preuve deviennent mutuellement exclusifs |

--- a/docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.fr.md
+++ b/docs/adr/0002-moderation-decision-enforcement-sor-with-fail-closed-screen.fr.md
@@ -1,0 +1,67 @@
+---
+i18n:
+  source: ./0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md
+  source_sha256: 926eb1be3327585cf54a190f2aa402ed4ee6d1b3cbd833c8f5a1e35edf516fd2
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md`](./0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0002 : Moderation est le SoR décision/enforcement avec une porte Screen étroite fail-closed
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** moderation (nouveau contexte TIER-0) ; producteurs de contenu ; audit (consommateur)
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+La logique de confiance & sécurité se disperserait aujourd'hui dans chaque service de contenu —
+chacun ré-implémentant des vérifications « est-ce actionné ? » sans réponse faisant autorité. Il nous
+faut un unique **cerveau et système de référence pour les décisions d'intégrité et l'enforcement**. La
+tension : un tel service doit pouvoir *bloquer* le contenu nuisible de façon autoritaire, mais
+l'essentiel de son travail (ingérer des signaux, enregistrer des décisions) ne doit pas siéger sur le
+write path synchrone comme passif de latence ou de disponibilité. Un service fail-open partout laisse
+passer du contenu nuisible pendant une panne ; un fail-closed partout rend toute publication otage de
+sa disponibilité.
+
+Moderation doit aussi être soigneusement cadré : ce n'est **pas** un classifieur (cela couplerait la
+politique au cycle de vie ML), **pas** un store de contenu, et **pas** une UI de revue.
+
+## Décision
+
+Nous construisons **`moderation` comme le SoR décision/enforcement TIER-0** exposant une **interface
+à trois plans**, chaque plan avec la posture de défaillance qu'exige sa sémantique :
+
+1. **Ingestion async** — signaux/signalements affluent via Kafka (`run_consumer`, fail-open). C'est la
+   voie de masse et elle ne bloque jamais les producteurs.
+2. **Enforcement hot-read** — « cette entité est-elle actionnée ? » servi depuis une voie de lecture
+   rapide, fail-open (absence d'enregistrement ≠ bloqué).
+3. **Porte `Screen` étroite fail-closed** — une unique vérification synchrone de pré-publication pour
+   les catégories screenées. Si moderation est indisponible, `Screen` **refuse** — le contenu n'est
+   pas publié.
+
+Moderation enregistre chaque décision une fois et émet un événement de preuve dédié
+`DecisionRecorded` pour que le [plan audit](./0001-audit-is-a-separate-evidence-plane.md) scelle la
+justification DSA ; les événements d'enforcement existants centrés-offender restent intacts.
+
+## Conséquences
+
+- **Positives :** une réponse faisant autorité à « est-ce actionné ? » ; les voies coûteuses restent
+  async et fail-open, donc la charge de moderation ne s'amplifie jamais sur les producteurs ; seule la
+  porte `Screen` délibérément étroite est fail-closed ; la séparation propre d'avec classifieur /
+  store / UI garde la politique découplée du ML.
+- **Négatives / compromis accepté :** `Screen` est une dépendance synchrone sur le write path — elle
+  doit être rapide et porter un timeout serré, et une panne de moderation bloque le *nouveau* contenu
+  dans les catégories screenées (un compromis sécurité-sur-disponibilité accepté pour cette surface
+  étroite).
+- **Clôt :** la logique de moderation dispersée et non-autoritaire à travers les services de contenu.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Rendre `Screen` fail-open | Laisse passer du contenu nuisible précisément pendant une panne — inacceptable pour la T&S |
+| Moderation comme classifieur | Couple la politique d'intégrité au cycle de vie du modèle ML ; confond « décider » et « détecter » |
+| Intégrer l'état de moderation dans chaque service de contenu | Pas de SoR faisant autorité, pas d'enforcement cohérent, pas de piste de preuve unique |

--- a/docs/adr/0003-realtime-is-a-fail-open-system-of-connection.fr.md
+++ b/docs/adr/0003-realtime-is-a-fail-open-system-of-connection.fr.md
@@ -1,0 +1,62 @@
+---
+i18n:
+  source: ./0003-realtime-is-a-fail-open-system-of-connection.md
+  source_sha256: 9adb2602d75624e93fab1ea213407f623ffbce270e5eeedef27edeb32fec35cc
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0003-realtime-is-a-fail-open-system-of-connection.md`](./0003-realtime-is-a-fail-open-system-of-connection.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0003 : Realtime est un System-of-Connection fail-open, jamais un record store
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** realtime (nouveau contexte TIER-1) ; chat, notification, counter, post
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Le push live côté client (DMs, notifications, pics d'engagement) est déjà implémenté deux fois — `chat`
+et `notification` streament chacun vers les clients à leur façon ad-hoc. Une troisième voie temps réel
+sur-mesure aggraverait la duplication et la surface opérationnelle. Il nous faut **un seul plan de
+livraison**. Deux pièges à éviter : le polling (un amplificateur de charge inversé — les clients
+martèlent le mesh pour découvrir que rien n'a changé), et laisser le plan de livraison accumuler une
+durabilité qu'il ne devrait pas posséder (auquel point une panne perd des données au lieu d'être
+récupérable).
+
+## Décision
+
+Nous construisons **`realtime` comme un System-of-Connection / Delivery TIER-1, fail-open** — un
+bulkhead devant le mesh gRPC qui **ne stocke jamais d'enregistrements** : s'il disparaît, les clients
+re-synchronisent depuis les SoR propriétaires. Règles constituantes :
+
+1. **Une socket multiplexée par appareil.** WSS sur `:443` portant une enveloppe
+   `{stream_seq, channel, ack_required, payload}` — **pas** gRPC-vers-client, **pas** SSE. Une socket
+   remplace les streams client par-feature.
+2. **Fan-out ciblé.** Lookup de registry + livraison ciblée, pas broadcast-and-filter.
+3. **Fail-open avec durabilité déléguée.** Si un destinataire est offline, déléguer à `notification`
+   (APNs/FCM) ; à la reconnexion le client re-synchronise depuis les SoR via un token de séquence. Une
+   livraison en vol perdue n'est jamais une donnée perdue.
+4. **Listeners séparés.** gRPC interne sur `:50066` (gateway) et `:50067` (dispatcher) ; le WebSocket
+   public est un listener *séparé* — brisant délibérément la convention un-port de la flotte. Deux
+   binaires : `realtime-gateway` (edge stateful) et `realtime-dispatcher` (worker stateless).
+
+## Conséquences
+
+- **Positives :** une socket multiplexée par appareil effondre les silos chat/notification ; une panne
+  ne peut perdre de données car realtime n'en possède aucune — la récupération est une re-sync ; la
+  charge de connexion est isolée du mesh gRPC.
+- **Négatives / compromis accepté :** un edge stateful avec des préoccupations C10M (conns inactives en
+  futures parkées, SLO mémoire dur par-connexion, file de shed bornée, reaping par heartbeat) ; il
+  brise intentionnellement la convention un-port, que le déploiement doit accommoder.
+- **Clôt :** le troisième silo temps réel ad-hoc, et la voie d'amplification de charge du polling.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Polling client | Amplificateur de charge inversé — la plupart des polls ne découvrent rien, martelant le mesh |
+| gRPC-streaming-vers-client / SSE | Pas de multiplexage ni d'enveloppe côté client ; recréerait des streams par-feature |
+| Fan-out broadcast-and-filter | Gaspilleur à l'échelle ; chaque node traite chaque message pour en jeter la plupart |
+| Faire de realtime un record store | Force des garanties de durabilité qu'il ne devrait pas posséder ; défait le modèle de récupération fail-open |

--- a/docs/adr/0004-account-is-the-single-identity-sor.fr.md
+++ b/docs/adr/0004-account-is-the-single-identity-sor.fr.md
@@ -1,0 +1,47 @@
+---
+i18n:
+  source: ./0004-account-is-the-single-identity-sor.md
+  source_sha256: 1ef35508a594e6edb0e41906636fe93904220ce6ef470dfac81e7fcfcb76eaa2
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0004-account-is-the-single-identity-sor.md`](./0004-account-is-the-single-identity-sor.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0004 : Account est le SoR d'identité unique et possède une voie d'événements sortante
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** account ; consommateurs audit, profile
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Une identité réelle (email, téléphone, KYC, rôles) doit vivre en un seul endroit, sinon l'effacement
+RGPD devient impossible — chaque copie fantôme est un enregistrement incontrôlé que l'Art. 17 ne peut
+atteindre. Account était aussi un **producteur fantôme** : il possédait l'identité mais ne publiait
+rien, donc les contextes aval n'avaient aucun moyen de réagir aux changements de cycle de vie hormis
+en allant chercher dans le store d'account.
+
+## Décision
+
+Account **est le système de référence unique du compte utilisateur** — existence, métadonnées
+d'identifiants, KYC, rôles et état RGPD — et **possède une voie d'événements sortante**
+(`account.v1.events`, publiée après chaque save durable). Les contextes aval (`audit`, `profile`)
+consomment des références ; aucun ne détient d'identité faisant autorité. Un `gdpr_deletion_requested`
+propage l'effacement (audit crypto-shred le sujet), fermant la boucle Art. 17 de bout en bout.
+
+## Conséquences
+
+- **Positives :** l'identité a un seul foyer ; l'effacement RGPD a un unique déclencheur faisant
+  autorité qui se propage ; l'aval reste découplé (événements, pas accès direct au store).
+- **Négatives / compromis accepté :** account doit garantir l'émission d'événement après save (une
+  discipline outbox/publish-après-save), ajoutant une responsabilité de write path.
+- **Clôt :** la lacune du producteur fantôme et le problème d'effacement de l'identité fantôme.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Laisser les services lire le store d'account directement | Couple chaque consommateur au schéma d'account ; pas de propagation d'effacement |
+| Répliquer l'identité dans chaque service | Multiplie les copies de PII ; rend l'effacement Art. 17 inapplicable |

--- a/docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.fr.md
+++ b/docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.fr.md
@@ -1,0 +1,51 @@
+---
+i18n:
+  source: ./0005-auth-federated-idp-with-platform-edge-tokens.md
+  source_sha256: 1c8d06299212ce64736e03ba23385a9ca17c2253842bec77622cbce2e8cf2dc5
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0005-auth-federated-idp-with-platform-edge-tokens.md`](./0005-auth-federated-idp-with-platform-edge-tokens.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0005 : Auth fédère un IdP et émet des edge tokens ES256 plateforme avec révocation par génération
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** auth ; account ; auth-context (lib de vérif) ; realtime ; tous les services
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+L'authentification recouvre trois préoccupations faciles à confondre : le **compte** (qui existe — un
+SoR), la **vérification** (ce token est-il valide — une préoccupation par-service) et l'**émission**
+(frapper un identifiant, gérer la session). Il faut aussi des tokens rapides et stateless-à-vérifier à
+l'edge *et* pouvoir révoquer instantanément — deux objectifs qui normalement s'opposent (les tokens
+stateless ne se rappellent pas).
+
+## Décision
+
+`auth` est un contexte distinct qui **fédère un IdP externe (Keycloak) pour les identifiants** et
+**émet les propres edge tokens ES256 courts de la plateforme**. Il est séparé d'`account` (le SoR
+d'identité) et d'`auth-context` (la bibliothèque de vérification en process que chaque service utilise
+— une vérification, pas un appel). La révocation instantanée malgré une vérification stateless est
+obtenue avec une **`Generation` monotone par-sujet** : l'incrémenter invalide toute une famille de
+tokens ; les refresh tokens sont à usage unique (la rotation invalide le précédent).
+
+## Conséquences
+
+- **Positives :** la vérification est bon marché et décentralisée (`auth-context`, pas d'appel à auth
+  par requête) ; les identifiants réutilisent un IdP durci ; la révocation est immédiate via le bump
+  de génération.
+- **Négatives / compromis accepté :** le compteur de génération doit être vérifié au moment de la
+  vérif (un petit lookup) pour que la révocation soit rapide ; le réglage de durée de vie des tokens
+  arbitre entre latence de révocation et coût de vérification.
+- **Clôt :** la confusion compte/vérif/émission ; la tension stateless-vs-révocable.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Tokens opaques vérifiés en appelant auth par requête | Réintroduit un saut synchrone à chaque appel authentifié |
+| Tokens longue durée, sans génération | Pas de révocation instantanée ; un token fuité reste valide jusqu'à expiration |
+| Construire notre propre store d'identifiants au lieu de fédérer | Re-résout un problème générique et sensible à la sécurité qu'un IdP résout déjà |

--- a/docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.fr.md
+++ b/docs/adr/0006-chat-shadowing-pattern-member-vs-audience-plane.fr.md
@@ -1,0 +1,47 @@
+---
+i18n:
+  source: ./0006-chat-shadowing-pattern-member-vs-audience-plane.md
+  source_sha256: b45f9ec9d6e22b3a966b5a6567da8f7130dcd4a82ae87b3938e3230006e67ebc
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0006-chat-shadowing-pattern-member-vs-audience-plane.md`](./0006-chat-shadowing-pattern-member-vs-audience-plane.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0006 : Chat utilise le Shadowing Pattern — plans de visibilité Membre vs Audience séparés
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** chat
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Une conversation a deux audiences distinctes avec des droits différents : les **membres** qui lisent
+et écrivent, et une **audience** plus large qui peut voir une conversation *publiée* mais pas y
+participer. Modéliser les deux avec un seul flag de visibilité fuit l'état membre-seul vers l'audience
+(ou cache le contenu publié de celle-ci), et une conversation publiée puis dépubliée doit voir sa vue
+audience démantelée proprement sans perturber le journal des membres.
+
+## Décision
+
+Chat modélise les deux comme **des plans séparés — le plan Membre et le plan Audience (le Shadowing
+Pattern)**. L'appartenance est autorisée à la frontière gRPC pour le plan membre ; la publication
+ouvre le plan audience ; la dépublication déclenche un `VisibilityWorker` qui consomme
+`chat.conversation.unpublished` et démantèle l'état du plan audience. Le journal de messages est
+stocké dans une partition ScyllaDB bucketée `(conversation_id, bucket)`, découplée de la visibilité.
+
+## Conséquences
+
+- **Positives :** l'état membre-seul ne fuit jamais vers l'audience ; publier/dépublier est une simple
+  bascule de plan, pas une réécriture par-message ; le journal à fort volume scale par bucket.
+- **Négatives / compromis accepté :** deux plans à garder cohérents, et un worker de démantèlement
+  async (avec sa propre DLQ) à opérer.
+- **Clôt :** la fuite de confusion de visibilité et le problème de démantèlement à la dépublication.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Un seul flag de visibilité par conversation | Fuit l'état membre vers l'audience ou cache le contenu publié |
+| Vérifications ACL par-message à la lecture | Coûteux sur un journal à fort volume ; ne modélise pas le plan audience |

--- a/docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.fr.md
+++ b/docs/adr/0007-comment-flat-thread-two-table-tombstone-purge.fr.md
@@ -1,0 +1,48 @@
+---
+i18n:
+  source: ./0007-comment-flat-thread-two-table-tombstone-purge.md
+  source_sha256: 2f4d26d34af653f25b9f33694dd83af6046c971533bc4bd0fb717cbe525b57eb
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0007-comment-flat-thread-two-table-tombstone-purge.md`](./0007-comment-flat-thread-two-table-tombstone-purge.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0007 : Comment utilise un fil plat nil-UUID, un layout Scylla deux tables et une suppression tombstone-vs-purge
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** comment
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Les commentaires sont un flux à forte écriture qui doit être lu à la fois par id et en ordre
+temporel, et la suppression a deux sens réellement différents : un utilisateur retirant son propre
+commentaire (laisser un marqueur « supprimé » visible) versus un retrait dur modération/RGPD (la ligne
+doit disparaître). Une seule sémantique de suppression ne peut servir les deux, et un seul motif
+d'accès ne peut servir à bas coût à la fois le lookup-par-id et les lectures ordonnées dans le temps.
+
+## Décision
+
+Comment modélise un **fil plat utilisant un sentinelle nil-UUID** pour les commentaires sans racine,
+les stocke dans un **layout ScyllaDB à deux tables** (une table LCS pour les lookups par id + une
+table TWCS pour le flux ordonné dans le temps), et fait de la suppression une **`DeletionStrategy`
+explicite — tombstone (marqueur visible) vs purge (retrait dur)**.
+
+## Conséquences
+
+- **Positives :** les deux motifs de lecture sont bon marché et avec la compaction appropriée (LCS vs
+  TWCS) ; la sémantique de suppression correspond aux cas d'usage réels ; le sentinelle nil-UUID garde
+  le modèle plat et simple.
+- **Négatives / compromis accepté :** des écritures à deux tables à garder cohérentes ; pas de
+  threading imbriqué (une simplification délibérée).
+- **Clôt :** l'ambiguïté de sémantique de suppression et le mismatch de motifs de lecture.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Table unique | Ne peut servir lookup-par-id et lectures ordonnées dans le temps avec la compaction appropriée |
+| Un seul flag « deleted » | Confond la suppression-utilisateur (tombstone) avec le purge modération/RGPD |
+| Arbre de fil imbriqué maintenant | Complexité prématurée pour le produit actuel |

--- a/docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.fr.md
+++ b/docs/adr/0008-counter-magnitudes-are-a-reconcilable-soref.fr.md
@@ -1,0 +1,53 @@
+---
+i18n:
+  source: ./0008-counter-magnitudes-are-a-reconcilable-soref.md
+  source_sha256: c13377d2ef4154091a23ec4e78d76167979380236efa92cdadf29b07f228d9a4
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0008-counter-magnitudes-are-a-reconcilable-soref.md`](./0008-counter-magnitudes-are-a-reconcilable-soref.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0008 : Counter est un System-of-Reference réconciliable pour les magnitudes, distinct de l'état d'arête
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** counter ; supersède les comptes bruts d'engagement ; producteur pour search, realtime
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+« Combien de vues/likes/followers ? » (une **magnitude**) et « qui a liké/suivi qui ? » (**état
+d'arête**) semblent liés mais ont des formes opposées : les magnitudes sont un agrégat à l'échelle
+firehose qui tolère l'approximation et la réconciliation ; l'état d'arête est une vérité
+relationnelle exacte. Stocker les magnitudes dans les services d'état d'arête (engagement,
+social-graph) couple une charge de comptage à forte écriture au write path relationnel et disperse le
+même compte à travers les services.
+
+## Décision
+
+`counter` est un **System of Reference dédié aux magnitudes** — exact-mais-réconciliable, jamais
+l'état d'arête. Il ingère un firehose pur-Kafka avec pré-agrégation fenêtrée N→1, stocke à travers un
+layout hot/warm/cold 3-tiers (Redis / Postgres SoRef+réconciliation / Scylla TWCS), utilise HLL pour
+les comptes uniques et CMS pour les tendances, et garde tous les effets de bord multi-tiers derrière
+un **ledger d'idempotence clé par `WindowId`** pour que les rejeux ne puissent double-compter. Il
+**supersède les comptes bruts de vues/partages d'engagement** et **réconcilie** les totaux faisant
+autorité face aux SoR propriétaires (dérive → `CTR-5002`). Les lectures **échouent ouvertes** (timeout
+dur → périmé/approximatif).
+
+## Conséquences
+
+- **Positives :** le comptage scale indépendamment des SoR d'arête ; un seul foyer par magnitude ;
+  sûr au rejeu ; les lectures hot ne bloquent jamais le produit.
+- **Négatives / compromis accepté :** les magnitudes sont cohérentes-à-terme et réconciliées, pas
+  transactionnellement exactes à l'instant de la lecture ; les sources de réconciliation (ex. comptes
+  de followers) doivent être exposées par les SoR d'arête.
+- **Clôt :** les compteurs dispersés et le couplage comptage-à-forte-écriture-sur-le-write-path-relationnel.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Garder les comptes dans engagement/social-graph | Couple le comptage firehose au write path relationnel ; duplique les comptes |
+| Compteurs transactionnels exacts | Ne scale pas au volume firehose ; fait fondre le hot path |
+| Approximatif-seulement (sans réconciliation) | Dérive sans borne de la vérité d'arête faisant autorité |

--- a/docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.fr.md
+++ b/docs/adr/0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.fr.md
@@ -1,0 +1,47 @@
+---
+i18n:
+  source: ./0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md
+  source_sha256: 083a3f2195e869e8236d265b3162ee0e7001505530984f383c59114136ca3ba0
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md`](./0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0009 : Engagement est Redis-primary avec des arêtes Lua-atomiques et durabilité Kafka write-behind
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** engagement ; counter (magnitudes) ; notification, geo-discovery
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Les réactions sont des bascules extrêmement fréquentes et idempotentes (like/unlike). Un aller-retour
+base par bascule ne peut suivre, et un read-modify-write non-atomique court sous concurrence
+(double-likes, unlikes perdus). Mais les réactions restent une **arête de référence** (« qui a réagi,
+comment ») qui doit survivre à une perte de cache.
+
+## Décision
+
+Engagement est **Redis-primary** : chaque react/unreact est une pose/effacement **Lua-atomique** de
+l'arête de réaction plus une mise à jour du score in-Redis (idempotent par construction), avec
+**Kafka write-behind** pour l'enregistrement durable et la propagation aval (`engagement.reactions`,
+`engagement.score_updated`). Engagement possède l'**arête** ; `counter` possède les **magnitudes**
+dérivées (voir ADR-0008). L'arête est la vérité ; le score est dérivé des `ReactionWeight`.
+
+## Conséquences
+
+- **Positives :** les bascules sur le hot path sont atomiques et rapides sans aller-retour base ; la
+  durabilité est préservée de façon asynchrone ; les magnitudes sont l'affaire de quelqu'un d'autre.
+- **Négatives / compromis accepté :** une fenêtre de lag write-behind où l'enregistrement durable
+  traîne derrière Redis ; la réconciliation/le rejeu dépend du stream Kafka.
+- **Clôt :** le goulot d'aller-retour base par bascule et les conditions de course sur les réactions.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Réactions base-primary | L'aller-retour par bascule ne peut soutenir le volume de réactions |
+| Read-modify-write Redis non-atomique | Court sous concurrence (réactions doubles/perdues) |
+| Garder les magnitudes ici aussi | Le comptage appartient à `counter` (ADR-0008) |

--- a/docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.fr.md
+++ b/docs/adr/0010-geo-discovery-h3-grid-dual-layer-redis-topk.fr.md
@@ -1,0 +1,50 @@
+---
+i18n:
+  source: ./0010-geo-discovery-h3-grid-dual-layer-redis-topk.md
+  source_sha256: aba36c04a6077f5b822a9b6fe167599d0738857c15d81b36a9e4e89e7b4c4843
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0010-geo-discovery-h3-grid-dual-layer-redis-topk.md`](./0010-geo-discovery-h3-grid-dual-layer-redis-topk.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0010 : Geo-discovery est un read-model spatial H3 grid_disk + Redis Top-K double-couche
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** geo-discovery ; amont post, engagement, profile
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Les requêtes de viewport carte doivent retourner les posts les plus pertinents dans un rectangle
+mouvant à latence interactive, sur une population de posts en changement constant et qui doit
+s'auto-élaguer (les posts périmés ne doivent pas s'attarder). Les requêtes lat/lng arbitraires
+s'indexent mal, et une liste par-cellule sans borne coûte de la mémoire et retourne du bruit.
+
+## Décision
+
+Geo-discovery est un **read-model spatial fail-open (SoReference)** construit sur **H3** : un viewport
+se mappe à un `H3 grid_disk` de cellules couvrantes ; chaque cellule est une **structure Redis
+double-couche (ZSET + cardinalité)** maintenue par des scripts Lua **Top-K / XX / prune** avec
+**rétention TTL** pour que l'index s'auto-élague. Les cartes sont projetées depuis les événements
+amont (`post.published`/`post.deleted`, `engagement.score_updated`, `profile.tier_changed`) ; geo ne
+possède aucune vérité source et un index dégradé retourne moins/des cartes plus périmées plutôt
+qu'une erreur.
+
+## Conséquences
+
+- **Positives :** les requêtes de viewport deviennent un ensemble borné de lookups de cellules ; les
+  résultats par-cellule sont classés et plafonnés ; la rétention est automatique via TTL ; l'index est
+  entièrement reconstructible depuis l'amont.
+- **Négatives / compromis accepté :** les résultats sont cohérents-à-terme et approximatifs (Top-K) ;
+  dépend de l'amont émettant le payload nécessaire (voir la lacune ouverte d'enrichissement post→geo).
+- **Clôt :** les problèmes d'indexation spatiale et de liste par-cellule sans borne.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Requêtes lat/lng sur un store générique | Mauvaise localité spatiale ; lent à l'échelle viewport |
+| Listes par-cellule sans borne | Explosion mémoire ; retourne du bruit peu pertinent |
+| Faire de geo un SoR | C'est une projection ; la durabilité vit dans `post` |

--- a/docs/adr/0011-media-byte-free-control-plane.fr.md
+++ b/docs/adr/0011-media-byte-free-control-plane.fr.md
@@ -1,0 +1,50 @@
+---
+i18n:
+  source: ./0011-media-byte-free-control-plane.md
+  source_sha256: 5e0f0f69761fbf93909e6cefe38c176b72a5e3acd59b8fb823d023faa1cc5310
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0011-media-byte-free-control-plane.md`](./0011-media-byte-free-control-plane.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0011 : Media est un plan de contrôle sans-octets avec livraison fail-open et Screen CSAM fail-closed
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** media ; moderation ; post, profile, search
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Média signifie de gros binaires. Pousser des octets via gRPC ou Kafka ruine les deux (limites de
+taille de message, pression sur le broker, mémoire). Pourtant le *cycle de vie* de l'asset —
+uploadé → screené → transformé → ready — doit être suivi de façon autoritaire, ne doit **jamais**
+laisser du contenu non-sûr (CSAM) atteindre `ready`, et doit continuer à servir même quand une
+dépendance non-sécurité est dégradée.
+
+## Décision
+
+`media` est un **plan de contrôle sans-octets** : les octets vont **direct au store objet via URL
+pré-signées**, jamais sur gRPC/Kafka ; media possède le **SoR métadonnées/cycle de vie** de l'asset
+(Postgres + Redis), les octets étant dans S3/MinIO référencés par `StorageKey`. Il fait tourner trois
+plans — (A) courtier d'upload, (B) pipeline de transformation Kafka async, (C) courtage
+livraison/CDN — avec une **posture de défaillance par catégorie** : la résolution de livraison
+**échoue ouverte**, tandis que le **`Screen` CSAM gardant la mise-en-ready échoue fermé** (un asset ne
+peut atteindre `ready` sans le passer ; un takedown de modération met en quarantaine/supprime).
+
+## Conséquences
+
+- **Positives :** le plan octets ne stresse jamais le mesh ; le cycle de vie fait autorité ; le
+  contenu non-sûr ne peut passer en ligne ; la livraison dégrade gracieusement.
+- **Négatives / compromis accepté :** les clients doivent gérer le handshake d'upload pré-signé ; le
+  Screen est une dépendance synchrone sur la mise-en-ready (bornée par un timeout dur).
+- **Clôt :** la pression octets-sur-le-fil et le risque de contenu-non-sûr-en-ligne.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Streamer les octets via le service / Kafka | Limites de taille, pression broker, explosion mémoire |
+| Stocker les octets dans la base | Mauvais outil ; gonfle le SoR ; pas de voie CDN |
+| Screen fail-open | Laisse du CSAM atteindre `ready` pendant une panne — inacceptable |

--- a/docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.fr.md
+++ b/docs/adr/0012-notification-write-collapse-fanout-claim-gated-counter.fr.md
@@ -1,0 +1,49 @@
+---
+i18n:
+  source: ./0012-notification-write-collapse-fanout-claim-gated-counter.md
+  source_sha256: 8906f0cdaaff40d67cc3ed00745e3a4ddcbc48cd9a3851812ad8b9c81d9d0e58
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0012-notification-write-collapse-fanout-claim-gated-counter.md`](./0012-notification-write-collapse-fanout-claim-gated-counter.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0012 : Notification utilise un fan-out write-collapse et un compteur de non-lus claim-gated idempotent
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** notification ; amont comment, engagement, post, social-graph
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Le fil d'activité d'un utilisateur a un fort fan-in : de nombreux événements (likes, commentaires,
+follows) ciblent un seul utilisateur, et un naïf « une écriture de fil par événement » amplifie les
+écritures et produit du spam bruyant par-événement (« 5 personnes ont aimé » devrait se réduire à une
+entrée). La livraison Kafka at-least-once signifie aussi que le redelivery ne doit pas double-compter
+le badge de non-lus.
+
+## Décision
+
+Notification est un **fil dérivé TIER-2** qui **write-collapse** le flux à fort fan-in vers le fil
+par-utilisateur (3 couches + un plafond horaire), adossé à un fil d'activité TWCS. Il garantit
+l'idempotence avec des **ids UUIDv5 déterministes**, un **`created_at` heure-d'événement** (pas
+d'ingestion), un **compteur de non-lus claim-gated** (`SET NX` pour qu'un redelivery ne puisse
+double-incrémenter), et une **coalescence d'expéditeur unique** (`SADD`). Le push live passe par le
+stream broadcast gRPC ; la livraison offline est déléguée (APNs/FCM).
+
+## Conséquences
+
+- **Positives :** amplification d'écriture bornée ; entrées coalescées, non-spammeuses ; comptes de
+  non-lus sûrs au redelivery ; les notifications manquées sont re-dérivables (fail-open).
+- **Négatives / compromis accepté :** la logique de coalescence ajoute de la complexité côté Redis ;
+  le fil est une vue dérivée, faisant autorité seulement pour lui-même.
+- **Clôt :** l'amplification d'écriture et les badges double-comptés sous livraison at-least-once.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Une écriture de fil par événement source | Amplification d'écriture + spam bruyant par-événement |
+| Incrémenter les non-lus sans claim | Le redelivery double-compte le badge |
+| `created_at` heure-d'ingestion | Désordonne le fil sous lag/rejeu de consommateur |

--- a/docs/adr/0013-post-two-table-scylla-with-published-language.fr.md
+++ b/docs/adr/0013-post-two-table-scylla-with-published-language.fr.md
@@ -1,0 +1,49 @@
+---
+i18n:
+  source: ./0013-post-two-table-scylla-with-published-language.md
+  source_sha256: 4cfed55e2c0bb070cf108fe47ee82ecd8fe38a4d2ea86949a9a3ebc520ba682d
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0013-post-two-table-scylla-with-published-language.md`](./0013-post-two-table-scylla-with-published-language.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0013 : Post utilise un layout ScyllaDB deux tables et est la source de fan-out en langage publié
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** post ; aval timeline, search, geo-discovery, counter, realtime
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Les posts sont du contenu à forte écriture lu de deux façons — par id de post et par auteur — et tout
+le côté lecture de la plateforme (fil, recherche, découverte, comptes, live) dépend de savoir quand le
+contenu change. Un store à accès unique ne peut servir les deux lectures à bas coût, et si les
+consommateurs accèdent au store de post toute la flotte se couple à son schéma.
+
+## Décision
+
+`post` est le **système de référence du contenu** dans un **layout ScyllaDB à deux tables**
+(`post.posts` par id + `post.posts_by_profile` par auteur), et émet **`post.v1.events`**
+(`published`/`updated`/`deleted`) comme son **Open-Host Service / Published Language** — la source de
+fan-out unique que consomme le côté lecture. Les enums proto mappent le tinyint domaine **+1 sans
+sentinelle UNSPECIFIED**. Post dénormalise l'état auteur et modération en consommant
+`profile.v1.events` / `moderation.v1.events`.
+
+## Conséquences
+
+- **Positives :** les deux motifs de lecture sont bon marché ; le côté lecture est découplé
+  (événements, pas accès direct au store) ; un cycle de vie de contenu faisant autorité pilote
+  fil/recherche/découverte/comptes/live.
+- **Négatives / compromis accepté :** une cohérence d'écriture à deux tables à maintenir ;
+  `post.v1.events` est un contrat d'API dur — un changement de schéma casse chaque consommateur.
+- **Clôt :** le mismatch de motifs de lecture et le couplage du côté lecture au store de post.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Table posts unique | Ne peut servir efficacement les lectures par-id et par-auteur |
+| Laisser les consommateurs lire le store de post | Couple tout le côté lecture au schéma de post |
+| Fan-out synchrone vers les consommateurs | Met le côté lecture sur le write path |

--- a/docs/adr/0014-profile-public-persona-with-dual-axis-visibility.fr.md
+++ b/docs/adr/0014-profile-public-persona-with-dual-axis-visibility.fr.md
@@ -1,0 +1,51 @@
+---
+i18n:
+  source: ./0014-profile-public-persona-with-dual-axis-visibility.md
+  source_sha256: cd78ea432c8d970d70c1285d1e1dba6389e729cee0da78534f863d4e0ecea1d0
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0014-profile-public-persona-with-dual-axis-visibility.md`](./0014-profile-public-persona-with-dual-axis-visibility.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0014 : Profile est le persona public au-dessus du SoR account avec visibilité bi-axiale
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** profile ; account ; aval post, search, geo-discovery, timeline
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+La face publique d'un utilisateur (handle, display name, bio, avatar, tier) est une préoccupation
+différente du compte privé de référence (identifiants, PII, KYC). Les regrouper met la PII dans le
+store de persona à lecture chaude. Deux parties distinctes peuvent aussi légitimement masquer un
+profil — le **propriétaire** (vie privée) et la **modération** (enforcement) — et un seul flag de
+visibilité ne peut représenter les deux sans que l'un prime silencieusement sur l'autre. Les handles
+doivent être globalement uniques sous des revendications concurrentes.
+
+## Décision
+
+`profile` est le **système de référence du persona public**, superposé au SoR `account` (provisionné
+en consommant `account.v1.events`) et ne détenant aucune PII. La visibilité est **bi-axiale** : un
+profil n'est visible que si le **propriétaire ET la modération** l'autorisent tous deux. Les handles
+sont **globalement uniques avec des revendications sans conflit** sous concurrence. Profile **possède
+et émet** `profile.v1.events` (y compris `handle_changed`, `profile_verified` et `tier_changed`) pour
+le côté lecture ; le **tier d'auteur est calculé par `social-graph`** mais possédé et publié ici.
+
+## Conséquences
+
+- **Positives :** la PII reste dans `account` ; les lectures de persona sont chaudes et sans PII ; les
+  deux autorités-de-masquage sont représentées indépendamment ; les read-models aval réagissent via
+  événements.
+- **Négatives / compromis accepté :** le persona doit rester cohérent-à-terme avec account ; la voie
+  de revendication de handle nécessite une gestion atomique de l'unicité.
+- **Clôt :** la PII-dans-le-store-de-persona et le problème de prime du flag-de-visibilité-unique.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Un seul service pour account + profile | Met la PII dans le store de persona à lecture chaude |
+| Flag de visibilité unique | Les masquages propriétaire et modération priment silencieusement l'un sur l'autre |
+| Calculer/posséder le tier dans profile | Le tier dérive du graphe de followers (`social-graph`) |

--- a/docs/adr/0015-search-opensearch-single-store-external-versioning.fr.md
+++ b/docs/adr/0015-search-opensearch-single-store-external-versioning.fr.md
@@ -1,0 +1,52 @@
+---
+i18n:
+  source: ./0015-search-opensearch-single-store-external-versioning.md
+  source_sha256: 3d128ced727eb36508feeeb9c13316b29b7ef9ccc413dfbfeb33831905ac081c
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0015-search-opensearch-single-store-external-versioning.md`](./0015-search-opensearch-single-store-external-versioning.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0015 : Search est un read-model OpenSearch avec versioning externe et voie de lecture fail-open
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** search ; amont post, profile, moderation, counter
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+La découverte nécessite un index inversé sur profils/posts/hashtags, alimenté par un flux d'événements
+at-least-once et **désordonné**. Un événement en retard ou dupliqué ne doit pas écraser un document
+plus récent, l'index doit respecter la visibilité propriétaire et modération, la ré-indexation ne doit
+pas causer de downtime de lecture, et un cluster de recherche dégradé ne doit pas faire tomber les
+surfaces appelantes.
+
+## Décision
+
+`search` est un **read-model (SoReference)** cohérent-à-terme sur **OpenSearch comme store canonique
+unique**, avec un **côté commande pur-Kafka** et un **RPC de lecture stateless**. Les écritures
+désordonnées sont gardées par une **`DocVersion` externe** (un script Painless à 2 versions rejette
+les updates périmées). Les résultats honorent l'**autorité de visibilité duale** (propriétaire +
+modération). La ré-indexation est **blue-green** (construire un nouvel index, basculer l'alias
+atomiquement — pas de downtime de lecture). La voie de lecture **échoue ouverte** (dégrade vers
+moins/des hits plus périmés, jamais d'erreur).
+
+## Conséquences
+
+- **Positives :** les événements désordonnés ne peuvent régresser un document ; pas de downtime de
+  lecture à la ré-indexation ; la visibilité est imposée au moment de la requête ; un cluster dégradé
+  dégrade la recherche, pas le produit.
+- **Négatives / compromis accepté :** la recherche est cohérente-à-terme ; OpenSearch est un store
+  unique (pas de seconde source de vérité — il est reconstructible depuis l'amont à la place).
+- **Clôt :** les courses d'écrasement-périmé, le downtime de ré-indexation et le blast radius de panne
+  de recherche.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Faire confiance à l'ordre des événements | At-least-once + réordonnancement corrompt l'index |
+| Ré-indexation en place | Downtime de lecture pendant la reconstruction |
+| Lectures fail-closed | Une panne de recherche casserait les surfaces appelantes |

--- a/docs/adr/0016-social-graph-four-table-scylla-logged-batch.fr.md
+++ b/docs/adr/0016-social-graph-four-table-scylla-logged-batch.fr.md
@@ -1,0 +1,52 @@
+---
+i18n:
+  source: ./0016-social-graph-four-table-scylla-logged-batch.md
+  source_sha256: 0158a446574f81f1bb8403089f02acaa132be52c603086b758482859bef7446b
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0016-social-graph-four-table-scylla-logged-batch.md`](./0016-social-graph-four-table-scylla-logged-batch.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0016 : Social-graph utilise un schéma Scylla 4 tables avec double-écritures logged-batch atomiques
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** social-graph ; aval timeline, counter ; profile (tier)
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+Une relation est intrinsèquement bidirectionnelle à requêter — « qui je suis » et « qui me suit » —
+donc chaque follow/block nécessite un index avant et un index inverse. Si ces deux écritures peuvent
+diverger, le graphe se corrompt (un follow visible d'un côté mais pas de l'autre). Les lectures
+chaudes (fan-out de timeline) ont besoin de l'ensemble des followers rapidement, et un block doit
+sectionner atomiquement les follows existants des deux côtés. Le tier d'auteur dérive du nombre de
+followers mais est *présenté* sur le profil.
+
+## Décision
+
+`social-graph` est le **système de référence des relations** sur un **schéma ScyllaDB 4 tables** (index
+avant + inverse pour follows et blocks) avec des **Redis hot Sets** pour les lectures de followers, et
+écrit les lignes avant + inverse en **logged batch** pour que la double-écriture soit atomique. Un
+block sectionne les follows existants (`SeveredFollows`). **Le tier d'auteur est calculé ici** depuis
+le nombre de followers franchissant `TierThresholds`, mais **possédé et émis par `profile`**
+(ADR-0014). `timeline`/`counter` lisent le graphe via gRPC (le producteur Kafka `social-graph.follows`
+est différé).
+
+## Conséquences
+
+- **Positives :** les index avant/inverse ne peuvent diverger ; les lectures de followers sont
+  chaudes ; les blocks sont cohérents ; le calcul du tier vit là où sont les données de followers.
+- **Négatives / compromis accepté :** les logged batches coûtent plus que des écritures indépendantes ;
+  la réconciliation des orphelins reste une dette suivie ; les consommateurs lisent via gRPC jusqu'à
+  ce que le stream de follows arrive.
+- **Clôt :** le risque de corruption par index divergents et les lectures de followers lentes.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Table unique avant-seulement | Les requêtes inverses (« qui me suit ») deviennent des full scans |
+| Écritures avant/inverse non-atomiques | Les index divergent → corruption du graphe |
+| Émettre le tier depuis social-graph | Le tier est *présenté* sur le profil (ADR-0014) |

--- a/docs/adr/0017-timeline-hybrid-push-pull-fanout.fr.md
+++ b/docs/adr/0017-timeline-hybrid-push-pull-fanout.fr.md
@@ -1,0 +1,51 @@
+---
+i18n:
+  source: ./0017-timeline-hybrid-push-pull-fanout.md
+  source_sha256: 27300f904aee5b26886c046da15f1081c7fda93ec66d4ee6d26ca70788e26a16
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`0017-timeline-hybrid-push-pull-fanout.md`](./0017-timeline-hybrid-push-pull-fanout.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants, codes, noms de types et statuts restent en anglais.
+
+# ADR-0017 : Timeline utilise un fan-out hybride push/pull
+
+- **Statut :** Accepted
+- **Date :** 2026-06-26
+- **Contexte(s) affecté(s) :** timeline ; amont post, social-graph, profile
+- **Décideurs :** arnaudmaillet (architecture)
+
+## Contexte et problème
+
+La génération de fil a deux modes d'échec classiques. **Fan-out à l'écriture** (matérialiser chaque
+post dans le fil de chaque follower) explose pour les auteurs à fort nombre de followers — un post de
+célébrité écrit des millions de lignes. **Fan-out à la lecture** (tirer les posts de chaque followee
+au moment de la lecture) explose pour les utilisateurs qui suivent beaucoup de comptes. Aucun extrême
+ne scale à la fois pour les distributions d'auteurs et de lecteurs.
+
+## Décision
+
+`timeline` est un **read-model de fil SoReference** utilisant un **fan-out hybride push/pull** : les
+auteurs tier-normal sont **poussés** (matérialisés dans les ZSETs de fil des followers à
+`post.published`) ; les auteurs haut-tier sont **tirés** au moment de la lecture, et les deux sont
+**fusionnés via un Lua `ZREVRANGEBYSCORE`**, paginés par `FeedCursor`. La frontière push/pull est
+pilotée par `AuthorTier` (consommé depuis `profile`). L'ensemble des followers est lu depuis
+`social-graph` via gRPC ; le fil est fail-open et reconstructible.
+
+## Conséquences
+
+- **Positives :** borne à la fois l'amplification d'écriture (pas de fan-out célébrité à des millions
+  de lignes) et l'amplification de lecture (pas de pull de milliers de followees) ; l'ordonnancement
+  est une seule fusion Lua.
+- **Négatives / compromis accepté :** complexité de la fusion au moment de la lecture ; la justesse
+  dépend du signal de tier d'auteur ; la performance du fan-out est une dette de réglage suivie.
+- **Clôt :** les problèmes d'amplification d'écriture célébrité et d'amplification de lecture
+  follower-lourd.
+
+## Alternatives rejetées
+
+| Option | Pourquoi rejetée |
+|---|---|
+| Pur fan-out à l'écriture | Les posts de célébrité écrivent des millions de lignes de fil |
+| Pur fan-out à la lecture | Les utilisateurs suivant beaucoup de comptes paient un coût de lecture énorme |
+| Seuil statique sans signal de tier | Mal-classe les auteurs ; nécessite l'entrée de tier `profile` |

--- a/docs/adr/README.fr.md
+++ b/docs/adr/README.fr.md
@@ -1,0 +1,67 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: 02a92d9fc6c9c98d7f3a504b6631dc51d1fccccc3cabdc657fa9f3706caad3b8
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les identifiants d'ADR, noms de fichiers, statuts et noms
+> de contextes restent en anglais.
+
+# Architecture Decision Records (ADR)
+
+> Un **ADR** capture une décision architecturale, les forces qui la sous-tendent et les alternatives
+> rejetées — le *pourquoi* que le code et les diagrammes ne peuvent exprimer et qui, sinon, s'évapore
+> dans les fils Slack et la mémoire tribale.
+
+## Conventions
+
+- **Format :** MADR allégé — voir [`0000-template.md`](./0000-template.md).
+- **Nommage :** `00NN-<kebab-title>.md`, numéro paddé à 4 chiffres, monotone croissant.
+- **Immuabilité :** un ADR Accepté n'est jamais édité pour changer sa décision. Pour l'inverser,
+  ajouter un **nouvel** ADR qui le remplace et basculer l'ancien en `Superseded by ADR-00MM`. La
+  piste préservée des décisions remplacées est l'objectif même.
+- **Liaison :** chaque ADR est référencé depuis le `DOMAIN.md §9` du service affecté (et, pour les
+  décisions inter-contexte, depuis `docs/domain/CONTEXT_MAP.md`). Ne jamais intégrer la justification
+  en ligne dans ces docs — relier l'ADR pour que le *pourquoi* vive en un seul endroit.
+
+## Cycle de vie du statut
+
+```
+Proposed --> Accepted --> Superseded by ADR-00MM
+                      \--> Deprecated
+```
+
+## Index
+
+| ADR | Titre | Statut | Contexte(s) |
+|---|---|---|---|
+| [0000](./0000-template.md) | _Template (pas une décision)_ | — | — |
+| [0001](./0001-audit-is-a-separate-evidence-plane.md) | Audit est un plan de preuve infalsifiable séparé, pas un agrégateur de logs | Accepté | audit |
+| [0002](./0002-moderation-decision-enforcement-sor-with-fail-closed-screen.md) | Moderation est le SoR décision/enforcement avec une porte Screen étroite fail-closed | Accepté | moderation |
+| [0003](./0003-realtime-is-a-fail-open-system-of-connection.md) | Realtime est un System-of-Connection fail-open, jamais un record store | Accepté | realtime |
+| [0004](./0004-account-is-the-single-identity-sor.md) | Account est le SoR d'identité unique et possède une voie d'événements sortante | Accepté | account |
+| [0005](./0005-auth-federated-idp-with-platform-edge-tokens.md) | Auth fédère un IdP et émet des edge tokens ES256 plateforme avec révocation par génération | Accepté | auth |
+| [0006](./0006-chat-shadowing-pattern-member-vs-audience-plane.md) | Chat utilise le Shadowing Pattern — plans de visibilité Membre vs Audience séparés | Accepté | chat |
+| [0007](./0007-comment-flat-thread-two-table-tombstone-purge.md) | Comment utilise un fil plat nil-UUID, Scylla deux tables, suppression tombstone-vs-purge | Accepté | comment |
+| [0008](./0008-counter-magnitudes-are-a-reconcilable-soref.md) | Counter est un SoReference réconciliable pour les magnitudes, distinct de l'état d'arête | Accepté | counter |
+| [0009](./0009-engagement-redis-primary-lua-atomic-with-kafka-write-behind.md) | Engagement est Redis-primary (Lua-atomique) avec durabilité Kafka write-behind | Accepté | engagement |
+| [0010](./0010-geo-discovery-h3-grid-dual-layer-redis-topk.md) | Geo-discovery est un read-model spatial H3 grid_disk + Redis Top-K double-couche | Accepté | geo-discovery |
+| [0011](./0011-media-byte-free-control-plane.md) | Media est un plan de contrôle sans-octets (livraison fail-open / Screen CSAM fail-closed) | Accepté | media |
+| [0012](./0012-notification-write-collapse-fanout-claim-gated-counter.md) | Notification utilise un fan-out write-collapse + un compteur de non-lus claim-gated | Accepté | notification |
+| [0013](./0013-post-two-table-scylla-with-published-language.md) | Post utilise un layout Scylla deux tables et est la source de fan-out en langage publié | Accepté | post |
+| [0014](./0014-profile-public-persona-with-dual-axis-visibility.md) | Profile est le persona public au-dessus du SoR account avec visibilité bi-axiale | Accepté | profile |
+| [0015](./0015-search-opensearch-single-store-external-versioning.md) | Search est un read-model OpenSearch avec versioning externe et lecture fail-open | Accepté | search |
+| [0016](./0016-social-graph-four-table-scylla-logged-batch.md) | Social-graph utilise un schéma Scylla 4 tables avec double-écritures logged-batch atomiques | Accepté | social-graph |
+| [0017](./0017-timeline-hybrid-push-pull-fanout.md) | Timeline utilise un fan-out hybride push/pull | Accepté | timeline |
+
+<!-- Ajouter une ligne par ADR au fur et à mesure. -->
+
+## Backlog
+
+Chaque service a désormais un ADR de keystone (0001–0017). Les prochains candidats sont les **choix
+verrouillés plus fins** qui les sous-tendent, à consigner comme leurs propres ADR lors de leur
+prochaine révision — ex. le mécanisme crypto-shred RtbF d'audit, son split dual-lane
+fail-open/fail-closed, et le schéma d'immuabilité hash-chain + WORM + témoin externe ; la rotation de
+session par `Generation` d'auth ; le flux producteur de tier d'auteur profile/social-graph.


### PR DESCRIPTION
Third and final phased PR adding French mirrors. Adds **`docs/adr/*.fr.md` for the index, the template, and all 17 keystone ADRs**.

## What

- `README.fr.md` + `0000-template.fr.md` + `0001-…` through `0017-….fr.md` (19 files).
- Each with provenance frontmatter (stamped via `i18n-drift.sh`) + the standard banner.
- **DNT honored:** ADR ids, error/type/topic names, and status keywords (`Accepted`/`Proposed`/`Superseded`) stay verbatim English; rationale prose, consequences, and rejected-alternatives cells are translated.

## Completes the French-mirror rollout

| PR | Scope | |
|---|---|---|
| #497 | gate generalization + 4 `docs/domain/*.fr.md` | ✅ merged |
| #498 | 17 `DOMAIN.fr.md` | ✅ merged |
| **this** | 19 `docs/adr/*.fr.md` | — |

## Verification

- `tools/i18n/i18n-drift.sh check` → **75/75 OK** (35 README + 4 docs/domain + 17 DOMAIN + 19 ADR).
- Every functional doc + ADR now has a hash-bound French mirror; CI gate covers them all.

## Remaining (separate)

- Wire `i18n-drift.sh check` as a CI step if not already enforced.
- Generate `EVENT_CATALOG.md` from the topology guard; regenerate a corrected C4 from `CONTEXT_MAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)