### PR TITLE
ci(i18n): enforce drift gate on all docs, not just READMEs

### DIFF
--- a/.github/workflows/i18n-drift.yml
+++ b/.github/workflows/i18n-drift.yml
@@ -1,22 +1,22 @@
 name: i18n-drift
 
-# Guards documentation translations against silent drift: if a canonical README.md changes
-# but its sibling translation (README.<lang>.md) still records the old source hash, the build
-# fails — forcing "retranslate and re-stamp, or mark status: stale".
-# See docs/i18n/TRANSLATION.md.
+# Guards documentation translations against silent drift: if a canonical doc (<name>.md —
+# README.md, DOMAIN.md, CONTEXT_MAP.md, an ADR, …) changes but its sibling translation
+# (<name>.<lang>.md) still records the old source hash, the build fails — forcing
+# "retranslate and re-stamp, or mark status: stale".
+# The gate (tools/i18n/i18n-drift.sh) scans every <name>.<lang>.md repo-wide, so the triggers
+# below cover any markdown change, not just READMEs. See docs/i18n/TRANSLATION.md.
 
 on:
   pull_request:
     paths:
-      - '**/README.md'
-      - '**/README.*.md'
+      - '**/*.md'
       - 'tools/i18n/**'
       - '.github/workflows/i18n-drift.yml'
   push:
     branches: [main, develop]
     paths:
-      - '**/README.md'
-      - '**/README.*.md'
+      - '**/*.md'
       - 'tools/i18n/**'
 
 jobs:


### PR DESCRIPTION
## Why

The `i18n-drift` workflow already runs the gate, but its `paths` filter only triggered on `**/README.md` / `**/README.*.md`. After #497–#499 the gate covers **any** `<name>.<lang>.md` (`DOMAIN.fr.md`, `CONTEXT_MAP.fr.md`, `docs/adr/*.fr.md`, …) — so a `DOMAIN.md` edit without re-stamping its mirror would **slip past CI** even though `i18n-drift.sh check` would catch it locally.

## What

Broaden the `pull_request` and `push` path filters to **`**/*.md`** (plus `tools/i18n/**` and the workflow file), matching the now-generic gate. The check command is unchanged — it already scans the whole repo; this only fixes *when* the job runs. Header comment updated to describe the general behavior.

## Verification

- `tools/i18n/i18n-drift.sh check` → PASS (75/75) locally.
- This PR touches the workflow file, so the `i18n-drift` check runs on it — see the PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)