### PR TITLE
docs(architecture): regenerate corrected C4 from CONTEXT_MAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ The platform's documentation is layered by concern, each layer derived from the 
   (AWS EKS, VPC, managed services; diagram generated from `aws_production.py`).
 - **How to build & run each service:** the per-crate `README.md`, following
   [`docs/templates/SERVICE_README.template.md`](docs/templates/SERVICE_README.template.md).
+- **System architecture (C4 Model):** [`docs/architecture/`](docs/architecture/README.md) —
+  a Structurizr workspace **regenerated from** `docs/domain/CONTEXT_MAP.md` as a derived artifact.
 
-> [!WARNING]
-> The previous **C4 Model / Structurizr** diagrams described a pre-fleet design that diverged
-> from the system that exists today. They have been **quarantined** under
-> [`docs/_legacy/`](docs/_legacy/README.md) and must not be trusted. A corrected C4 model will be
-> regenerated from the functional documentation (`docs/domain/`) as a derived artifact.
+> [!NOTE]
+> The C4 model in [`docs/architecture/`](docs/architecture/README.md) is regenerated from the
+> functional documentation. The previous, pre-fleet Structurizr diagrams have been **quarantined**
+> under [`docs/_legacy/`](docs/_legacy/README.md) and must not be trusted.
 
 ## Development & Build
 

--- a/docs/_legacy/README.md
+++ b/docs/_legacy/README.md
@@ -34,7 +34,7 @@ before the current fleet, and never updated since.
 
 ## Disposition
 
-This C4 model will be **regenerated from the new functional documentation** (the per-service
-Domain Cards in `crates/services/<svc>/docs/DOMAIN.md` plus `docs/domain/CONTEXT_MAP.md`) as a
-*derived* artifact, so the diagram can no longer drift without the doc — and its CI gate —
-catching it. Once that regenerated model exists, this directory may be deleted outright.
+This C4 model has been **superseded by a corrected model regenerated from the functional
+documentation** (the per-service Domain Cards plus `docs/domain/CONTEXT_MAP.md`), now living at
+[`docs/architecture/`](../architecture/README.md). This `_legacy/` directory is retained only for
+historical reference and **may be deleted outright** — nothing current references it.

--- a/docs/architecture/README.fr.md
+++ b/docs/architecture/README.fr.md
@@ -1,0 +1,56 @@
+---
+i18n:
+  source: ./README.md
+  source_sha256: bfa91e2dc29ecf642d1f875b9c213b379fdfd1f9490032520963058bdedfce42
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
+> En cas de divergence, l'anglais prime. Les noms de fichiers, identifiants, topics et noms de types
+> restent en anglais.
+
+# Architecture (C4) — régénérée
+
+Ce répertoire contient le **modèle C4 corrigé**, exprimé comme un workspace Structurizr
+([`workspace.dsl`](./workspace.dsl)).
+
+> **Artefact dérivé.** Ce modèle est *généré depuis* la documentation domaine — ce n'est pas une
+> source de vérité. La vérité est le code plus [`docs/domain/CONTEXT_MAP.md`](../domain/CONTEXT_MAP.md)
+> et les Domain Cards par service (`crates/services/<svc>/docs/DOMAIN.md`). Si le diagramme
+> diverge de ceux-ci, le diagramme est périmé — le régénérer, ne pas s'y fier.
+
+Il **supersède** le modèle pré-flotte mis en quarantaine dans [`docs/_legacy/`](../_legacy/README.md),
+qui décrivait une architecture jamais livrée (services fantômes, mauvaise stack, 7 services manquants).
+Ne pas référencer le modèle hérité.
+
+## Ce qui est modélisé
+
+- **System Context** — la plateforme et ses dépendances externes (Keycloak, S3/MinIO, CloudFront, APNs/FCM, KMS/témoin).
+- **Containers** — les 17 services (realtime scindé en gateway + dispatcher), les technologies de datastore partagées (ScyllaDB / PostgreSQL / Redis / OpenSearch) et le backbone d'événements Kafka.
+- **Dynamic** — le flux « post publié → fan-out » comme exemple travaillé.
+- La forme du service encode le rôle (service / worker / edge) ; la couleur encode la classe de sous-domaine (**Core** rouge, **Supporting** bleu), les deux tirés de `CONTEXT_MAP.md`. Les arêtes async (via Kafka) sont en pointillés ; les arêtes gRPC sync sont pleines.
+
+## Choix de modélisation
+
+- **Un container par service.** Les services à deux binaires (audit, counter, search, notification) sont notés dans leur description ; `realtime` est scindé en `realtime-gateway` et `realtime-dispatcher` car l'edge WebSocket public est architecturalement distinct.
+- **Les datastores sont un container par technologie.** L'isolation par-service (keyspace / base / namespace) vit dans chaque Domain Card, pas ici.
+- **L'async route via Kafka.** Les arêtes producteur→Kafka et Kafka→consommateur portent les noms de topics ; la *sémantique* producteur→consommateur vit dans [`EVENT_CATALOG.md`](../domain/EVENT_CATALOG.md).
+- Le trafic API client synchrone (lecture/écriture) entre via l'ingress de la plateforme (voir [`docs/infrastructure`](../infrastructure/README.md)) et n'est pas énuméré, pour garder la vue container lisible.
+
+## Rendu
+
+Rendre avec le [Structurizr CLI](https://structurizr.com/help/cli) ou en important `workspace.dsl`
+dans [Structurizr Lite](https://structurizr.com/lite) :
+
+```bash
+docker run -it --rm -p 8080:8080 -v "$PWD/docs/architecture:/usr/local/structurizr" structurizr/lite
+```
+
+## Le garder vrai
+
+Quand `CONTEXT_MAP.md` ou une Domain Card change une relation, un store ou une classe de
+sous-domaine, mettre à jour `workspace.dsl` dans le même changement. Le modèle est petit et
+maintenu à la main à dessein ; un futur générateur pourrait l'émettre depuis les Domain Cards + la
+garde de registre de topologie d'événements.
+
+> 🇬🇧 Source anglaise : [`README.md`](./README.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,44 @@
+# Architecture (C4) — regenerated
+
+This directory holds the **corrected C4 model**, expressed as a Structurizr workspace
+([`workspace.dsl`](./workspace.dsl)).
+
+> **Derived artifact.** This model is *generated from* the domain documentation — it is not a source
+> of truth. The truth is the code plus [`docs/domain/CONTEXT_MAP.md`](../domain/CONTEXT_MAP.md) and
+> the per-service Domain Cards (`crates/services/<svc>/docs/DOMAIN.md`). If the diagram disagrees
+> with those, the diagram is stale — regenerate it, don't trust it.
+
+It **supersedes** the pre-fleet model quarantined in [`docs/_legacy/`](../_legacy/README.md), which
+described an architecture that never shipped (phantom services, wrong stack, 7 missing services).
+Do not reference the legacy model.
+
+## What's modelled
+
+- **System Context** — the platform and its external dependencies (Keycloak, S3/MinIO, CloudFront, APNs/FCM, KMS/witness).
+- **Containers** — the 17 services (realtime split into its gateway + dispatcher), the shared datastore technologies (ScyllaDB / PostgreSQL / Redis / OpenSearch), and the Kafka event backbone.
+- **Dynamic** — the "post published → fan-out" flow as a worked example.
+- Service shape encodes role (service / worker / edge); colour encodes subdomain class (**Core** red, **Supporting** blue), both taken from `CONTEXT_MAP.md`. Async edges (through Kafka) are dashed; sync gRPC edges are solid.
+
+## Modelling choices
+
+- **One container per service.** Dual-binary services (audit, counter, search, notification) are noted in their description; `realtime` is split into `realtime-gateway` and `realtime-dispatcher` because the public WebSocket edge is architecturally distinct.
+- **Datastores are one container per technology.** Per-service isolation (keyspace / database / namespace) lives in each Domain Card, not here.
+- **Async routes through Kafka.** Producer→Kafka and Kafka→consumer edges carry the topic names; the producer→consumer *semantics* live in [`EVENT_CATALOG.md`](../domain/EVENT_CATALOG.md).
+- Synchronous client read/write API traffic enters via the platform ingress (see [`docs/infrastructure`](../infrastructure/README.md)) and is not enumerated, to keep the container view readable.
+
+## Rendering
+
+Render with the [Structurizr CLI](https://structurizr.com/help/cli) or by importing `workspace.dsl`
+into [Structurizr Lite](https://structurizr.com/lite):
+
+```bash
+docker run -it --rm -p 8080:8080 -v "$PWD/docs/architecture:/usr/local/structurizr" structurizr/lite
+```
+
+## Keeping it true
+
+When `CONTEXT_MAP.md` or a Domain Card changes a relationship, store, or subdomain class, update
+`workspace.dsl` in the same change. The model is small and hand-maintained on purpose; a future
+generator could emit it from the Domain Cards + the event-topology registry guard.
+
+> 🇫🇷 Miroir français : [`README.fr.md`](./README.fr.md).

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -1,0 +1,196 @@
+# docs/architecture/workspace.dsl
+#
+# Corrected C4 model — REGENERATED from docs/domain/CONTEXT_MAP.md + the per-service Domain Cards
+# (crates/services/<svc>/docs/DOMAIN.md). This is a DERIVED artifact: the source of truth is the
+# code and CONTEXT_MAP.md. If they disagree, the docs are right and this file is stale — regenerate.
+#
+# Supersedes the pre-fleet model quarantined in docs/_legacy/ (do NOT reference that one).
+#
+# Conventions:
+#   - One container per service (dual-binary services noted in the description; realtime's gateway
+#     and dispatcher are modelled separately because the public WS edge is architecturally distinct).
+#   - Datastores are modelled as one container per technology; per-service isolation (keyspace / db /
+#     namespace) is documented in each Domain Card, not duplicated here.
+#   - Async edges route through Kafka (publishes / consumes); sync edges are direct gRPC.
+#   - Subdomain class (Core / Supporting) and tier come from CONTEXT_MAP.md.
+
+workspace "Core Platform" "Social platform backend — corrected C4, derived from the domain documentation." {
+
+    model {
+        user = person "Client Apps" "End users on mobile / web." "User"
+
+        # --- External systems -------------------------------------------------------------------
+        keycloak     = softwareSystem "Keycloak (IdP)" "Federated identity provider for credentials." "External"
+        objectStore  = softwareSystem "Object Store (S3 / MinIO)" "Media bytes + audit WORM archive (Object Lock)." "External"
+        cdn          = softwareSystem "CDN (CloudFront)" "Media delivery edge." "External"
+        push         = softwareSystem "Push (APNs / FCM)" "Offline device push." "External"
+        kms          = softwareSystem "KMS / HSM + Witness" "Key custody + external checkpoint witness (RFC3161 / cross-account WORM)." "External"
+
+        backend = softwareSystem "Core Platform" "Rust/tonic microservice fleet (hexagonal; CQRS; Kafka event backbone)." {
+
+            # --- Shared backbone ---------------------------------------------------------------
+            kafka     = container "Kafka" "Event backbone — every async edge (Published Language topics) flows through here." "Apache Kafka" "MessageBroker"
+            scylla    = container "ScyllaDB" "High-write column store (per-service keyspaces)." "ScyllaDB" "Datastore"
+            postgres  = container "PostgreSQL" "Relational store (per-service databases)." "PostgreSQL" "Datastore"
+            redis     = container "Redis" "Caches, hot indexes, routing/presence, Lua-atomic counters." "Redis" "Datastore"
+            opensearch = container "OpenSearch" "Inverted index (search read-model, single canonical store)." "OpenSearch" "Datastore"
+
+            # --- Identity & Access (Supporting / TIER-0) ---------------------------------------
+            group "Identity & Access" {
+                account = container "account" "Identity SoR — accounts, credentials metadata, KYC, roles, GDPR state." "Rust/tonic" "Service,Supporting"
+                auth    = container "auth" "Authentication — sessions, refresh, federated IdP broker, ES256 edge tokens." "Rust/tonic" "Service,Supporting"
+                profile = container "profile" "Public persona over the account SoR — handle, bio, tier, dual-axis visibility." "Rust/tonic" "Service,Supporting"
+            }
+
+            # --- Content & Social (Core) -------------------------------------------------------
+            group "Content & Social" {
+                post        = container "post" "Content SoR — two-table Scylla; post.v1.events is the read-side fan-out source." "Rust/tonic" "Service,Core"
+                comment     = container "comment" "Comment threads — flat tree, tombstone/purge." "Rust/tonic" "Service,Core"
+                chat        = container "chat" "Conversations & messaging — Shadowing Pattern; runs its own live plane." "Rust/tonic" "Service,Core"
+                engagement  = container "engagement" "Reaction edges — Redis-primary Lua-atomic, Kafka write-behind." "Rust/tonic" "Service,Core"
+                socialGraph = container "social-graph" "Follower/following + block relations; computes author tier." "Rust/tonic" "Service,Core"
+            }
+
+            # --- Discovery & Delivery (Supporting) --------------------------------------------
+            group "Discovery & Delivery" {
+                timeline = container "timeline" "Home-feed read-model — hybrid push/pull fan-out." "Rust/tonic" "Service,Supporting"
+                search   = container "search" "Discovery read-model over OpenSearch (+ async indexer worker)." "Rust/tonic" "Service,Supporting"
+                geo      = container "geo-discovery" "Spatial discovery — H3 grid + dual-layer Redis Top-K." "Rust/tonic" "Service,Supporting"
+                counter  = container "counter" "Magnitudes SoReference — read server + stream worker; publishes counter.v1.popularity." "Rust/tonic" "Service,Supporting"
+                realtimeGateway    = container "realtime-gateway" "Stateful WSS edge — millions of multiplexed client connections." "Rust/tonic + axum" "Edge,Supporting"
+                realtimeDispatcher = container "realtime-dispatcher" "Stateless fan-out worker — resolves recipients, node-hop delivery." "Rust/Tokio" "Worker,Supporting"
+                notification = container "notification" "Activity-feed read-model + push fan-out (write-collapse)." "Rust/tonic" "Service,Supporting"
+            }
+
+            # --- Trust, Safety & Compliance (TIER-0) ------------------------------------------
+            group "Trust, Safety & Compliance" {
+                moderation = container "moderation" "Integrity decision/enforcement SoR — three-plane; fail-closed Screen gate." "Rust/tonic" "Service,Core"
+                media      = container "media" "Media control plane — pre-signed uploads; transform; delivery brokerage." "Rust/tonic" "Service,Supporting"
+                audit      = container "audit" "Tamper-evident compliance evidence — hash-chained ledger (server + worker)." "Rust/tonic" "Service,Supporting"
+            }
+
+            # === Service ↔ datastore =============================================================
+            account -> postgres "reads/writes"
+            auth -> postgres "reads/writes" ; auth -> redis "session/revocation cache"
+            profile -> scylla "reads/writes" ; profile -> redis "L1 entity cache"
+            post -> scylla "reads/writes (by id + by author)"
+            comment -> scylla "reads/writes (LCS + TWCS)"
+            chat -> scylla "message log (bucketed)" ; chat -> redis "sharded pub/sub"
+            engagement -> redis "Lua-atomic edges" ; engagement -> scylla "durable write-behind"
+            socialGraph -> scylla "4-table relations" ; socialGraph -> redis "hot relation Sets"
+            timeline -> redis "feed ZSETs" ; timeline -> scylla "materialized feeds"
+            search -> opensearch "index + query"
+            geo -> redis "H3 ZSET + cardinality" ; geo -> scylla "map_post_cards"
+            counter -> redis "hot counters" ; counter -> postgres "warm SoRef + ledger" ; counter -> scylla "cold TWCS"
+            notification -> scylla "TWCS activity feed" ; notification -> redis "write-collapse counters"
+            moderation -> postgres "decision/case SoR" ; moderation -> scylla "signal history" ; moderation -> redis "enforcement projection + Screen corpus"
+            media -> postgres "asset SoR" ; media -> redis "cache"
+            audit -> postgres "append-only ledger"
+            realtimeGateway -> redis "connection/presence registry + node-hop pub/sub"
+            realtimeDispatcher -> redis "resolve + publish (node-hop)"
+
+            # === Async (Published Language via Kafka) ===========================================
+            # producers
+            account -> kafka "publishes account.v1.events" "" "Async"
+            auth -> kafka "publishes auth.v1.events" "" "Async"
+            profile -> kafka "publishes profile.v1.events" "" "Async"
+            post -> kafka "publishes post.v1.events" "" "Async"
+            comment -> kafka "publishes comment.created/deleted" "" "Async"
+            engagement -> kafka "publishes engagement.reactions/score_updated" "" "Async"
+            counter -> kafka "publishes counter.v1.popularity" "" "Async"
+            moderation -> kafka "publishes moderation.v1.events" "" "Async"
+            media -> kafka "publishes media.v1.events" "" "Async"
+            chat -> kafka "publishes chat.* (own live plane)" "" "Async"
+            notification -> kafka "publishes notification.v1.events" "" "Async"
+            socialGraph -> kafka "publishes relation events (follows stream deferred)" "" "Async"
+            # consumers
+            kafka -> audit "account/auth/moderation .v1.events" "" "Async"
+            kafka -> profile "account.v1.events" "" "Async"
+            kafka -> post "profile.v1.events, moderation.v1.events" "" "Async"
+            kafka -> search "post/profile/moderation .v1.events, counter.v1.popularity" "" "Async"
+            kafka -> timeline "post.v1.events" "" "Async"
+            kafka -> geo "post.published, engagement.score_updated, profile.tier_changed" "" "Async"
+            kafka -> counter "post.v1.events, engagement.*, view/impression/click" "" "Async"
+            kafka -> notification "comment.created, engagement.reactions, post.published" "" "Async"
+            kafka -> engagement "comment.created/deleted" "" "Async"
+            kafka -> realtimeDispatcher "notification.v1.events, counter.v1.popularity, post.v1.events" "" "Async"
+            kafka -> media "moderation.v1.events (takedown), media.v1.events (transform)" "" "Async"
+            kafka -> moderation "post/comment/chat content, moderation.reports/signals" "" "Async"
+
+            # === Sync (gRPC) =====================================================================
+            media -> moderation "Screen (sync, fail-closed)" "gRPC" "Sync"
+            moderation -> account "suspension/ban execution" "gRPC" "Sync"
+            timeline -> socialGraph "follower-set reads (fan-out)" "gRPC" "Sync"
+            counter -> socialGraph "follower-count reconciliation" "gRPC" "Sync"
+            post -> media "MediaAttachment references" "gRPC" "Sync"
+            comment -> post "PostId references" "gRPC" "Sync"
+            auth -> account "SubjectLink ↔ AccountId" "gRPC" "Sync"
+            realtimeGateway -> auth "edge-token verify at handshake (auth-context)" "in-process verify" "Sync"
+            realtimeGateway -> realtimeDispatcher "node-hop delivery (via Redis pub/sub)" "Redis" "Async"
+
+            # === External =======================================================================
+            auth -> keycloak "federates credentials (OIDC)"
+            media -> objectStore "asset bytes (control plane)"
+            media -> cdn "delivery resolution"
+            audit -> objectStore "WORM archive (Object Lock)"
+            audit -> kms "sign checkpoints + per-subject DEK custody"
+            notification -> push "offline device push"
+            realtimeDispatcher -> push "delegate offline delivery"
+
+            # === User edges =====================================================================
+            user -> realtimeGateway "live updates (WSS :443)"
+            user -> auth "login / token refresh"
+            user -> objectStore "direct upload (pre-signed URL)"
+            user -> cdn "media delivery"
+            # Synchronous client read/write API traffic enters the mesh via the platform ingress
+            # (see docs/infrastructure) to the relevant service; not enumerated here to keep the
+            # container view readable.
+        }
+
+        # --- Subdomain note (from CONTEXT_MAP.md) -------------------------------------------------
+        # Core = post, comment, chat, social-graph, engagement, moderation.
+        # Supporting = account, auth, profile, audit, media, notification, realtime, search,
+        #              geo-discovery, counter, timeline.
+    }
+
+    views {
+        systemContext backend "SystemContext" "The platform and the external systems it depends on." {
+            include *
+            autolayout lr
+        }
+
+        container backend "Containers" "Services, datastores, and the Kafka backbone." {
+            include *
+            autolayout lr
+        }
+
+        dynamic backend "PostPublishFanOut" "What happens when a post is published." {
+            post -> kafka "publishes post.v1.events"
+            kafka -> timeline "consumes → fan-out to follower feeds"
+            kafka -> search "consumes → index the post"
+            kafka -> geo "consumes → add map card"
+            kafka -> counter "consumes → count"
+            kafka -> realtimeDispatcher "consumes → broadcast to live viewers"
+            autolayout lr
+        }
+
+        styles {
+            element "User" { shape Person background #2c3e50 color #ffffff }
+            element "External" { background #95a5a6 color #ffffff }
+            # shape from role, colour from subdomain class (Core vs Supporting)
+            element "Service" { shape RoundedBox color #ffffff }
+            element "Worker" { shape Hexagon color #ffffff }
+            element "Edge" { shape RoundedBox color #ffffff }
+            element "Supporting" { background #1168bd color #ffffff }
+            element "Core" { background #b8341b color #ffffff }
+            element "Datastore" { shape Cylinder background #6b4f9e color #ffffff }
+            element "MessageBroker" { shape Pipe background #d98c00 color #ffffff }
+            relationship "Async" { dashed true color #d98c00 }
+            relationship "Sync" { dashed false color #2c3e50 }
+        }
+    }
+
+    configuration {
+        scope softwareSystem
+    }
+}

--- a/docs/domain/CONTEXT_MAP.fr.md
+++ b/docs/domain/CONTEXT_MAP.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./CONTEXT_MAP.md
-  source_sha256: 78fa1c52c786aafc0762034fcf7a106e368e71555bbeaf6d4d9f9f9d9e1a8f08
+  source_sha256: 6281e15dbbca5e65c857a66f57a36f91cb005b895ffc291fbfce9a73408012ec
   translated_at: 2026-06-28
   status: complete
 ---
@@ -110,6 +110,7 @@ sont des read-models ou des puits de preuve. Voir le §8 de chaque Domain Card.
 
 ## Diagramme
 
-> Une vue C4 Container/Component sera **régénérée à partir de cette carte** (et des Domain Cards) en
-> tant qu'artefact dérivé. D'ici là, ce document fait autorité. Ne **pas** lier le C4 hérité dans
-> [`docs/_legacy/`](../_legacy/README.md).
+> Le modèle C4 a été **régénéré à partir de cette carte** (et des Domain Cards) en tant qu'artefact
+> dérivé : [`docs/architecture/workspace.dsl`](../architecture/workspace.dsl). Ce document reste la
+> source faisant autorité pour les relations ; le diagramme est généré pour y correspondre. Ne **pas**
+> lier le C4 hérité dans [`docs/_legacy/`](../_legacy/README.md).

--- a/docs/domain/CONTEXT_MAP.md
+++ b/docs/domain/CONTEXT_MAP.md
@@ -98,6 +98,7 @@ read-models or evidence sinks. See each Domain Card §8.
 
 ## Diagram
 
-> A C4 Container/Component view will be **regenerated from this map** (and the per-service Domain
-> Cards) as a derived artifact. Until then, this document is authoritative. Do **not** link the
-> legacy C4 in [`docs/_legacy/`](../_legacy/README.md).
+> The C4 model has been **regenerated from this map** (and the per-service Domain Cards) as a derived
+> artifact: [`docs/architecture/workspace.dsl`](../architecture/workspace.dsl). This document remains
+> the authoritative source for the relationships; the diagram is generated to match it. Do **not**
+> link the legacy C4 in [`docs/_legacy/`](../_legacy/README.md).

--- a/docs/domain/README.fr.md
+++ b/docs/domain/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 1e51acfcac71c9d01929176c1891ba9cc2a8bd67dfd8adc8e940ed89501671e0
+  source_sha256: a536df526782b80e4d5be226e8b9e41b6bccb94237a3d54d09a2306356c9f759
   translated_at: 2026-06-28
   status: complete
 ---
@@ -37,8 +37,9 @@ La source de vérité sur *ce qui existe* est **le code**, jamais un diagramme :
 - la **garde de registre de topologie d'événements** (vérifiée par machine, donc fiable).
 
 Toute la documentation ici en *dérive*. Le modèle C4 hérité a été mis en quarantaine dans
-[`docs/_legacy/`](../_legacy/README.md) et **ne doit pas être référencé** ; un modèle C4 corrigé
-sera *régénéré à partir* des Domain Cards + `CONTEXT_MAP.md`.
+[`docs/_legacy/`](../_legacy/README.md) et **ne doit pas être référencé** ; un modèle C4 corrigé a été
+*régénéré à partir* des Domain Cards + `CONTEXT_MAP.md` dans
+[`docs/architecture/`](../architecture/README.md).
 
 ## Contenu
 

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -26,8 +26,9 @@ The source of truth for *what exists* is **the code**, never a diagram:
 - the **event-topology registry guard** (machine-checked, therefore trustworthy).
 
 All documentation here is *derived from* those. The legacy C4 model has been quarantined to
-[`docs/_legacy/`](../_legacy/README.md) and **must not be referenced**; a corrected C4 model
-will be *regenerated from* the Domain Cards + `CONTEXT_MAP.md`.
+[`docs/_legacy/`](../_legacy/README.md) and **must not be referenced**; a corrected C4 model has been
+*regenerated from* the Domain Cards + `CONTEXT_MAP.md` at
+[`docs/architecture/`](../architecture/README.md).
 
 ## Contents
 


### PR DESCRIPTION
## Why

The legacy C4 was quarantined back in #490 as pre-fleet fiction. This closes that loop: a **corrected C4 model, regenerated from `docs/domain/CONTEXT_MAP.md`** + the per-service Domain Cards, living in the now-vacated `docs/architecture/`.

## What

**`docs/architecture/workspace.dsl`** — a Structurizr workspace:
- 17 services (realtime split into `realtime-gateway` + `realtime-dispatcher`, since the public WS edge is distinct), shared datastore-technology containers (ScyllaDB / PostgreSQL / Redis / OpenSearch), and the Kafka backbone.
- Async edges routed through Kafka with topic labels; sync gRPC edges direct; external systems (Keycloak, S3/MinIO, CloudFront, APNs/FCM, KMS/witness).
- **Shape = role** (service / worker / edge), **colour = subdomain class** (Core red / Supporting blue) — both pulled straight from `CONTEXT_MAP.md`.
- Views: System Context, Container, a "post published → fan-out" dynamic view, and styles.

**`docs/architecture/README.md`** (+ FR mirror) — what's modelled, the modelling choices (why datastores are per-technology, why async routes through Kafka), how to render via Structurizr Lite, and the "this is a derived artifact — keep it in sync or regenerate" rule.

**Re-pointed references:**
- `docs/domain/README.md` + `CONTEXT_MAP.md` (Diagram section): C4 is now regenerated (was "will be").
- Root `README.md`: `[!WARNING]` → `[!NOTE]`, pointing at the live C4.
- `docs/_legacy/` tombstone: disposition updated to "superseded, may be deleted".
- All affected FR mirrors re-translated + re-stamped.

## Notes & caveats

- **Not rendered locally** (no Structurizr in this env): braces balanced, 23 containers, 68 relationships, dynamic view references only existing edges. Render with `docker run ... structurizr/lite` (command in the README) to eyeball layout.
- **Datastores modelled per-technology**, not per-service, for container-diagram readability; per-service keyspace/db isolation lives in the Domain Cards.
- Synchronous client API ingress is intentionally not enumerated (no BFF exists in the fleet); only the known client edges (WSS, login, pre-signed upload, CDN) are drawn.

## Verification

- i18n drift gate: **PASS (76 translations)**; all new-doc links resolve.
- Legacy C4 remains quarantined and unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)