### PR TITLE
docs(event-catalog): generate the topic-wiring block from the topology registry

### DIFF
--- a/.github/workflows/event-catalog.yml
+++ b/.github/workflows/event-catalog.yml
@@ -1,0 +1,34 @@
+name: event-catalog
+
+# Guards the Kafka topic topology and the generated catalog:
+#   - the phantom-edge contract tests (a consumer with no producer fails the build), and
+#   - the golden test that the generated wiring block in docs/domain/EVENT_CATALOG.md(.fr.md)
+#     still matches the registry — i.e. someone changed PRODUCERS/CONSUMERS without regenerating.
+# Regenerate locally with: tools/event-catalog/sync.sh --write
+#
+# Runs only when the registry, the catalog docs, or the tooling change, so it stays cheap.
+
+on:
+  pull_request:
+    paths:
+      - 'crates/contracts/event-topology/**'
+      - 'docs/domain/EVENT_CATALOG.md'
+      - 'docs/domain/EVENT_CATALOG.fr.md'
+      - 'tools/event-catalog/**'
+      - '.github/workflows/event-catalog.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'crates/contracts/event-topology/**'
+      - 'docs/domain/EVENT_CATALOG.md'
+      - 'docs/domain/EVENT_CATALOG.fr.md'
+      - 'tools/event-catalog/**'
+
+jobs:
+  topology:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Topology contract + generated-catalog golden tests
+        run: cargo test -p event-topology

--- a/crates/contracts/event-topology/Cargo.toml
+++ b/crates/contracts/event-topology/Cargo.toml
@@ -11,3 +11,8 @@ description = "Fleet Kafka topic topology registry + the contract test that fail
 # stay cheap to compile and free of cycles — it is the registry every service is
 # checked against, not a participant in the mesh.
 [dependencies]
+
+# Generator for the docs/domain/EVENT_CATALOG.md wiring block (std-only).
+[[bin]]
+name = "gen-event-catalog"
+path = "src/bin/gen_event_catalog.rs"

--- a/crates/contracts/event-topology/src/bin/gen_event_catalog.rs
+++ b/crates/contracts/event-topology/src/bin/gen_event_catalog.rs
@@ -1,0 +1,9 @@
+//! Print the generated topic-wiring block for docs/domain/EVENT_CATALOG.md, rendered from the
+//! event-topology registry. Stdout only — `tools/event-catalog/sync.sh` splices it into the doc
+//! between the BEGIN/END markers.
+//!
+//!   cargo run -p event-topology --bin gen-event-catalog
+
+fn main() {
+    println!("{}", event_topology::render_catalog_block());
+}

--- a/crates/contracts/event-topology/src/lib.rs
+++ b/crates/contracts/event-topology/src/lib.rs
@@ -228,6 +228,104 @@ pub const SERVICES: &[&str] = &[
     "audit",
 ];
 
+// ---------------------------------------------------------------------------------------------
+// Event-catalog generation
+//
+// docs/domain/EVENT_CATALOG.md carries a machine-generated "topic wiring" block (topics →
+// producer → consumers, plus the deferred and orphan tables) rendered from the registry above, so
+// the wiring half of the catalog cannot drift from the contract tests. Humans author only the
+// *semantic* tables (what each event means); this block owns the *wiring*.
+//
+// Regenerate with `cargo run -p event-topology --bin gen-event-catalog`
+// (or `tools/event-catalog/sync.sh --write`). The golden test below fails the build if the block
+// committed in the doc no longer matches the registry.
+// ---------------------------------------------------------------------------------------------
+
+/// Opening marker of the generated block in EVENT_CATALOG.md (and its translations).
+pub const CATALOG_BEGIN: &str =
+    "<!-- BEGIN GENERATED: topic-wiring · source crates/contracts/event-topology · do not edit by hand -->";
+/// Closing marker of the generated block.
+pub const CATALOG_END: &str = "<!-- END GENERATED: topic-wiring -->";
+
+/// Consumers of `topic`, in registry (source) order.
+fn consumers_of(topic: &str) -> Vec<&'static str> {
+    CONSUMERS
+        .iter()
+        .filter(|(t, _)| *t == topic)
+        .map(|(_, s)| *s)
+        .collect()
+}
+
+fn code_list(items: &[&str]) -> String {
+    if items.is_empty() {
+        "—".to_string()
+    } else {
+        items
+            .iter()
+            .map(|s| format!("`{s}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// Render the complete generated topic-wiring block (markers included) from the registry.
+/// Deterministic: ordering follows the source order of [`PRODUCERS`] / [`DEFERRED`] /
+/// [`ORPHAN_PRODUCERS`].
+pub fn render_catalog_block() -> String {
+    let mut out = String::new();
+    out.push_str(CATALOG_BEGIN);
+    out.push('\n');
+    out.push_str(
+        "> ⚙️ Generated from the event-topology registry \
+         (`crates/contracts/event-topology`). Do not edit by hand — change the registry and run \
+         `cargo run -p event-topology --bin gen-event-catalog` (or `tools/event-catalog/sync.sh \
+         --write`). The *meaning* of each event is authored in the semantic sections below.\n\n",
+    );
+
+    out.push_str("### Produced topics → consumers\n\n");
+    out.push_str("| Topic | Producer | Consumers |\n|---|---|---|\n");
+    for (topic, producer) in PRODUCERS {
+        let consumers = consumers_of(topic);
+        let cell = if consumers.is_empty() {
+            "— *(orphan — see below)*".to_string()
+        } else {
+            code_list(&consumers)
+        };
+        out.push_str(&format!("| `{topic}` | `{producer}` | {cell} |\n"));
+    }
+
+    out.push_str("\n### Deferred — consumed, producer intentionally not in-repo\n\n");
+    out.push_str("| Topic | Consumer(s) | Why |\n|---|---|---|\n");
+    for (topic, reason) in DEFERRED {
+        out.push_str(&format!(
+            "| `{topic}` | {} | {reason} |\n",
+            code_list(&consumers_of(topic))
+        ));
+    }
+
+    out.push_str("\n### Orphan producers — produced, no in-repo consumer\n\n");
+    out.push_str("| Topic | Producer | Why |\n|---|---|---|\n");
+    for (topic, reason) in ORPHAN_PRODUCERS {
+        let producer = PRODUCERS
+            .iter()
+            .find(|(t, _)| t == topic)
+            .map(|(_, s)| *s)
+            .unwrap_or("—");
+        out.push_str(&format!("| `{topic}` | `{producer}` | {reason} |\n"));
+    }
+
+    out.push('\n');
+    out.push_str(CATALOG_END);
+    out
+}
+
+/// Extract the `CATALOG_BEGIN..=CATALOG_END` block from a document, if present.
+pub fn extract_catalog_block(doc: &str) -> Option<&str> {
+    let start = doc.find(CATALOG_BEGIN)?;
+    let end = doc[start..].find(CATALOG_END)? + start + CATALOG_END.len();
+    Some(&doc[start..end])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -375,5 +473,40 @@ mod tests {
                 "topic {topic:?} is excepted without a reason"
             );
         }
+    }
+
+    // --- generated event-catalog block stays in sync with the registry -----------------------
+
+    const EVENT_CATALOG: &str =
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../docs/domain/EVENT_CATALOG.md"));
+    const EVENT_CATALOG_FR: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../docs/domain/EVENT_CATALOG.fr.md"
+    ));
+
+    /// The generated wiring block committed in the English catalog must match the registry.
+    #[test]
+    fn generated_block_matches_registry_en() {
+        let committed = extract_catalog_block(EVENT_CATALOG)
+            .expect("BEGIN/END markers missing in docs/domain/EVENT_CATALOG.md");
+        assert_eq!(
+            committed,
+            render_catalog_block(),
+            "docs/domain/EVENT_CATALOG.md generated block is STALE — \
+             run `tools/event-catalog/sync.sh --write` and commit"
+        );
+    }
+
+    /// The French mirror carries the identical (language-invariant) wiring block.
+    #[test]
+    fn generated_block_matches_registry_fr() {
+        let committed = extract_catalog_block(EVENT_CATALOG_FR)
+            .expect("BEGIN/END markers missing in docs/domain/EVENT_CATALOG.fr.md");
+        assert_eq!(
+            committed,
+            render_catalog_block(),
+            "docs/domain/EVENT_CATALOG.fr.md generated block is STALE — \
+             run `tools/event-catalog/sync.sh --write` and commit"
+        );
     }
 }

--- a/docs/domain/EVENT_CATALOG.fr.md
+++ b/docs/domain/EVENT_CATALOG.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./EVENT_CATALOG.md
-  source_sha256: 4124a4f580517b57ac43551aa1a2a121a00d30f522efe102a04d242f2659d237
+  source_sha256: fb20e6a0d6d8151278ad094f920a9588aa20f0f78e4cbaa49d751f15c308a509
   translated_at: 2026-06-28
   status: complete
 ---
@@ -18,16 +18,77 @@ i18n:
 
 ## Source de vérité & maintenance
 
-La liste des topics, producteurs et consommateurs est **vérifiée par machine** par la garde de
-registre de topologie d'événements (avec ses tests de contrat). Les colonnes **topic / producteur /
-consommateur** ici devraient être **réconciliées avec ce registre** (idéalement générées depuis lui)
-afin de ne pas dériver ; seules les colonnes **sémantiques** (*signifie* / *déclencheur*) sont
-rédigées à la main. Tant que la génération n'est pas câblée, considérer la garde de topologie — et
-non cette table — comme l'autorité sur *quelles* arêtes existent ; cette table fait autorité sur leur
-*sens*.
+Ce catalogue a deux moitiés :
+
+- **Le câblage des topics** (quel service produit/consomme quel topic) est **généré** depuis le
+  registre de topologie d'événements (`crates/contracts/event-topology`) dans le bloc ci-dessous —
+  il fait autorité sur *quelles* arêtes existent et ne peut dériver (un golden test +
+  `tools/event-catalog/sync.sh` l'imposent). Ne pas l'éditer à la main ; changer le registre et
+  régénérer.
+- **La sémantique des événements** (ce que chaque événement *signifie*, quand il se déclenche, qui
+  réagit et *pourquoi*) est rédigée à la main dans les sections par-domaine qui suivent.
 
 Croiser chaque arête dans [`CONTEXT_MAP.md`](./CONTEXT_MAP.md), et le détail par événement dans le
 §8 de chaque producteur.
+
+## Câblage des topics (généré)
+
+<!-- BEGIN GENERATED: topic-wiring · source crates/contracts/event-topology · do not edit by hand -->
+> ⚙️ Generated from the event-topology registry (`crates/contracts/event-topology`). Do not edit by hand — change the registry and run `cargo run -p event-topology --bin gen-event-catalog` (or `tools/event-catalog/sync.sh --write`). The *meaning* of each event is authored in the semantic sections below.
+
+### Produced topics → consumers
+
+| Topic | Producer | Consumers |
+|---|---|---|
+| `account.v1.events` | `account` | `audit`, `profile` |
+| `profile.v1.events` | `profile` | `search`, `post` |
+| `post.published` | `post` | `notification`, `geo-discovery` |
+| `post.updated` | `post` | — *(orphan — see below)* |
+| `post.deleted` | `post` | `timeline` |
+| `post.v1.events` | `post` | `timeline`, `search`, `realtime` |
+| `comment.created` | `comment` | `notification`, `engagement` |
+| `comment.deleted` | `comment` | `engagement` |
+| `engagement.reactions` | `engagement` | `counter`, `notification`, `engagement` |
+| `social-graph.followed` | `social-graph` | `timeline` |
+| `social-graph.unfollowed` | `social-graph` | `timeline` |
+| `social-graph.blocked` | `social-graph` | — *(orphan — see below)* |
+| `social-graph.author_tier_changed` | `social-graph` | `profile` |
+| `chat.conversation.created` | `chat` | — *(orphan — see below)* |
+| `chat.conversation.published` | `chat` | — *(orphan — see below)* |
+| `chat.conversation.unpublished` | `chat` | `chat` |
+| `chat.member.joined` | `chat` | — *(orphan — see below)* |
+| `chat.member.left` | `chat` | — *(orphan — see below)* |
+| `chat.message.sent` | `chat` | — *(orphan — see below)* |
+| `counter.v1.popularity` | `counter` | `realtime`, `geo-discovery` |
+| `moderation.v1.events` | `moderation` | `audit`, `search`, `media` |
+| `auth.v1.events` | `auth` | `audit` |
+| `media.v1.events` | `media` | `media` |
+
+### Deferred — consumed, producer intentionally not in-repo
+
+| Topic | Consumer(s) | Why |
+|---|---|---|
+| `audit.v1.events` | `audit` | Generic privileged-record ingest lane. Domain producers emit their own topics (account/auth/moderation .v1.events) which audit consumes directly; this lane is fed by the sync gRPC RecordPrivileged path and future generic producers. |
+| `moderation.reports` | `moderation` | External user-report intake — produced by the client/edge, not a fleet service. |
+| `moderation.signals` | `moderation` | External ML-classifier signals — produced off-fleet. |
+| `view.v1.events` | `counter` | Upstream view telemetry producer not yet built (counter-analytics blueprint deferral). |
+| `impression.v1.events` | `counter` | Upstream impression telemetry producer not yet built (counter deferral). |
+| `click.v1.events` | `counter` | Upstream click telemetry producer not yet built (counter deferral). |
+| `social-graph.follows` | `counter` | Counter wants a single combined follow stream; social-graph emits the split past-tense social-graph.followed/.unfollowed instead. Combined producer is deferred — TRACKED NAMING MISMATCH, not just a missing emitter. |
+
+### Orphan producers — produced, no in-repo consumer
+
+| Topic | Producer | Why |
+|---|---|---|
+| `post.updated` | `post` | No stream consumer — search/timeline/realtime act on post.v1.events PostUpdated; the legacy per-type topic is emitted for completeness. |
+| `social-graph.blocked` | `social-graph` | Block is enforced on the gRPC read path; no stream consumer yet. |
+| `chat.conversation.created` | `chat` | Chat owns its own delivery plane; reserved for future fan-out. |
+| `chat.conversation.published` | `chat` | Chat delivery-plane headroom. |
+| `chat.member.joined` | `chat` | Chat delivery-plane headroom. |
+| `chat.member.left` | `chat` | Chat delivery-plane headroom. |
+| `chat.message.sent` | `chat` | Future realtime/notification consolidation; chat streams to clients directly today. |
+
+<!-- END GENERATED: topic-wiring -->
 
 ## Identité & Compte — `account.v1.events` (producteur : `account`)
 
@@ -117,7 +178,11 @@ Croiser chaque arête dans [`CONTEXT_MAP.md`](./CONTEXT_MAP.md), et le détail p
 | `asset_quarantined` / `asset_deleted` / `asset_restored` | une transition sécurité/cycle de vie | échec Screen / takedown / restauration | intégrations, livraison |
 | `asset_failed` | le traitement a échoué | timeout/erreur | UX d'upload |
 
-## Social Graph — événements de relation (producteur : `social-graph`) — **producteur Kafka différé**
+## Social Graph — événements de relation (producteur : `social-graph`)
+
+> Les topics scindés au passé ci-dessous **sont** produits et consommés (voir le bloc de câblage).
+> Seul le stream *combiné* `social-graph.follows` que `counter` préférerait est différé (un
+> mismatch de nommage suivi) ; `counter` réconcilie via gRPC en attendant.
 
 | Événement | Signifie | Émis quand | Consommateurs & pourquoi |
 |---|---|---|---|

--- a/docs/domain/EVENT_CATALOG.md
+++ b/docs/domain/EVENT_CATALOG.md
@@ -6,15 +6,76 @@
 
 ## Source of truth & maintenance
 
-The list of topics, producers, and consumers is **machine-checked** by the event-topology registry
-guard (with its contract tests). The **topic / producer / consumer** columns here should be
-**reconciled with that registry** (ideally generated from it) so they cannot drift; only the
-**semantic** columns (*means* / *trigger*) are authored by humans. Until generation is wired, treat
-the registry guard — not this table — as the authority on *which* edges exist; this table is the
-authority on what they *mean*.
+This catalog has two halves:
+
+- **Topic wiring** (which service produces/consumes which topic) is **generated** from the
+  event-topology registry (`crates/contracts/event-topology`) into the block below — it is the
+  authority on *which* edges exist and cannot drift (a golden test + `tools/event-catalog/sync.sh`
+  enforce it). Don't hand-edit it; change the registry and regenerate.
+- **Event semantics** (what each event *means*, when it fires, who reacts and *why*) are authored by
+  humans in the per-domain sections that follow.
 
 Cross-reference each edge in [`CONTEXT_MAP.md`](./CONTEXT_MAP.md), and the per-event detail in each
 producer's `DOMAIN.md §8`.
+
+## Topic wiring (generated)
+
+<!-- BEGIN GENERATED: topic-wiring · source crates/contracts/event-topology · do not edit by hand -->
+> ⚙️ Generated from the event-topology registry (`crates/contracts/event-topology`). Do not edit by hand — change the registry and run `cargo run -p event-topology --bin gen-event-catalog` (or `tools/event-catalog/sync.sh --write`). The *meaning* of each event is authored in the semantic sections below.
+
+### Produced topics → consumers
+
+| Topic | Producer | Consumers |
+|---|---|---|
+| `account.v1.events` | `account` | `audit`, `profile` |
+| `profile.v1.events` | `profile` | `search`, `post` |
+| `post.published` | `post` | `notification`, `geo-discovery` |
+| `post.updated` | `post` | — *(orphan — see below)* |
+| `post.deleted` | `post` | `timeline` |
+| `post.v1.events` | `post` | `timeline`, `search`, `realtime` |
+| `comment.created` | `comment` | `notification`, `engagement` |
+| `comment.deleted` | `comment` | `engagement` |
+| `engagement.reactions` | `engagement` | `counter`, `notification`, `engagement` |
+| `social-graph.followed` | `social-graph` | `timeline` |
+| `social-graph.unfollowed` | `social-graph` | `timeline` |
+| `social-graph.blocked` | `social-graph` | — *(orphan — see below)* |
+| `social-graph.author_tier_changed` | `social-graph` | `profile` |
+| `chat.conversation.created` | `chat` | — *(orphan — see below)* |
+| `chat.conversation.published` | `chat` | — *(orphan — see below)* |
+| `chat.conversation.unpublished` | `chat` | `chat` |
+| `chat.member.joined` | `chat` | — *(orphan — see below)* |
+| `chat.member.left` | `chat` | — *(orphan — see below)* |
+| `chat.message.sent` | `chat` | — *(orphan — see below)* |
+| `counter.v1.popularity` | `counter` | `realtime`, `geo-discovery` |
+| `moderation.v1.events` | `moderation` | `audit`, `search`, `media` |
+| `auth.v1.events` | `auth` | `audit` |
+| `media.v1.events` | `media` | `media` |
+
+### Deferred — consumed, producer intentionally not in-repo
+
+| Topic | Consumer(s) | Why |
+|---|---|---|
+| `audit.v1.events` | `audit` | Generic privileged-record ingest lane. Domain producers emit their own topics (account/auth/moderation .v1.events) which audit consumes directly; this lane is fed by the sync gRPC RecordPrivileged path and future generic producers. |
+| `moderation.reports` | `moderation` | External user-report intake — produced by the client/edge, not a fleet service. |
+| `moderation.signals` | `moderation` | External ML-classifier signals — produced off-fleet. |
+| `view.v1.events` | `counter` | Upstream view telemetry producer not yet built (counter-analytics blueprint deferral). |
+| `impression.v1.events` | `counter` | Upstream impression telemetry producer not yet built (counter deferral). |
+| `click.v1.events` | `counter` | Upstream click telemetry producer not yet built (counter deferral). |
+| `social-graph.follows` | `counter` | Counter wants a single combined follow stream; social-graph emits the split past-tense social-graph.followed/.unfollowed instead. Combined producer is deferred — TRACKED NAMING MISMATCH, not just a missing emitter. |
+
+### Orphan producers — produced, no in-repo consumer
+
+| Topic | Producer | Why |
+|---|---|---|
+| `post.updated` | `post` | No stream consumer — search/timeline/realtime act on post.v1.events PostUpdated; the legacy per-type topic is emitted for completeness. |
+| `social-graph.blocked` | `social-graph` | Block is enforced on the gRPC read path; no stream consumer yet. |
+| `chat.conversation.created` | `chat` | Chat owns its own delivery plane; reserved for future fan-out. |
+| `chat.conversation.published` | `chat` | Chat delivery-plane headroom. |
+| `chat.member.joined` | `chat` | Chat delivery-plane headroom. |
+| `chat.member.left` | `chat` | Chat delivery-plane headroom. |
+| `chat.message.sent` | `chat` | Future realtime/notification consolidation; chat streams to clients directly today. |
+
+<!-- END GENERATED: topic-wiring -->
 
 ## Identity & Account — `account.v1.events` (producer: `account`)
 
@@ -103,7 +164,11 @@ producer's `DOMAIN.md §8`.
 | `asset_quarantined` / `asset_deleted` / `asset_restored` | a safety/lifecycle transition | Screen fail / takedown / restore | embeds, delivery |
 | `asset_failed` | processing failed | timeout/error | upload UX |
 
-## Social Graph — relation events (producer: `social-graph`) — **Kafka producer deferred**
+## Social Graph — relation events (producer: `social-graph`)
+
+> The split, past-tense topics below **are** produced and consumed (see the wiring block). Only the
+> *combined* `social-graph.follows` stream `counter` would prefer is deferred (a tracked naming
+> mismatch); `counter` reconciles via gRPC meanwhile.
 
 | Event | Means | Emitted when | Consumers & why |
 |---|---|---|---|

--- a/tools/event-catalog/sync.sh
+++ b/tools/event-catalog/sync.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# sync.sh — keep the generated topic-wiring block in docs/domain/EVENT_CATALOG.md (and its
+# translations) in lock-step with the event-topology registry.
+#
+# The block is rendered by the `gen-event-catalog` binary from the const tables in
+# crates/contracts/event-topology; this script splices it between the BEGIN/END markers in each
+# catalog doc. The wiring half of the catalog is therefore generated; the semantic half is authored.
+#
+# Usage:
+#   tools/event-catalog/sync.sh --write   # regenerate the block in every catalog doc (in place)
+#   tools/event-catalog/sync.sh --check   # fail if any doc's block is stale (CI gate)
+#
+# The same check is enforced by `cargo test -p event-topology` (generated_block_matches_registry_*).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BEGIN="<!-- BEGIN GENERATED: topic-wiring · source crates/contracts/event-topology · do not edit by hand -->"
+END="<!-- END GENERATED: topic-wiring -->"
+DOCS=(
+  "$ROOT/docs/domain/EVENT_CATALOG.md"
+  "$ROOT/docs/domain/EVENT_CATALOG.fr.md"
+)
+
+block_file="$(mktemp)"
+trap 'rm -f "$block_file"' EXIT
+cargo run -q -p event-topology --bin gen-event-catalog --manifest-path "$ROOT/Cargo.toml" > "$block_file"
+
+# splice <doc> : replace the BEGIN..END region (inclusive) of <doc> with the generated block.
+splice() {
+  awk -v bf="$block_file" -v B="$BEGIN" -v E="$END" '
+    BEGIN { while ((getline line < bf) > 0) blk = blk line "\n"; sub(/\n$/, "", blk) }
+    index($0, B) { print blk; insec = 1; next }
+    insec && index($0, E) { insec = 0; next }
+    insec { next }
+    { print }
+  ' "$1"
+}
+
+mode="${1:---check}"
+fail=0
+for doc in "${DOCS[@]}"; do
+  [ -f "$doc" ] || { echo "MISSING $doc" >&2; fail=1; continue; }
+  if ! grep -qF "$BEGIN" "$doc"; then
+    echo "NO MARKERS in $doc — add the $BEGIN / $END block once, then re-run." >&2; fail=1; continue
+  fi
+  case "$mode" in
+    --write)
+      tmp="$(mktemp)"; splice "$doc" > "$tmp" && mv "$tmp" "$doc"
+      echo "wrote $doc"
+      ;;
+    --check)
+      if ! diff -q <(splice "$doc") "$doc" >/dev/null; then
+        echo "STALE  $doc — run tools/event-catalog/sync.sh --write" >&2; fail=1
+      else
+        echo "OK     $doc"
+      fi
+      ;;
+    *) echo "usage: $0 {--write|--check}" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$mode" = "--write" ]; then
+  echo "note: re-stamp the FR mirror after writing — tools/i18n/i18n-drift.sh stamp docs/domain/EVENT_CATALOG.fr.md"
+fi
+exit "$fail"


### PR DESCRIPTION
## Why

`EVENT_CATALOG.md` carried a "to be reconciled with the topology guard" note. This wires that up: the **topic-wiring half is now generated** from the `event-topology` registry, so it can't drift from the phantom-edge contract tests. Humans keep authoring only the *semantic* sections.

## What

**`crates/contracts/event-topology`**
- `render_catalog_block()` + `CATALOG_BEGIN`/`END` markers + `extract_catalog_block()` — renders topic→producer→consumers, plus the Deferred and Orphan tables, deterministically from the const registry.
- `gen-event-catalog` bin prints the block.
- **Two golden tests** (`generated_block_matches_registry_en` / `_fr`) assert the committed blocks in both catalog docs match the registry — the build fails on drift.

**`tools/event-catalog/sync.sh`** — `--write` splices the freshly-generated block between the markers in `EVENT_CATALOG.md` + `.fr.md`; `--check` fails if stale. Mirrors the i18n gate ergonomics.

**`docs/domain/EVENT_CATALOG.md` (+ FR)**
- Intro reworked: **generated wiring** vs **authored semantics**.
- Generated block inserted (the same language-invariant block in both EN and FR).
- Corrected a stale note: the split `social-graph.followed/.unfollowed/.author_tier_changed` topics **are** wired (the generator surfaced this); only the *combined* `social-graph.follows` is deferred. FR mirror re-stamped.

**CI** — `event-catalog.yml` runs `cargo test -p event-topology` on registry/catalog/tooling changes. Bonus: this is the first time the topology **contract tests run in CI** (they previously weren't in any workflow).

## What the generator surfaced (more accurate than the hand draft)

- `engagement.reactions` is also **self-consumed** by `engagement` (write-behind).
- `post` emits both legacy `post.published/.updated/.deleted` **and** unified `post.v1.events`.
- `media.v1.events` is **self-consumed** (Plane-B pipeline); `chat.*` topics are mostly orphan headroom.

## Verification

- `cargo test -p event-topology` → **10 passed** (8 phantom-edge + 2 golden).
- `tools/event-catalog/sync.sh --check` → OK (both docs).
- i18n drift gate → **PASS (76)**.

## How to maintain

Change `PRODUCERS`/`CONSUMERS` in the registry → run `tools/event-catalog/sync.sh --write` → re-stamp the FR mirror. CI fails if you forget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)