### PR TITLE
docs(foundation,platform): DOMAIN contracts for the 14 shared infra crates

### DIFF
--- a/crates/foundation/error/docs/DOMAIN.fr.md
+++ b/crates/foundation/error/docs/DOMAIN.fr.md
@@ -1,0 +1,163 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 1847c3ce0897c5ea218ee90badf44cbef485c1ac13aa94ca5e8dbf507ba10067
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `error` — Contrat de Domaine & Fonctionnel
+
+> Le contrat d'erreur distribuée : un trait, une forme wire, zéro fuite — il répond à *« comment chaque service expose-t-il ses propres erreurs de façon uniforme, observable, et sans fuiter d'internes aux clients ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Le contrat d'erreur à l'échelle du workspace : un trait, un vocabulaire de sévérité, une enveloppe typée, et une forme wire sûre pour les clients |
+> | **Couche** | `foundation` — un crate de contrat quasi-racine (presque tout en dépend) |
+> | **Classe de sous-domaine** | **Generic** — un contrat transversal ; son levier est l'uniformité + l'anti-fuite |
+> | **Abstraction(s) primaire(s)** | `AppError` + `DistributedError<E>` (`error::traits`, `error::context`) |
+> | **Empreinte** | pure (aucune IO, aucun état, aucun thread de fond) ; `axum` est une dev-dependency uniquement |
+> | **Posture en cas d'échec** | N/A — il *décrit* les échecs ; il ne peut jamais en *causer* un (aucune IO, aucun état) |
+> | **Dépend de** | `thiserror`, `tracing`, `http`, `uuid`, `chrono` |
+> | **Consommé par** | `cqrs`, `transport`, `resilience`, `validation`, et chaque crate de service |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `error` fait autorité dans la flotte pour le **contrat d'erreur** : il répond à
+**« comment un service expose-t-il son propre enum d'erreur typé pour que le logging, le paging, la
+classification de retry, et le JSON client soient uniformes à travers chaque service — et que les identifiants
+de trace n'atteignent jamais un client ? »**
+
+**Le problème difficile.** Chaque service a besoin de son *propre* enum d'erreur (pour pattern-matcher), mais
+la plateforme a besoin d'*une* sortie observable et sûre pour les clients. `error` réconcilie cela avec une
+enveloppe typée (`DistributedError<E>` garde le type concret — pas de `Box<dyn Error>`) et une frontière de
+divulgation stricte (`trace_id`/`span_id` vivent sur le contexte pour les logs mais sont structurellement
+absents de la forme wire client).
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Définir une erreur métier/domaine quelconque → chaque service possède son enum ; ce crate ne possède que le contrat.
+- ❌ Décider le comportement de retry → il expose `is_retryable()` ; `resilience` y agit.
+- ❌ Posséder la config de logging (format, sampling, alerting) → c'est le bootstrap du binaire consommateur.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| App error | Le contrat qu'un service implémente sur son enum | `AppError` |
+| Error code | Code stable, visible client, lisible machine (ex. `AUTH_TOKEN_EXPIRED`) | `AppError::error_code` |
+| Severity | Le vocabulaire d'urgence unifié pilotant paging/niveau de log | `Severity` |
+| Context | Métadonnées de requête/trace enveloppant une erreur | `ErrorContext` |
+| Distributed error | L'enveloppe typée, préservant le type | `DistributedError<E>` |
+| Api error response | Le JSON client agnostique au framework et sans fuite | `ApiErrorResponse`, `into_api_response` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `AppError` | trait (seam) | Seuls `error_code()` + `http_status()` sont requis ; le reste a des défauts sûrs en production |
+| `IntoApiResponse` | trait blanket | Un seul `to_api_response` canonique pour chaque `AppError` ; ne doit **pas** être surchargé |
+| `DistributedError<E>` | enveloppe typée | Préserve le `E` concret de bout en bout (pas d'effacement) ; `.log()` émet trace+span ids |
+| `ErrorContext` | type valeur | Porte `trace_id`/`span_id` — présent dans les logs, **absent** de la forme wire client |
+| `ApiErrorResponse` | forme wire | La seule struct envoyée aux clients ; ne contient aucun trace/span id |
+| `Severity` | enum | `Ord` comme `Critical < High < Medium < Low < Info` (« plus d'urgence = valeur plus basse ») |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Les quatre piliers — contrat (`AppError`/`IntoApiResponse`), vocabulaire (`Severity`), contexte
+  (`ErrorContext`/`DistributedError`), et format wire (`ApiErrorResponse`). La frontière anti-fuite est imposée
+  *structurellement* ici.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Tout enum d'erreur de domaine concret | chaque crate de service | Ce crate est contrat-seulement, agnostique au consommateur |
+| Format de logging / sampling / routage d'alertes | le binaire consommateur (`telemetry`) | La policy opérationnelle n'est pas le travail du contrat |
+| Le glue framework `axum`/HTTP | le service (newtype) | `axum` reste une dev-dependency ; la forme wire est agnostique au framework |
+
+**La liste « do-not-depend-on » :** jamais un crate de service, jamais `axum`/`tonic` hors dev-deps, jamais
+d'IO réseau ou d'état — pour que `error` ne puisse jamais être la cause d'une panne en cascade.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | `error_code` est une API publique stable (clients/dashboards s'y indexent) | convention de contrat | un renommage est cassant, nécessite une migration |
+| I2 | `trace_id`/`span_id` n'atteignent jamais un client | système de types (`ApiErrorResponse` les omet) + `into_api_response` les retire | fuite structurelle seulement si vous sérialisez `ErrorContext` directement |
+| I3 | Le type d'erreur concret est préservé de bout en bout (pas de `Box<dyn Error>`) | générique `DistributedError<E>` | perte du pattern-matching |
+| I4 | Les nouvelles méthodes `AppError` doivent porter un défaut sûr en production | définition du trait | casse les implémenteurs existants |
+| I5 | L'impl blanket `IntoApiResponse` n'est pas surchargée | impl blanket | formes client divergentes |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Chemin d'erreur.** L'enum d'un service implémente `AppError` ; la frontière l'enveloppe en
+`DistributedError<E>` avec un `ErrorContext`. `.log()` émet un événement `tracing` à `severity().log_level()`
+(avec `trace_id`/`span_id` *à l'intérieur* du log). Le body client est construit via `into_api_response(&err)`
+— qui retire les trace/span ids — et retourné avec `http_status()`. Aucun heap sur le chemin chaud : les
+méthodes `AppError` retournent `&'static str` et l'enveloppe est allouée sur la pile jusqu'au retour (les
+services peuvent la `Box` sur les chemins sensibles à la latence pour garder le `Result` petit).
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| chaque crate de service | aval | Published Contract | `impl AppError` sur leur enum | sortie d'erreur uniforme à l'échelle de la flotte |
+| `cqrs` | aval | Conformist | `CqrsError` implémente/délègue `AppError` | le mapping d'erreur du bus |
+| `resilience` | aval | Conformist | `AppError::is_retryable` | la classification de retry |
+| `validation` | aval | Conformist | `ValidationError: AppError` (422) | le mapping d'erreur de validation |
+| `transport` | aval | Conformist | `grpc_severity` / mapping d'erreur | la sévérité d'erreur gRPC |
+
+> **Seam de stabilité :** `AppError` (surtout `error_code`) et `ApiErrorResponse` sont le contrat auquel chaque
+> consommateur se lie ; les changements de `error_code` sont cassants pour les clients.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| log d'erreur structuré | `tracing` (niveau = sévérité) | `DistributedError::log()` est appelé | pipeline de logs ; corréler par `request_id` (visible client) ou `trace_id`+`span_id` (logs seulement) |
+
+Aucune métrique, aucun store externe. Le seul effet de bord est l'événement `tracing` optionnel.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Enveloppe typée (`DistributedError<E>`), pas d'effacement `Box<dyn Error>` | [`README §Architecture`](../README.md) | Accepted |
+| Divulgation à deux niveaux — seuls `error_code`+`http_status` requis, le reste par défaut | [`README §Architecture`](../README.md) | Accepted |
+| Fuite rendue structurellement impossible (trace/span absents de la forme wire) | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — un contrat transversal ; le levier est l'uniformité, l'observabilité, et
+  l'anti-fuite, pas la valeur métier.
+- **Stabilité :** contrat stable — `error_code` est traité comme une API publique.
+- **Volatilité :** faible — les nouvelles méthodes `AppError` sont additives (par défaut) ; la forme wire est stabilisée.
+- **Capacités différées :** aucune structurelle ; des payloads de détails plus riches se sérialisent via
+  `ApiErrorResponse.details` au besoin.

--- a/crates/foundation/error/docs/DOMAIN.md
+++ b/crates/foundation/error/docs/DOMAIN.md
@@ -1,0 +1,150 @@
+# `error` — Domain & Functional Contract
+
+> The distributed-error contract: one trait, one wire shape, zero leakage — it answers *"how does every service expose its own errors uniformly, observably, and without leaking internals to clients?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | The workspace-wide error contract: a trait, a severity vocabulary, a typed envelope, and a client-safe wire shape |
+> | **Layer** | `foundation` — a near-root contract crate (almost everything depends on it) |
+> | **Subdomain class** | **Generic** — a cross-cutting contract; its leverage is uniformity + leak-safety |
+> | **Primary abstraction(s)** | `AppError` + `DistributedError<E>` (`error::traits`, `error::context`) |
+> | **Footprint** | pure (no IO, no state, no background threads); `axum` is a dev-dependency only |
+> | **Failure posture** | N/A — it *describes* failures; it can never *cause* one (no IO, no state) |
+> | **Depends on** | `thiserror`, `tracing`, `http`, `uuid`, `chrono` |
+> | **Consumed by** | `cqrs`, `transport`, `resilience`, `validation`, and every service crate |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `error` is the fleet's authority for the **error contract**: it answers
+**"how does a service expose its own typed error enum so that logging, paging, retry classification, and
+the client-facing JSON are uniform across every service — and trace identifiers never reach a client?"**
+
+**The hard problem.** Every service needs its *own* error enum (to pattern-match on), yet the platform
+needs *one* observable, client-safe output. `error` reconciles this with a typed envelope
+(`DistributedError<E>` keeps the concrete type — no `Box<dyn Error>`) and a strict disclosure boundary
+(`trace_id`/`span_id` live on the context for logs but are structurally absent from the client wire shape).
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Define any domain/business error → each service owns its enum; this crate owns only the contract.
+- ❌ Decide retry behaviour → it exposes `is_retryable()`; `resilience` acts on it.
+- ❌ Own logging configuration (format, sampling, alerting) → that is the consuming binary's bootstrap.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| App error | The contract a service implements on its enum | `AppError` |
+| Error code | Stable, client-visible, machine-readable code (e.g. `AUTH_TOKEN_EXPIRED`) | `AppError::error_code` |
+| Severity | The unified urgency vocabulary driving paging/log level | `Severity` |
+| Context | Request/trace metadata wrapping an error | `ErrorContext` |
+| Distributed error | The typed, type-preserving envelope | `DistributedError<E>` |
+| Api error response | The framework-agnostic, leak-free client JSON | `ApiErrorResponse`, `into_api_response` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `AppError` | trait (seam) | Only `error_code()` + `http_status()` are required; the rest carry production-safe defaults |
+| `IntoApiResponse` | blanket trait | One canonical `to_api_response` for every `AppError`; must **not** be overridden |
+| `DistributedError<E>` | typed envelope | Preserves the concrete `E` end-to-end (no erasure); `.log()` emits trace+span ids |
+| `ErrorContext` | value type | Carries `trace_id`/`span_id` — present in logs, **absent** from the client wire shape |
+| `ApiErrorResponse` | wire shape | The only struct sent to clients; contains no trace/span ids |
+| `Severity` | enum | `Ord` as `Critical < High < Medium < Low < Info` ("higher urgency = lower value") |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The four pillars — contract (`AppError`/`IntoApiResponse`), vocabulary (`Severity`), context
+  (`ErrorContext`/`DistributedError`), and wire format (`ApiErrorResponse`). The leak boundary is enforced
+  *structurally* here.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| Any concrete domain error enum | each service crate | This crate is contract-only, consumer-agnostic |
+| Logging format / sampling / alert routing | the consuming binary (`telemetry`) | Operational policy is not the contract's job |
+| `axum`/HTTP framework glue | the service (newtype) | `axum` stays a dev-dependency; the wire shape is framework-agnostic |
+
+**The "do-not-depend-on" list:** never a service crate, never `axum`/`tonic` in non-dev deps, never network
+IO or state — so `error` can never be the cause of a cascading failure.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `error_code` is stable public API (clients/dashboards key off it) | contract convention | a rename is a breaking change requiring migration |
+| I2 | `trace_id`/`span_id` never reach a client | type system (`ApiErrorResponse` omits them) + `into_api_response` strips them | structural leak only if you serialize `ErrorContext` directly |
+| I3 | The concrete error type is preserved end-to-end (no `Box<dyn Error>`) | `DistributedError<E>` generic | loss of pattern-matching |
+| I4 | New `AppError` methods must carry a production-safe default | trait definition | breaks existing implementors |
+| I5 | The `IntoApiResponse` blanket impl is not overridden | blanket impl | divergent client shapes |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Error path.** A service's enum implements `AppError`; the boundary wraps it as `DistributedError<E>` with
+an `ErrorContext`. `.log()` emits one `tracing` event at `severity().log_level()` (with `trace_id`/`span_id`
+*inside* the log). The client body is built through `into_api_response(&err)` — which strips trace/span ids —
+and returned with `http_status()`. No heap on the hot path: `AppError` methods return `&'static str` and the
+envelope is stack-allocated until returned (services may `Box` it on latency-sensitive paths to keep
+`Result` small).
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| every service crate | downstream | Published Contract | `impl AppError` on their enum | uniform error output fleet-wide |
+| `cqrs` | downstream | Conformist | `CqrsError` implements/delegates `AppError` | bus error mapping |
+| `resilience` | downstream | Conformist | `AppError::is_retryable` | retry classification |
+| `validation` | downstream | Conformist | `ValidationError: AppError` (422) | validation error mapping |
+| `transport` | downstream | Conformist | `grpc_severity` / error mapping | gRPC error severity |
+
+> **Stability seam:** `AppError` (esp. `error_code`) and `ApiErrorResponse` are the contract every consumer
+> binds to; `error_code` changes are client-breaking.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| structured error log | `tracing` (level = severity) | `DistributedError::log()` is called | log pipeline; correlate by `request_id` (client-visible) or `trace_id`+`span_id` (logs only) |
+
+No metrics, no external store. The only side effect is the optional `tracing` event.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Typed envelope (`DistributedError<E>`), no `Box<dyn Error>` erasure | [`README §Architecture`](../README.md) | Accepted |
+| Two-tier disclosure — only `error_code`+`http_status` required, rest defaulted | [`README §Architecture`](../README.md) | Accepted |
+| Leakage made structurally impossible (trace/span absent from the wire shape) | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — a cross-cutting contract; leverage is uniformity, observability, and
+  leak-safety, not business value.
+- **Stability:** stable contract — `error_code` is treated as public API.
+- **Volatility:** low — new `AppError` methods are additive (defaulted); the wire shape is settled.
+- **Deferred capabilities:** none structural; richer details payloads serialize through
+  `ApiErrorResponse.details` as needed.

--- a/crates/foundation/health/docs/DOMAIN.fr.md
+++ b/crates/foundation/health/docs/DOMAIN.fr.md
@@ -1,0 +1,142 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: d754558442162e438424cb2ad2ca4d0d3ca2003f33dfb6397ea13605648b2beb
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `health` — Contrat de Domaine & Fonctionnel
+
+> Un contrat de probe en feuille du graphe : l'abstraction qui répond à *« ce backend est-il joignable maintenant ? »* — pour que les crates de stockage publient des probes que le runtime sonde, sans arête entre eux.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Le contrat de probe liveness/readiness qui pilote le statut de santé gRPC d'un service |
+> | **Couche** | `foundation` — une feuille délibérée du graphe (minuscule, ne dépend que de `async-trait` + `anyhow`) |
+> | **Classe de sous-domaine** | **Generic** — une abstraction à un trait ; sa valeur est le découplage, pas le code |
+> | **Abstraction(s) primaire(s)** | `HealthProbe` + `FnProbe` (`health`) |
+> | **Empreinte** | pure (aucune IO, aucun spawn) — il définit le contrat, n'ouvre jamais une connexion |
+> | **Posture en cas d'échec** | **fail-to-`NOT_SERVING`, auto-effaçant** — tout `Err` rétrograde le service jusqu'à ce qu'un tick ultérieur l'efface |
+> | **Dépend de** | `async-trait`, `anyhow` |
+> | **Consommé par** | `service-runtime` (sonde les probes → santé gRPC), crates de stockage (`scylla`/`redis`/`postgres` exposent des probes) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `health` définit le **contrat de probe** que la flotte utilise pour gater la readiness : il
+répond à **« le runtime peut-il demander à n'importe quel backend "es-tu joignable ?" sans dépendre du crate
+de ce backend ? »**
+
+**Le problème difficile.** Un crate de stockage sait *comment* vérifier son backend ; le runtime sait *quand*
+vérifier et *quoi* faire du résultat. Mettre le trait dans l'un ou l'autre couplerait le stockage au runtime
+(ou l'inverse). Un crate feuille minuscule permet aux deux côtés de ne dépendre que de lui, pour qu'un crate de
+stockage publie une probe et que le runtime la consomme avec **aucune arête entre eux** — la raison d'être même
+de ce crate.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Ouvrir des connexions ou lancer de vraies requêtes → le `health::probe` du crate de stockage le fait.
+- ❌ Planifier le sondage ou connaître gRPC → relève de la boucle de readiness de `service-runtime`.
+- ❌ Tenir un état d'échec collant → il n'y en a pas ; la readiness se redérive à chaque tick.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Probe | Une vérification de joignabilité bon marché sondée à chaque tick | `HealthProbe` |
+| Name | Identifiant court pour les logs (`"scylla"`, `"redis"`) | `HealthProbe::name` |
+| Check | Le ping de joignabilité async ; `Ok` = joignable | `HealthProbe::check` |
+| Fn-probe | Une probe backée par closure pour une dépendance sur mesure | `FnProbe` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `HealthProbe` | trait (seam) | `check()` doit être bon marché + idempotent (tourne à chaque tick) ; `Ok(())` = joignable, tout `Err` rétrograde |
+| `FnProbe<F>` | adaptateur | Enveloppe un `Fn() -> Future` pour qu'une probe n'ait pas besoin de type dédié ; la closure est ré-invoquée à chaque tick |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Le *contrat* de probe seulement — la forme du trait et l'adaptateur closure. Rien d'autre.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Clients backend live + la vérification réelle | crates de stockage (`scylla`/`redis`/`postgres`) | Ils possèdent leur client ; ils ne dépendent que de cette feuille |
+| Cadence de sondage + câblage de santé gRPC | `service-runtime` | Le runtime planifie et mappe les résultats vers `ServingStatus` |
+
+**La liste « do-not-depend-on » :** jamais un client de stockage, jamais `tonic`, jamais `service-runtime`.
+Ajouter une telle arête réintroduirait le couplage que ce crate a été créé pour briser.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | `check()` est bon marché (un ping de joignabilité, pas une requête) | convention de contrat | une probe lourde fait flapper le service sous charge |
+| I2 | Tout `Err` d'une seule probe rétrograde tout le service | boucle de readiness de `service-runtime` | service → `NOT_SERVING` jusqu'au prochain tick propre |
+| I3 | Aucun état d'échec collant — la readiness se redérive à chaque tick | par conception (aucun état ici) | — |
+| I4 | Une closure `FnProbe` doit être ré-appelable (`Fn`, pas `FnOnce`) | borne de type | erreur de compilation |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+N/A — crate de contrat pur, aucun flot de contrôle runtime propre. La boucle de sondage (premier tick immédiat,
+écritures uniquement sur transition vers le reporter gRPC) vit dans `service-runtime` ; la vérification de
+joignabilité réelle vit dans le `health::probe` de chaque crate de stockage. Ce crate n'est que le trait qui
+les joint.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| crates de stockage | aval | Published Contract | `impl HealthProbe` sur leur client | le signal de readiness de chaque service |
+| `service-runtime` | aval | Published Contract | sonde `Vec<Arc<dyn HealthProbe>>` | le mapping readiness → santé gRPC |
+
+> **Seam de stabilité :** le trait `HealthProbe` est l'API publique entière ; un changement de signature se
+> propage à chaque crate de stockage *et* au runtime simultanément — à traiter comme un changement cassant dur.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+N/A — pur. Il n'émet rien ; les événements `tracing` de readiness (`"health status changed"`) sont émis par
+`service-runtime` quand il agit sur un résultat de probe.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Placer le trait de probe dans une feuille du graphe pour que stockage et runtime ne se couplent jamais | [`README §Architecture`](../README.md) | Accepted |
+| Fail-to-`NOT_SERVING`, auto-effaçant (aucun état collant) | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — un contrat de commodité ; son levier est purement la forme du graphe de dépendances.
+- **Stabilité :** contrat stable — le trait est stabilisé ; le changer est un changement cassant à l'échelle de la flotte.
+- **Volatilité :** très faible — la surface est de deux items.
+- **Capacités différées :** aucune ; une santé plus riche (dégradé vs down, dépendances pondérées) serait un
+  nouvel enum sur le résultat, mais n'est pas modélisée aujourd'hui.

--- a/crates/foundation/health/docs/DOMAIN.md
+++ b/crates/foundation/health/docs/DOMAIN.md
@@ -1,0 +1,128 @@
+# `health` — Domain & Functional Contract
+
+> A graph-leaf probe contract: the abstraction that answers *"is this backend reachable right now?"* — so storage crates can publish probes the runtime polls, with no edge between them.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | The liveness/readiness probe contract that drives a service's gRPC health status |
+> | **Layer** | `foundation` — a deliberate graph-leaf (tiny, depends on `async-trait` + `anyhow` only) |
+> | **Subdomain class** | **Generic** — a one-trait abstraction; its value is the decoupling, not the code |
+> | **Primary abstraction(s)** | `HealthProbe` + `FnProbe` (`health`) |
+> | **Footprint** | pure (no IO, no spawn) — it defines the contract, never opens a connection |
+> | **Failure posture** | **fail-to-`NOT_SERVING`, self-clearing** — any `Err` demotes the service until a later tick clears it |
+> | **Depends on** | `async-trait`, `anyhow` |
+> | **Consumed by** | `service-runtime` (polls probes → gRPC health), storage crates (`scylla`/`redis`/`postgres` expose probes) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `health` defines the **probe contract** the fleet uses to gate readiness: it answers
+**"can the runtime ask any backend 'are you reachable?' without depending on that backend's crate?"**
+
+**The hard problem.** A storage crate knows *how* to check its backend; the runtime knows *when* to check
+and *what* to do with the result. Putting the trait in either side would couple storage to the runtime (or
+vice-versa). A tiny leaf crate lets both sides depend only on it, so a storage crate publishes a probe and
+the runtime consumes it with **no edge between them** — the entire reason this crate exists.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Open connections or run real queries → the storage crate's `health::probe` does that.
+- ❌ Schedule polling or know about gRPC → owned by `service-runtime`'s readiness loop.
+- ❌ Hold sticky failure state → there is none; readiness re-derives from the latest tick.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Probe | A cheap reachability check the runtime polls each tick | `HealthProbe` |
+| Name | Short identifier for logs (`"scylla"`, `"redis"`) | `HealthProbe::name` |
+| Check | The async reachability ping; `Ok` = reachable | `HealthProbe::check` |
+| Fn-probe | A closure-backed probe for a bespoke dependency | `FnProbe` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `HealthProbe` | trait (seam) | `check()` must be cheap + idempotent (runs every readiness tick); `Ok(())` = reachable, any `Err` demotes |
+| `FnProbe<F>` | adapter | Wraps an `Fn() -> Future` so a probe needs no bespoke type; the closure is re-invoked every tick |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The probe *contract* only — the trait shape and the closure adapter. Nothing else.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| Live backend clients + the actual check | storage crates (`scylla`/`redis`/`postgres`) | They own their client; they depend only on this leaf |
+| Polling cadence + gRPC health wiring | `service-runtime` | The runtime schedules and maps results to `ServingStatus` |
+
+**The "do-not-depend-on" list:** never a storage client, never `tonic`, never `service-runtime`. Adding any
+such edge would reintroduce the coupling this crate was created to break.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `check()` is cheap (a reachability ping, not a query) | contract convention | a heavy probe flaps the service under load |
+| I2 | Any single probe `Err` demotes the whole service | `service-runtime` readiness loop | service → `NOT_SERVING` until next clean tick |
+| I3 | No sticky failure state — readiness re-derives each tick | by design (no state here) | — |
+| I4 | A `FnProbe` closure must be re-callable (`Fn`, not `FnOnce`) | type bound | compile error |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+N/A — pure contract crate, no runtime control flow of its own. The polling loop (first tick immediate,
+transition-only writes to the gRPC reporter) lives in `service-runtime`; the actual reachability check lives
+in each storage crate's `health::probe`. This crate is only the trait that joins them.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| storage crates | downstream | Published Contract | `impl HealthProbe` over their client | every service's readiness signal |
+| `service-runtime` | downstream | Published Contract | polls `Vec<Arc<dyn HealthProbe>>` | the readiness → gRPC-health mapping |
+
+> **Stability seam:** the `HealthProbe` trait is the entire public API; a signature change ripples to every
+> storage crate *and* the runtime simultaneously — treat it as a hard breaking change.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+N/A — pure. It emits nothing; the readiness `tracing` events (`"health status changed"`) are emitted by
+`service-runtime` when it acts on a probe result.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Place the probe trait in a graph-leaf so storage and runtime never couple | [`README §Architecture`](../README.md) | Accepted |
+| Fail-to-`NOT_SERVING`, self-clearing (no sticky state) | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — a commodity contract; its leverage is purely the dependency-graph shape.
+- **Stability:** stable contract — the trait has settled; changing it is a fleet-wide breaking change.
+- **Volatility:** very low — the surface is two items.
+- **Deferred capabilities:** none; richer health (degraded vs down, weighted dependencies) would be a new
+  enum on the result, but is not modelled today.

--- a/crates/foundation/infra-config/docs/DOMAIN.fr.md
+++ b/crates/foundation/infra-config/docs/DOMAIN.fr.md
@@ -1,0 +1,169 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 8d2ca3b63563fbed5a47381399fd8ff16bb5d75687a4b6a20d7a6a51931d4a23
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `infra-config` — Contrat de Domaine & Fonctionnel
+
+> Configuration externalisée & hot-reload fail-closed : la couche IO/policy qui répond à *« avec quels chiffres tournent les crates de middleware pures, et comment changent-ils sans redémarrage ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Config infra externalisée — parser, valider, résoudre les bindings, et hot-reloader les `[section]`s que les crates pures ne doivent pas parser elles-mêmes |
+> | **Couche** | `foundation` — la couche policy/IO alimentant les crates de middleware pures |
+> | **Classe de sous-domaine** | **Supporting** — le plan de contrôle opérationnel de la policy à l'échelle de la flotte ; fort levier pendant les incidents |
+> | **Abstraction(s) primaire(s)** | `InfraRegistry` + `Reloadable` (`infra_config::infra`, `infra_config::reload`) |
+> | **Empreinte** | IO/avec état — possède l'IO fichier, le parsing TOML, un watcher `notify`, et les swaps `ArcSwap` |
+> | **Posture en cas d'échec** | **fail-closed** — un document malformé ou invalide est rejeté ; la config saine précédente reste vivante |
+> | **Dépend de** | `notify`, `toml`, `serde`, `arc-swap`, `tokio`, `resilience` + `traffic` (`serde`) |
+> | **Consommé par** | `service-runtime` (charge + surveille) ; les services lisent les profils `[cache]`/`[resilience]` résolus |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `infra-config` fait autorité dans la flotte pour la **policy d'infrastructure externalisée** :
+il répond à **« d'où viennent les timeouts/quotas/TTL/sampling, et comment se re-règlent-ils à chaud ? »** —
+pour que les crates de mécanisme pures (`resilience`, `traffic`, les adaptateurs de cache, les dials télémétrie)
+restent libres d'IO.
+
+**Le problème difficile.** Les boutons critiques en incident (un timeout de circuit, un quota de débit, un
+filtre de log) doivent changer *sans redéploiement*, mais les crates qui les *utilisent* doivent rester pures
+et testables unitairement. `infra-config` absorbe toutes les parties dangereuses — IO fichier, parsing,
+validation, sémantique d'inode-swap des ConfigMaps K8s, swap sans race — derrière un unique chemin de reload
+fail-closed partagé par chaque section.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Posséder le *mécanisme* qu'une section configure (couches Tower, le limiteur, adaptateurs de cache) → ce
+  sont les crates pures (`resilience`, `traffic`, …).
+- ❌ Appliquer les dials télémétrie directement → il expose un `TelemetrySink` ; `service-runtime` fait le pont vers `telemetry`.
+- ❌ Hot-reloader la *topologie* (quels profils/sections existent, quelle dépendance binde où) → figée au boot.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Section | Une catégorie d'infrastructure dans le document | `[resilience]`, `[cache]`, `[traffic]`, `[telemetry]` |
+| Catalog | Profils nommés + une table de bindings, une forme par section | `Catalog<L>`, `catalog::validate_bindings` |
+| Binding | Un nom de dépendance/namespace → un profil de classe-de-service | (résolu dans chaque `*Registry`) |
+| Wire vs Runtime | Spec serde plate parsée du TOML vs handle `ArcSwap` lu par le chemin de données | `*ProfileSpec` vs `*Profile` |
+| Registry | Le détenteur résolu et hot-reloadable d'une section | `InfraRegistry`, `ResilienceRegistry`, `CacheRegistry`, `TrafficRegistry`, `TelemetryRegistry` |
+| Reloadable | La cible du watcher — parse + valide + swap | `Reloadable::reload` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `InfrastructureConfig` | document parsé | `from_toml` + `validate` ; les nouvelles sections sont `Option<…>` pour la compat ascendante |
+| `InfraRegistry` | registry agrégé | Résout chaque section ; `apply` swap tout-ou-rien |
+| `Reloadable` | trait (seam) | Découple le watcher de la forme de toute section ; `reload(raw)` est fail-closed |
+| `Catalog<L>` | forme partagée | Un seul chemin de résolution/validation réutilisé par chaque section |
+| `spawn_watcher` | fonction | Retourne un guard qui **doit rester vivant** pour que la surveillance continue |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- L'IO fichier, le parsing TOML, la validation fail-closed, les bindings de flotte, et le chemin de hot-reload
+  basé sur `notify` — la *plomberie de policy* dont chaque crate de mécanisme pure doit rester libre.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Couches Tower / état de circuit-breaker | `resilience` | Le mécanisme est pur ; ce crate ne fournit que ses chiffres |
+| Le limiteur GCRA | `traffic` | Même séparation de pureté |
+| Le pipeline télémétrie | `telemetry` | Ce crate expose un `TelemetrySink` ; le pont vit dans `service-runtime` |
+
+**La liste « do-not-depend-on » :** jamais `tonic`/`http` ni un crate de service. Il dépend *vers le haut* des
+crates pures (`resilience`, `traffic`) uniquement pour leurs types wire `serde` — jamais leur runtime.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | Chaque section présente valide *avant* tout swap (tout-ou-rien) | `apply` / `Reloadable::reload` | `ConfigError::Validation` ; la config précédente reste vivante |
+| I2 | Tous les swaps se font dans **une** tâche écrivain (pas de lecture déchirée/race) | l'unique watcher spawné | — |
+| I3 | Un binding/`default_profile` doit référencer un profil défini | `catalog::validate_bindings` | `ConfigError::Validation` |
+| I4 | Le watcher observe le **répertoire parent**, pas le chemin du fichier | `spawn_watcher` | (sinon l'inode-swap de ConfigMap K8s passe inaperçu) |
+| I5 | La topologie (sections/profils/bindings) est figée au boot ; seuls les *contenus* hot-reloadent | câblage à la résolution | nécessite un redémarrage |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Boot.** `load_from_path` lit + parse `infrastructure.toml` ; `InfraRegistry::from_config` valide chaque
+section et résout les bindings en handles runtime backés par `ArcSwap`. Un document malformé/invalide fait
+échouer le boot — le pod ne sert jamais une mauvaise config.
+
+**Boucle de hot-reload.** `spawn_watcher` surveille le *répertoire parent* (K8s échange l'inode du symlink
+`..data`, donc une surveillance du chemin de fichier devient sourde après le premier changement). Un événement
+`notify` → coalescence des rafales → relecture → `Reloadable::reload` : parse + valide **toutes** les sections
+présentes, puis swap **toutes** via `ArcSwap` (fail-closed, tout-ou-rien). Le guard retourné par `spawn_watcher`
+doit survivre au processus.
+
+**Chemin de données.** Les consommateurs tiennent des handles runtime (`*Profile`) et font `ArcSwap::load` d'un
+snapshot par opération — sans verrou, toujours cohérent au sein d'une seule décision.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `resilience` | amont | Conformist (types `serde`) | `ResilienceProfileSpec` | le parsing de `[resilience]` |
+| `traffic` | amont | Conformist (types `serde`) | `TrafficProfileSpec` | le parsing de `[traffic]` |
+| `service-runtime` | aval | Published Contract | `load_from_path`, `spawn_watcher`, `InfraRegistry` | le boot de flotte + hot-reload |
+| `telemetry` | indirect | Separated Interface | `TelemetrySink` (ponté par `service-runtime`) | le re-réglage live log/sampling |
+
+> **Seam de stabilité :** `InfraRegistry`, `Reloadable`, et les variantes de `ConfigError` sont le contrat
+> public sur lequel `service-runtime` se construit.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| reload appliqué / rejeté | `tracing` | un document de config est swappé ou échoue la validation | dashboards ops pendant un push de config |
+| surveillance fichier | effet de bord | un watcher `notify` sur le répertoire parent de la config | la couche inotify/FSEvents de l'OS |
+
+Il ne mute aucun store externe ; ses seuls effets de bord sont la lecture du fichier de config et le swap des
+handles `ArcSwap` en mémoire.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Séparation mécanisme pur vs IO/policy (le middleware ne lie ni `notify`/`toml`) | [`README §Architecture`](../README.md) | Accepted |
+| Swap fail-closed, toutes-sections-ou-aucune dans une tâche écrivain unique | [`README §Architecture`](../README.md) | Accepted |
+| Surveiller le répertoire parent pour survivre aux inode-swaps de ConfigMap K8s | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Supporting — le plan de contrôle de la policy à l'échelle de la flotte ; son levier est
+  opérationnel (re-régler un incident sans redéploiement).
+- **Stabilité :** en évolution — ajouter une nouvelle `[section]` est le chemin de croissance attendu (un spec
+  + un type live + un registry, réutilisant `Catalog<L>`).
+- **Volatilité :** moyenne — les *contenus* de section sont de la config ; la *machinerie de résolution* est stabilisée.
+- **Capacités différées :** aucune structurelle ; chaque nouvelle préoccupation infra devient une nouvelle section.

--- a/crates/foundation/infra-config/docs/DOMAIN.md
+++ b/crates/foundation/infra-config/docs/DOMAIN.md
@@ -1,0 +1,155 @@
+# `infra-config` — Domain & Functional Contract
+
+> Externalized configuration & fail-closed hot-reload: the IO/policy layer that answers *"what numbers do the pure middleware crates run with, and how do they change without a restart?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Externalized infra config — parse, validate, resolve bindings, and hot-reload the `[section]`s the pure crates must not parse themselves |
+> | **Layer** | `foundation` — the policy/IO layer feeding the pure middleware crates |
+> | **Subdomain class** | **Supporting** — the operational control plane for fleet-wide policy; high leverage during incidents |
+> | **Primary abstraction(s)** | `InfraRegistry` + `Reloadable` (`infra_config::infra`, `infra_config::reload`) |
+> | **Footprint** | IO/stateful — owns file IO, TOML parsing, a `notify` watcher, and `ArcSwap` swaps |
+> | **Failure posture** | **fail-closed** — a malformed or invalid document is rejected; the previous good config stays live |
+> | **Depends on** | `notify`, `toml`, `serde`, `arc-swap`, `tokio`, `resilience` + `traffic` (`serde`) |
+> | **Consumed by** | `service-runtime` (loads + watches); services read resolved `[cache]`/`[resilience]` profiles |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `infra-config` is the fleet's authority for **externalized infrastructure policy**: it
+answers **"where do the timeouts/quotas/TTLs/sampling come from, and how do they retune live?"** — so the
+pure mechanism crates (`resilience`, `traffic`, the cache adapters, telemetry dials) stay free of IO.
+
+**The hard problem.** Incident-critical knobs (a circuit timeout, a rate quota, a log filter) must change
+*without a redeploy*, but the crates that *use* them must remain pure and unit-testable. `infra-config`
+absorbs all the dangerous parts — file IO, parsing, validation, K8s ConfigMap inode-swap semantics,
+race-free swapping — behind one fail-closed reload path shared by every section.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Own the *mechanism* a section configures (Tower layers, the limiter, cache adapters) → those are the
+  pure crates (`resilience`, `traffic`, …).
+- ❌ Apply telemetry dials directly → it exposes a `TelemetrySink`; `service-runtime` bridges it to `telemetry`.
+- ❌ Hot-reload *topology* (which profiles/sections exist, which dependency binds where) → fixed at boot.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Section | One infrastructure category in the document | `[resilience]`, `[cache]`, `[traffic]`, `[telemetry]` |
+| Catalog | Named profiles + a binding table, one shape per section | `Catalog<L>`, `catalog::validate_bindings` |
+| Binding | A dependency/namespace name → a class-of-service profile | (resolved inside each `*Registry`) |
+| Wire vs Runtime | Flat serde spec parsed from TOML vs `ArcSwap`-backed handle the data path reads | `*ProfileSpec` vs `*Profile` |
+| Registry | The resolved, hot-reloadable holder for a section | `InfraRegistry`, `ResilienceRegistry`, `CacheRegistry`, `TrafficRegistry`, `TelemetryRegistry` |
+| Reloadable | The watcher's target — parse + validate + swap | `Reloadable::reload` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `InfrastructureConfig` | parsed document | `from_toml` + `validate`; new sections are `Option<…>` for backward compat |
+| `InfraRegistry` | aggregate registry | Resolves every section; `apply` swaps all-or-nothing |
+| `Reloadable` | trait (seam) | Decouples the watcher from any section's shape; `reload(raw)` is fail-closed |
+| `Catalog<L>` | shared shape | One resolution/validation path reused by every section |
+| `spawn_watcher` | function | Returns a guard that **must stay alive** for the watch to continue |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- File IO, TOML parsing, fail-closed validation, fleet bindings, and the `notify`-based hot-reload path —
+  the *policy plumbing* every pure mechanism crate must stay free of.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| Tower layers / circuit-breaker state | `resilience` | The mechanism is pure; this crate only supplies its numbers |
+| The GCRA limiter | `traffic` | Same purity split |
+| The telemetry pipeline | `telemetry` | This crate exposes a `TelemetrySink`; the bridge lives in `service-runtime` |
+
+**The "do-not-depend-on" list:** never `tonic`/`http` or any service crate. It depends *up* on the pure
+crates (`resilience`, `traffic`) only for their `serde` wire types — never their runtime.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Every present section validates *before* any section swaps (all-or-nothing) | `apply` / `Reloadable::reload` | `ConfigError::Validation`; previous config stays live |
+| I2 | All swaps happen in **one** writer task (no torn reads/races) | the single spawned watcher | — |
+| I3 | A binding/`default_profile` must reference a defined profile | `catalog::validate_bindings` | `ConfigError::Validation` |
+| I4 | The watcher observes the **parent directory**, not the file path | `spawn_watcher` | (else K8s ConfigMap inode-swap goes undetected) |
+| I5 | Topology (sections/profiles/bindings) is fixed at boot; only *contents* hot-reload | resolve-time wiring | requires restart |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Boot.** `load_from_path` reads + parses `infrastructure.toml`; `InfraRegistry::from_config` validates
+every section and resolves bindings into `ArcSwap`-backed runtime handles. A malformed/invalid document
+fails the boot — the pod never serves bad config.
+
+**Hot-reload loop.** `spawn_watcher` watches the *parent directory* (K8s swaps the `..data` symlink inode,
+so a file-path watch goes deaf after the first change). A `notify` event → coalesce bursts → re-read →
+`Reloadable::reload`: parse + validate **all** present sections, then swap **all** via `ArcSwap` (fail-closed,
+all-or-nothing). The guard returned by `spawn_watcher` must outlive the process.
+
+**Data path.** Consumers hold runtime handles (`*Profile`) and `ArcSwap::load` a snapshot per operation —
+lock-free, always consistent within a single decision.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `resilience` | upstream | Conformist (`serde` types) | `ResilienceProfileSpec` | `[resilience]` parsing |
+| `traffic` | upstream | Conformist (`serde` types) | `TrafficProfileSpec` | `[traffic]` parsing |
+| `service-runtime` | downstream | Published Contract | `load_from_path`, `spawn_watcher`, `InfraRegistry` | fleet boot + hot-reload |
+| `telemetry` | indirect | Separated Interface | `TelemetrySink` (bridged by `service-runtime`) | live log/sampling retuning |
+
+> **Stability seam:** `InfraRegistry`, `Reloadable`, and the `ConfigError` variants are the public contract
+> `service-runtime` builds on.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| reload applied / rejected | `tracing` | a config document is swapped or fails validation | ops dashboards during a config push |
+| filesystem watch | side-effect | a `notify` watcher on the config's parent dir | the OS inotify/FSEvents layer |
+
+It mutates no external store; its only side effects are reading the config file and swapping in-process
+`ArcSwap` handles.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Pure mechanism vs IO/policy split (middleware links no `notify`/`toml`) | [`README §Architecture`](../README.md) | Accepted |
+| Fail-closed, all-sections-or-nothing swap in a single writer task | [`README §Architecture`](../README.md) | Accepted |
+| Watch the parent directory to survive K8s ConfigMap inode swaps | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Supporting — the control plane for fleet-wide policy; its leverage is operational
+  (retune an incident without a redeploy).
+- **Stability:** evolving — adding a new `[section]` is the expected growth path (a spec + a live type + a
+  registry, reusing `Catalog<L>`).
+- **Volatility:** medium — section *contents* are config; the *resolution machinery* is settled.
+- **Deferred capabilities:** none structural; each new infra concern becomes a new section.

--- a/crates/foundation/resilience/docs/DOMAIN.fr.md
+++ b/crates/foundation/resilience/docs/DOMAIN.fr.md
@@ -1,0 +1,178 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 296c08fb171e964208dde7fb81814d14592b18c404fc7ae3e08d22a37ba75c8e
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `resilience` — Contrat de Domaine & Fonctionnel
+
+> Tolérance aux pannes en sortie : le middleware Tower pur qui répond à *« cet appel sortant doit-il être tenté, retenté, ou échoué rapidement ? »* — le miroir côté client de `traffic`.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Protection contre les pannes en cascade à la frontière de transport sortante (circuit breaker · retry · timeout) |
+> | **Couche** | `foundation` — un mécanisme de middleware Tower pur |
+> | **Classe de sous-domaine** | **Generic** — patterns de résilience standard ; le levier est la cohérence à l'échelle de la flotte + le hot-reload |
+> | **Abstraction(s) primaire(s)** | `ResilienceProfile` + les trois types `*Layer` (`resilience::profile`, `::{circuit_breaker, retry, timeout}`) |
+> | **Empreinte** | pure (aucune IO, aucun `notify`, aucune tâche spawnée) ; feature `serde` désactivée par défaut |
+> | **Posture en cas d'échec** | **fail-fast** — un downstream malsain fait sauter le circuit et les requêtes ne sont *pas* transmises (`CircuitOpen`) |
+> | **Dépend de** | `tower`, `arc-swap`, `tokio`, `thiserror`, `rand`, `error`, `serde` (optionnel) |
+> | **Consommé par** | `transport` (clients gRPC/Kafka), le bus `cqrs` ; configuré via `infra-config` |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `resilience` fait autorité dans la flotte pour la **tolérance aux pannes en sortie** : il répond
+à **« ce downstream est-il assez sain pour être appelé, et si un appel échoue de façon transitoire, comment
+retenter sans amplifier la panne ? »** — à l'échelle de la flotte, sans toucher la logique métier.
+
+**Le problème difficile.** Trois patterns (timeout, circuit breaker, retry) doivent se composer dans un ordre
+*porteur* et se reconfigurer à chaud pendant un incident, tout en restant une bibliothèque pure et testable
+unitairement. `resilience` garde le mécanisme pur (profils nommés derrière des handles `ArcSwap`) et pousse le
+parsing/validation/bindings dans `infra-config`, pour qu'un push de config re-règle un channel vivant sans rebuild.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Protéger un *serveur* de la charge entrante (entrée) → c'est `traffic`, le crate miroir.
+- ❌ Parser ou valider sa config → relève de `infra-config`.
+- ❌ Retenter au niveau du channel gRPC → les bodies HTTP/2 sont des streams ; le retry relève de la couche
+  application (voir `transport`), les couches circuit/timeout enveloppent le channel.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Profile | Une classe-de-service nommée regroupant un timeout + CB + retry | `ResilienceProfile`, `ResilienceProfileSpec` |
+| Circuit breaker | La machine à états fail-fast sur la santé d'un downstream | `CircuitBreakerLayer`, `CircuitBreakerConfig` |
+| Retry policy | Si une erreur à la tentative N est retentable | `RetryPolicy`, `DefaultRetryPolicy` |
+| Backoff | L'échéancier de délai entre tentatives | `BackoffStrategy`, `ExponentialBackoff`, `JitterKind` |
+| Resilience error | L'enveloppe d'issue émise par le middleware | `ResilienceError::{CircuitOpen, Timeout, MaxRetriesExhausted, Inner}` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `ResilienceProfile` | handle runtime | Regroupe les trois couches ; timeout/CB derrière `ArcSwap` partagé pour le hot-reload |
+| `ResilienceError<E>` | enveloppe d'erreur | `Inner(E)` est la *seule* variante portant l'état downstream ; le reste est émis par le middleware |
+| `CircuitBreakerLayer` / `…Service` | couche Tower | Possède le `Arc<StateMachine>` ; les clones partagent l'état (tonic clone par RPC) |
+| `RetryLayer` | couche Tower | Exige `S: Clone` **et** `Req: Clone` (réémet la requête par tentative) |
+| `BackoffStrategy` | trait (seam) | `next_delay(attempt)` ; `ExponentialBackoff` défaut au jitter `Full` |
+
+**Machine à états du circuit breaker.**
+
+```
+Closed --(failure_threshold échecs consécutifs)--> Open
+Open   --(open_duration écoulé)--> HalfOpen
+HalfOpen --(success_threshold succès)--> Closed
+HalfOpen --(tout échec de probe)--> Open          (half_open_max_calls plafonne les probes concurrentes)
+```
+
+> Une requête atteignant un circuit `Open` n'est **pas transmise** — elle retourne `CircuitOpen` immédiatement.
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Les trois couches de middleware, leurs machines à états/types de config, et l'ordre de composition. L'état
+  de circuit, la comptabilité de retry, et l'application du timeout vivent ici et nulle part ailleurs.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Parsing TOML / validation / bindings / surveillance fichier | `infra-config` | Frontière de pureté — le mécanisme ne lie ni `notify`/`toml` |
+| Mapper `ResilienceError` → `TransportError`/`Status` | `transport` | Le couplage transport reste hors du crate pur |
+| Le *sens* de retentabilité d'une erreur | `error` (`AppError::is_retryable`) | `DefaultRetryPolicy` y délègue |
+
+**La liste « do-not-depend-on » :** jamais `notify`, `toml`, `tonic`, ou `http`. La feature `serde` (désactivée
+par défaut) est la seule surface optionnelle — désactivée, le crate ne lie aucun code serde/derive.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | L'ordre des couches est Timeout ⊃ CircuitBreaker ⊃ Retry | composition (appelant) | le circuit mal-compte les retries / saute trop tard |
+| I2 | La config est échantillonnée une fois par `call` (un `ArcSwap::load`) | le `call` de chaque couche | valeurs incohérentes en cours de décision |
+| I3 | Un swap de config ne réinitialise jamais l'état vivant (compteurs, timers, circuit) | store `ArcSwap` | — |
+| I4 | `Inner(E)` est la seule variante portant l'état d'erreur downstream | système de types | — |
+| I5 | L'exposant est borné (≤30) pour éviter l'overflow `u64` du backoff | `ExponentialBackoff` | — |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Chemin chaud — un `call`.** Le `TimeoutLayer` le plus externe arme une échéance ; `CircuitBreakerLayer`
+vérifie l'état (`Open` → retourne `CircuitOpen` sans transmettre) et, si `Closed`/`HalfOpen`, transmet ;
+`RetryLayer` réémet sur erreurs retentables avec `ExponentialBackoff` + jitter `Full` jusqu'à `max_attempts`.
+Chaque couche fait `ArcSwap::load` de sa config une fois pour que la décision raisonne sur des valeurs cohérentes.
+
+**Pourquoi l'ordre est porteur.** Le circuit doit se situer *à l'extérieur* du retry pour compter chaque
+tentative (y compris les retries) et sauter à temps ; inversez-les et le circuit ne voit que le premier appel.
+Timeout le plus externe borne le budget *total* de la requête, retries inclus.
+
+**Reconfiguration.** `infra-config` appelle `ResilienceProfile::apply(spec)` ; le store `ArcSwap` est sans
+verrou et laisse l'état de circuit, les compteurs de retry, et les timers intacts — un channel vivant se re-règle
+sans rebuild.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `error` | amont | Conformist | `AppError::is_retryable` (`DefaultRetryPolicy`) | la classification de retry |
+| `transport` | aval | Published Contract | les trois `*Layer` + `ResilienceProfile` | chaque client gRPC/Kafka résilient |
+| bus `cqrs` | aval | Published Contract | enveloppe le dispatch sortant | la résilience couche application |
+| `infra-config` | aval | Conformist (`serde`) | `ResilienceProfileSpec` | le parsing/hot-reload de `[resilience]` |
+| `traffic` | frère (miroir) | — | partage la forme catalog+bindings, direction opposée | symétrie |
+
+> **Seam de stabilité :** `ResilienceError`, les types `*Layer`, et `ResilienceProfile` sont une API publique
+> consommée par `transport`.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| transition de circuit | `tracing` INFO (`prev`/`next`) | la machine à états bouge | dashboards de résilience |
+| circuit déclenché / probe échouée | `tracing` WARN | seuil franchi / probe half-open échoue | paging sur `CircuitOpen` |
+| retry planifié / timeout de requête | `tracing` WARN (`attempt`, `delay_ms`, `timeout_ms`) | un retry est mis en file / échéance atteinte | alertes niveau warn |
+
+Pas encore d'export de métriques OTel (un TODO noté) ; aucune mutation d'état externe.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Middleware pur ; profils derrière `ArcSwap`, parsing dans `infra-config` | [`README §Architecture`](../README.md) | Accepted |
+| Ordre des couches Timeout ⊃ CircuitBreaker ⊃ Retry (le circuit compte les retries, saute à temps) | [`README §Architecture`](../README.md) | Accepted |
+| Défaut `JitterKind::Full` pour vaincre les retries en lockstep à l'échelle de la flotte | [`README §Architecture`](../README.md) | Accepted |
+| Aucun `RetryLayer` au niveau du channel (buffering de body HTTP/2) | [`transport README`](../../../platform/transport/README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — patterns de résilience classiques ; le levier est l'uniformité à l'échelle de
+  la flotte + le re-réglage live, pas la nouveauté.
+- **Stabilité :** contrat stable — prêt pour la production, aucun stub.
+- **Volatilité :** faible — les trois patterns sont stabilisés ; la croissance est dans les stratégies de backoff / policies.
+- **Capacités différées :** des instruments de métriques OTel pour les couches (aujourd'hui seulement des événements `tracing`).

--- a/crates/foundation/resilience/docs/DOMAIN.md
+++ b/crates/foundation/resilience/docs/DOMAIN.md
@@ -1,0 +1,166 @@
+# `resilience` — Domain & Functional Contract
+
+> Egress fault tolerance: the pure Tower middleware that answers *"should this outbound call be attempted, retried, or fast-failed?"* — the client-side mirror of `traffic`.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Cascading-failure protection at the outbound transport boundary (circuit breaker · retry · timeout) |
+> | **Layer** | `foundation` — a pure Tower-middleware mechanism |
+> | **Subdomain class** | **Generic** — standard resilience patterns; leverage is fleet-wide consistency + hot-reload |
+> | **Primary abstraction(s)** | `ResilienceProfile` + the three `*Layer` types (`resilience::profile`, `::{circuit_breaker, retry, timeout}`) |
+> | **Footprint** | pure (no IO, no `notify`, no spawned tasks); `serde` feature off by default |
+> | **Failure posture** | **fail-fast** — an unhealthy downstream trips the circuit and requests are *not* forwarded (`CircuitOpen`) |
+> | **Depends on** | `tower`, `arc-swap`, `tokio`, `thiserror`, `rand`, `error`, `serde` (optional) |
+> | **Consumed by** | `transport` (gRPC/Kafka clients), the `cqrs` bus; configured via `infra-config` |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `resilience` is the fleet's authority for **egress fault tolerance**: it answers
+**"is this downstream healthy enough to call, and if a call fails transiently, how do we retry without
+amplifying the outage?"** — fleet-wide, without touching business logic.
+
+**The hard problem.** Three patterns (timeout, circuit breaker, retry) must compose in a *load-bearing*
+order and reconfigure live during an incident, while staying a pure, unit-testable library. `resilience`
+keeps the mechanism pure (named profiles behind `ArcSwap` handles) and pushes parsing/validation/bindings
+into `infra-config`, so a config push retunes a live channel with no rebuild.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Protect a *server* from inbound load (ingress) → that is `traffic`, the mirror crate.
+- ❌ Parse or validate its config → owned by `infra-config`.
+- ❌ Retry at the gRPC channel level → HTTP/2 bodies are streams; retry belongs at the application layer
+  (see `transport`), the circuit/timeout layers wrap the channel.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Profile | A named class-of-service bundling one timeout + CB + retry | `ResilienceProfile`, `ResilienceProfileSpec` |
+| Circuit breaker | The fail-fast state machine over a downstream's health | `CircuitBreakerLayer`, `CircuitBreakerConfig` |
+| Retry policy | Whether an error at attempt N is retryable | `RetryPolicy`, `DefaultRetryPolicy` |
+| Backoff | The delay schedule between attempts | `BackoffStrategy`, `ExponentialBackoff`, `JitterKind` |
+| Resilience error | The middleware-emitted outcome envelope | `ResilienceError::{CircuitOpen, Timeout, MaxRetriesExhausted, Inner}` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `ResilienceProfile` | runtime handle | Bundles the three layers; timeout/CB behind shared `ArcSwap` for hot-reload |
+| `ResilienceError<E>` | error envelope | `Inner(E)` is the *only* variant carrying downstream state; the rest are middleware-emitted |
+| `CircuitBreakerLayer` / `…Service` | Tower layer | Owns the `Arc<StateMachine>`; clones share state (tonic clones per RPC) |
+| `RetryLayer` | Tower layer | Requires `S: Clone` **and** `Req: Clone` (re-issues the request per attempt) |
+| `BackoffStrategy` | trait (seam) | `next_delay(attempt)`; `ExponentialBackoff` defaults to `Full` jitter |
+
+**Circuit-breaker state machine.**
+
+```
+Closed --(failure_threshold consecutive failures)--> Open
+Open   --(open_duration elapsed)--> HalfOpen
+HalfOpen --(success_threshold successes)--> Closed
+HalfOpen --(any probe failure)--> Open          (half_open_max_calls caps concurrent probes)
+```
+
+> A request hitting an `Open` circuit is **not forwarded** — it returns `CircuitOpen` immediately.
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The three middleware layers, their state machines/config types, and the composition order. The circuit
+  state, retry accounting, and timeout enforcement live here and nowhere else.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| TOML parsing / validation / bindings / file-watching | `infra-config` | Purity boundary — the mechanism links no `notify`/`toml` |
+| Mapping `ResilienceError` → `TransportError`/`Status` | `transport` | Transport coupling stays out of the pure crate |
+| The retryability *meaning* of an error | `error` (`AppError::is_retryable`) | `DefaultRetryPolicy` delegates to it |
+
+**The "do-not-depend-on" list:** never `notify`, `toml`, `tonic`, or `http`. The `serde` feature (off by
+default) is the only optional surface — with it off the crate links no serde/derive code.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Layer order is Timeout ⊃ CircuitBreaker ⊃ Retry | composition (caller) | circuit miscounts retries / trips too late |
+| I2 | Config is sampled once per `call` (one `ArcSwap::load`) | each layer's `call` | inconsistent mid-decision values |
+| I3 | A config swap never resets live state (counters, timers, circuit) | `ArcSwap` store | — |
+| I4 | `Inner(E)` is the only variant carrying downstream error state | type system | — |
+| I5 | Exponent is clamped (≤30) to avoid `u64` overflow in backoff | `ExponentialBackoff` | — |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Hot path — one `call`.** Outermost `TimeoutLayer` arms a deadline; `CircuitBreakerLayer` checks state
+(`Open` → return `CircuitOpen` without forwarding) and, if `Closed`/`HalfOpen`, forwards; `RetryLayer`
+re-issues on retryable errors with `ExponentialBackoff` + `Full` jitter up to `max_attempts`. Each layer
+`ArcSwap::load`s its config once so the decision reasons against consistent values.
+
+**Why the order is load-bearing.** The circuit must sit *outside* retry so it counts every attempt (incl.
+retries) and trips on time; invert them and the circuit only ever sees the first call. Timeout outermost
+bounds the *total* request budget including all retries.
+
+**Reconfiguration.** `infra-config` calls `ResilienceProfile::apply(spec)`; the `ArcSwap` store is lock-free
+and leaves circuit state, retry counters, and timers untouched — so a live channel retunes without a rebuild.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `error` | upstream | Conformist | `AppError::is_retryable` (`DefaultRetryPolicy`) | retry classification |
+| `transport` | downstream | Published Contract | the three `*Layer`s + `ResilienceProfile` | every resilient gRPC/Kafka client |
+| `cqrs` bus | downstream | Published Contract | wraps outbound dispatch | application-layer resilience |
+| `infra-config` | downstream | Conformist (`serde`) | `ResilienceProfileSpec` | `[resilience]` parsing/hot-reload |
+| `traffic` | sibling (mirror) | — | shares the catalog+bindings shape, opposite direction | symmetry |
+
+> **Stability seam:** `ResilienceError`, the `*Layer` types, and `ResilienceProfile` are public API consumed
+> by `transport`.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| circuit transition | `tracing` INFO (`prev`/`next`) | state machine moves | resilience dashboards |
+| circuit tripped / probe failed | `tracing` WARN | threshold crossed / half-open probe fails | paging on `CircuitOpen` |
+| retry scheduled / request timeout | `tracing` WARN (`attempt`, `delay_ms`, `timeout_ms`) | a retry is queued / deadline hit | warn-level alerts |
+
+No OTel metric exports yet (a noted TODO); no external state mutation.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Pure middleware; profiles behind `ArcSwap`, parsing in `infra-config` | [`README §Architecture`](../README.md) | Accepted |
+| Layer order Timeout ⊃ CircuitBreaker ⊃ Retry (circuit counts retries, trips on time) | [`README §Architecture`](../README.md) | Accepted |
+| `JitterKind::Full` default to defeat fleet-wide thundering-herd retries | [`README §Architecture`](../README.md) | Accepted |
+| No `RetryLayer` at the channel level (HTTP/2 body buffering) | [`transport README`](../../../platform/transport/README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — textbook resilience patterns; the leverage is fleet-wide uniformity + live
+  retuning, not novelty.
+- **Stability:** stable contract — production-ready, no stubs.
+- **Volatility:** low — the three patterns are settled; growth is in backoff strategies / policies.
+- **Deferred capabilities:** OTel metric instruments for the layers (today only `tracing` events).

--- a/crates/foundation/traffic/docs/DOMAIN.fr.md
+++ b/crates/foundation/traffic/docs/DOMAIN.fr.md
@@ -1,0 +1,166 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 62dd4ecd4802678cf6d86fdd90ef5f98c924b455111ad382d99f6b3acff66417
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `traffic` — Contrat de Domaine & Fonctionnel
+
+> Rate limiting côté serveur : le mécanisme pur qui répond à *« ce caller peut-il passer maintenant ? »* — le miroir en entrée de `resilience`.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Rate limiting en entrée — la décision d'admission par réplica pour la charge entrante |
+> | **Couche** | `foundation` — une feuille pure ; ne dépend que de `arc-swap`, `async-trait`, `governor` |
+> | **Classe de sous-domaine** | **Generic** — un limiteur GCRA de commodité ; la différenciation est dans *l'emplacement*, pas l'algorithme |
+> | **Abstraction(s) primaire(s)** | `TrafficProfile` + `QuotaBackend` (`traffic::profile`, `traffic::backend`) |
+> | **Empreinte** | pure (aucune IO, aucun spawn) ; la feature `serde` désactivée par défaut la garde sans derive |
+> | **Posture en cas d'échec** | **fail-open** — le limiteur ne fait qu'*ajouter* un `Throttle` ; il ne peut pas faire échouer une requête par erreur |
+> | **Dépend de** | `arc-swap`, `async-trait`, `governor`, `serde` (optionnel) |
+> | **Consommé par** | `transport` (extraction de clé + mapping `RESOURCE_EXHAUSTED`), `infra-config` (parse `[traffic]`), `traffic-redis` (implémente `QuotaBackend`) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `traffic` fait autorité dans la flotte pour la **décision d'admission en entrée** : étant
+donné une clé, il répond à **« ce caller est-il dans son budget pour la fenêtre courante, ou doit-il être
+throttlé ? »**
+
+**Le problème difficile.** Un limiteur n'est utile qu'au bord du transport, mais coupler l'*algorithme* à
+`tonic`/`http` le rendrait intestable et forcerait chaque consommateur à hériter d'une stack web. `traffic`
+sépare la décision (pure, ici) de l'extraction-et-mapping (couplée au transport, dans `transport`), pour que
+le même mécanisme serve tout futur transport sans changement.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Extraire une clé d'une requête / mapper `Throttle` → `RESOURCE_EXHAUSTED` → relève de `transport`.
+- ❌ Parser ou valider la section de config `[traffic]` → relève de `infra-config`.
+- ❌ Coordonner un budget global à la flotte entre réplicas → relève de `traffic-redis` (le `QuotaBackend`).
+- ❌ Protéger un *caller* d'un downstream lent (sortie) → c'est `resilience`, le crate miroir.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Profile | Un limiteur nommé de classe-de-service résolu depuis la config | `TrafficProfile`, `TrafficProfileSpec` |
+| Decision | Le verdict du chemin chaud pour une clé | `TrafficDecision::{Allow, Throttle}` |
+| Mode | La localité d'état du limiteur | `Mode::{Local, Distributed}` |
+| Scope | La dimension de clé (par méthode / par caller) | `Scope` |
+| Quota / backend | Le seam « louer N jetons » pour le mode distribué | `Quota`, `QuotaBackend`, `QuotaError` |
+| Enforce vs shadow | Si un `Throttle` rejette vraiment ou ne fait que compter | `TrafficProfile::enforce` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `TrafficProfile` | handle runtime | Tient le limiteur GCRA derrière `ArcSwap` ; `check(key)` est le chemin chaud, `apply`/`prune` le mutent |
+| `TrafficDecision` | type valeur | Exactement deux issues — `Allow` ou `Throttle { retry_after }` ; jamais une erreur |
+| `Mode` | enum | `Local` est appliqué ; `Distributed` est *parsé-mais-rejeté* jusqu'à l'arrivée du backend |
+| `QuotaBackend` | trait (seam) | Le contrat atomique « louer des jetons » qu'un backend distribué doit honorer |
+
+**Cycle de vie du Mode.**
+
+```
+config parse --(Mode::Local)--> appliqué (governor par réplica)
+config parse --(Mode::Distributed)--> REJETÉ par la validation infra-config (Step 1)
+```
+
+> Seul `Mode::Local` est atteignable en production aujourd'hui. `Distributed` est modélisé pour la
+> compatibilité ascendante et rejeté à la validation de config jusqu'au câblage de `traffic-redis` (Step 2).
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Le mécanisme de limiteur, les *types* de config, et `check(key) -> TrafficDecision`. La comptabilité GCRA
+  et l'état par clé vivent ici et nulle part ailleurs.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| `tonic` / `http` / extraction de clé | `transport` | Garde le mécanisme agnostique au transport et testable unitairement |
+| Parsing TOML / validation / bindings | `infra-config` | Frontière de pureté — un crate pur ne lie ni `notify`/`toml` |
+| Leasing de jetons inter-réplicas | `traffic-redis` | L'état distribué est un `QuotaBackend` injecté, pas intégré |
+
+**La liste « do-not-depend-on » :** jamais `tonic`, `http`, `notify`, `toml`, ni un client Redis. La feature
+`serde` est la *seule* surface optionnelle, désactivée par défaut pour que le cœur ne lie aucun code derive.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | `check(key)` ne retourne jamais d'erreur — seulement `Allow`/`Throttle` | système de types (`TrafficDecision` n'a pas de variante erreur) | inatteignable |
+| I2 | L'état du limiteur par clé doit être borné | runtime — l'appelant lance `prune()` sur un timer | croissance mémoire non bornée |
+| I3 | `Mode::Distributed` n'est pas appliqué tant qu'aucun backend n'est câblé | validation `infra-config` | config rejetée au boot |
+| I4 | Les swaps de config sont lock-free et ne réinitialisent jamais les compteurs vivants | `ArcSwap` dans `apply` | — |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Chemin chaud — `check(key)`.** Un lookup/update de cellule GCRA contre l'état `governor` par clé, retournant
+`Allow` ou `Throttle { retry_after }`. Aucune allocation sur le chemin commun, aucun réseau en mode `Local`.
+
+**Swap de config — `apply(spec)`.** Piloté par le hot-reload de `infra-config` : `ArcSwap::store` échange le
+spec du profil sans verrou. L'état vivant du limiteur (cellules, timers) survit au swap intact.
+
+**Bornage mémoire — `prune()`.** L'état GCRA par clé accumule une entrée par clé distincte (non borné pour le
+scope `per_caller`). Le consommateur (la boucle de prune de `service-runtime`) appelle `prune()` à une cadence
+pour évincer les clés inactives ; `key_count()` dimensionne la cadence.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `transport` | aval | Published Contract | `check` / `TrafficDecision` | le limiting en entrée de chaque serveur gRPC |
+| `infra-config` | aval | Conformist (`serde`) | types wire `TrafficProfileSpec` | le parsing/validation de `[traffic]` |
+| `traffic-redis` | aval | Separated Interface | trait `QuotaBackend` | l'application du mode distribué |
+| `resilience` | frère (miroir) | — | partage la forme catalog+bindings, direction opposée | symétrie du modèle mental |
+
+> **Seam de stabilité :** `TrafficDecision` et `QuotaBackend` sont une API publique — un changement est
+> cassant pour `transport` et `traffic-redis` respectivement.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+N/A — mécanisme pur. Il n'émet aucun événement `tracing` ni métrique propre ; la métrique de throttle
+(`infra_traffic_throttled_total{status}`) est enregistrée par `transport` là où la décision est appliquée.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Séparer le limiteur pur du glue transport (miroir de `resilience`) | [`README §Architecture`](../README.md) | Accepted |
+| `Local` appliqué maintenant, `Distributed` parsé-mais-rejeté jusqu'au Step 2 | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — un limiteur GCRA de commodité ; le levier est le layering, pas le calcul.
+- **Stabilité :** en évolution — le mode `Distributed` arrive au Step 2 (le seam `QuotaBackend` existe déjà).
+- **Volatilité :** faible — `Allow`/`Throttle` et `check(key)` sont stabilisés ; la croissance est additive
+  (nouveaux scopes).
+- **Capacités différées :** l'application distribuée globale à la flotte via `traffic-redis` (Step 2), déjà
+  modélisée par `Mode::Distributed` + `QuotaBackend`.

--- a/crates/foundation/traffic/docs/DOMAIN.md
+++ b/crates/foundation/traffic/docs/DOMAIN.md
@@ -1,0 +1,153 @@
+# `traffic` — Domain & Functional Contract
+
+> Server-side rate limiting: the pure mechanism that answers *"may this caller pass right now?"* — the ingress mirror of `resilience`.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Ingress rate limiting — the per-replica admission decision for inbound load |
+> | **Layer** | `foundation` — a pure leaf; depends only on `arc-swap`, `async-trait`, `governor` |
+> | **Subdomain class** | **Generic** — a commodity GCRA limiter; differentiation is in *where* it sits, not the algorithm |
+> | **Primary abstraction(s)** | `TrafficProfile` + `QuotaBackend` (`traffic::profile`, `traffic::backend`) |
+> | **Footprint** | pure (no IO, no spawn); `serde` feature off by default keeps it derive-free |
+> | **Failure posture** | **fail-open** — the limiter only ever *adds* a `Throttle`; it cannot fail a request by erroring |
+> | **Depends on** | `arc-swap`, `async-trait`, `governor`, `serde` (optional) |
+> | **Consumed by** | `transport` (key extraction + `RESOURCE_EXHAUSTED` mapping), `infra-config` (parses `[traffic]`), `traffic-redis` (implements `QuotaBackend`) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `traffic` is the fleet's authority for the **ingress admission decision**: given a key,
+it answers **"is this caller within budget for the current window, or must it be throttled?"**
+
+**The hard problem.** A limiter is only useful at the transport edge, but coupling the *algorithm* to
+`tonic`/`http` would make it untestable and force every consumer to inherit a web stack. `traffic`
+splits the decision (pure, here) from the extraction-and-mapping (transport-coupled, in `transport`),
+so the same mechanism serves any future transport unchanged.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Extract a key from a request / map `Throttle` → `RESOURCE_EXHAUSTED` → owned by `transport`.
+- ❌ Parse or validate the `[traffic]` config section → owned by `infra-config`.
+- ❌ Coordinate a fleet-global budget across replicas → owned by `traffic-redis` (the `QuotaBackend`).
+- ❌ Protect a *caller* from a slow downstream (egress) → that is `resilience`, the mirror crate.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Profile | A named class-of-service limiter resolved from config | `TrafficProfile`, `TrafficProfileSpec` |
+| Decision | The hot-path verdict for one key | `TrafficDecision::{Allow, Throttle}` |
+| Mode | State locality of the limiter | `Mode::{Local, Distributed}` |
+| Scope | The keying dimension (per-method / per-caller) | `Scope` |
+| Quota / backend | The "lease N tokens" seam for distributed mode | `Quota`, `QuotaBackend`, `QuotaError` |
+| Enforce vs shadow | Whether a `Throttle` actually rejects or only counts | `TrafficProfile::enforce` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `TrafficProfile` | runtime handle | Holds the GCRA limiter behind `ArcSwap`; `check(key)` is the hot path, `apply`/`prune` mutate it |
+| `TrafficDecision` | value type | Exactly two outcomes — `Allow` or `Throttle { retry_after }`; never an error |
+| `Mode` | enum | `Local` is enforced; `Distributed` is *parsed-but-rejected* until the backend ships |
+| `QuotaBackend` | trait (seam) | The atomic "lease tokens" contract a distributed backend must honour |
+
+**Mode lifecycle.**
+
+```
+config parse --(Mode::Local)--> enforced (per-replica governor)
+config parse --(Mode::Distributed)--> REJECTED by infra-config validation (Step 1)
+```
+
+> Only `Mode::Local` is reachable in production today. `Distributed` is modelled for
+> forward-compatibility and rejected at config-validation time until `traffic-redis` is wired (Step 2).
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The limiter mechanism, the config *types*, and `check(key) -> TrafficDecision`. The GCRA accounting
+  and per-key state live here and nowhere else.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| `tonic` / `http` / key extraction | `transport` | Keeps the mechanism transport-agnostic and unit-testable |
+| TOML parsing / validation / bindings | `infra-config` | Purity boundary — a pure crate links no `notify`/`toml` |
+| Cross-replica token leasing | `traffic-redis` | Distributed state is an injected `QuotaBackend`, not a built-in |
+
+**The "do-not-depend-on" list:** never `tonic`, `http`, `notify`, `toml`, or a Redis client. The
+`serde` feature is the *only* optional surface, and it is off by default so the core links no derive code.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `check(key)` never returns an error — only `Allow`/`Throttle` | type system (`TrafficDecision` has no error variant) | unreachable |
+| I2 | Per-key limiter state must be bounded | runtime — caller runs `prune()` on a timer | unbounded memory growth |
+| I3 | `Mode::Distributed` is not enforced until a backend is wired | `infra-config` validation | config rejected at boot |
+| I4 | Config swaps are lock-free and never reset live counters | `ArcSwap` in `apply` | — |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Hot path — `check(key)`.** One GCRA cell lookup/update against the per-key `governor` state, returning
+`Allow` or `Throttle { retry_after }`. No allocation on the common path, no network in `Local` mode.
+
+**Config swap — `apply(spec)`.** Driven by `infra-config` hot-reload: `ArcSwap::store` swaps the profile
+spec lock-free. Live limiter state (cells, timers) survives the swap untouched.
+
+**Memory bounding — `prune()`.** Per-key GCRA state accumulates one entry per distinct key (unbounded for
+`per_caller` scope). The consumer (`service-runtime`'s prune loop) calls `prune()` on a cadence to evict
+idle keys; `key_count()` sizes the cadence.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `transport` | downstream | Published Contract | `check` / `TrafficDecision` | ingress limiting on every gRPC server |
+| `infra-config` | downstream | Conformist (`serde`) | `TrafficProfileSpec` wire types | `[traffic]` parsing/validation |
+| `traffic-redis` | downstream | Separated Interface | `QuotaBackend` trait | distributed-mode enforcement |
+| `resilience` | sibling (mirror) | — | shares the catalog+bindings shape, opposite direction | mental-model symmetry |
+
+> **Stability seam:** `TrafficDecision` and `QuotaBackend` are public API — a change is a breaking change
+> for `transport` and `traffic-redis` respectively.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+N/A — pure mechanism. It emits no `tracing` events and no metrics of its own; the throttle metric
+(`infra_traffic_throttled_total{status}`) is recorded by `transport` where the decision is applied.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Split the pure limiter from the transport glue (mirror of `resilience`) | [`README §Architecture`](../README.md) | Accepted |
+| `Local` enforced now, `Distributed` parsed-but-rejected until Step 2 | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — a commodity GCRA limiter; the leverage is the layering, not the math.
+- **Stability:** evolving — `Distributed` mode lands in Step 2 (the `QuotaBackend` seam already exists).
+- **Volatility:** low — `Allow`/`Throttle` and `check(key)` are settled; growth is additive (new scopes).
+- **Deferred capabilities:** fleet-global distributed enforcement via `traffic-redis` (Step 2), already
+  modelled by `Mode::Distributed` + `QuotaBackend`.

--- a/crates/foundation/validate-core/docs/DOMAIN.fr.md
+++ b/crates/foundation/validate-core/docs/DOMAIN.fr.md
@@ -1,0 +1,144 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 2f46c67d540bbe6e0ed3a49ee439585f826eca5dfd7f3751ef33ad7fbff0e603
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `validate-core` — Contrat de Domaine & Fonctionnel
+
+> L'abstraction de validation zéro-dépendance : une Separated Interface répondant à *« comment `cqrs` et `validation` peuvent-ils partager un contrat de validation sans dépendre l'un de l'autre ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | La frontière d'abstraction de validation — le trait `Validate` + la primitive `FieldViolation` |
+> | **Couche** | `foundation` — une vraie feuille du graphe ; **zéro dépendance** par contrainte dure |
+> | **Classe de sous-domaine** | **Generic** — une Separated Interface ; toute sa valeur est l'inversion de dépendance qu'elle permet |
+> | **Abstraction(s) primaire(s)** | `Validate` + `FieldViolation` (`validate_core`) |
+> | **Empreinte** | pure (zéro dep, aucune IO, aucun état) — le feature set vide *impose* le zéro-dep |
+> | **Posture en cas d'échec** | N/A — il ne fait que *décrire* les échecs niveau champ |
+> | **Dépend de** | **rien** (imposé) |
+> | **Consommé par** | `cqrs` (comme supertrait de `Command`), `validation` (middleware + type d'erreur) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `validate-core` fait autorité dans la flotte pour l'**abstraction de validation** : il répond à
+**« que signifie pour un type de se valider lui-même, et comment `cqrs` et `validation` s'accordent là-dessus
+sans se coupler l'un à l'autre ? »**
+
+**Le problème difficile.** `cqrs::Command` a besoin de `Validate` comme supertrait, et `validation` fournit le
+middleware + le type d'erreur concret — mais si `Validate` vivait dans `validation`, alors `cqrs` hériterait de
+toute la stack middleware/HTTP/erreur de `validation`. Un troisième crate sans dépendance permet aux deux côtés
+de pointer *vers l'intérieur* vers la même abstraction. La contrainte zéro-dépendance n'est pas accessoire —
+c'est la raison d'être entière du crate.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Fournir le *middleware* de validation ou le mapping `AppError`/HTTP → relève de `validation`.
+- ❌ Tirer un framework, runtime async, ou `std::collections` → cela défairait l'inversion.
+- ❌ Décider *quand* la validation tourne dans le pipeline → c'est la décision de composition de `validation`.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Field violation | Un échec niveau champ unique (chemin du champ + code stable + message) | `FieldViolation` |
+| Validation code | Un code `VAL-xxxx` stable, lisible machine | `FieldViolation::code` (`&'static str`) |
+| Validate | Le trait qu'un type implémente pour exprimer ses propres vérifications d'invariants | `Validate` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `FieldViolation` | type valeur | `field`/`code` sont `&'static str` (aucun heap sur le chemin chaud) ; `message` est la seule allocation |
+| `Validate` | trait (seam) | `validate()` doit **agréger** toutes les violations, jamais court-circuiter ; le défaut est un no-op `Ok(())` |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Exactement deux items publics — `FieldViolation` et `Validate`. Rien d'autre, par conception.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Le middleware `ValidationLayer` + `ValidationError` | `validation` | La moitié opérationnelle dépend *vers le haut* de cette abstraction |
+| Le câblage du supertrait `Command` | `cqrs` | `cqrs` dépend *vers le haut* de cette abstraction, pas de `validation` |
+
+**La liste « do-not-depend-on » :** **tout.** `[dependencies]` doit rester vide ; aucun `use` de
+`std::collections`, async, ou framework d'erreur. La CI/revue repousse toute arête ajoutée — la garantie
+zéro-dep est le contrat.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | Le crate a **zéro** dépendance | `[dependencies]` vide + feature set vide | rejet CI/revue |
+| I2 | `validate()` agrège *toutes* les violations (pas de court-circuit) | convention de contrat | rapport d'erreur partiel |
+| I3 | Un `Err(violations)` retourné est non-vide | convention (`validation::ValidationError::new` debug-asserte) | debug panic en aval |
+| I4 | `field`/`code` restent `&'static str` (jamais `String`) | définition de type | heap sur le chemin de validation |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+N/A — crate d'abstraction pur, aucun flot de contrôle runtime. Le `validate()` d'un type tourne de façon
+synchrone là où l'appelant l'invoque (en pratique, dans `validation::ValidationLayer`, avant le premier
+`.await`). Il n'y a aucun état, aucun cycle de vie, aucun travail de fond.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `cqrs` | aval | Separated Interface | `Validate` comme supertrait de `Command` | la validabilité de chaque commande |
+| `validation` | aval | Separated Interface | `ValidationError` enveloppe `Vec<FieldViolation>` | le middleware + le mapping d'erreur |
+
+> **Seam de stabilité :** `Validate` et `FieldViolation` sont l'API publique entière ; un changement se propage
+> aux deux consommateurs à la fois. La forme de convergence (les deux pointent vers l'intérieur, aucun vers
+> l'autre) est la garantie architecturale.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+N/A — pur, zéro-dépendance. Il n'émet rien (même pas de `tracing` — ce serait une dépendance). Le log
+« validation failed » est émis par `validation`.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Separated Interface dans un troisième crate (pas un module dans `validation`) pour briser le cycle `cqrs`↔`validation` | [`README §Architecture`](../README.md) | Accepted |
+| Agrégation plutôt que court-circuit (tous les champs en échec en un aller-retour) | [`README §Architecture`](../README.md) | Accepted |
+| Zéro dépendance comme contrainte imposée et porteuse | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — une Separated Interface ; son levier est purement le graphe de dépendances
+  qu'elle rend possible.
+- **Stabilité :** contrat stable — les deux items sont stabilisés.
+- **Volatilité :** minimale — toute croissance risque la garantie zéro-dep, donc la croissance est activement résistée.
+- **Capacités différées :** aucune ; une validation plus riche (async, cross-field) vivrait dans `validation`,
+  jamais ici.

--- a/crates/foundation/validate-core/docs/DOMAIN.md
+++ b/crates/foundation/validate-core/docs/DOMAIN.md
@@ -1,0 +1,133 @@
+# `validate-core` — Domain & Functional Contract
+
+> The zero-dependency validation abstraction: a Separated Interface answering *"how can `cqrs` and `validation` share a validation contract without depending on each other?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | The validation abstraction boundary — the `Validate` trait + `FieldViolation` primitive |
+> | **Layer** | `foundation` — a true graph-leaf; **zero dependencies** by hard constraint |
+> | **Subdomain class** | **Generic** — a Separated Interface; its entire value is the dependency-inversion it enables |
+> | **Primary abstraction(s)** | `Validate` + `FieldViolation` (`validate_core`) |
+> | **Footprint** | pure (zero deps, no IO, no state) — the empty feature set *enforces* zero-dep |
+> | **Failure posture** | N/A — it only *describes* field-level failures |
+> | **Depends on** | **nothing** (enforced) |
+> | **Consumed by** | `cqrs` (as a `Command` supertrait), `validation` (middleware + error type) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `validate-core` is the fleet's authority for the **validation abstraction**: it answers
+**"what does it mean for a type to validate itself, and how do `cqrs` and `validation` agree on that without
+coupling to each other?"**
+
+**The hard problem.** `cqrs::Command` needs `Validate` as a supertrait, and `validation` provides the
+middleware + concrete error type — but if `Validate` lived in `validation`, then `cqrs` would inherit
+`validation`'s entire middleware/HTTP/error stack. A third, dependency-free crate lets both sides point
+*inward* at the same abstraction. The zero-dependency constraint is not incidental — it is the crate's
+entire reason to exist.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Provide the validation *middleware* or the `AppError`/HTTP mapping → owned by `validation`.
+- ❌ Pull in any framework, async runtime, or `std::collections` → that would defeat the inversion.
+- ❌ Decide *when* validation runs in the pipeline → that is `validation`'s composition decision.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Field violation | A single field-level failure (field path + stable code + message) | `FieldViolation` |
+| Validation code | A stable, machine-readable `VAL-xxxx` code | `FieldViolation::code` (`&'static str`) |
+| Validate | The trait a type implements to express its own invariant checks | `Validate` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `FieldViolation` | value type | `field`/`code` are `&'static str` (no heap on the hot path); `message` is the only allocation |
+| `Validate` | trait (seam) | `validate()` must **aggregate** all violations, never short-circuit; default is a no-op `Ok(())` |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- Exactly two public items — `FieldViolation` and `Validate`. Nothing else, by design.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| `ValidationLayer` middleware + `ValidationError` | `validation` | The operational half depends *up* on this abstraction |
+| The `Command` supertrait wiring | `cqrs` | `cqrs` depends *up* on this abstraction, not on `validation` |
+
+**The "do-not-depend-on" list:** **everything.** `[dependencies]` must remain empty; no `use` of
+`std::collections`, async, or any error framework. CI/review pushes back on any added edge — the zero-dep
+guarantee is the contract.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | The crate has **zero** dependencies | empty `[dependencies]` + empty feature set | CI/review rejection |
+| I2 | `validate()` aggregates *all* violations (no short-circuit) | contract convention | partial error reporting |
+| I3 | A returned `Err(violations)` is non-empty | convention (`validation::ValidationError::new` debug-asserts it) | debug panic downstream |
+| I4 | `field`/`code` stay `&'static str` (never `String`) | type definition | heap on the validation path |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+N/A — pure abstraction crate, no runtime control flow. A type's `validate()` runs synchronously where the
+caller invokes it (in practice, inside `validation::ValidationLayer`, before the first `.await`). There is no
+state, no lifecycle, no background work.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `cqrs` | downstream | Separated Interface | `Validate` as a `Command` supertrait | every command's validate-ability |
+| `validation` | downstream | Separated Interface | `ValidationError` wraps `Vec<FieldViolation>` | the middleware + error mapping |
+
+> **Stability seam:** `Validate` and `FieldViolation` are the entire public API; a change ripples to both
+> consumers at once. The convergence shape (both point inward, neither at the other) is the architectural
+> guarantee.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+N/A — pure, zero-dependency. It emits nothing (no `tracing` even — that would be a dependency). The
+"validation failed" log is emitted by `validation`.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Separated Interface in a third crate (not a module in `validation`) to break the `cqrs`↔`validation` cycle | [`README §Architecture`](../README.md) | Accepted |
+| Aggregation over short-circuit (all failing fields in one round-trip) | [`README §Architecture`](../README.md) | Accepted |
+| Zero dependencies as an enforced, load-bearing constraint | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — a Separated Interface; its leverage is purely the dependency graph it makes
+  possible.
+- **Stability:** stable contract — the two items have settled.
+- **Volatility:** minimal — any growth risks the zero-dep guarantee, so growth is actively resisted.
+- **Deferred capabilities:** none; richer validation (async, cross-field) would live in `validation`, never
+  here.

--- a/crates/platform/auth-context/docs/DOMAIN.fr.md
+++ b/crates/platform/auth-context/docs/DOMAIN.fr.md
@@ -1,0 +1,167 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: f7a102b1814481eae2e1a9da33bdf387c5c891c1b204d62e904e5126a0e236a0
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `auth-context` — Contrat de Domaine & Fonctionnel
+
+> Le traducteur de sécurité en entrée : il répond à *« qui est ce caller ? »* — convertissant un Bearer token opaque en principal typé et le propageant à travers la call-stack async.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Authentification en entrée : vérification JWT (token → `CurrentPrincipal` typé) + propagation d'identité task-local |
+> | **Couche** | `platform` — le traducteur de sécurité à la frontière entrante d'un service |
+> | **Classe de sous-domaine** | **Generic** — vérification OIDC/JWT standard ; le levier est l'agnosticisme de provider + la propagation sans thread |
+> | **Abstraction(s) primaire(s)** | `JwtDecoder` + `CurrentPrincipal<C>` + `ClaimsExtractor<C>` (`auth_context`) |
+> | **Empreinte** | IO/avec état — une tâche de fond de refresh JWKS + un cache ; la vérification est du CPU pur |
+> | **Posture en cas d'échec** | **fail-closed sur un mauvais token** (rejet) mais **fail-soft sur un IdP instable** (les clés périmées continuent de fonctionner) |
+> | **Dépend de** | `jsonwebtoken`, `tokio`, `reqwest` (JWKS), `tracing`, `uuid`, `cqrs` (optionnel) |
+> | **Consommé par** | les frontières entrantes des services / la gateway (tout ce qui authentifie une requête) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) ; lié : [`ADR-0005 (auth)`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `auth-context` fait autorité dans la flotte pour l'**authentification de requête** : il répond à
+**« qui est ce caller, et comment rendre cette identité disponible partout en aval sans la faufiler à travers
+chaque signature de fonction ? »** Il fait de l'authentification (vérifier + extraire + propager), pas de la
+policy d'autorisation et pas du transport.
+
+**Le problème difficile.** La vérification de token doit être une opération de chemin chaud *CPU pur* (aucun
+réseau par requête), or les clés publiques tournent et vivent à un endpoint JWKS OIDC, et l'identité résultante
+doit atteindre la logique métier profonde sans polluer les signatures. `auth-context` récupère+cache les clés
+dans une tâche de fond (les clés périmées continuent de marcher pendant un blip de l'IdP), garde l'extraction de
+claims pluggable par IdP, et lie le principal à un `tokio::task_local!`.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Autoriser (décider ce qu'un principal peut faire) → c'est la policy du service.
+- ❌ Émettre ou rafraîchir des tokens / courtier l'IdP → c'est le service `auth` (`ADR-0005`).
+- ❌ Posséder le transport / la couche HTTP entrante → il convertit un token qu'un caller a déjà extrait.
+- ❌ Propager l'identité à travers `tokio::spawn` automatiquement → re-binder avec `with_principal` dans la tâche.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Principal | L'identité authentifiée typée (id, tenant, permissions, claims bruts) | `CurrentPrincipal<C>`, `PrincipalId`, `Permission` |
+| Claims extractor | La stratégie par IdP mappant claims bruts → un principal | `ClaimsExtractor<C>`, `OidcClaimsExtractor` |
+| JWKS cache / refresher | Les clés publiques cachées + la boucle de refresh de fond | `JwksCache`, `JwksRefresher`, `JwksClient` |
+| Decoder | Le point d'entrée vérifier-puis-extraire | `JwtDecoder` |
+| Task-local principal | Identité liée à la call-stack async, lue sans faufilage | `with_principal`, `current_principal` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `JwtDecoder<C, E>` | vérificateur | `decode(token)` = lookup `kid` du header → `jsonwebtoken::decode` (sig + `exp`/`nbf`/`iss`/`aud`) → extract |
+| `CurrentPrincipal<C>` | type valeur | Les claims bruts voyagent comme le générique `C` (identité type-safe) |
+| `ClaimsExtractor<C>` | trait (seam) | Le point de stratégie unique — un nouvel IdP/flow est un nouvel extractor, pas un fork du decoder |
+| `JwksCache` | cache | Lecture `RwLock` O(1) sur le chemin chaud ; `replace` swap l'ensemble de clés atomiquement |
+| `with_principal` / `current_principal` | propagation | Liaison `task_local!` ; **non** héritée à travers `spawn` |
+| `AuthError` | enum | La raison de rejet précise (`InvalidSignature`, `TokenExpired`, `UnknownKid`, …) |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- La vérification (signature + claims standard), la stratégie d'extraction de claims, le cache JWKS + la tâche
+  de refresh de fond, et la propagation task-local.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| La policy d'autorisation (ce qu'un principal peut faire) | chaque service | Ce crate s'arrête à l'identité, pas aux décisions de permission |
+| L'émission de token / le courtage IdP | service `auth` | L'émission est une préoccupation System-of-Record (`ADR-0005`) |
+| L'injection d'enveloppe dans `cqrs` | gaté derrière `cqrs-integration` | Garde l'arête `cqrs` optionnelle |
+
+**La liste « do-not-depend-on » :** jamais un crate de service ; la dépendance `cqrs` est gatée par feature
+(`cqrs-integration`) pour que les appelants non-CQRS ne lient aucun `cqrs`.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | La vérification ne fait aucun appel réseau (les clés viennent du cache) | `JwtDecoder::decode` | latence du chemin chaud / couplage IdP |
+| I2 | Un IdP instable ne fait pas échouer le chemin chaud (les clés périmées marchent) | boucle de backoff `JwksRefresher` | (dégradé seulement si aucune clé ne correspond) |
+| I3 | Le principal task-local n'est **pas** propagé à travers `tokio::spawn` | sémantique `task_local!` | identité manquante dans la sous-tâche — re-binder |
+| I4 | Un nouvel IdP/flow est un nouveau `ClaimsExtractor`, pas un changement du decoder | seam de stratégie | un fork du decoder |
+| I5 | La validation `iss`/`aud` est activée par défaut en prod | `AuthContextConfig` | risque de confusion de token si désactivée |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Démarrage.** `JwksRefresher::spawn` réchauffe le cache immédiatement, puis boucle : fetch → `replace(keys)`,
+délai = `refresh_interval` ; en erreur → WARN, délai = backoff (1s → `max_backoff`, ×2). Le guard du refresher
+doit survivre au processus.
+
+**Chemin chaud — par requête.** `decode_header()` lit le `kid` (sans crypto) → `JwksCache::get(kid)` (lecture
+`RwLock` O(1)) → `jsonwebtoken::decode` (RS256/ES256 + `exp`/`nbf`/`iss`/`aud`, avec marge `AUTH_CLOCK_SKEW_SECS`)
+→ `ClaimsExtractor::extract` → `CurrentPrincipal<C>`. Puis `with_principal(p, fut)` lie le task-local pour la
+durée de la requête ; `inject_into_span()` (et optionnellement `inject_into_envelope`) surfacent l'identité vers
+l'observabilité/CQRS.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| frontières entrantes / gateway | aval | Published Contract | `decode` + `with_principal` | l'authentification de requête |
+| `cqrs` | amont (optionnel) | Open-Host (étend) | `inject_into_envelope` (`cqrs-integration`) | l'identité dans les métadonnées de commande |
+| service `auth` | pair (runtime) | Customer/Supplier | consomme le JWKS que l'IdP publie | la rotation de clés / la validité de token |
+
+> **Seam de stabilité :** `CurrentPrincipal<C>`, `ClaimsExtractor<C>`, `JwtDecoder`, et `AuthError` sont une API
+> publique ; la règle `task_local!`-pas-à-travers-spawn est un contrat que les appelants doivent respecter.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| JWKS cache refreshed | `tracing` INFO (`key_count`, `next_refresh_secs`) | un refresh de fond réussi | dashboards d'auth |
+| refresh failed | `tracing` WARN (`error`, `retry_after_secs`) | une erreur de fetch JWKS | alerte P2 si > 3/min |
+| key loaded / undecodable key skipped | `tracing` DEBUG/WARN | parsing de l'ensemble JWKS | monitoring de rotation de clés |
+
+Effets de bord : un fetch HTTP sortant par intervalle de refresh (pas par requête) ; une liaison `task_local!`
+par requête. `JwksCache::is_empty()` pendant > 30s est un P1 (ne peut rien authentifier).
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| JWKS caché + refresh de fond ; la vérification est du CPU pur sur le chemin chaud | [`README §Architecture`](../README.md) | Accepted |
+| `ClaimsExtractor<C>` pluggable pour l'agnosticisme de provider | [`README §Architecture`](../README.md) | Accepted |
+| Propagation task-local au lieu du faufilage par signature | [`README §Architecture`](../README.md) | Accepted |
+| Authentification-seulement ; l'émission/courtage est le service `auth` | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — vérification OIDC/JWT standard ; le levier est l'agnosticisme de provider et la
+  propagation sans thread.
+- **Stabilité :** contrat stable.
+- **Volatilité :** faible — les nouveaux IdP/flows arrivent comme de nouveaux `ClaimsExtractor`, pas des changements de surface.
+- **Capacités différées :** le mapping de claims service-account / machine-to-machine (`azp`/`client_id` →
+  user_id) est un extractor custom, pas encore intégré.

--- a/crates/platform/auth-context/docs/DOMAIN.md
+++ b/crates/platform/auth-context/docs/DOMAIN.md
@@ -1,0 +1,156 @@
+# `auth-context` — Domain & Functional Contract
+
+> The inbound security translator: it answers *"who is this caller?"* — converting an opaque Bearer token into a typed principal and propagating it through the async call-stack.
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Inbound authentication: JWT verification (token → typed `CurrentPrincipal`) + task-local identity propagation |
+> | **Layer** | `platform` — the security translator at a service's inbound boundary |
+> | **Subdomain class** | **Generic** — standard OIDC/JWT verification; leverage is provider-agnosticism + zero-thread propagation |
+> | **Primary abstraction(s)** | `JwtDecoder` + `CurrentPrincipal<C>` + `ClaimsExtractor<C>` (`auth_context`) |
+> | **Footprint** | IO/stateful — a background JWKS refresher task + a cache; verification is pure CPU |
+> | **Failure posture** | **fail-closed on a bad token** (reject) but **fail-soft on a flaky IdP** (stale keys keep working) |
+> | **Depends on** | `jsonwebtoken`, `tokio`, `reqwest` (JWKS), `tracing`, `uuid`, `cqrs` (optional) |
+> | **Consumed by** | service inbound boundaries / the gateway (anything authenticating a request) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md); related: [`ADR-0005 (auth)`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `auth-context` is the fleet's authority for **request authentication**: it answers
+**"who is this caller, and how do I make that identity available everywhere downstream without threading it
+through every function signature?"** It does authentication (verify + extract + propagate), not authorization
+policy and not transport.
+
+**The hard problem.** Token verification must be a *pure CPU* hot-path operation (no network per request), yet
+public keys rotate and live at an OIDC JWKS endpoint, and the resulting identity must reach deep business
+logic without polluting signatures. `auth-context` fetches+caches keys in a background task (stale keys keep
+working through an IdP blip), keeps claims-extraction pluggable per IdP, and binds the principal to a
+`tokio::task_local!`.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Authorize (decide what a principal may do) → that is the service's policy.
+- ❌ Issue or refresh tokens / broker the IdP → that is the `auth` service (`ADR-0005`).
+- ❌ Own transport / the inbound HTTP layer → it converts a token a caller already extracted.
+- ❌ Propagate identity across `tokio::spawn` automatically → re-bind with `with_principal` inside the task.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Principal | The typed authenticated identity (id, tenant, permissions, raw claims) | `CurrentPrincipal<C>`, `PrincipalId`, `Permission` |
+| Claims extractor | The per-IdP strategy mapping raw claims → a principal | `ClaimsExtractor<C>`, `OidcClaimsExtractor` |
+| JWKS cache / refresher | The cached public keys + the background refresh loop | `JwksCache`, `JwksRefresher`, `JwksClient` |
+| Decoder | The verify-then-extract entry point | `JwtDecoder` |
+| Task-local principal | Identity bound to the async call-stack, read without threading | `with_principal`, `current_principal` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `JwtDecoder<C, E>` | verifier | `decode(token)` = header `kid` lookup → `jsonwebtoken::decode` (sig + `exp`/`nbf`/`iss`/`aud`) → extract |
+| `CurrentPrincipal<C>` | value type | The raw claims travel as generic `C` (type-safe identity) |
+| `ClaimsExtractor<C>` | trait (seam) | The single strategy point — a new IdP/flow is a new extractor, not a decoder fork |
+| `JwksCache` | cache | O(1) `RwLock` read on the hot path; `replace` swaps the key set atomically |
+| `with_principal` / `current_principal` | propagation | `task_local!` binding; **not** inherited across `spawn` |
+| `AuthError` | enum | The precise rejection reason (`InvalidSignature`, `TokenExpired`, `UnknownKid`, …) |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- Verification (signature + standard claims), claims-extraction strategy, the JWKS cache + background
+  refresher, and task-local propagation.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| Authorization policy (what a principal may do) | each service | This crate ends at identity, not permission decisions |
+| Token issuance / IdP brokerage | `auth` service | Issuance is a System-of-Record concern (`ADR-0005`) |
+| Envelope injection into `cqrs` | gated behind `cqrs-integration` | Keeps the `cqrs` edge optional |
+
+**The "do-not-depend-on" list:** never a service crate; the `cqrs` dependency is feature-gated
+(`cqrs-integration`) so non-CQRS callers link no `cqrs`.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Verification makes no network call (keys come from cache) | `JwtDecoder::decode` | hot-path latency / IdP coupling |
+| I2 | A flaky IdP does not fail the hot path (stale keys keep working) | `JwksRefresher` backoff loop | (degraded only when no key matches) |
+| I3 | The task-local principal is **not** propagated across `tokio::spawn` | `task_local!` semantics | missing identity in the sub-task — re-bind |
+| I4 | A new IdP/flow is a new `ClaimsExtractor`, not a decoder change | strategy seam | a fork of the decoder |
+| I5 | `iss`/`aud` validation is on by default in prod | `AuthContextConfig` | token-confusion risk if disabled |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Startup.** `JwksRefresher::spawn` warms the cache immediately, then loops: fetch → `replace(keys)`, delay =
+`refresh_interval`; on error → WARN, delay = backoff (1s → `max_backoff`, ×2). The refresher guard must outlive
+the process.
+
+**Hot path — per request.** `decode_header()` reads the `kid` (no crypto) → `JwksCache::get(kid)` (O(1)
+`RwLock` read) → `jsonwebtoken::decode` (RS256/ES256 + `exp`/`nbf`/`iss`/`aud`, with `AUTH_CLOCK_SKEW_SECS`
+leeway) → `ClaimsExtractor::extract` → `CurrentPrincipal<C>`. Then `with_principal(p, fut)` binds the
+task-local for the request's duration; `inject_into_span()` (and optionally `inject_into_envelope`) surface the
+identity to observability/CQRS.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| service inbound boundaries / gateway | downstream | Published Contract | `decode` + `with_principal` | request authentication |
+| `cqrs` | upstream (optional) | Open-Host (extends) | `inject_into_envelope` (`cqrs-integration`) | identity in command metadata |
+| `auth` service | peer (runtime) | Customer/Supplier | consumes JWKS the IdP publishes | key rotation / token validity |
+
+> **Stability seam:** `CurrentPrincipal<C>`, `ClaimsExtractor<C>`, `JwtDecoder`, and `AuthError` are public API;
+> the `task_local!`-not-across-spawn rule is a contract callers must respect.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| JWKS cache refreshed | `tracing` INFO (`key_count`, `next_refresh_secs`) | a successful background refresh | auth dashboards |
+| refresh failed | `tracing` WARN (`error`, `retry_after_secs`) | a JWKS fetch error | P2 alert if > 3/min |
+| key loaded / undecodable key skipped | `tracing` DEBUG/WARN | parsing the JWKS set | key-rotation monitoring |
+
+Side effects: one outbound HTTP fetch per refresh interval (not per request); a `task_local!` binding per
+request. `JwksCache::is_empty()` for > 30s is a P1 (can authenticate nothing).
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| JWKS cached + background-refreshed; verification is pure CPU on the hot path | [`README §Architecture`](../README.md) | Accepted |
+| Pluggable `ClaimsExtractor<C>` for provider-agnosticism | [`README §Architecture`](../README.md) | Accepted |
+| Task-local propagation instead of signature-threading | [`README §Architecture`](../README.md) | Accepted |
+| Authentication-only; issuance/brokerage is the `auth` service | [`ADR-0005`](../../../../docs/adr/0005-auth-federated-idp-with-platform-edge-tokens.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — standard OIDC/JWT verification; leverage is provider-agnosticism and
+  zero-thread propagation.
+- **Stability:** stable contract.
+- **Volatility:** low — new IdPs/flows land as new `ClaimsExtractor`s, not surface changes.
+- **Deferred capabilities:** service-account / machine-to-machine claim mapping (`azp`/`client_id` → user_id)
+  is a custom extractor, not yet a built-in.

--- a/crates/platform/cqrs/docs/DOMAIN.fr.md
+++ b/crates/platform/cqrs/docs/DOMAIN.fr.md
@@ -1,0 +1,173 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 3948dc98bcebed2b9ac18fcf3795c3ef0fa3c7b5a4bdc27556b0350f8d631166
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `cqrs` — Contrat de Domaine & Fonctionnel
+
+> Le bus Command/Query in-process : une couche de dispatch zéro-overhead répondant à *« quel handler unique possède cette opération, et comment son contexte causal se propage-t-il ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Dispatch applicatif : un Command Bus + Query Bus statique et in-process avec un pipeline de middleware typé |
+> | **Couche** | `platform` — la couche de dispatch applicatif entre handlers de transport et handlers de domaine |
+> | **Classe de sous-domaine** | **Generic** — un bus CQRS ; le levier est le chemin chaud sans dispatch dynamique + middleware uniforme |
+> | **Abstraction(s) primaire(s)** | `Command`/`Query` + `Envelope<T>` + `CommandBus`/`QueryBus` (`cqrs`) |
+> | **Empreinte** | pure (in-process, aucune file, aucun réseau, aucun env) |
+> | **Posture en cas d'échec** | N/A — il route ; les échecs sont ceux du handler, surfacés en `CqrsError` |
+> | **Dépend de** | `error`, `validate-core`, `uuid`, `chrono`, `dashmap`, `tracing` |
+> | **Consommé par** | chaque service (bus command/query) ; `validation` & `auth-context` l'étendent |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `cqrs` fait autorité dans la flotte pour le **dispatch applicatif** : il répond à
+**« quel handler enregistré unique possède cette commande/query, et comment `correlation_id`/`causation_id`
+voyagent-ils de bout en bout ? »** — sans dispatch dynamique sur le chemin chaud.
+
+**Le problème difficile.** Un bus qui route par type implique d'ordinaire de la réflexion ou une vtable à
+chaque appel. `cqrs` route par `TypeId` (un `HashMap::get` + un `Box::new` pour franchir une frontière
+d'effacement *scellée*), garde les handlers monomorphisés via RPIT natif (pas de `async_trait`), et impose la
+séparation écriture/lecture dans le système de types — les commandes mutent et retournent `()`, les queries
+retournent des données et ne portent aucun effet de bord.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Être une file de messages / un bus réseau → il est purement in-process.
+- ❌ Posséder la *règle* de validation → `Validate` vit dans `validate-core` ; le middleware dans `validation`.
+- ❌ Persister l'idempotence durablement → le `InMemoryIdempotencyStore` fourni est non borné ; swappez un store TTL.
+- ❌ Posséder l'init tracing/télémétrie → il émet spans/logs mais `telemetry::init()` est un prérequis.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Command / Query | Une écriture (retourne `()`) / une lecture (retourne des données typées) | `Command`, `Query` |
+| Handler | Le propriétaire unique d'un type command/query | `CommandHandler`, `QueryHandler` |
+| Envelope | Le porteur de message avec la chaîne causale | `Envelope<T>` (`message_id`/`correlation_id`/`causation_id`) |
+| Bus | Le dispatcheur routant vers un handler | `CommandBus`, `QueryBus`, `InMemoryCommandBus` |
+| Layer / pipeline | Middleware enveloppant le dispatch | `CommandLayer`, `MiddlewarePipeline`, `Tracing`/`Logging`/`Idempotency` |
+| Cqrs error | L'enveloppe d'erreur niveau dispatch | `CqrsError` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `Envelope<T>` | porteur de message | `new` démarre une chaîne causale fraîche ; `new_caused_by` hérite la corrélation + fixe la causation |
+| `Command` / `Query` | trait (seam) | Séparation écriture/lecture ; supertrait `Command: validate_core::Validate` |
+| `CommandBus` / `QueryBus` | trait | **Non object-safe** (`dispatch<C>` générique) — tenir le bus concret ou son `Arc` |
+| `CqrsError` | enveloppe d'erreur | `Handler(e)` délègue `error_code`/`http_status`/`severity` à l'erreur originale du handler |
+| `IdempotencyStore` | trait (seam) | `mark_processed` ne tourne que sur `Ok` → les handlers échoués restent retentables |
+| `CommandLayer`/`QueryLayer` | trait (seam) | Middleware custom ; le bus final est un type concret décoré |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Le mécanisme de dispatch, le modèle enveloppe + chaîne causale, la forme du pipeline de middleware, et les
+  couches fournies (`Tracing`/`Logging`/`Idempotency`). Le seul `dyn` est scellé dans des bridges effacés `pub(crate)`.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Le trait `Validate` | `validate-core` | `cqrs` dépend *vers le haut* de l'abstraction, pas de `validation` |
+| Le middleware de validation (`ValidationLayer`) | `validation` | Il étend `cqrs` via `CommandLayer` |
+| L'injection d'identité dans les enveloppes | `auth-context` (`cqrs-integration`) | Il étend `cqrs`, pas l'inverse |
+| L'idempotence durable (Redis TTL) | le service | Le store in-memory est un défaut à swapper |
+
+**La liste « do-not-depend-on » :** jamais `tonic`/`rdkafka`/réseau/env — il reste un bus in-process pur.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | Un type command/query a **exactement un** handler | `register` du builder (eager) | `CqrsError::DuplicateRegistration` au build |
+| I2 | Dispatcher un type non enregistré échoue vite | dispatch `InMemoryCommandBus` | `CqrsError::HandlerNotFound` |
+| I3 | Aucun dispatch dynamique sur le chemin chaud (routage TypeId, RPIT natif) | système de types | `BoxFuture` uniquement dans le bridge scellé |
+| I4 | L'idempotence ne marque que sur `Ok` (les échecs restent retentables) | `IdempotencyLayer` | — |
+| I5 | Les queries ne portent aucun effet de bord (aucun chemin d'écriture via `QueryBus`) | système de types (séparation écriture/lecture) | — |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Build (démarrage).** `CommandBusBuilder::register::<C, _>(handler)` enregistre par `TypeId` (échoue vite sur
+doublons) → `.build()` produit un `InMemoryCommandBus` immuable backé par `Arc`. `MiddlewarePipeline::new(raw)`
+le décore ensuite ; le **premier** `.layer()` est le plus externe.
+
+**Dispatch (chemin chaud).** Un handler de transport enveloppe le payload en `Envelope::new(correlation_id,
+payload)` et appelle `bus.dispatch(env)`. La chaîne décorée tourne (ex. Validation → Idempotency → Tracing →
+Logging → `InMemoryCommandBus`) : un `HashMap::get` (O(1), sans verrou) + un `Box::new` pour franchir la
+frontière d'effacement, puis `TypedHandlerBridge<H,C>` appelle `Arc<H>.handle(envelope)`. Clone du bus =
+`Arc::clone`.
+
+**Chaînage causal.** Dans un handler, `Envelope::new_caused_by(&incoming, payload)` hérite `correlation_id` +
+métadonnées et fixe `causation_id`, pour qu'un flot multi-étapes garde une seule trace.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `validate-core` | amont | Separated Interface | supertrait `Validate` sur `Command` | la validabilité de chaque commande |
+| `error` | amont | Conformist | `CqrsError: AppError`, `Error: AppError` du handler | la délégation d'erreur |
+| chaque service | aval | Published Contract | bus command/query | tout le dispatch applicatif |
+| `validation` | aval | Open-Host (étend) | `ValidationLayer: CommandLayer` | le middleware de validation d'entrée |
+| `auth-context` | aval | Open-Host (étend) | `inject_into_envelope` (`cqrs-integration`) | la propagation d'identité dans les enveloppes |
+
+> **Seam de stabilité :** les traits `Command`/`Query`/`*Handler`/`*Bus` et `Envelope<T>` sont une API
+> publique ; la non-object-safety des traits de dispatch est un contrat que les appelants doivent respecter
+> (tenir des types concrets).
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| span `cqrs.command.dispatch` / `cqrs.query.dispatch` | `tracing` (`TracingLayer`) | chaque dispatch (`otel.kind=INTERNAL`, `message.type/id`, `correlation.id`) | back-ends de trace distribuée |
+| log start / complete-or-failed | `tracing` (`LoggingLayer`) | chaque dispatch (`elapsed_ms`, `error.code`) | dashboards latence + taux d'erreur |
+
+La surface d'effet de bord est le `IdempotencyStore` qu'il écrit ; le store in-memory fourni est local au
+processus et non borné.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Routage TypeId, pas de réflexion/vtable ; `dyn` uniquement dans des bridges scellés `pub(crate)` | [`README §Architecture`](../README.md) | Accepted |
+| Pas de `async_trait` — RPIT natif de bout en bout ; `BoxFuture` uniquement dans les bridges effacés | [`README §Architecture`](../README.md) | Accepted |
+| L'idempotence ne marque que sur `Ok` (les handlers échoués restent retentables) | [`README §Architecture`](../README.md) | Accepted |
+| Séparation écriture/lecture imposée par le système de types | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — un bus CQRS ; le levier est le chemin chaud sans overhead et une forme de
+  pipeline uniforme à travers chaque service.
+- **Stabilité :** contrat stable — les traits et l'enveloppe sont stabilisés.
+- **Volatilité :** faible — la croissance est de nouvelles couches fournies, écrites selon les mêmes invariants
+  de moteur (pas de `async_trait`, aucune allocation sur le chemin commun).
+- **Capacités différées :** un `IdempotencyStore` durable/TTL (Redis `SET NX EX`) — le seam existe ; le défaut
+  est in-memory.

--- a/crates/platform/cqrs/docs/DOMAIN.md
+++ b/crates/platform/cqrs/docs/DOMAIN.md
@@ -1,0 +1,159 @@
+# `cqrs` — Domain & Functional Contract
+
+> The in-process Command/Query bus: a zero-overhead dispatch layer answering *"which single handler owns this operation, and how does its causal context propagate?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Application-dispatch: a static, in-process Command Bus + Query Bus with a typed middleware pipeline |
+> | **Layer** | `platform` — the application-dispatch layer between transport handlers and domain handlers |
+> | **Subdomain class** | **Generic** — a CQRS bus; leverage is the zero-dispatch hot path + uniform middleware |
+> | **Primary abstraction(s)** | `Command`/`Query` + `Envelope<T>` + `CommandBus`/`QueryBus` (`cqrs`) |
+> | **Footprint** | pure (in-process, no queue, no network, no env) |
+> | **Failure posture** | N/A — it routes; failures are the handler's, surfaced as `CqrsError` |
+> | **Depends on** | `error`, `validate-core`, `uuid`, `chrono`, `dashmap`, `tracing` |
+> | **Consumed by** | every service (command/query buses); `validation` & `auth-context` extend it |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `cqrs` is the fleet's authority for **application dispatch**: it answers
+**"which single registered handler owns this command/query, and how do `correlation_id`/`causation_id`
+travel end-to-end?"** — with no dynamic dispatch on the hot path.
+
+**The hard problem.** A bus that routes by type usually means reflection or a vtable on every call. `cqrs`
+routes by `TypeId` (one `HashMap::get` + one `Box::new` to cross a *sealed* erasure boundary), keeps
+handlers monomorphised via native RPIT (no `async_trait`), and enforces write/read separation in the type
+system — commands mutate and return `()`, queries return data and carry no side-effects.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Be a message queue / network bus → it is purely in-process.
+- ❌ Own the validation *rule* → `Validate` lives in `validate-core`; the middleware in `validation`.
+- ❌ Persist idempotency durably → the bundled `InMemoryIdempotencyStore` is unbounded; swap a TTL store.
+- ❌ Own tracing/telemetry init → it emits spans/logs but `telemetry::init()` is a prerequisite.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Command / Query | A write (returns `()`) / a read (returns typed data) | `Command`, `Query` |
+| Handler | The single owner of a command/query type | `CommandHandler`, `QueryHandler` |
+| Envelope | The message carrier with the causal chain | `Envelope<T>` (`message_id`/`correlation_id`/`causation_id`) |
+| Bus | The dispatcher routing to a handler | `CommandBus`, `QueryBus`, `InMemoryCommandBus` |
+| Layer / pipeline | Middleware wrapping dispatch | `CommandLayer`, `MiddlewarePipeline`, `Tracing`/`Logging`/`Idempotency` |
+| Cqrs error | The dispatch-level error envelope | `CqrsError` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `Envelope<T>` | message carrier | `new` starts a fresh causal chain; `new_caused_by` inherits correlation + sets causation |
+| `Command` / `Query` | trait (seam) | Write/read separation; `Command: validate_core::Validate` supertrait |
+| `CommandBus` / `QueryBus` | trait | **Not object-safe** (`dispatch<C>` is generic) — hold the concrete bus or its `Arc` |
+| `CqrsError` | error envelope | `Handler(e)` delegates `error_code`/`http_status`/`severity` to the original handler error |
+| `IdempotencyStore` | trait (seam) | `mark_processed` runs only on `Ok` → failed handlers stay retryable |
+| `CommandLayer`/`QueryLayer` | trait (seam) | Custom middleware; the final bus is a concrete decorated type |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The dispatch mechanism, the envelope + causal-chain model, the middleware-pipeline shape, and the bundled
+  layers (`Tracing`/`Logging`/`Idempotency`). The only `dyn` is sealed inside `pub(crate)` erased bridges.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| The `Validate` trait | `validate-core` | `cqrs` depends *up* on the abstraction, not on `validation` |
+| The validation middleware (`ValidationLayer`) | `validation` | It extends `cqrs` via `CommandLayer` |
+| Identity injection into envelopes | `auth-context` (`cqrs-integration`) | It extends `cqrs`, not the reverse |
+| Durable idempotency (Redis TTL) | the service | The in-memory store is a default to be swapped |
+
+**The "do-not-depend-on" list:** never `tonic`/`rdkafka`/network/env — it stays a pure in-process bus.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | A command/query type has **exactly one** handler | builder `register` (eager) | `CqrsError::DuplicateRegistration` at build |
+| I2 | Dispatching an unregistered type fails fast | `InMemoryCommandBus` dispatch | `CqrsError::HandlerNotFound` |
+| I3 | No dynamic dispatch on the hot path (TypeId routing, native RPIT) | type system | `BoxFuture` only inside the sealed bridge |
+| I4 | Idempotency marks only on `Ok` (failures stay retryable) | `IdempotencyLayer` | — |
+| I5 | Queries carry no side-effects (no write path through `QueryBus`) | type system (write/read split) | — |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Build (startup).** `CommandBusBuilder::register::<C, _>(handler)` registers by `TypeId` (fails fast on
+duplicates) → `.build()` yields an immutable `Arc`-backed `InMemoryCommandBus`. `MiddlewarePipeline::new(raw)`
+then decorates it; the **first** `.layer()` is outermost.
+
+**Dispatch (hot path).** A transport handler wraps the payload in `Envelope::new(correlation_id, payload)`
+and calls `bus.dispatch(env)`. The decorated chain runs (e.g. Validation → Idempotency → Tracing → Logging →
+`InMemoryCommandBus`): one `HashMap::get` (O(1), no lock) + one `Box::new` to cross the erasure boundary,
+then `TypedHandlerBridge<H,C>` calls `Arc<H>.handle(envelope)`. Bus clone = `Arc::clone`.
+
+**Causal chaining.** Inside a handler, `Envelope::new_caused_by(&incoming, payload)` inherits
+`correlation_id` + metadata and sets `causation_id`, so a multi-step flow keeps one trace.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `validate-core` | upstream | Separated Interface | `Validate` supertrait on `Command` | every command's validate-ability |
+| `error` | upstream | Conformist | `CqrsError: AppError`, handler `Error: AppError` | error delegation |
+| every service | downstream | Published Contract | command/query buses | all application dispatch |
+| `validation` | downstream | Open-Host (extends) | `ValidationLayer: CommandLayer` | input validation middleware |
+| `auth-context` | downstream | Open-Host (extends) | `inject_into_envelope` (`cqrs-integration`) | identity propagation into envelopes |
+
+> **Stability seam:** the `Command`/`Query`/`*Handler`/`*Bus` traits and `Envelope<T>` are public API; the
+> non-object-safety of the dispatch traits is a contract callers must respect (hold concrete types).
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| `cqrs.command.dispatch` / `cqrs.query.dispatch` span | `tracing` (`TracingLayer`) | each dispatch (`otel.kind=INTERNAL`, `message.type/id`, `correlation.id`) | distributed-trace backends |
+| start / complete-or-failed log | `tracing` (`LoggingLayer`) | each dispatch (`elapsed_ms`, `error.code`) | latency + error-rate dashboards |
+
+Side-effect surface is the `IdempotencyStore` it writes to; the bundled in-memory store is process-local and
+unbounded.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| TypeId routing, no reflection/vtable; `dyn` only in sealed `pub(crate)` bridges | [`README §Architecture`](../README.md) | Accepted |
+| No `async_trait` — native RPIT end-to-end; `BoxFuture` only in erased bridges | [`README §Architecture`](../README.md) | Accepted |
+| Idempotency marks only on `Ok` (failed handlers stay retryable) | [`README §Architecture`](../README.md) | Accepted |
+| Write/read separation enforced by the type system | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — a CQRS bus; leverage is the zero-overhead hot path and one uniform pipeline
+  shape across every service.
+- **Stability:** stable contract — the traits and envelope are settled.
+- **Volatility:** low — growth is new bundled layers, authored to the same engine invariants (no
+  `async_trait`, no allocation on the common path).
+- **Deferred capabilities:** a durable/TTL `IdempotencyStore` (Redis `SET NX EX`) — the seam exists; the
+  default is in-memory.

--- a/crates/platform/service-runtime/docs/DOMAIN.fr.md
+++ b/crates/platform/service-runtime/docs/DOMAIN.fr.md
@@ -1,0 +1,173 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 01aab4383d39a7a33a052b5a2fe577957a3e3ce9a69a5416e158964d079fd8c9
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `service-runtime` — Contrat de Domaine & Fonctionnel
+
+> Le bootstrap unifié de la flotte : implémentez un trait, obtenez un service déployable. Il répond à *« quelle est l'unique séquence de boot que chaque service exécute, et que possède encore un service ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | L'unique séquence de boot que chaque service exécute : telemetry → config + hot-reload → compose → serve (trace + traffic + health) → drain |
+> | **Couche** | `platform` — la composition root partagée par chaque binaire `*-server` |
+> | **Classe de sous-domaine** | **Supporting** — l'épine dorsale opérationnelle ; un seul endroit pour faire évoluer les préoccupations process à l'échelle de la flotte |
+> | **Abstraction(s) primaire(s)** | Le trait `Service` + `serve::<S>(addr)` (`service_runtime`) |
+> | **Empreinte** | IO/avec état — bind les sockets, spawn les boucles watcher + readiness + prune, possède le shutdown |
+> | **Posture en cas d'échec** | **fail-closed au boot** (une mauvaise config ne sert jamais) + **santé dynamique** (`NOT_SERVING` jusqu'à ce que les probes passent) |
+> | **Dépend de** | `tonic`, `telemetry`, `infra-config`, `traffic`, `health`, `error`, `transport` |
+> | **Consommé par** | chaque binaire `crates/apps/<svc>-server` (via `serve::<S>(addr)`) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `service-runtime` fait autorité dans la flotte pour **la séquence de boot** : il répond à
+**« comment chaque service démarre, observe, configure, limite le débit, rapporte sa santé, et drain de façon
+identique — pour qu'un binaire de service soit un one-liner ? »** La séparation est délibérée : le runtime
+possède les préoccupations process ; le service ne possède que son câblage de domaine, ses services gRPC
+concrets, et ses probes backend.
+
+**Le problème difficile.** Les préoccupations process (observabilité, IO config + hot-reload, rate-limiting en
+entrée, bind de socket, shutdown gracieux, la boucle de readiness qui pilote la santé gRPC depuis la liveness
+backend) sont identiques à travers 17 services et faciles à rater subtilement. Les centraliser derrière un trait
+— avec un seam `RoutesBuilder` type-erased pour que la stack de couches Tower ne fuite jamais dans la signature
+du service — fait qu'un nouveau service est `~10` lignes et qu'un changement à l'échelle de la flotte est une
+seule édition ici.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Posséder le câblage de domaine (repos, caches, bus, workers) → le `build` du service.
+- ❌ Définir les *mécanismes* telemetry/config/traffic/health → ce sont `telemetry`/`infra-config`/`traffic`/`health`.
+- ❌ Exposer les types de couches Tower aux services → le seam `register` les masque.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Service | Le trait qu'un service déployable implémente (la seule surface) | `Service` |
+| Composition root | L'étape pure de construction du graphe du service | `Service::build` |
+| Register | Brancher les services gRPC concrets du service sur un builder type-erased | `Service::register`, `RoutesBuilder` |
+| Readiness loop | La boucle de fond mappant probes → statut de santé gRPC | `spawn_readiness` |
+| Traffic prune loop | La boucle de fond bornant la mémoire du rate-limiter | `spawn_traffic_prune` |
+| Telemetry control sink | Le pont appliquant la config `[telemetry]` au pipeline vivant | `TelemetryControlSink` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `Service` | trait (seam) | Consts `NAME`/`VERSION`/`GRPC_SERVICE_NAME` + `build`/`health_probes`/`register` |
+| `serve::<S>(addr)` | point d'entrée | Tout le boot+serve+drain de production ; un binaire n'est que cet appel |
+| `GRPC_SERVICE_NAME` | const de contrat | **Doit** égaler le `NamedService::NAME` du serveur concret (la clé de santé) |
+| ré-exports | ergonomie | `HealthProbe`/`FnProbe` (de `health`), `InfraRegistry` (de `infra-config`) |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+
+| Préoccupation | Propriétaire |
+|---|---|
+| Init télémétrie, OTLP, dials log/sampling | **runtime** |
+| Chargement config + watcher hot-reload + pont telemetry sink | **runtime** |
+| Couches trace + rate-limit en entrée, boucle de prune | **runtime** |
+| Santé gRPC, boucle de readiness, shutdown gracieux | **runtime** |
+
+**Le service possède** (pas ce crate) : le câblage de domaine (`build`), les services gRPC concrets + reflection
+(`register`), les probes backend (`health_probes`).
+
+**La liste « do-not-depend-on » :** il compose les crates platform/foundation mais ne possède aucun de leurs
+mécanismes ; il ne doit pas tirer un crate de service/domaine. Le pont `TelemetryControlSink` vit ici précisément
+parce qu'il a besoin à la fois de `infra-config` et `telemetry`, qui ne doivent pas dépendre l'un de l'autre.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | Le boot est fail-closed : une config malformée empêche le pod de jamais servir | `serve` (chargement config) | le pod ne devient jamais ready |
+| I2 | `GRPC_SERVICE_NAME` doit égaler le `NamedService::NAME` concret | convention de contrat | le client voit `NOT_SERVING` à jamais |
+| I3 | Avec des probes, un service est `NOT_SERVING` jusqu'à ce que toutes passent ; tout échec le rétrograde | `spawn_readiness` | la readiness reflète la joignabilité backend réelle |
+| I4 | Le guard du watcher de config survit au processus | `serve` garde `_watcher` en scope | la config gèle à la valeur de boot |
+| I5 | Les types de couches Tower n'atteignent jamais `register` | seam `RoutesBuilder` type-erased | types de couches fuités dans les signatures de service |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**`serve::<S>(addr)` — l'unique séquence de boot.**
+
+1. `telemetry::init` (logs + traces OTLP + métriques) ; le guard est gardé (le drop flush spans/logs). *(boot)*
+2. `load_from_path` + `InfraRegistry::from_config` — **fail-closed** ; un mauvais document abort le boot. *(boot)*
+3. Enregistrer le `TelemetryControlSink` pour que les dials `[telemetry]` s'appliquent immédiatement et à chaque changement ultérieur. *(boot)*
+4. `spawn_watcher` (gardé vivant) — hot-reload de resilience/cache/traffic/telemetry. *(fond)*
+5. `S::build(infra)` — la composition root du service. *(boot)*
+6. Construire le serveur gRPC : `InboundTraceLayer` (externe) + `TrafficLayer` (interne, seulement si `[traffic]`
+   présent) ; ajouter le service de santé + `S::register(routes)`. *(boot)*
+7. `spawn_readiness` (probes → santé gRPC, écritures uniquement sur transition) + `spawn_traffic_prune` (borne la
+   mémoire du limiteur). *(fond)*
+8. `serve_with_shutdown` — servir jusqu'au SIGINT, puis drain les requêtes en vol. *(durée de vie → shutdown)*
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `telemetry` | amont | Conformist | `init` + `TelemetryControl` | le boot d'observabilité + les dials live |
+| `infra-config` | amont | Conformist | `load_from_path`/`spawn_watcher`/`InfraRegistry` | le boot config + hot-reload |
+| `transport` | amont | Conformist | `GrpcServerBuilder` (+ traffic) | la stack serveur gRPC |
+| `health` | amont | Conformist | `HealthProbe` (ré-exporté) | la boucle de readiness |
+| chaque binaire `*-server` | aval | Published Contract | `impl Service` + `serve::<S>` | le boot de toute la flotte |
+
+> **Seam de stabilité :** le trait `Service` (surtout `GRPC_SERVICE_NAME` ↔ `NamedService::NAME`) est l'unique
+> surface à laquelle chaque service se lie ; le changer touche les 17.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| `gRPC server listening` / `shutdown complete` | `tracing` INFO | boot / drain | ops |
+| `gRPC health status changed` | `tracing` INFO | une transition de readiness | les readiness probes K8s |
+| `traffic registry pruned` | `tracing` DEBUG | chaque tick de prune | monitoring mémoire du limiteur |
+
+Effets de bord : bind le socket d'écoute, spawn les tâches watcher/readiness/prune, installe le handler SIGINT.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Un trait `Service` possède la séquence de boot ; un binaire est un one-liner | [`README §Architecture`](../README.md) | Accepted |
+| Le seam `RoutesBuilder` type-erased garde les couches Tower hors des signatures de service | [`README §Architecture`](../README.md) | Accepted |
+| Santé gRPC dynamique pilotée par les probes backend (pas épinglée `SERVING` au boot) | [`README §Architecture`](../README.md) | Accepted |
+| Boot config fail-closed + hot-reload à écrivain unique | [`infra-config README`](../../../foundation/infra-config/README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Supporting — l'épine dorsale opérationnelle ; le levier est l'uniformité des
+  préoccupations process à l'échelle de la flotte.
+- **Stabilité :** contrat stable — le trait `Service` est stabilisé à travers 17 services.
+- **Volatilité :** faible — les nouvelles préoccupations process (une nouvelle boucle de fond, une nouvelle
+  couche) sont ajoutées ici une fois.
+- **Capacités différées :** câblage SIGTERM→drain au-delà de SIGINT ; des hooks de drain/health plus riches pour
+  les services edge avec état (notés dans le travail realtime).

--- a/crates/platform/service-runtime/docs/DOMAIN.md
+++ b/crates/platform/service-runtime/docs/DOMAIN.md
@@ -1,0 +1,159 @@
+# `service-runtime` — Domain & Functional Contract
+
+> The unified fleet bootstrap: implement one trait, get a deployable service. It answers *"what is the one boot sequence every service runs, and what does a service still own?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | The single boot sequence every service runs: telemetry → config + hot-reload → compose → serve (trace + traffic + health) → drain |
+> | **Layer** | `platform` — the composition root shared by every `*-server` binary |
+> | **Subdomain class** | **Supporting** — the operational backbone; one place to evolve fleet-wide process concerns |
+> | **Primary abstraction(s)** | `Service` trait + `serve::<S>(addr)` (`service_runtime`) |
+> | **Footprint** | IO/stateful — binds sockets, spawns the watcher + readiness + prune loops, owns shutdown |
+> | **Failure posture** | **fail-closed at boot** (bad config never serves) + **dynamic health** (`NOT_SERVING` until probes pass) |
+> | **Depends on** | `tonic`, `telemetry`, `infra-config`, `traffic`, `health`, `error`, `transport` |
+> | **Consumed by** | every `crates/apps/<svc>-server` binary (via `serve::<S>(addr)`) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `service-runtime` is the fleet's authority for **the boot sequence**: it answers
+**"how does every service start, observe, configure, rate-limit, report health, and drain identically — so a
+service binary is a one-liner?"** The split is deliberate: the runtime owns process-wide concerns; the service
+owns only its domain wiring, its concrete gRPC services, and its backend probes.
+
+**The hard problem.** Process-wide concerns (observability, config IO + hot-reload, ingress rate-limiting,
+socket binding, graceful shutdown, the readiness loop that drives gRPC health from backend liveness) are
+identical across 17 services and easy to get subtly wrong. Centralising them behind one trait — with a
+type-erased `RoutesBuilder` seam so the Tower layer stack never leaks into the service's signature — means a
+new service is `~10` lines and a fleet-wide change is one edit here.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Own domain wiring (repos, caches, buses, workers) → the service's `build`.
+- ❌ Define the telemetry/config/traffic/health *mechanisms* → those are `telemetry`/`infra-config`/`traffic`/`health`.
+- ❌ Expose the Tower layer types to services → the `register` seam hides them.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Service | The trait a deployable service implements (the only surface) | `Service` |
+| Composition root | The service's pure graph-building step | `Service::build` |
+| Register | Plugging the service's concrete gRPC services onto a type-erased builder | `Service::register`, `RoutesBuilder` |
+| Readiness loop | The background poll mapping probes → gRPC health status | `spawn_readiness` |
+| Traffic prune loop | The background loop bounding rate-limiter memory | `spawn_traffic_prune` |
+| Telemetry control sink | The bridge applying `[telemetry]` config to the live pipeline | `TelemetryControlSink` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `Service` | trait (seam) | `NAME`/`VERSION`/`GRPC_SERVICE_NAME` consts + `build`/`health_probes`/`register` |
+| `serve::<S>(addr)` | entrypoint | The entire production boot+serve+drain; a binary is just this call |
+| `GRPC_SERVICE_NAME` | const contract | **Must** equal the concrete server's `NamedService::NAME` (the health key) |
+| re-exports | ergonomics | `HealthProbe`/`FnProbe` (from `health`), `InfraRegistry` (from `infra-config`) |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+
+| Concern | Owner |
+|---|---|
+| Telemetry init, OTLP, log/sampling dials | **runtime** |
+| Config load + hot-reload watcher + telemetry sink bridge | **runtime** |
+| Ingress trace + rate-limit layers, prune loop | **runtime** |
+| gRPC health, readiness loop, graceful shutdown | **runtime** |
+
+**The service owns** (not this crate): domain wiring (`build`), concrete gRPC services + reflection
+(`register`), backend probes (`health_probes`).
+
+**The "do-not-depend-on" list:** it composes the platform/foundation crates but owns none of their mechanisms;
+it must not pull in a service/domain crate. The `TelemetryControlSink` bridge lives here precisely because it
+needs both `infra-config` and `telemetry`, which must not depend on each other.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Boot is fail-closed: a malformed config stops the pod from ever serving | `serve` (config load) | pod never becomes ready |
+| I2 | `GRPC_SERVICE_NAME` must equal the concrete `NamedService::NAME` | contract convention | client sees `NOT_SERVING` forever |
+| I3 | With probes, a service is `NOT_SERVING` until all pass; any failure demotes it | `spawn_readiness` | readiness reflects real backend reachability |
+| I4 | The config watcher guard outlives the process | `serve` keeps `_watcher` in scope | config freezes at boot value |
+| I5 | Tower layer types never reach `register` | type-erased `RoutesBuilder` seam | leaked layer types in service signatures |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**`serve::<S>(addr)` — the one boot sequence.**
+
+1. `telemetry::init` (logs + OTLP traces + metrics); the guard is kept (drop flushes spans/logs). *(boot)*
+2. `load_from_path` + `InfraRegistry::from_config` — **fail-closed**; a bad document aborts the boot. *(boot)*
+3. Register the `TelemetryControlSink` so `[telemetry]` dials apply immediately and on every later change. *(boot)*
+4. `spawn_watcher` (kept alive) — hot-reload of resilience/cache/traffic/telemetry. *(background)*
+5. `S::build(infra)` — the service composition root. *(boot)*
+6. Build the gRPC server: `InboundTraceLayer` (outer) + `TrafficLayer` (inner, only if `[traffic]` present);
+   add the health service + `S::register(routes)`. *(boot)*
+7. `spawn_readiness` (probes → gRPC health, transition-only writes) + `spawn_traffic_prune` (bounds limiter
+   memory). *(background)*
+8. `serve_with_shutdown` — serve until SIGINT, then drain in-flight requests. *(lifetime → shutdown)*
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `telemetry` | upstream | Conformist | `init` + `TelemetryControl` | observability boot + live dials |
+| `infra-config` | upstream | Conformist | `load_from_path`/`spawn_watcher`/`InfraRegistry` | config boot + hot-reload |
+| `transport` | upstream | Conformist | `GrpcServerBuilder` (+ traffic) | the gRPC server stack |
+| `health` | upstream | Conformist | `HealthProbe` (re-exported) | the readiness loop |
+| every `*-server` binary | downstream | Published Contract | `impl Service` + `serve::<S>` | the entire fleet's boot |
+
+> **Stability seam:** the `Service` trait (esp. `GRPC_SERVICE_NAME` ↔ `NamedService::NAME`) is the single
+> surface every service binds to; changing it touches all 17.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| `gRPC server listening` / `shutdown complete` | `tracing` INFO | boot / drain | ops |
+| `gRPC health status changed` | `tracing` INFO | a readiness transition | K8s readiness probes |
+| `traffic registry pruned` | `tracing` DEBUG | each prune tick | limiter-memory monitoring |
+
+Side effects: binds the listen socket, spawns the watcher/readiness/prune tasks, installs the SIGINT handler.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| One `Service` trait owns the boot sequence; a binary is a one-liner | [`README §Architecture`](../README.md) | Accepted |
+| Type-erased `RoutesBuilder` seam keeps Tower layers out of service signatures | [`README §Architecture`](../README.md) | Accepted |
+| Dynamic gRPC health driven by backend probes (not pinned `SERVING` at boot) | [`README §Architecture`](../README.md) | Accepted |
+| Fail-closed config boot + single-writer hot-reload | [`infra-config README`](../../../foundation/infra-config/README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Supporting — the operational backbone; leverage is fleet-wide uniformity of process
+  concerns.
+- **Stability:** stable contract — the `Service` trait is settled across 17 services.
+- **Volatility:** low — new process-wide concerns (a new background loop, a new layer) are added here once.
+- **Deferred capabilities:** SIGTERM→drain wiring beyond SIGINT; richer drain/health hooks for stateful edge
+  services (noted in the realtime work).

--- a/crates/platform/telemetry/docs/DOMAIN.fr.md
+++ b/crates/platform/telemetry/docs/DOMAIN.fr.md
@@ -1,0 +1,169 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 8d5ac66734950caf48ac4ffd737772d04aec7fee3e8a9daf97596381f6faa8b4
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `telemetry` — Contrat de Domaine & Fonctionnel
+
+> Le bootstrap d'observabilité : logs + traces OTLP + métriques en un `init()`. Il répond à *« comment chaque binaire obtient-il une observabilité uniforme en un appel avec re-réglage live ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Bootstrap d'observabilité en un appel : logging structuré + tracing distribué OTLP + métriques Prometheus/OTLP, avec dials live sans verrou |
+> | **Couche** | `platform` — l'unique bootstrap d'observabilité que chaque binaire appelle (via `service-runtime`) |
+> | **Classe de sous-domaine** | **Supporting** — le substrat d'observabilité ; fort levier opérationnel (un schéma, re-réglage live) |
+> | **Abstraction(s) primaire(s)** | `init` + `TelemetryGuard` + `TelemetryControl` (`telemetry`) |
+> | **Empreinte** | IO/avec état — installe le subscriber global au processus, spawn les tâches OTLP/métriques ; nécessite un runtime Tokio |
+> | **Posture en cas d'échec** | **tolérant aux pannes** — les buffers droppent à capacité plutôt que de backpressurer l'app ; les échecs d'export sont silencieux + retentés |
+> | **Dépend de** | `tracing(-subscriber)`, `opentelemetry(_sdk)`, `arc-swap`, `prometheus`/`axum` (optionnel) |
+> | **Consommé par** | `service-runtime` (appelle `init` dans `serve`) ; les crates de stockage émettent dans le subscriber installé |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `telemetry` fait autorité dans la flotte pour **le pipeline d'observabilité** : il répond à
+**« comment un binaire monte-t-il logs, traces, et métriques avec un schéma et un appel — et re-règle le filtre
+de log et le sampling à chaud pendant un incident sans redémarrage ? »**
+
+**Le problème difficile.** Trois pipelines indépendants (logging, tracing, métriques) doivent s'initialiser dans
+le bon ordre, flush dans le bon ordre au shutdown, ne jamais bloquer le chemin chaud, et exposer des dials live
+sans verrou pour la réponse aux incidents. `telemetry` câble les trois derrière un `init()` retournant un guard
+à portée de durée de vie dont le drop flush spans → métriques → logs dans l'ordre, et un `TelemetryControl` qui
+swap le filtre de log et le sampler via `ArcSwap`.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Définir les métriques applicatives → les services obtiennent un meter du global OTel.
+- ❌ Sonder la santé ou posséder la readiness → c'est `health` + `service-runtime`.
+- ❌ Décider quand/où il est appelé → dans la flotte, `service-runtime` appelle `init`, pas les services directement.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Init | L'unique appel de bootstrap ; installe le subscriber global + les pipelines | `init`, `TelemetryConfig` |
+| Guard | Le handle à portée de durée de vie dont le drop flush tout dans l'ordre | `TelemetryGuard` |
+| Control | Les dials live clonables (filtre de log + sampling) | `TelemetryControl` |
+| Sampling strategy | La policy de head-sampling, parent-based pour garder les traces entières | `SamplingStrategy::{AlwaysOn, AlwaysOff, TraceIdRatio}` |
+| Metrics exporter | Pull Prometheus ou push OTLP | `MetricsExporterKind`, `PrometheusHandle` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `init(config)` | point d'entrée | Appeler **une fois**, dans un runtime Tokio, avant toute macro `tracing::` |
+| `TelemetryGuard` | guard RAII | Lier à une var **nommée** ; drop = flush ordonné (spans → métriques → logs) ; les erreurs s'impriment, ne panic jamais |
+| `TelemetryControl` | dials live | `set_log_filter`/`set_sampling` swap sans verrou, sans redémarrage ; le sampling parent-based garde les traces entières |
+| `TelemetryConfig::from_env` | config | Lit `RUST_LOG`/`OTEL_*`/`LOG_FORMAT`/`METRICS_EXPORTER` |
+| `PrometheusHandle` / `metrics_route` | surface de feature | `prometheus-exporter` (activé par défaut) ; texte `GET /metrics` |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- La construction du pipeline, le shutdown ordonné, et les dials de re-réglage live. Un schéma de log, une
+  convention d'attributs de span, une convention de labels de métriques.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Les définitions de métriques applicatives | chaque service (via le meter global OTel) | Le crate fournit le pipeline, pas les métriques métier |
+| Le parsing de la section de config `[telemetry]` | `infra-config` | Il expose un `TelemetrySink` ; `service-runtime` fait le pont (les deux crates ne doivent pas dépendre l'un de l'autre) |
+| Santé/readiness | `health` + `service-runtime` | Préoccupation séparée |
+
+**La liste « do-not-depend-on » :** jamais `infra-config` (le pont vit dans `service-runtime`), jamais un crate
+de service. `prometheus`/`axum` sont optionnels (gatés par feature).
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | `init` est appelé exactement une fois (le slot global `tracing` est unique) | subscriber global | `TelemetryError::SubscriberInit` |
+| I2 | `init` tourne dans un runtime Tokio, avant toute macro `tracing::` | OTel SDK | panic (les tâches spawn) / événements précoces droppés |
+| I3 | Le guard est lié à une var nommée et survit au processus | RAII | flush précoce ; logs/spans disparaissent à la sortie |
+| I4 | Le chemin chaud ne bloque jamais sur la télémétrie (drop-à-capacité, échecs d'export silencieux) | writers non-bloquants + export batch | perte de données préférée au backpressure |
+| I5 | Le sampling est parent-based pour que les traces distribuées restent entières | `DynamicSampler` | traces cassées quand le volume est réduit |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Init.** Construire un `Registry` avec `EnvFilter` (`RUST_LOG`|`LOG_FILTER`) + une couche de log non-bloquante
+JSON/Pretty (`tracing_appender`) + une couche de trace OTLP (gRPC:4317 | HTTP:4318 → `BatchSpanProcessor` →
+`TracerProvider` {Resource, Sampler}) → `try_init()` installe le subscriber global au processus. Un pipeline de
+métriques (pull Prometheus ou push OTLP toutes les 60s) est construit indépendamment. Retourne
+`TelemetryGuard { _log_guard, tracer_provider, metrics_pipeline }`.
+
+**Dials live.** `TelemetryControl` tient un handle `tracing_subscriber::reload` (filtre de log) et un
+`DynamicSampler` (`ShouldSample` sur `ArcSwap`) ; les deux swap sans verrou et sans redémarrage. `service-runtime`
+enregistre ce control comme le sink de la section de config `[telemetry]`, pour qu'un push de ConfigMap re-règle
+la flotte.
+
+**Shutdown.** Le drop du guard flush dans l'ordre : `TracerProvider::shutdown()` (spans) →
+`MetricsPipeline::shutdown()` → `WorkerGuard` (join le thread de log). Les erreurs s'impriment sur stderr, ne
+panic jamais. Un second `init()` retourne `SubscriberInit` plutôt que d'écraser le premier.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `service-runtime` | aval | Published Contract | `init` + `TelemetryControl` | le boot d'observabilité + les dials live |
+| `transport` | aval | Conformist | propagateur global + versions OTel épinglées | la propagation de trace (contexte compatible wire) |
+| crates stockage/service | aval | Conformist | émettent dans le subscriber installé | l'apparition même de leurs logs/spans |
+| `infra-config` | indirect | Separated Interface | `TelemetrySink` (ponté dans `service-runtime`) | le re-réglage live piloté par config |
+
+> **Seam de stabilité :** `init`/`TelemetryGuard`/`TelemetryControl` sont une API publique ; les versions OTel
+> épinglées sont un contrat de compatibilité wire avec `transport`.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| gauges de process | métriques Prometheus | `prometheus-exporter` activé | `process_cpu_seconds_total`, `process_open_fds`, RSS, … |
+| spans / métriques exportés | OTLP | batché hors du chemin chaud | le collector (Jaeger/Honeycomb/Datadog) |
+| logs/spans/métriques de chaque service | relayés | dès qu'un service instrumente | c'est le substrat qu'ils chevauchent |
+
+Effets de bord : installe le subscriber global, spawn les tâches Tokio batch-span + OTLP-reader, sert
+optionnellement `/metrics`.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Un `init()` pour les trois pipelines ; drop du guard = flush ordonné | [`README §Architecture`](../README.md) | Accepted |
+| Dials live sans verrou (`TelemetryControl`) pour le filtre de log + sampling parent-based | [`README §Architecture`](../README.md) | Accepted |
+| Tolérant aux pannes par conception (drop-à-capacité, retries d'export silencieux) | [`README §Architecture`](../README.md) | Accepted |
+| Le pont vers `infra-config` vit dans `service-runtime` (éviter une dépendance circulaire) | [`service-runtime README`](../../service-runtime/README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Supporting — le substrat d'observabilité ; le levier est un schéma à l'échelle de la
+  flotte + le re-réglage live.
+- **Stabilité :** contrat stable.
+- **Volatilité :** faible-moyenne — les options d'exporter/back-end évoluent ; la forme `init`/guard/control est stabilisée.
+- **Capacités différées :** aucune structurelle ; de nouveaux exporters ou stratégies de sampling sont des enums additifs.

--- a/crates/platform/telemetry/docs/DOMAIN.md
+++ b/crates/platform/telemetry/docs/DOMAIN.md
@@ -1,0 +1,157 @@
+# `telemetry` — Domain & Functional Contract
+
+> The observability bootstrap: logs + OTLP traces + metrics in one `init()`. It answers *"how does every binary get uniform observability with one call and live retuning?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | One-call observability bootstrap: structured logging + OTLP distributed tracing + Prometheus/OTLP metrics, with lock-free live dials |
+> | **Layer** | `platform` — the single observability bootstrap every binary calls (via `service-runtime`) |
+> | **Subdomain class** | **Supporting** — the observability substrate; high operational leverage (one schema, live retuning) |
+> | **Primary abstraction(s)** | `init` + `TelemetryGuard` + `TelemetryControl` (`telemetry`) |
+> | **Footprint** | IO/stateful — installs the process-global subscriber, spawns OTLP/metrics tasks; requires a Tokio runtime |
+> | **Failure posture** | **failure-tolerant** — buffers drop at capacity rather than backpressure the app; export failures are silent + retried |
+> | **Depends on** | `tracing(-subscriber)`, `opentelemetry(_sdk)`, `arc-swap`, `prometheus`/`axum` (optional) |
+> | **Consumed by** | `service-runtime` (calls `init` in `serve`); storage crates emit into the installed subscriber |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `telemetry` is the fleet's authority for **the observability pipeline**: it answers
+**"how does a binary stand up logs, traces, and metrics with one schema and one call — and retune log filter
+and sampling live during an incident without a restart?"**
+
+**The hard problem.** Three independent pipelines (logging, tracing, metrics) must initialise in the right
+order, flush in the right order on shutdown, never block the hot path, and expose lock-free live dials for
+incident response. `telemetry` wires all three behind one `init()` returning a lifetime-scoped guard whose drop
+flushes spans → metrics → logs in order, and a `TelemetryControl` that swaps the log filter and sampler over
+`ArcSwap`.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Define application metrics → services obtain a meter from the OTel global.
+- ❌ Poll health or own readiness → that is `health` + `service-runtime`.
+- ❌ Decide when/where it's called → in the fleet, `service-runtime` calls `init`, not services directly.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Init | The single bootstrap call; install the process-global subscriber + pipelines | `init`, `TelemetryConfig` |
+| Guard | The lifetime-scoped handle whose drop flushes everything in order | `TelemetryGuard` |
+| Control | The cloneable live dials (log filter + sampling) | `TelemetryControl` |
+| Sampling strategy | Head-sampling policy, parent-based to keep traces whole | `SamplingStrategy::{AlwaysOn, AlwaysOff, TraceIdRatio}` |
+| Metrics exporter | Prometheus pull or OTLP push | `MetricsExporterKind`, `PrometheusHandle` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `init(config)` | entrypoint | Call **once**, inside a Tokio runtime, before any `tracing::` macro |
+| `TelemetryGuard` | RAII guard | Bind to a **named** var; drop = ordered flush (spans → metrics → logs); errors print, never panic |
+| `TelemetryControl` | live dials | `set_log_filter`/`set_sampling` swap lock-free, no restart; parent-based sampling keeps traces whole |
+| `TelemetryConfig::from_env` | config | Reads `RUST_LOG`/`OTEL_*`/`LOG_FORMAT`/`METRICS_EXPORTER` |
+| `PrometheusHandle` / `metrics_route` | feature surface | `prometheus-exporter` (default on); `GET /metrics` text |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- Pipeline construction, ordered shutdown, and the live-retuning dials. One log schema, one span-attribute
+  convention, one metric-label convention.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| Application metric definitions | each service (via OTel global meter) | The crate provides the pipeline, not the business metrics |
+| The `[telemetry]` config section parsing | `infra-config` | It exposes a `TelemetrySink`; `service-runtime` bridges it (the two crates must not depend on each other) |
+| Health/readiness | `health` + `service-runtime` | Separate concern |
+
+**The "do-not-depend-on" list:** never `infra-config` (the bridge lives in `service-runtime`), never a service
+crate. `prometheus`/`axum` are optional (feature-gated).
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `init` is called exactly once (the `tracing` global slot is single) | global subscriber | `TelemetryError::SubscriberInit` |
+| I2 | `init` runs inside a Tokio runtime, before any `tracing::` macro | OTel SDK | panic (tasks spawn) / dropped early events |
+| I3 | The guard is bound to a named var and outlives the process | RAII | early flush; logs/spans vanish at exit |
+| I4 | The hot path never blocks on telemetry (drop-at-capacity, silent export failures) | non-blocking writers + batch export | data loss preferred over backpressure |
+| I5 | Sampling is parent-based so distributed traces stay whole | `DynamicSampler` | broken traces when volume is dropped |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Init.** Build a `Registry` with `EnvFilter` (`RUST_LOG`|`LOG_FILTER`) + a non-blocking JSON/Pretty log layer
+(`tracing_appender`) + an OTLP trace layer (gRPC:4317 | HTTP:4318 → `BatchSpanProcessor` → `TracerProvider`
+{Resource, Sampler}) → `try_init()` installs the process-global subscriber. A metrics pipeline (Prometheus pull
+or OTLP push every 60s) is built independently. Returns `TelemetryGuard { _log_guard, tracer_provider,
+metrics_pipeline }`.
+
+**Live dials.** `TelemetryControl` holds a `tracing_subscriber::reload` handle (log filter) and a
+`DynamicSampler` (`ShouldSample` over `ArcSwap`); both swap lock-free with no restart. `service-runtime`
+registers this control as the sink for the `[telemetry]` config section, so a ConfigMap push retunes the fleet.
+
+**Shutdown.** Guard drop flushes in order: `TracerProvider::shutdown()` (spans) → `MetricsPipeline::shutdown()`
+→ `WorkerGuard` (join the log thread). Errors print to stderr, never panic. A second `init()` returns
+`SubscriberInit` rather than clobbering the first.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `service-runtime` | downstream | Published Contract | `init` + `TelemetryControl` | observability boot + live dials |
+| `transport` | downstream | Conformist | global propagator + pinned OTel versions | trace propagation (wire-compatible context) |
+| storage/service crates | downstream | Conformist | emit into the installed subscriber | their logs/spans appearing at all |
+| `infra-config` | indirect | Separated Interface | `TelemetrySink` (bridged in `service-runtime`) | live config-driven retuning |
+
+> **Stability seam:** `init`/`TelemetryGuard`/`TelemetryControl` are public API; the pinned OTel versions are a
+> wire-compatibility contract with `transport`.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| process gauges | Prometheus metrics | `prometheus-exporter` on | `process_cpu_seconds_total`, `process_open_fds`, RSS, … |
+| exported spans / metrics | OTLP | batched off the hot path | the collector (Jaeger/Honeycomb/Datadog) |
+| every service's logs/spans/metrics | relayed | whenever a service instruments | this is the substrate they ride on |
+
+Side effects: installs the global subscriber, spawns the batch-span + OTLP-reader Tokio tasks, optionally serves
+`/metrics`.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| One `init()` for all three pipelines; guard drop = ordered flush | [`README §Architecture`](../README.md) | Accepted |
+| Lock-free live dials (`TelemetryControl`) for log filter + parent-based sampling | [`README §Architecture`](../README.md) | Accepted |
+| Failure-tolerant by design (drop-at-capacity, silent export retries) | [`README §Architecture`](../README.md) | Accepted |
+| Bridge to `infra-config` lives in `service-runtime` (avoid a circular dep) | [`service-runtime README`](../../service-runtime/README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Supporting — the observability substrate; leverage is one schema fleet-wide + live
+  retuning.
+- **Stability:** stable contract.
+- **Volatility:** low-medium — exporter/back-end options evolve; the `init`/guard/control shape is settled.
+- **Deferred capabilities:** none structural; new exporters or sampling strategies are additive enums.

--- a/crates/platform/test-support/docs/DOMAIN.fr.md
+++ b/crates/platform/test-support/docs/DOMAIN.fr.md
@@ -1,0 +1,151 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 417f78a8edb2da7aac6a92ba1d3fc5940365299d0a19252c2b388f9443c56dea
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `test-support` — Contrat de Domaine & Fonctionnel
+
+> L'épine dorsale des tests d'intégration : containers, migrations, et l'await anti-flake. Il répond à *« qu'est-ce qui est identique à travers chaque suite live de service, pour que chaque suite ne porte que ses propres scénarios ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Échafaudage de tests d'intégration agnostique au backend : orchestration de containers, runners de migration, et la primitive de synchronisation `await_until` |
+> | **Couche** | `platform` — **dev-only** ; jamais lié dans un binaire de service |
+> | **Classe de sous-domaine** | **Supporting** — infrastructure de test ; le levier est la cohérence + la discipline anti-flake |
+> | **Abstraction(s) primaire(s)** | `containers::*` + `migrate::*` + `await_until` (`test_support`) |
+> | **Empreinte** | dev-only — une `[dev-dependency]` ; boot des containers Docker ; nécessite un daemon Docker en marche |
+> | **Posture en cas d'échec** | N/A — échafaudage de test ; la correction = aucun flake, pas la résilience runtime |
+> | **Dépend de** | `testcontainers(-modules)`, `rdkafka`, `tokio`, `scylla(-storage)`, `sqlx`, `tracing` |
+> | **Consommé par** | la suite live de chaque service (`tests/<svc>_it/`), comme une `[dev-dependency]` |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `test-support` fait autorité dans la flotte pour l'**infrastructure de test live** : il répond à
+**« comment chaque service boote-t-il ses vrais backends (Scylla/Redis/Kafka/Postgres/MinIO), applique les
+migrations une fois, et synchronise les assertions sans dormir ? »** — pour que la suite de chaque service ne
+porte que son graphe de composition root et ses scénarios.
+
+**Le problème difficile.** Les suites d'intégration live sont flaky et lentes quand chacune réinvente le boot de
+container, l'assignation de port, l'application de migration, et (pire) des `sleep` fixes en course avec des
+containers lents. `test-support` extrait les cinq piliers de la suite gold-standard `chat` pour que les parties
+*identiques* soient écrites une fois et que la discipline anti-flake (`await_until`, jamais `sleep`) soit imposée
+par la primitive partagée.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Être lié dans un binaire de service → il est dev-only ; cela tirerait l'échafaudage de test en production.
+- ❌ Posséder la logique de test / les scénarios → ceux-ci vivent dans le `tests/<svc>_it/` de chaque service.
+- ❌ Fournir l'isolation par teardown → l'isolation est par namespacing (clés UUID fraîches), une discipline par harness.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Ready entry point | Boot le container (une fois) + applique les migrations (une fois), retourne l'endpoint | `scylla_ready`, `postgres_ready` |
+| Migration runner | Application DDL idempotente avec adaptation mono-nœud | `scylla_apply`, `postgres_apply` |
+| The await primitive | Sonder l'état observable contre une deadline — jamais `sleep` | `await_until` |
+| Namespacing | Clés UUID fraîches par scénario pour l'isolation parallèle | (discipline dans chaque harness) |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `containers::*_ready` | boot+migrate paresseux | Backé par `OnceCell` ; un ensemble de containers par binaire de test ; ports OS-mappés |
+| `containers::ensure_topics` | helper Kafka | Pré-création explicite de topics (pas de races d'auto-create) |
+| `migrate::*_apply` | runner idempotent | ScyllaDB `SimpleStrategy RF=1` / Postgres SQL brut, appliqué une fois |
+| `await_until(label, deadline, probe)` | primitive de sync | LA règle anti-flake — sonder, jamais sleep fixe |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Les parties identiques à travers chaque suite live de service : orchestration de containers, runners de
+  migration, et la primitive de synchronisation.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Les scénarios + le graphe de composition root | le `tests/<svc>_it/` de chaque service | Spécifique au service ; pas identique |
+| La discipline de namespacing | chaque harness | Le crate fournit l'infra partagée ; l'isolation est une règle par scénario |
+| Tout chemin de code de production | — | Il est dev-only ; jamais sous `[dependencies]` |
+
+**La liste « do-not-depend-on » :** il ne doit jamais apparaître sous les `[dependencies]` d'un service — seulement
+`[dev-dependencies]`. Le lier dans un binaire tire `testcontainers`/`rdkafka` en production.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | Dev-only — jamais lié dans un binaire de service | placement de dépendance (`[dev-dependencies]`) | l'échafaudage de test fuit en prod |
+| I2 | Un ensemble de containers par binaire de test ; les backends bootent paresseusement une fois | `OnceCell` | conflits de port / boots gaspillés |
+| I3 | Chaque endpoint utilise le port hôte mappé assigné par l'OS | `containers` | collisions de port entre suites parallèles |
+| I4 | Migrations appliquées exactement une fois (adaptation mono-nœud) | `OnceCell` + runners | erreurs de réplication sur un nœud |
+| I5 | Zéro sleep fixe — la synchronisation est `await_until` uniquement | la primitive (discipline) | CI flaky |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Par binaire de test.** Un scénario appelle p.ex. `containers::scylla_ready("chat", "migrations")` : le backend
+boote paresseusement via un `OnceCell` (partagé par chaque scénario du binaire), les migrations s'appliquent une
+fois (adaptation mono-nœud), et l'endpoint OS-mappé est retourné. Le harness pilote ensuite le `App::build` du
+service contre cet endpoint, lance un scénario (frappant des clés UUID fraîches pour l'isolation), et asserte
+avec `await_until(label, deadline, probe)` — sondant l'état observable jusqu'à vrai ou la deadline, jamais en dormant.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `scylla-storage` / `sqlx` | amont | Conformist | runners de migration | le setup de schéma des tests live |
+| `testcontainers(-modules)` | amont | Conformist | boot de container + ports mappés | toute l'orchestration |
+| la suite live de chaque service | aval | Published Contract | `*_ready` + `await_until` | chaque suite d'intégration |
+
+> **Seam de stabilité :** `await_until` et les points d'entrée `*_ready` sont le contrat partagé sur lequel
+> chaque suite se construit ; le placement dev-only est lui-même une règle architecturale imposée.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+N/A en tant que signal de production — il n'émet que du `tracing` de temps-de-test. Effets de bord (temps-de-test) :
+démarre des containers Docker, applique des migrations, crée des topics Kafka. Rien de cela n'atteint un binaire déployé.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Extraire les cinq piliers identiques du gold standard `chat` | [`README §Architecture`](../README.md) | Accepted |
+| `await_until` comme primitive de synchronisation unique (anti-flake) | [`README §Architecture`](../README.md) | Accepted |
+| Isolation par namespacing, pas teardown (suites parallèles sur containers partagés) | [`README §Architecture`](../README.md) | Accepted |
+| Dev-only — jamais une dépendance de production | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Supporting — infrastructure de test ; le levier est l'uniformité + la règle anti-flake imposée.
+- **Stabilité :** contrat stable — les cinq piliers sont stabilisés.
+- **Volatilité :** faible — les nouveaux backends sont ajoutés comme de nouvelles features `testcontainers-modules` + un point d'entrée `*_ready`.
+- **Capacités différées :** aucune ; les nouveaux modules de backend sont additifs.

--- a/crates/platform/test-support/docs/DOMAIN.md
+++ b/crates/platform/test-support/docs/DOMAIN.md
@@ -1,0 +1,139 @@
+# `test-support` — Domain & Functional Contract
+
+> The integration-test backbone: containers, migrations, and the anti-flake await. It answers *"what is identical across every service's live suite, so each suite carries only its own scenarios?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Backend-agnostic integration-test scaffolding: container orchestration, migration runners, and the `await_until` synchronisation primitive |
+> | **Layer** | `platform` — **dev-only**; never linked into a service binary |
+> | **Subdomain class** | **Supporting** — test infrastructure; leverage is consistency + the anti-flake discipline |
+> | **Primary abstraction(s)** | `containers::*` + `migrate::*` + `await_until` (`test_support`) |
+> | **Footprint** | dev-only — a `[dev-dependency]`; boots Docker containers; requires a running Docker daemon |
+> | **Failure posture** | N/A — test scaffolding; correctness = no flakes, not runtime resilience |
+> | **Depends on** | `testcontainers(-modules)`, `rdkafka`, `tokio`, `scylla(-storage)`, `sqlx`, `tracing` |
+> | **Consumed by** | every service's live suite (`tests/<svc>_it/`), as a `[dev-dependency]` |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `test-support` is the fleet's authority for **live-test infrastructure**: it answers
+**"how does every service boot its real backends (Scylla/Redis/Kafka/Postgres/MinIO), apply migrations once,
+and synchronise assertions without sleeping?"** — so each service's suite carries only its composition-root
+graph and its scenarios.
+
+**The hard problem.** Live integration suites are flaky and slow when each re-invents container boot, port
+assignment, migration application, and (worst) fixed `sleep`s racing slow containers. `test-support` extracts
+the five pillars from the `chat` gold-standard suite so the *identical* parts are written once and the anti-flake
+discipline (`await_until`, never `sleep`) is enforced by the shared primitive.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Be linked into a service binary → it is dev-only; that would drag test scaffolding into production.
+- ❌ Own test logic / scenarios → those live in each service's `tests/<svc>_it/`.
+- ❌ Provide isolation by teardown → isolation is by namespacing (fresh UUID keys), a per-harness discipline.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Ready entry point | Boot the container (once) + apply migrations (once), return the endpoint | `scylla_ready`, `postgres_ready` |
+| Migration runner | Idempotent DDL apply with single-node adaptation | `scylla_apply`, `postgres_apply` |
+| The await primitive | Poll observable state against a deadline — never `sleep` | `await_until` |
+| Namespacing | Fresh UUID keys per scenario for parallel isolation | (discipline in each harness) |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `containers::*_ready` | lazy boot+migrate | `OnceCell`-backed; one container set per test binary; OS-mapped ports |
+| `containers::ensure_topics` | Kafka helper | Explicit topic pre-creation (no auto-create races) |
+| `migrate::*_apply` | idempotent runner | ScyllaDB `SimpleStrategy RF=1` / raw-SQL Postgres, applied once |
+| `await_until(label, deadline, probe)` | sync primitive | THE anti-flake rule — poll, never fixed-sleep |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The parts identical across every service's live suite: container orchestration, migration runners, and the
+  synchronisation primitive.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| Scenarios + the composition-root graph | each service's `tests/<svc>_it/` | Service-specific; not identical |
+| The namespacing discipline | each harness | The crate provides shared infra; isolation is a per-scenario rule |
+| Any production code path | — | It is dev-only; never under `[dependencies]` |
+
+**The "do-not-depend-on" list:** it must never appear under a service's `[dependencies]` — only
+`[dev-dependencies]`. Linking it into a binary drags `testcontainers`/`rdkafka` into production.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Dev-only — never linked into a service binary | dependency placement (`[dev-dependencies]`) | test scaffolding leaks into prod |
+| I2 | One container set per test binary; backends boot lazily once | `OnceCell` | port conflicts / wasted boots |
+| I3 | Every endpoint uses the OS-assigned mapped host port | `containers` | port collisions across parallel suites |
+| I4 | Migrations applied exactly once (single-node adaptation) | `OnceCell` + runners | replication errors on one node |
+| I5 | Zero fixed sleeps — synchronisation is `await_until` only | the primitive (discipline) | flaky CI |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Per test binary.** A scenario calls e.g. `containers::scylla_ready("chat", "migrations")`: the backend boots
+lazily through a `OnceCell` (shared by every scenario in the binary), migrations apply once (single-node
+adaptation), and the OS-mapped endpoint is returned. The harness then drives the service's `App::build` against
+that endpoint, runs a scenario (minting fresh UUID keys for isolation), and asserts with
+`await_until(label, deadline, probe)` — polling observable state until true or the deadline, never sleeping.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `scylla-storage` / `sqlx` | upstream | Conformist | migration runners | live-test schema setup |
+| `testcontainers(-modules)` | upstream | Conformist | container boot + mapped ports | the whole orchestration |
+| every service's live suite | downstream | Published Contract | `*_ready` + `await_until` | every integration suite |
+
+> **Stability seam:** `await_until` and the `*_ready` entry points are the shared contract every suite builds
+> on; the dev-only placement is itself an enforced architectural rule.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+N/A as a production signal — it emits only test-time `tracing`. Side effects (test-time): starts Docker
+containers, applies migrations, creates Kafka topics. None of this reaches a deployed binary.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Extract the five identical pillars from the `chat` gold standard | [`README §Architecture`](../README.md) | Accepted |
+| `await_until` as the single synchronisation primitive (anti-flake) | [`README §Architecture`](../README.md) | Accepted |
+| Isolation by namespacing, not teardown (parallel suites on shared containers) | [`README §Architecture`](../README.md) | Accepted |
+| Dev-only — never a production dependency | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Supporting — test infrastructure; leverage is uniformity + the enforced anti-flake rule.
+- **Stability:** stable contract — the five pillars are settled.
+- **Volatility:** low — new backends are added as new `testcontainers-modules` features + a `*_ready` entry.
+- **Deferred capabilities:** none; new backend modules are additive.

--- a/crates/platform/traffic-redis/docs/DOMAIN.fr.md
+++ b/crates/platform/traffic-redis/docs/DOMAIN.fr.md
@@ -1,0 +1,160 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: d44c9a4d39e4aa5c7d44da290db437f63c3c56892245929fa00eb0485822d84d
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `traffic-redis` — Contrat de Domaine & Fonctionnel
+
+> Le backend distribué de `traffic` : il répond à *« comment des réplicas partagent-ils un unique budget de débit global à la flotte sans un aller-retour Redis par requête ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Un `QuotaBackend` qui fait que les profils `distributed` de `traffic` appliquent un budget global à la flotte via du leasing amorti (Step 2) |
+> | **Couche** | `platform` — la moitié IO de `traffic` (le mécanisme pur est le crate foundation) |
+> | **Classe de sous-domaine** | **Generic** — un backend de limiteur à budget loué ; le levier est l'amortissement, pas l'algèbre |
+> | **Abstraction(s) primaire(s)** | `RedisLeaseBackend` + `LeaseBook` + `ClaimSource` (`traffic_redis`) |
+> | **Empreinte** | IO/avec état — un cache de lease local + un script Lua de claim single-key contre Redis |
+> | **Posture en cas d'échec** | **fail-soft via policy** — un échec de claim surface en `QuotaError` ; `transport` applique `on_backend_error` (dégrader ou rejeter) |
+> | **Dépend de** | `traffic`, `redis-storage`, `fred` (`i-scripts`), `async-trait`, `dashmap` |
+> | **Consommé par** | `transport` (câblé comme le `QuotaBackend` des profils `distributed`) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `traffic-redis` fait autorité dans la flotte pour le **budget de rate-limit distribué** : il
+répond à **« quelle est la part de chaque réplica du budget global par fenêtre, rechargée uniquement quand son
+lease local s'épuise ? »** — implémentant `traffic::QuotaBackend` pour que les profils `distributed` appliquent
+une limite globale à la flotte sans un hop réseau par requête.
+
+**Le problème difficile.** Un limiteur global à la flotte naïf fait un aller-retour Redis par requête — un
+amplificateur de latence et de charge. `traffic-redis` loue plutôt un *chunk* (`burst` jetons) par clé par
+réplica et le sert localement, ne croisant vers Redis que sur recharge ou pour découvrir une fenêtre épuisée. Le
+chemin chaud touche rarement le réseau ; une fenêtre entièrement épuisée est cachée localement pour qu'un flot
+hors-budget ne martèle pas Redis.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Posséder le mécanisme de limiteur / la config / la décision `check()` → ce sont `traffic` (foundation).
+- ❌ Posséder le glue gRPC (extraction de clé, mapping de décision, policy `on_backend_error`) → c'est `transport`.
+- ❌ Servir les profils `local` → seuls les profils `distributed` consultent le backend.
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Lease | Un chunk du budget global qu'un réplica réclame et sert localement | `LeaseBook` |
+| Claim source | Le seam atomique « louer N jetons pour une clé dans une fenêtre » | `ClaimSource`, `RedisClaimSource` |
+| Window budget | Jetons disponibles dans une fenêtre de lease pour un rps donné | `window_budget(rps, lease_ms)` |
+| Lease backend | L'impl `QuotaBackend` câblant le book à Redis | `RedisLeaseBackend` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `RedisLeaseBackend` | impl `QuotaBackend` | Câblé comme `Arc<dyn traffic::QuotaBackend>` dans `transport` ; `prune(lease_ms)` borne la mémoire |
+| `LeaseBook` | algorithme pur | Le cache de lease local + la logique de budget fenêtré ; agnostique au transport et à Redis, testé unitairement |
+| `ClaimSource` | trait (seam) | Le contrat de claim atomique ; une impl in-memory garde la suite unitaire hermétique |
+| `RedisClaimSource` | adaptateur fin | Un script Lua single-key → cluster-slot-safe (pas de `CROSSSLOT`) |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Le *quota backend* distribué : l'algorithme de lease (`LeaseBook`), le seam de claim (`ClaimSource`), et
+  l'adaptateur Redis (`RedisClaimSource` / `RedisLeaseBackend`).
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Le mécanisme de limiteur + `check()` + les types de config | `traffic` (foundation) | Ce crate n'est que le backend derrière le seam `QuotaBackend` |
+| L'extraction de clé + le mapping de policy `on_backend_error` | `transport` | Le couplage transport reste dehors ; ce crate surface un `QuotaError` |
+
+**La liste « do-not-depend-on » :** jamais `tonic`/`http`. Il dépend *vers le haut* de `traffic` (pour
+`QuotaBackend`) et de `redis-storage`/`fred` pour le claim Lua.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | L'I/O backend s'amortit sur `burst` requêtes/clé/réplica (aucun hop par requête) | `LeaseBook` | amplification de latence/charge |
+| I2 | Le claim atomique est un script Lua single-key (slot-safe) | `RedisClaimSource` | `CROSSSLOT` sur un Redis Cluster |
+| I3 | `LeaseBook` est pur et testé contre un `ClaimSource` in-memory | structure du crate | suite unitaire non hermétique |
+| I4 | `prune(lease_ms)` tourne sur un timer avec `lease_ms` égalant la fenêtre du profil | appelant (`transport`/boucle) | mémoire non bornée ou dérive de comptabilité |
+| I5 | Un échec de claim est fail-soft (surfacé en `QuotaError`, pas un panic) | `RedisLeaseBackend` | échec du chemin chaud |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Chemin chaud — un check `distributed`.** `RedisLeaseBackend` consulte `LeaseBook` : si la clé a un lease local
+restant, le servir (aucun réseau). Quand le lease local est épuisé, appeler `ClaimSource` → `RedisClaimSource`
+lance le script Lua single-key pour réclamer `window_budget(rps, lease_ms)` jetons atomiquement ; une fenêtre
+entièrement épuisée est cachée localement pour que les requêtes hors-budget suivantes soient rejetées sans
+toucher Redis.
+
+**Échec.** Une erreur de claim devient `traffic::QuotaError` ; `transport` la mappe à la policy
+`on_backend_error` du profil (dégrader vers le governor local, ou rejeter). Les requêtes servies depuis un lease
+local existant ne sont pas affectées par un blip Redis.
+
+**Bornage mémoire.** `RedisLeaseBackend::prune(lease_ms)` évince les leases par clé inactifs sur un timer ;
+`tracked_keys()` dimensionne la cadence. Le `lease_ms` doit égaler la fenêtre de lease des profils ou la
+comptabilité dérive.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `traffic` | amont | Separated Interface | `impl QuotaBackend` | l'application du mode distribué |
+| `redis-storage` / `fred` | amont | Conformist | script de claim Lua `eval` | le claim atomique |
+| `transport` | aval | Separated Interface (injecté) | `with_traffic_backend(Arc<dyn QuotaBackend>)` | le limiting global à la flotte |
+
+> **Seam de stabilité :** le contrat public du crate est `traffic::QuotaBackend` (implémenté, pas défini ici) —
+> l'inversion est ce qui permet à `transport` de le câbler sans que `transport` connaisse Redis.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+N/A — aucun `tracing`/métrique propre ; la métrique de throttle est enregistrée par `transport`. Effets de bord :
+un `eval` Lua Redis single-key par recharge (pas par requête) et un cache de lease `dashmap` local.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Louer-un-chunk (amorti) au lieu de check-par-requête | [`README §Architecture`](../README.md) | Accepted |
+| `LeaseBook` pur derrière un seam `ClaimSource` (suite unitaire hermétique) | [`README §Architecture`](../README.md) | Accepted |
+| Claim Lua single-key pour la cluster-slot-safety | [`README §Architecture`](../README.md) | Accepted |
+| Fail-soft via la policy `on_backend_error` du profil | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — un backend de limiteur à budget loué ; le levier est l'amortissement qui garde
+  le chemin chaud hors du réseau.
+- **Stabilité :** en évolution — c'est `traffic` Step 2 ; l'application `distributed` dépend du câblage de ce crate.
+- **Volatilité :** faible — l'algorithme de lease est stabilisé ; la croissance est opérationnelle (cadence de prune, observabilité).
+- **Capacités différées :** des policies de dégradation plus riches et de la télémétrie par clé ; aujourd'hui la
+  forme limite/décision est héritée de `traffic`.

--- a/crates/platform/traffic-redis/docs/DOMAIN.md
+++ b/crates/platform/traffic-redis/docs/DOMAIN.md
@@ -1,0 +1,147 @@
+# `traffic-redis` — Domain & Functional Contract
+
+> The distributed backend for `traffic`: it answers *"how do replicas share one fleet-global rate budget without a Redis round-trip per request?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | A `QuotaBackend` that makes `traffic` `distributed` profiles enforce a fleet-global budget via amortized leasing (Step 2) |
+> | **Layer** | `platform` — the IO half of `traffic` (the pure mechanism is the foundation crate) |
+> | **Subdomain class** | **Generic** — a leased-budget limiter backend; leverage is the amortization, not the algebra |
+> | **Primary abstraction(s)** | `RedisLeaseBackend` + `LeaseBook` + `ClaimSource` (`traffic_redis`) |
+> | **Footprint** | IO/stateful — a local lease cache + a single-key Lua claim script against Redis |
+> | **Failure posture** | **fail-soft via policy** — a claim failure surfaces as `QuotaError`; `transport` applies `on_backend_error` (degrade or reject) |
+> | **Depends on** | `traffic`, `redis-storage`, `fred` (`i-scripts`), `async-trait`, `dashmap` |
+> | **Consumed by** | `transport` (wired as the `QuotaBackend` for `distributed` profiles) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `traffic-redis` is the fleet's authority for **distributed rate-limit budget**: it answers
+**"what is each replica's slice of the global per-window budget, refilled only when its local lease runs
+out?"** — implementing `traffic::QuotaBackend` so `distributed` profiles enforce a fleet-global limit without a
+network hop per request.
+
+**The hard problem.** A naïve fleet-global limiter does one Redis round-trip per request — a latency and load
+amplifier. `traffic-redis` instead leases a *chunk* (`burst` tokens) per key per replica and serves it locally,
+crossing to Redis only on refill or to discover a spent window. The hot path rarely touches the network; a
+fully-spent window is cached locally so an over-budget flood does not hammer Redis.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Own the limiter mechanism / config / `check()` decision → those are `traffic` (foundation).
+- ❌ Own the gRPC glue (key extraction, decision mapping, `on_backend_error` policy) → that is `transport`.
+- ❌ Serve `local` profiles → only `distributed` profiles consult the backend.
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Lease | A chunk of the global budget a replica claims and serves locally | `LeaseBook` |
+| Claim source | The atomic "lease N tokens for key in window" seam | `ClaimSource`, `RedisClaimSource` |
+| Window budget | Tokens available in one lease window for a given rps | `window_budget(rps, lease_ms)` |
+| Lease backend | The `QuotaBackend` impl wiring the book to Redis | `RedisLeaseBackend` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `RedisLeaseBackend` | `QuotaBackend` impl | Wired as `Arc<dyn traffic::QuotaBackend>` in `transport`; `prune(lease_ms)` bounds memory |
+| `LeaseBook` | pure algorithm | The local lease cache + windowed-budget logic; transport- and Redis-agnostic, unit-tested |
+| `ClaimSource` | trait (seam) | The atomic-claim contract; an in-memory impl keeps the unit suite hermetic |
+| `RedisClaimSource` | thin adapter | One single-key Lua script → cluster-slot-safe (no `CROSSSLOT`) |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The distributed *quota backend*: the lease algorithm (`LeaseBook`), the claim seam (`ClaimSource`), and the
+  Redis adapter (`RedisClaimSource` / `RedisLeaseBackend`).
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| The limiter mechanism + `check()` + config types | `traffic` (foundation) | This crate is only the backend behind the `QuotaBackend` seam |
+| Key extraction + `on_backend_error` policy mapping | `transport` | Transport coupling stays out; this crate surfaces a `QuotaError` |
+
+**The "do-not-depend-on" list:** never `tonic`/`http`. It depends *up* on `traffic` (for `QuotaBackend`) and on
+`redis-storage`/`fred` for the Lua claim.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | Backend I/O amortizes over `burst` requests/key/replica (no per-request hop) | `LeaseBook` | latency/load amplification |
+| I2 | The atomic claim is a single-key Lua script (slot-safe) | `RedisClaimSource` | `CROSSSLOT` on a Redis Cluster |
+| I3 | `LeaseBook` is pure and tested against an in-memory `ClaimSource` | crate structure | non-hermetic unit suite |
+| I4 | `prune(lease_ms)` runs on a timer with `lease_ms` matching the profile window | caller (`transport`/loop) | unbounded memory or accounting drift |
+| I5 | A claim failure is fail-soft (surfaced as `QuotaError`, not a panic) | `RedisLeaseBackend` | hot-path failure |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Hot path — a `distributed` check.** `RedisLeaseBackend` consults `LeaseBook`: if the key has remaining
+local lease, serve it (no network). When the local lease is exhausted, call `ClaimSource` → `RedisClaimSource`
+runs the single-key Lua script to claim `window_budget(rps, lease_ms)` tokens atomically; a fully-spent window
+is cached locally so subsequent over-budget requests are rejected without touching Redis.
+
+**Failure.** A claim error becomes `traffic::QuotaError`; `transport` maps it to the profile's
+`on_backend_error` policy (degrade to the local governor, or reject). Requests served from an existing local
+lease are unaffected by a Redis blip.
+
+**Memory bounding.** `RedisLeaseBackend::prune(lease_ms)` evicts idle per-key leases on a timer; `tracked_keys()`
+sizes the cadence. The `lease_ms` must equal the profiles' lease window or accounting drifts.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `traffic` | upstream | Separated Interface | `impl QuotaBackend` | distributed-mode enforcement |
+| `redis-storage` / `fred` | upstream | Conformist | Lua `eval` claim script | the atomic claim |
+| `transport` | downstream | Separated Interface (injected) | `with_traffic_backend(Arc<dyn QuotaBackend>)` | fleet-global limiting |
+
+> **Stability seam:** the crate's public contract is `traffic::QuotaBackend` (implemented, not defined here) —
+> the inversion is what lets `transport` wire it without `transport` knowing about Redis.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+N/A — no `tracing`/metrics of its own; the throttle metric is recorded by `transport`. Side effects: a
+single-key Redis Lua `eval` per refill (not per request) and a local `dashmap` lease cache.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Lease-a-chunk (amortized) instead of check-per-request | [`README §Architecture`](../README.md) | Accepted |
+| Pure `LeaseBook` behind a `ClaimSource` seam (hermetic unit suite) | [`README §Architecture`](../README.md) | Accepted |
+| Single-key Lua claim for cluster-slot-safety | [`README §Architecture`](../README.md) | Accepted |
+| Fail-soft via the profile's `on_backend_error` policy | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — a leased-budget limiter backend; leverage is the amortization that keeps the
+  hot path off the network.
+- **Stability:** evolving — this is `traffic` Step 2; `distributed` enforcement depends on this crate being
+  wired.
+- **Volatility:** low — the lease algorithm is settled; growth is operational (prune cadence, observability).
+- **Deferred capabilities:** richer degradation policies and per-key telemetry; today the limit/decision shape
+  is inherited from `traffic`.

--- a/crates/platform/transport/docs/DOMAIN.fr.md
+++ b/crates/platform/transport/docs/DOMAIN.fr.md
@@ -1,0 +1,177 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 04ef012a3280e5878afb81cba74a5dabf21e4f1b782a1f62de217e7bfcdd6889
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `transport` — Contrat de Domaine & Fonctionnel
+
+> La couche de communication partagée : gRPC + Kafka derrière une API, répondant à *« comment n'importe quel service parle-t-il à n'importe quel autre avec des traces de bout en bout et une livraison at-least-once, gratuitement ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Communication inter-services sur deux paradigmes (gRPC sync + Kafka async) avec propagation de trace W3C automatique et un runtime de consommateur obligatoire |
+> | **Couche** | `platform` — l'unique couche wire que chaque service utilise |
+> | **Classe de sous-domaine** | **Generic** — transport de commodité ; le levier est le tracing uniforme + le standard `run_consumer` |
+> | **Abstraction(s) primaire(s)** | `GrpcClientBuilder`/`GrpcServerBuilder`, `KafkaProducerHandle`/`KafkaConsumerHandle`, `run_consumer` (`transport::{grpc, kafka}`) |
+> | **Empreinte** | IO/avec état — possède les sockets, le client Kafka, et la boucle de consommateur |
+> | **Posture en cas d'échec** | **fail-fast en sortie** (`CircuitOpen`/`Timeout`) + **Kafka at-least-once** (commit uniquement après une issue terminale) |
+> | **Dépend de** | `tonic`/`tower`, `rdkafka`, `resilience`, `traffic`, `telemetry`, `error`, `opentelemetry` |
+> | **Consommé par** | chaque service (clients/serveurs gRPC, producteurs/consommateurs Kafka) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `transport` fait autorité dans la flotte pour **le wire** : il répond à
+**« comment un service appelle-t-il un autre (gRPC) ou publie/consomme un événement (Kafka) de sorte que les
+traces se propagent de bout en bout et que les sémantiques de livraison soient uniformes ? »** — sans
+boilerplate par service.
+
+**Le problème difficile.** Deux transports, une seule histoire de trace. Les deux doivent auto-propager le
+TraceContext W3C (`traceparent`/`tracestate`), câbler les couches de résilience (sortie) et de traffic (entrée),
+et donner à Kafka un *unique* runtime de consommateur at-least-once correct pour que le comportement
+retry/DLQ/offset soit identique à l'échelle de la flotte plutôt que réinventé (et subtilement cassé) par service.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Posséder les types de domaine, schémas, ou la logique des handlers → il ne possède que le wire + la plomberie de trace.
+- ❌ Retenter au niveau du channel gRPC → les bodies HTTP/2 sont des streams (coût de buffering) ; le retry va à la couche app.
+- ❌ Définir le *mécanisme* résilience/traffic → ce sont `resilience`/`traffic` ; ce crate les câble.
+- ❌ Initialiser la télémétrie → `telemetry::init()` est un prérequis dur (enregistre le propagateur).
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Resilient channel | Un channel gRPC enveloppé de trace + circuit-breaker + timeout | `ResilientChannel`, `GrpcClientBuilder::build_resilient` |
+| Traced server | Un serveur gRPC avec couches inbound-trace + ingress-traffic préinstallées | `GrpcServerBuilder`, `TracedGrpcServer` |
+| Event envelope | Le porteur de publication Kafka typé | `EventEnvelope<T>`, `PublishablePayload` |
+| Consumed message | Un message Kafka entrant décodé (erreur de décode = `payload: Err`, pas un abort du stream) | `ConsumedMessage<T>`, `ConsumablePayload` |
+| Consumer runtime | La machine à états par message obligatoire (retry/DLQ/commit) | `run_consumer`, `ProcessOutcome`, `ClassifyError` |
+| Propagation | Inject/extract du contexte de trace sur les deux transports | `inject_context`, `extract_context`, `set_parent` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `TransportError` | enveloppe d'erreur | Aplatit gRPC/Kafka/Codec + `CircuitOpen`/`Timeout`/`MaxRetriesExhausted` |
+| `ResilientChannel` | alias de type | `BoxCloneService<…, TransportError>` ; `Clone` bon marché ; lit CB/timeout d'un `ArcSwap` `ResilienceProfile` |
+| `KafkaProducerHandle` | handle | Backé par `Arc`, `Clone` ; `publish` injecte le contexte de trace dans les headers |
+| `KafkaConsumerHandle` | handle | `stream` (erreur décode ≠ abort) + `commit` (offset+1, commit manuel par défaut) |
+| `run_consumer` | runtime | Possède la machine à états retry/DLQ/commit — **obligatoire** pour chaque consommateur |
+| `ProcessOutcome` | enum | `Done`/`Retry`/`Reject` pilotent la décision terminale-ou-redélivrée du runner |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Le wire (clients/serveurs gRPC + Kafka), la plomberie de trace, le *câblage* des couches résilience/traffic,
+  et le runtime de consommateur. Les sémantiques de livraison (le standard `run_consumer`) sont possédées ici.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Le mécanisme de résilience (CB/retry/timeout) | `resilience` | Ce crate le *câble* ; il ne le définit pas |
+| Le limiteur de traffic | `traffic` | Idem — `TrafficLayer` est câblé mais inerte tant qu'aucun registry n'est fourni |
+| Le pipeline télémétrie + le propagateur global | `telemetry` | `transport` exige `init()` d'abord ; il ne possède pas le pipeline |
+| Les schémas d'événements de domaine / la logique des handlers | crates de service | Le transport porte des payloads opaques + le contexte de trace |
+
+**La liste « do-not-depend-on » :** jamais un crate de service/domaine. Les versions OTel sont épinglées sur
+celles de `telemetry` pour un contexte compatible au niveau wire.
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | `telemetry::init()` tourne avant tout appel transport (sinon inject/extract sont des no-ops) | prérequis runtime | spans déconnectés / `traceparent` manquant |
+| I2 | Un offset Kafka commit uniquement après une issue **terminale** (succès ou dead-letter réussi) | `run_consumer` | un message poison est évacué sans perte |
+| I3 | Une erreur broker/stream ou un échec de publication DLQ retourne `Err` **sans** committer | `run_consumer` | reprise au dernier offset committé, aucune perte |
+| I4 | Un échec de décode dead-letter immédiatement (n'abort pas le stream) | `stream` + `run_consumer` | poison isolé dans la DLQ |
+| I5 | Aucun `RetryLayer` au niveau du channel | composition de la stack client | (le retry relève de la couche app) |
+| I6 | L'idempotence est la responsabilité du consommateur (at-least-once ⇒ vraie redélivrance) | convention de contrat | effets de bord dupliqués |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Stack client gRPC.** `TimeoutLayer → CircuitBreakerLayer → OutboundTraceLayer → tonic Channel`
+(`ResilientChannel`). La couche outbound injecte `traceparent`/`tracestate` dans les headers HTTP/2 ; CB et
+timeout lisent des valeurs hot-reloadables depuis l'`ArcSwap` du `ResilienceProfile` d'origine.
+
+**Stack serveur gRPC.** `InboundTraceLayer` (externe — trace même les requêtes throttlées) `→ TrafficLayer`
+(limite en entrée, inerte tant que `service-runtime` ne fournit pas un `TrafficRegistry` ; le mode shadow charge
+les cellules sans rejeter) `→ handler`.
+
+**Consommateur Kafka (`run_consumer`).** Par message : décode (`payload: Err` ⇒ dead-letter + commit) ; sinon
+lance `process` → `ProcessOutcome` : `Done` ⇒ commit ; `Retry` ⇒ backoff+jitter en place jusqu'à
+`max_attempts`, puis dead-letter + commit ; `Reject` ⇒ dead-letter + commit. Une erreur broker ou un **échec de
+publication DLQ** ⇒ retourne `Err` sans committer, pour que l'appelant rebuild et reprenne au dernier offset
+committé. Les enregistrements DLQ portent `x-dlq-origin-*` + le contexte de trace.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `resilience` | amont | Conformist | `*Layer` + `ResilienceProfile` | le câblage de résilience en sortie |
+| `traffic` | amont | Conformist | `check` / `TrafficDecision` → `RESOURCE_EXHAUSTED` | le limiting en entrée |
+| `telemetry` | amont | Conformist | propagateur global + versions OTel épinglées | la propagation de trace |
+| `error` | amont | Conformist | `grpc_severity`, mapping d'erreur | la sévérité d'erreur gRPC |
+| chaque service | aval | Published Contract | builders client/serveur + `run_consumer` | toutes les communications inter-services |
+| `traffic-redis` | aval-de-nous (injecté) | Separated Interface | `with_traffic_backend(Arc<dyn QuotaBackend>)` | le rate limiting distribué |
+
+> **Seam de stabilité :** `run_consumer` + sa table de livraison est un **standard de flotte obligatoire** ;
+> `TransportError`, les builders, et les handles Kafka sont une API publique.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| span `grpc.server` | `tracing`/OTel | chaque RPC entrant (`rpc.system=grpc`, `rpc.method`) | back-ends de trace |
+| `traceparent`/`tracestate` injectés | header wire | chaque appel client gRPC + publication Kafka | l'extract du récepteur |
+| enregistrement DLQ | effet de bord Kafka | une issue terminale `Retry`-épuisé/`Reject`/échec de décode | consommateurs DLQ / ops |
+| `infra_traffic_throttled_total{status}` | métrique (via câblage traffic) | une décision `Throttle` (shadow ou enforce) | dashboards de rate-limit |
+
+Effets de bord : ouvre des sockets, publie/consomme Kafka, écrit des enregistrements DLQ, commit des offsets.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Les deux transports auto-propagent le TraceContext W3C | [`README §Architecture`](../README.md) | Accepted |
+| Aucun `RetryLayer` au niveau transport (buffering de body HTTP/2) — retry à la couche app | [`README §Architecture`](../README.md) | Accepted |
+| `run_consumer` est le runtime de consommateur obligatoire ; commit uniquement après une issue terminale | [`README §Consumer runtime standard`](../README.md) | Accepted |
+| Traffic câblé-mais-inerte tant que non configuré ; mode shadow avant enforce | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — transport de commodité ; la différenciation est le tracing uniforme + un
+  unique runtime de consommateur at-least-once correct.
+- **Stabilité :** contrat stable — `run_consumer` est un standard de flotte ; les builders/handles sont stabilisés.
+- **Volatilité :** faible-moyenne — la croissance est dans l'observabilité (les instruments de meter Prometheus
+  sont un TODO) et les boutons de config, pas la forme.
+- **Capacités différées :** instruments de meter Prometheus pour les métriques niveau transport ; déploiement
+  TLS/mTLS plus riche.

--- a/crates/platform/transport/docs/DOMAIN.md
+++ b/crates/platform/transport/docs/DOMAIN.md
@@ -1,0 +1,165 @@
+# `transport` — Domain & Functional Contract
+
+> The shared communication layer: gRPC + Kafka behind one API, answering *"how does any service talk to any other with end-to-end traces and at-least-once delivery, for free?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Inter-service communication over two paradigms (sync gRPC + async Kafka) with automatic W3C trace propagation and a mandatory consumer runtime |
+> | **Layer** | `platform` — the single wire layer every service uses |
+> | **Subdomain class** | **Generic** — commodity transport; leverage is uniform tracing + the `run_consumer` standard |
+> | **Primary abstraction(s)** | `GrpcClientBuilder`/`GrpcServerBuilder`, `KafkaProducerHandle`/`KafkaConsumerHandle`, `run_consumer` (`transport::{grpc, kafka}`) |
+> | **Footprint** | IO/stateful — owns sockets, the Kafka client, and the consumer loop |
+> | **Failure posture** | **fail-fast egress** (`CircuitOpen`/`Timeout`) + **at-least-once Kafka** (commit only after a terminal outcome) |
+> | **Depends on** | `tonic`/`tower`, `rdkafka`, `resilience`, `traffic`, `telemetry`, `error`, `opentelemetry` |
+> | **Consumed by** | every service (gRPC clients/servers, Kafka producers/consumers) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `transport` is the fleet's authority for **the wire**: it answers
+**"how does a service call another (gRPC) or publish/consume an event (Kafka) such that traces propagate
+end-to-end and delivery semantics are uniform?"** — with zero boilerplate per service.
+
+**The hard problem.** Two transports, one trace story. Both must auto-propagate W3C TraceContext
+(`traceparent`/`tracestate`), wire in resilience (egress) and traffic (ingress) layers, and give Kafka a
+*single* correct at-least-once consumer runtime so retry/DLQ/offset behaviour is identical fleet-wide rather
+than re-invented (and subtly broken) per service.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Own domain types, schemas, or handler logic → it owns only the wire + trace plumbing.
+- ❌ Retry at the gRPC channel level → HTTP/2 bodies are streams (buffering cost); retry goes at the app layer.
+- ❌ Define the resilience/traffic *mechanism* → those are `resilience`/`traffic`; this crate wires them.
+- ❌ Initialise telemetry → `telemetry::init()` is a hard prerequisite (registers the propagator).
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Resilient channel | A gRPC channel wrapped with trace + circuit-breaker + timeout | `ResilientChannel`, `GrpcClientBuilder::build_resilient` |
+| Traced server | A gRPC server with inbound-trace + ingress-traffic layers pre-installed | `GrpcServerBuilder`, `TracedGrpcServer` |
+| Event envelope | The typed Kafka publish carrier | `EventEnvelope<T>`, `PublishablePayload` |
+| Consumed message | A decoded inbound Kafka message (decode error = `payload: Err`, not a stream abort) | `ConsumedMessage<T>`, `ConsumablePayload` |
+| Consumer runtime | The mandatory per-message state machine (retry/DLQ/commit) | `run_consumer`, `ProcessOutcome`, `ClassifyError` |
+| Propagation | Inject/extract trace context across both transports | `inject_context`, `extract_context`, `set_parent` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `TransportError` | error envelope | Flattens gRPC/Kafka/Codec + `CircuitOpen`/`Timeout`/`MaxRetriesExhausted` |
+| `ResilientChannel` | type alias | `BoxCloneService<…, TransportError>`; cheaply `Clone`; reads CB/timeout from a `ResilienceProfile` `ArcSwap` |
+| `KafkaProducerHandle` | handle | `Arc`-backed, `Clone`; `publish` injects trace context into headers |
+| `KafkaConsumerHandle` | handle | `stream` (decode error ≠ abort) + `commit` (offset+1, manual commit default) |
+| `run_consumer` | runtime | Owns the retry/DLQ/commit state machine — **mandatory** for every consumer |
+| `ProcessOutcome` | enum | `Done`/`Retry`/`Reject` drive the runner's terminal-vs-redeliver decision |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The wire (gRPC + Kafka clients/servers), the trace plumbing, the resilience/traffic layer *wiring*, and the
+  consumer runtime. Delivery semantics (the `run_consumer` standard) are owned here.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| The resilience mechanism (CB/retry/timeout) | `resilience` | This crate *wires* it; it doesn't define it |
+| The traffic limiter | `traffic` | Same — `TrafficLayer` is wired but inert until a registry is supplied |
+| Telemetry pipeline + global propagator | `telemetry` | `transport` requires `init()` first; it doesn't own the pipeline |
+| Domain event schemas / handler logic | service crates | Transport carries opaque payloads + trace context |
+
+**The "do-not-depend-on" list:** never a service/domain crate. OTel versions are pinned to `telemetry`'s for
+wire-compatible context.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `telemetry::init()` runs before any transport call (else inject/extract are no-ops) | runtime prerequisite | disconnected spans / missing `traceparent` |
+| I2 | A Kafka offset commits only after a **terminal** outcome (success or successful dead-letter) | `run_consumer` | a poison message is evicted without loss |
+| I3 | A broker/stream error or DLQ-publish failure returns `Err` **without** committing | `run_consumer` | resume from last committed offset, no loss |
+| I4 | A decode failure dead-letters immediately (does not abort the stream) | `stream` + `run_consumer` | poison isolated to the DLQ |
+| I5 | No `RetryLayer` at the channel level | client stack composition | (retry belongs at the app layer) |
+| I6 | Idempotency is the consumer's responsibility (at-least-once ⇒ real redelivery) | contract convention | duplicate side-effects |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**gRPC client stack.** `TimeoutLayer → CircuitBreakerLayer → OutboundTraceLayer → tonic Channel`
+(`ResilientChannel`). The outbound layer injects `traceparent`/`tracestate` into the HTTP/2 headers; CB and
+timeout read hot-reloadable values from the originating `ResilienceProfile`'s `ArcSwap`.
+
+**gRPC server stack.** `InboundTraceLayer` (outer — traces even throttled requests) `→ TrafficLayer` (ingress
+limit, inert until `service-runtime` supplies a `TrafficRegistry`; shadow mode charges cells without
+rejecting) `→ handler`.
+
+**Kafka consumer (`run_consumer`).** Per message: decode (`payload: Err` ⇒ dead-letter + commit); else run
+`process` → `ProcessOutcome`: `Done` ⇒ commit; `Retry` ⇒ in-place backoff+jitter up to `max_attempts`, then
+dead-letter + commit; `Reject` ⇒ dead-letter + commit. A broker error or **DLQ publish failure** ⇒ return
+`Err` without committing, so the caller rebuilds and resumes from the last committed offset. DLQ records carry
+`x-dlq-origin-*` + the trace context.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `resilience` | upstream | Conformist | `*Layer`s + `ResilienceProfile` | egress resilience wiring |
+| `traffic` | upstream | Conformist | `check` / `TrafficDecision` → `RESOURCE_EXHAUSTED` | ingress limiting |
+| `telemetry` | upstream | Conformist | global propagator + pinned OTel versions | trace propagation |
+| `error` | upstream | Conformist | `grpc_severity`, error mapping | gRPC error severity |
+| every service | downstream | Published Contract | client/server builders + `run_consumer` | all inter-service comms |
+| `traffic-redis` | downstream-of-us (injected) | Separated Interface | `with_traffic_backend(Arc<dyn QuotaBackend>)` | distributed rate limiting |
+
+> **Stability seam:** `run_consumer` + its delivery table is a **mandatory fleet standard**; `TransportError`,
+> the builders, and the Kafka handles are public API.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| `grpc.server` span | `tracing`/OTel | each inbound RPC (`rpc.system=grpc`, `rpc.method`) | trace backends |
+| injected `traceparent`/`tracestate` | wire header | each gRPC client call + Kafka publish | the receiver's extract |
+| DLQ record | Kafka side-effect | a terminal `Retry`-exhausted/`Reject`/decode failure | DLQ consumers / ops |
+| `infra_traffic_throttled_total{status}` | metric (via traffic wiring) | a `Throttle` decision (shadow or enforce) | rate-limit dashboards |
+
+Side effects: opens sockets, publishes/consumes Kafka, writes DLQ records, commits offsets.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Both transports auto-propagate W3C TraceContext | [`README §Architecture`](../README.md) | Accepted |
+| No `RetryLayer` at the transport level (HTTP/2 body buffering) — retry at the app layer | [`README §Architecture`](../README.md) | Accepted |
+| `run_consumer` is the mandatory consumer runtime; commit only after a terminal outcome | [`README §Consumer runtime standard`](../README.md) | Accepted |
+| Traffic wired-but-inert until configured; shadow mode before enforce | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — commodity transport; the differentiation is uniform tracing + a single,
+  correct at-least-once consumer runtime.
+- **Stability:** stable contract — `run_consumer` is a fleet standard; the builders/handles are settled.
+- **Volatility:** low-medium — growth is in observability (Prometheus meter instruments are a TODO) and
+  config knobs, not the shape.
+- **Deferred capabilities:** Prometheus meter instruments for transport-level metrics; richer TLS/mTLS
+  rollout.

--- a/crates/platform/validation/docs/DOMAIN.fr.md
+++ b/crates/platform/validation/docs/DOMAIN.fr.md
@@ -1,0 +1,162 @@
+---
+i18n:
+  source: ./DOMAIN.md
+  source_sha256: 45c95b19e718597f2e3d2550dabb8c8e45a42fa452ce3231f7e3babb6827b059
+  translated_at: 2026-06-28
+  status: complete
+---
+> 🇫🇷 Traduction française — la version **anglaise** [`DOMAIN.md`](./DOMAIN.md) fait foi.
+> En cas de divergence, l'anglais prime. Les contrats (codes d'erreur, topics, variables
+> d'environnement, noms de types, identifiants d'ADR) restent en anglais.
+
+# `validation` — Contrat de Domaine & Fonctionnel
+
+> La moitié opérationnelle de la validation : middleware + type d'erreur. Il répond à *« où dans le pipeline de commandes les entrées invalides sont-elles rejetées, et comment cet échec est-il façonné pour les clients ? »*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Capacité partagée** | Middleware de validation d'entrée pour le bus de commandes CQRS + le `ValidationError` concret (422) et le catalogue `VAL-xxxx` |
+> | **Couche** | `platform` — la moitié opérationnelle de l'abstraction `validate-core` |
+> | **Classe de sous-domaine** | **Generic** — validation d'entrée standard ; le levier est le rejet précoce + les erreurs de champ agrégées |
+> | **Abstraction(s) primaire(s)** | `ValidationLayer` + `ValidationError` (`validation`) |
+> | **Empreinte** | pure (middleware in-process, aucune IO, aucun env) |
+> | **Posture en cas d'échec** | **fail-closed pour une entrée invalide** — rejetée avant tout span, enregistrement d'idempotence, ou travail DB |
+> | **Dépend de** | `validate-core`, `cqrs`, `error` |
+> | **Consommé par** | les composition roots de service (placé le plus à l'extérieur du pipeline de commandes) |
+> | **Journal des décisions** | aucun — justification dans [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Capacité Technique & Non-Objectifs &nbsp;·&nbsp; CORE
+
+**Capacité.** `validation` fait autorité dans la flotte pour l'**application de la validation d'entrée** : il
+répond à **« comment le contrat abstrait `Validate` est-il transformé en middleware de pipeline qui rejette les
+commandes invalides au point le plus précoce, avec un 422 façonné pour le client portant chaque champ en échec ? »**
+
+**Le problème difficile.** La validation doit rejeter *avant* qu'une ressource async ne soit consommée (span,
+enregistrement d'idempotence, transaction DB), agréger toutes les erreurs de champ en un aller-retour, et ne rien
+coûter pour les commandes valides — tout en gardant le trait abstrait `Validate` dans un crate sans dépendance
+pour que `cqrs` puisse l'exiger sans hériter de ce middleware. `validation` est la moitié opérationnelle ;
+`validate-core` est l'abstraction.
+
+**Non-objectifs — ce que ce crate ne fait délibérément PAS :**
+- ❌ Définir le trait `Validate` ou `FieldViolation` → ils vivent dans `validate-core` (pour que `cqrs` dépende de
+  l'abstraction, pas de ce middleware).
+- ❌ Décider les *règles* d'une commande → l'impl `Validate` de chaque commande les possède.
+- ❌ Posséder le placement dans le pipeline comme config → c'est une décision de composition root (le plus à l'extérieur).
+
+---
+
+## 2. Langage Omniprésent &nbsp;·&nbsp; CORE
+
+| Terme | Sens dans ce crate | Symbole de code |
+|---|---|---|
+| Validation layer | Le `CommandLayer` zéro-taille qui appelle `validate()` avant le dispatch | `ValidationLayer`, `ValidationCommandBus` |
+| Validation error | Le `AppError` concret (422, `Severity::Low`) enveloppant les violations | `ValidationError` |
+| Details map | `field → "VAL-xxxx: message"` pour `ApiErrorResponse.details` | `ValidationError::to_details_map` |
+| VAL-xxxx catalogue | Les constantes de code de validation stables | `VAL_1001_REQUIRED` … `VAL_9000_CUSTOM` |
+
+---
+
+## 3. Modèle Public & Surface de Contrat &nbsp;·&nbsp; CORE
+
+| Élément | Nature | Frontière de contrat / invariant gardée |
+|---|---|---|
+| `ValidationLayer` | `CommandLayer` zéro-taille | Doit être la couche **la plus à l'extérieur** ; inline `validate()`, éliminé pour les commandes no-op |
+| `ValidationCommandBus<S>` | bus décoré | Appelle `payload.validate()` ; `Err` court-circuite avant que le handler ne tourne |
+| `ValidationError` | impl `AppError` | `error_code "VAL-0001"`, HTTP 422, `Severity::Low`, retryable false, catégorie `VALIDATION` |
+| `to_details_map()` | méthode | `field → code: message` agrégé, directement dans `ApiErrorResponse.details` |
+| constantes `VAL_xxxx` | catalogue | Codes stables (`1001 REQUIRED`…`9000 CUSTOM`) |
+
+---
+
+## 4. Propriété & Frontières Architecturales &nbsp;·&nbsp; CORE
+
+**Ce crate possède :**
+- Le middleware (`ValidationLayer`/`ValidationCommandBus`), le `ValidationError` concret, et le catalogue de
+  constantes `VAL-xxxx`.
+
+**Ce crate ne possède délibérément PAS / ne doit PAS lier :**
+
+| Préoccupation | Vit dans | Pourquoi l'arête pointe ainsi |
+|---|---|---|
+| Le trait `Validate` + `FieldViolation` | `validate-core` | Pour que `cqrs` dépende de l'abstraction sans ce middleware |
+| Les règles de validation par commande | l'impl `Validate` de chaque commande | Le middleware est générique sur `C: Command` |
+| Le contrat `AppError` / la forme wire | `error` | `ValidationError` l'*implémente* |
+
+**La liste « do-not-depend-on » :** jamais un crate de service/domaine ; il se situe entre `cqrs` (qu'il étend) et
+`validate-core`/`error` (auxquels il se conforme).
+
+---
+
+## 5. Invariants & Règles de Contrat &nbsp;·&nbsp; CORE
+
+| # | Invariant | Appliqué à | En cas de violation |
+|---|---|---|---|
+| I1 | `ValidationLayer` est la couche de commande **la plus à l'extérieur** | composition root (`.layer()` en premier) | travail gaspillé avant rejet |
+| I2 | Le rejet a lieu avant le premier `.await` (aucune ressource async consommée) | `ValidationCommandBus` | les commandes invalides coûtent du travail DB/span/idempotence |
+| I3 | Tous les champs en échec retournés en un aller-retour | `to_details_map` sur `Vec<FieldViolation>` | erreurs client en morceaux |
+| I4 | Les commandes valides incurrent un coût ~zéro (couche zéro-taille, `validate()` inliné) | système de types | overhead inutile |
+| I5 | `CqrsError::Handler` enveloppe une erreur type-erased — pas downcastable en `ValidationError` | effacement `cqrs` | inspecter via `error_code()`/`Display`, pas downcast |
+
+---
+
+## 6. Flot de Contrôle & Cycle de Vie &nbsp;·&nbsp; DEEP
+
+**Par commande.** `ValidationCommandBus` (le plus à l'extérieur) appelle `envelope.payload.validate()` :
+- `Ok(())` → transmettre au pipeline interne (idempotency → tracing → logging → handler).
+- `Err(violations)` → envelopper en `ValidationError` → retourner `CqrsError::Handler(ValidationError)` ; le
+  handler n'est **jamais** appelé et aucune ressource async n'est touchée.
+
+Pour les commandes utilisant le défaut no-op de `Validate`, le compilateur élimine l'appel entièrement — les
+commandes valides ne paient rien.
+
+---
+
+## 7. Couplage de Crate (tranche du graphe de dépendances) &nbsp;·&nbsp; DEEP
+
+| Crate voisin | Direction | Pattern | Mécanisme | Ce qui casse s'il change |
+|---|---|---|---|---|
+| `validate-core` | amont | Separated Interface | `Validate` + `FieldViolation` | ce que le middleware peut valider |
+| `cqrs` | amont | Open-Host (étend) | `ValidationLayer: CommandLayer` | l'intégration au pipeline |
+| `error` | amont | Conformist | `ValidationError: AppError` (422) | le mapping d'erreur client |
+| composition roots de service | aval | Published Contract | placer `ValidationLayer` le plus à l'extérieur | le rejet d'entrée |
+
+> **Seam de stabilité :** `ValidationError` (`error_code "VAL-0001"`) et le catalogue `VAL-xxxx` sont une API
+> publique visible client ; la règle de placement-le-plus-à-l'extérieur de `ValidationLayer` est un contrat.
+
+---
+
+## 8. Signaux Émis & Effets de Bord &nbsp;·&nbsp; DEEP
+
+| Signal | Nature | Émis quand | Qui observe |
+|---|---|---|---|
+| `command validation failed — dispatch short-circuited` | `tracing` DEBUG (`command.type`, `violation.count`) | une commande échoue la validation | dashboards filtrés sur `category = VALIDATION` |
+
+DEBUG est intentionnel — les échecs de validation sont un comportement client attendu, pas des incidents. Aucune
+mutation d'état externe. Un pic sur `error_code = VAL-0001` peut indiquer un changement cassant côté client ou un
+mauvais déploiement.
+
+---
+
+## 9. Décisions & Justification &nbsp;·&nbsp; DEEP
+
+| Décision | Où consignée | Statut |
+|---|---|---|
+| Placement le plus à l'extérieur — rejeter avant idempotency/tracing/DB | [`README §Architecture`](../README.md) | Accepted |
+| Coût zéro pour les commandes valides (couche zéro-taille, `validate()` inliné) | [`README §Architecture`](../README.md) | Accepted |
+| Erreurs de champ agrégées via `to_details_map()` | [`README §Architecture`](../README.md) | Accepted |
+| Séparation trait/middleware avec `validate-core` (brise le cycle `cqrs`↔`validation`) | [`validate-core README`](../../../foundation/validate-core/README.md) | Accepted |
+
+---
+
+## 10. Classification & Évolution &nbsp;·&nbsp; DEEP
+
+- **Classification :** Generic — validation d'entrée standard ; le levier est le rejet précoce à l'échelle + les
+  erreurs de champ agrégées.
+- **Stabilité :** contrat stable — `VAL-0001` et le catalogue `VAL-xxxx` sont visibles client.
+- **Volatilité :** faible — les nouveaux codes sont des constantes additives.
+- **Capacités différées :** un accès downcast structuré au `ValidationError` après l'effacement `cqrs`
+  (aujourd'hui : inspecter via `error_code()`/`Display`, ou valider explicitement avant le dispatch).

--- a/crates/platform/validation/docs/DOMAIN.md
+++ b/crates/platform/validation/docs/DOMAIN.md
@@ -1,0 +1,149 @@
+# `validation` — Domain & Functional Contract
+
+> The operational half of validation: middleware + error type. It answers *"where in the command pipeline do invalid inputs get rejected, and how is that failure shaped for clients?"*
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | Input-validation middleware for the CQRS command bus + the concrete `ValidationError` (422) and the `VAL-xxxx` catalogue |
+> | **Layer** | `platform` — the operational half of the `validate-core` abstraction |
+> | **Subdomain class** | **Generic** — standard input validation; leverage is early rejection + aggregated field errors |
+> | **Primary abstraction(s)** | `ValidationLayer` + `ValidationError` (`validation`) |
+> | **Footprint** | pure (in-process middleware, no IO, no env) |
+> | **Failure posture** | **fail-closed for invalid input** — rejected before any span, idempotency record, or DB work |
+> | **Depends on** | `validate-core`, `cqrs`, `error` |
+> | **Consumed by** | service composition roots (placed outermost on the command pipeline) |
+> | **Decision log** | none — rationale in [`README §Architecture`](../README.md) |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `validation` is the fleet's authority for **input-validation enforcement**: it answers
+**"how is the abstract `Validate` contract turned into pipeline middleware that rejects invalid commands at the
+earliest point, with a client-shaped 422 carrying every failing field?"**
+
+**The hard problem.** Validation must reject *before* any async resource is consumed (span, idempotency record,
+DB transaction), aggregate all field errors into one round-trip, and cost nothing for valid commands — while
+keeping the abstract `Validate` trait in a dependency-free crate so `cqrs` can require it without inheriting this
+middleware. `validation` is the operational half; `validate-core` is the abstraction.
+
+**Non-goals — what this crate deliberately does NOT do:**
+- ❌ Define the `Validate` trait or `FieldViolation` → those live in `validate-core` (so `cqrs` depends on the
+  abstraction, not this middleware).
+- ❌ Decide a command's *rules* → each command's `Validate` impl owns those.
+- ❌ Own pipeline placement as config → it is a composition-root decision (outermost).
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| Validation layer | The zero-size `CommandLayer` that calls `validate()` before dispatch | `ValidationLayer`, `ValidationCommandBus` |
+| Validation error | The concrete `AppError` (422, `Severity::Low`) wrapping the violations | `ValidationError` |
+| Details map | `field → "VAL-xxxx: message"` for `ApiErrorResponse.details` | `ValidationError::to_details_map` |
+| VAL-xxxx catalogue | The stable validation-code constants | `VAL_1001_REQUIRED` … `VAL_9000_CUSTOM` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `ValidationLayer` | zero-size `CommandLayer` | Must be the **outermost** layer; inlines `validate()`, eliminated for no-op commands |
+| `ValidationCommandBus<S>` | decorated bus | Calls `payload.validate()`; `Err` short-circuits before the handler runs |
+| `ValidationError` | `AppError` impl | `error_code "VAL-0001"`, HTTP 422, `Severity::Low`, retryable false, category `VALIDATION` |
+| `to_details_map()` | method | Aggregated `field → code: message`, straight into `ApiErrorResponse.details` |
+| `VAL_xxxx` constants | catalogue | Stable codes (`1001 REQUIRED`…`9000 CUSTOM`) |
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+**This crate owns:**
+- The middleware (`ValidationLayer`/`ValidationCommandBus`), the concrete `ValidationError`, and the `VAL-xxxx`
+  constant catalogue.
+
+**This crate deliberately does NOT own / must NOT link:**
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| The `Validate` trait + `FieldViolation` | `validate-core` | So `cqrs` depends on the abstraction without this middleware |
+| Per-command validation rules | each command's `Validate` impl | The middleware is generic over `C: Command` |
+| The `AppError` contract / wire shape | `error` | `ValidationError` *implements* it |
+
+**The "do-not-depend-on" list:** never a service/domain crate; it sits between `cqrs` (extends it) and
+`validate-core`/`error` (conforms to them).
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `ValidationLayer` is the **outermost** command layer | composition root (`.layer()` first) | wasted work before rejection |
+| I2 | Rejection happens before the first `.await` (no async resource consumed) | `ValidationCommandBus` | invalid commands cost DB/span/idempotency work |
+| I3 | All failing fields returned in one round-trip | `to_details_map` over `Vec<FieldViolation>` | piecemeal client errors |
+| I4 | Valid commands incur ~zero cost (zero-size layer, inlined `validate()`) | type system | unnecessary overhead |
+| I5 | `CqrsError::Handler` wraps a type-erased error — not downcastable to `ValidationError` | `cqrs` erasure | inspect via `error_code()`/`Display`, not downcast |
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+**Per command.** `ValidationCommandBus` (outermost) calls `envelope.payload.validate()`:
+- `Ok(())` → forward to the inner pipeline (idempotency → tracing → logging → handler).
+- `Err(violations)` → wrap as `ValidationError` → return `CqrsError::Handler(ValidationError)`; the handler is
+  **never** called and no async resource is touched.
+
+For commands using the no-op `Validate` default, the compiler eliminates the call entirely — valid commands pay
+nothing.
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `validate-core` | upstream | Separated Interface | `Validate` + `FieldViolation` | what the middleware can validate |
+| `cqrs` | upstream | Open-Host (extends) | `ValidationLayer: CommandLayer` | pipeline integration |
+| `error` | upstream | Conformist | `ValidationError: AppError` (422) | client error mapping |
+| service composition roots | downstream | Published Contract | place `ValidationLayer` outermost | input rejection |
+
+> **Stability seam:** `ValidationError` (`error_code "VAL-0001"`) and the `VAL-xxxx` catalogue are public,
+> client-visible API; `ValidationLayer`'s outermost-placement rule is a contract.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| `command validation failed — dispatch short-circuited` | `tracing` DEBUG (`command.type`, `violation.count`) | a command fails validation | dashboards filtered on `category = VALIDATION` |
+
+DEBUG is intentional — validation failures are expected client behaviour, not incidents. No external state
+mutation. A spike on `error_code = VAL-0001` may indicate a client breaking change or a bad deploy.
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| Outermost placement — reject before idempotency/tracing/DB | [`README §Architecture`](../README.md) | Accepted |
+| Zero-cost for valid commands (zero-size layer, inlined `validate()`) | [`README §Architecture`](../README.md) | Accepted |
+| Aggregated field errors via `to_details_map()` | [`README §Architecture`](../README.md) | Accepted |
+| Trait/middleware split with `validate-core` (breaks the `cqrs`↔`validation` cycle) | [`validate-core README`](../../../foundation/validate-core/README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** Generic — standard input validation; leverage is early rejection at scale + aggregated
+  field errors.
+- **Stability:** stable contract — `VAL-0001` and the `VAL-xxxx` catalogue are client-visible.
+- **Volatility:** low — new codes are additive constants.
+- **Deferred capabilities:** structured downcast access to `ValidationError` after `cqrs` erasure (today:
+  inspect via `error_code()`/`Display`, or validate explicitly before dispatch).

--- a/docs/domain/README.fr.md
+++ b/docs/domain/README.fr.md
@@ -1,7 +1,7 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: d6a559f60da5ec140b40edd1b2aa958c24b5f808a1caf21a52d81ab3091831af
+  source_sha256: 45671c0f3716c4c40b31a9ac33be15594fbc64c5b9968d1e880295765b0a70d1
   translated_at: 2026-06-28
   status: complete
 ---
@@ -73,10 +73,46 @@ TIER-2 conserve CORE plus des sections DEEP réduites à une ligne.
 | `social-graph` | Relations followers / following | [`crates/services/social-graph/docs/DOMAIN.md`](../../crates/services/social-graph/docs/DOMAIN.md) | ✅ |
 | `timeline` | Fan-out de timeline | [`crates/services/timeline/docs/DOMAIN.md`](../../crates/services/timeline/docs/DOMAIN.md) | ✅ |
 
+## Contrats de bibliothèque d'infrastructure partagée (`foundation/` + `platform/`)
+
+Les 14 bibliothèques transversales que chaque service compose. Ce ne sont **pas** des bounded contexts —
+elles ne possèdent aucune donnée métier et n'émettent aucun événement de domaine ; elles possèdent une
+**capacité technique** (un mécanisme, un contrat, une séquence de boot). Leur `DOMAIN.md` suit donc la
+**variante bibliothèque** ([`docs/templates/DOMAIN.lib.template.md`](../templates/DOMAIN.lib.template.md)) :
+même squelette à 10 sections et tiering CORE/DEEP, mais la section « propriété des données » devient une
+frontière de *direction de dépendance / pureté* et la section « événements de domaine » se réduit aux
+signaux émis (`tracing`/métriques/aucun).
+
+**`foundation/`** — feuilles pures et contrats quasi-racine (aucune IO sauf indication) :
+
+| Crate | Capacité partagée | `DOMAIN.md` | Statut |
+|---|---|---|---|
+| `error` | Contrat d'erreur distribuée (trait · sévérité · forme wire) | [`crates/foundation/error/docs/DOMAIN.md`](../../crates/foundation/error/docs/DOMAIN.md) | ✅ |
+| `health` | Contrat de probe liveness/readiness (feuille du graphe) | [`crates/foundation/health/docs/DOMAIN.md`](../../crates/foundation/health/docs/DOMAIN.md) | ✅ |
+| `infra-config` | Config externalisée & hot-reload fail-closed | [`crates/foundation/infra-config/docs/DOMAIN.md`](../../crates/foundation/infra-config/docs/DOMAIN.md) | ✅ |
+| `resilience` | Tolérance aux pannes en sortie (circuit breaker · retry · timeout) | [`crates/foundation/resilience/docs/DOMAIN.md`](../../crates/foundation/resilience/docs/DOMAIN.md) | ✅ |
+| `traffic` | Rate limiting en entrée (mécanisme GCRA pur) | [`crates/foundation/traffic/docs/DOMAIN.md`](../../crates/foundation/traffic/docs/DOMAIN.md) | ✅ |
+| `validate-core` | Abstraction de validation zéro-dépendance (Separated Interface) | [`crates/foundation/validate-core/docs/DOMAIN.md`](../../crates/foundation/validate-core/docs/DOMAIN.md) | ✅ |
+
+**`platform/`** — les couches dispatch applicatif, transport, sécurité, et runtime :
+
+| Crate | Capacité partagée | `DOMAIN.md` | Statut |
+|---|---|---|---|
+| `auth-context` | Vérification JWT en entrée + identité task-local | [`crates/platform/auth-context/docs/DOMAIN.md`](../../crates/platform/auth-context/docs/DOMAIN.md) | ✅ |
+| `cqrs` | Bus Command/Query in-process + pipeline de middleware | [`crates/platform/cqrs/docs/DOMAIN.md`](../../crates/platform/cqrs/docs/DOMAIN.md) | ✅ |
+| `service-runtime` | Bootstrap unifié de la flotte (le trait `Service` + `serve`) | [`crates/platform/service-runtime/docs/DOMAIN.md`](../../crates/platform/service-runtime/docs/DOMAIN.md) | ✅ |
+| `telemetry` | Bootstrap d'observabilité en un appel (logs · traces · métriques) | [`crates/platform/telemetry/docs/DOMAIN.md`](../../crates/platform/telemetry/docs/DOMAIN.md) | ✅ |
+| `test-support` | Échafaudage de tests d'intégration (dev-only) | [`crates/platform/test-support/docs/DOMAIN.md`](../../crates/platform/test-support/docs/DOMAIN.md) | ✅ |
+| `traffic-redis` | Backend distribué Redis-lease pour `traffic` | [`crates/platform/traffic-redis/docs/DOMAIN.md`](../../crates/platform/traffic-redis/docs/DOMAIN.md) | ✅ |
+| `transport` | gRPC + Kafka avec propagation de trace + `run_consumer` | [`crates/platform/transport/docs/DOMAIN.md`](../../crates/platform/transport/docs/DOMAIN.md) | ✅ |
+| `validation` | Middleware de validation d'entrée CQRS + codes `VAL-xxxx` | [`crates/platform/validation/docs/DOMAIN.md`](../../crates/platform/validation/docs/DOMAIN.md) | ✅ |
+
 ## Rédaction
 
-- Modèle : [`docs/templates/DOMAIN.template.md`](../templates/DOMAIN.template.md) — copier vers
+- Modèle service : [`docs/templates/DOMAIN.template.md`](../templates/DOMAIN.template.md) — copier vers
   `crates/services/<svc>/docs/DOMAIN.md` et le remplir.
+- Modèle bibliothèque partagée : [`docs/templates/DOMAIN.lib.template.md`](../templates/DOMAIN.lib.template.md)
+  — pour `crates/foundation/*` et `crates/platform/*` ; même squelette, sections orientées bibliothèque.
 - Décisions : consigner la justification dans des ADR immuables sous [`docs/adr/`](../adr/README.md)
   et les relier depuis `DOMAIN.md §9` — ne jamais intégrer le *pourquoi* en ligne.
 - i18n : l'anglais est canonique ; un miroir `DOMAIN.fr.md` suit le

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -63,10 +63,45 @@ CORE plus collapsed one-line DEEP sections.
 | `social-graph` | Follower / following relations | [`crates/services/social-graph/docs/DOMAIN.md`](../../crates/services/social-graph/docs/DOMAIN.md) | ✅ |
 | `timeline` | Timeline fan-out | [`crates/services/timeline/docs/DOMAIN.md`](../../crates/services/timeline/docs/DOMAIN.md) | ✅ |
 
+## Shared infrastructure library contracts (`foundation/` + `platform/`)
+
+The 14 cross-cutting libraries every service composes onto. These are **not** bounded contexts — they own
+no business data and emit no domain events; they own a **technical capability** (a mechanism, a contract, a
+boot sequence). Their `DOMAIN.md` therefore follows the **library variant**
+([`docs/templates/DOMAIN.lib.template.md`](../templates/DOMAIN.lib.template.md)): same 10-section skeleton
+and CORE/DEEP tiering, but the "data ownership" section becomes a *dependency-direction / purity* boundary
+and the "domain events" section collapses to emitted signals (`tracing`/metrics/none).
+
+**`foundation/`** — pure leaves and near-root contracts (no IO unless stated):
+
+| Crate | Shared capability | `DOMAIN.md` | Status |
+|---|---|---|---|
+| `error` | Distributed-error contract (trait · severity · wire shape) | [`crates/foundation/error/docs/DOMAIN.md`](../../crates/foundation/error/docs/DOMAIN.md) | ✅ |
+| `health` | Liveness/readiness probe contract (graph-leaf) | [`crates/foundation/health/docs/DOMAIN.md`](../../crates/foundation/health/docs/DOMAIN.md) | ✅ |
+| `infra-config` | Externalized config & fail-closed hot-reload | [`crates/foundation/infra-config/docs/DOMAIN.md`](../../crates/foundation/infra-config/docs/DOMAIN.md) | ✅ |
+| `resilience` | Egress fault tolerance (circuit breaker · retry · timeout) | [`crates/foundation/resilience/docs/DOMAIN.md`](../../crates/foundation/resilience/docs/DOMAIN.md) | ✅ |
+| `traffic` | Ingress rate limiting (pure GCRA mechanism) | [`crates/foundation/traffic/docs/DOMAIN.md`](../../crates/foundation/traffic/docs/DOMAIN.md) | ✅ |
+| `validate-core` | Zero-dependency validation abstraction (Separated Interface) | [`crates/foundation/validate-core/docs/DOMAIN.md`](../../crates/foundation/validate-core/docs/DOMAIN.md) | ✅ |
+
+**`platform/`** — the application-dispatch, transport, security, and runtime layers:
+
+| Crate | Shared capability | `DOMAIN.md` | Status |
+|---|---|---|---|
+| `auth-context` | Inbound JWT verification + task-local identity | [`crates/platform/auth-context/docs/DOMAIN.md`](../../crates/platform/auth-context/docs/DOMAIN.md) | ✅ |
+| `cqrs` | In-process Command/Query bus + middleware pipeline | [`crates/platform/cqrs/docs/DOMAIN.md`](../../crates/platform/cqrs/docs/DOMAIN.md) | ✅ |
+| `service-runtime` | Unified fleet bootstrap (the `Service` trait + `serve`) | [`crates/platform/service-runtime/docs/DOMAIN.md`](../../crates/platform/service-runtime/docs/DOMAIN.md) | ✅ |
+| `telemetry` | One-call observability bootstrap (logs · traces · metrics) | [`crates/platform/telemetry/docs/DOMAIN.md`](../../crates/platform/telemetry/docs/DOMAIN.md) | ✅ |
+| `test-support` | Integration-test scaffolding (dev-only) | [`crates/platform/test-support/docs/DOMAIN.md`](../../crates/platform/test-support/docs/DOMAIN.md) | ✅ |
+| `traffic-redis` | Redis-lease distributed backend for `traffic` | [`crates/platform/traffic-redis/docs/DOMAIN.md`](../../crates/platform/traffic-redis/docs/DOMAIN.md) | ✅ |
+| `transport` | gRPC + Kafka with trace propagation + `run_consumer` | [`crates/platform/transport/docs/DOMAIN.md`](../../crates/platform/transport/docs/DOMAIN.md) | ✅ |
+| `validation` | CQRS input-validation middleware + `VAL-xxxx` codes | [`crates/platform/validation/docs/DOMAIN.md`](../../crates/platform/validation/docs/DOMAIN.md) | ✅ |
+
 ## Authoring
 
-- Template: [`docs/templates/DOMAIN.template.md`](../templates/DOMAIN.template.md) — copy to
+- Service template: [`docs/templates/DOMAIN.template.md`](../templates/DOMAIN.template.md) — copy to
   `crates/services/<svc>/docs/DOMAIN.md` and fill it.
+- Shared-library template: [`docs/templates/DOMAIN.lib.template.md`](../templates/DOMAIN.lib.template.md) —
+  for `crates/foundation/*` and `crates/platform/*`; same skeleton, library-oriented sections.
 - Decisions: capture rationale as immutable ADRs under [`docs/adr/`](../adr/README.md) and link
   them from `DOMAIN.md §9` — never inline the *why*.
 - i18n: English is canonical; a `DOMAIN.fr.md` mirror follows the

--- a/docs/templates/DOMAIN.lib.template.md
+++ b/docs/templates/DOMAIN.lib.template.md
@@ -1,0 +1,208 @@
+<!--
+================================================================================
+ SHARED-LAYER DOMAIN DOC — LIBRARY BLUEPRINT (foundation/ + platform/)
+================================================================================
+ Copy this file to crates/<layer>/<crate>/docs/DOMAIN.md and fill every
+ <placeholder>. Mirror to DOMAIN.fr.md (English is canonical; the i18n drift
+ gate enforces hash parity on every DOMAIN.*.md).
+
+ WHY A SEPARATE TEMPLATE.
+   The service template (DOMAIN.template.md) documents a *bounded context* — a
+   System of Record/Reference with aggregates, Kafka events, and data ownership.
+   The crates in `foundation/` and `platform/` are NOT bounded contexts: they own
+   no business data, emit no domain events, and have no aggregate. They own a
+   *technical capability* (a mechanism, a contract, a boot sequence) consumed by
+   the contexts above them. This template keeps the same 10-section skeleton and
+   the same CORE/DEEP tiering so the catalog stays uniform and grep-able, but
+   reframes each section through a library lens.
+
+ SCOPE BOUNDARY — read before writing:
+   This file explains the ARCHITECTURAL CONTRACT: the capability owned, the
+   invariants enforced, the dependency direction, and the coupling to consumers.
+   It must NOT restate the README (public API signatures, env vars, build,
+   runbook, gotchas). If a line tells a reader HOW to call/run the crate, it
+   belongs in README.md. If it tells them WHY the boundary is where it is, it
+   belongs here.
+
+ GROUND TRUTH:
+   Derive every statement from the code — `src/lib.rs`, the public types, the
+   Cargo.toml dependency edges, and the feature flags. Never invent an ADR
+   number: foundation/platform crates have no dedicated ADRs (ADR-0001..0017 are
+   service decisions); their rationale lives in the README §Architecture and is
+   linked, not fabricated.
+
+ TIER RULE (how much to fill)
+   CORE — every crate:
+     Domain Card · Technical Capability & Non-Goals · Ubiquitous Language
+     · Public Model & Contract Surface · Ownership & Architectural Boundaries
+     · Invariants & Contract Rules
+   DEEP — full prose for crates with real machinery (a state machine, a boot
+   sequence, a hot-reload path, a consumer runtime):
+     Control Flow & Lifecycle · Crate Coupling · Emitted Signals & Side-Effects
+     · Decisions & Rationale · Classification & Evolution
+   Do NOT delete DEEP sections on a thin leaf crate — collapse each to one honest
+   line, e.g. "N/A — pure contract crate, no runtime control flow", so the
+   catalog stays uniform.
+
+ VOICE
+   An architectural contract, not an essay. Prefer tables. Every sentence must
+   constrain a caller, a maintainer, or a reviewer — if it constrains none, cut it.
+================================================================================
+-->
+
+# `<crate>` — Domain & Functional Contract
+
+<!-- Tagline rule: name the technical capability and the one question it answers
+     for the fleet, not a feature list. -->
+
+> **Domain Card**
+>
+> | | |
+> |---|---|
+> | **Shared capability** | `<the one technical concern this crate owns>` |
+> | **Layer** | `<foundation \| platform>` — `<one-line: where it sits in the dependency graph>` |
+> | **Subdomain class** | `<Generic \| Supporting>` — `<why it's classed so (technical, not product, value)>` |
+> | **Primary abstraction(s)** | `<Trait/Type>` (`<crate::path>`) |
+> | **Footprint** | `<pure (no IO/no spawn) \| IO/stateful \| dev-only>` — `<feature-gated surface, if any>` |
+> | **Failure posture** | `<fail-closed \| fail-open \| N/A>` — `<one-line consequence>` |
+> | **Depends on** | `<workspace crates it links>` |
+> | **Consumed by** | `<workspace crates / layer that link it>` |
+> | **Decision log** | `<ADR link if one exists, else: none — rationale in README §Architecture>` |
+
+---
+
+## 1. Technical Capability & Non-Goals &nbsp;·&nbsp; CORE
+
+**Capability.** `<crate>` is the fleet's authority for **<the one technical capability>**: it answers
+**"<the single question the rest of the fleet delegates to it>"**.
+
+**The hard problem** (1–2 sentences): `<the cross-cutting tension that forced a dedicated shared crate
+rather than per-service code>`.
+
+**Non-goals — what this crate deliberately does NOT do** (the boundary, stated as denials):
+- ❌ `<concern that looks adjacent but belongs to crate X>` → owned by `<crate>`.
+- ❌ `<…>`
+
+---
+
+## 2. Ubiquitous Language &nbsp;·&nbsp; CORE
+
+> Technical terms used *by this crate's public surface*. The code symbol is mandatory — a term with
+> no symbol is aspirational, not real.
+
+| Term | Meaning in this crate | Code symbol |
+|---|---|---|
+| `<Term>` | `<precise definition>` | `<path::Type>` |
+
+---
+
+## 3. Public Model & Contract Surface &nbsp;·&nbsp; CORE
+
+> The library equivalent of a domain model: the public types/traits and the invariant each one
+> guards. Name the type, not its full signature (that's the README's job).
+
+| Element | Kind | Contract / invariant boundary it guards |
+|---|---|---|
+| `<Trait>` | trait (seam) | `<the contract implementors must honour>` |
+| `<Type>` | value type | `<validity rule enforced at construction>` |
+
+**Lifecycle / state machine** (only if the crate owns one):
+
+```
+<State> --(<transition>)--> <State> --> <Terminal>
+```
+
+> `<the rule that makes illegal transitions unreachable, and the error/Status that rejects them>`.
+
+---
+
+## 4. Ownership & Architectural Boundaries &nbsp;·&nbsp; CORE
+
+> The most important section for a shared crate. The "boundary" here is a *dependency-direction*
+> rule, not a data-ownership rule — violating it (e.g. adding `tonic` to a pure crate) is an
+> architecture bug, not a doc nit.
+
+**This crate owns:**
+- `<the mechanism/contract>` — `<what part of the concern lives here and nowhere else>`.
+
+**This crate deliberately does NOT own / must NOT link** (the purity / inversion rule):
+
+| Concern | Lives in | Why the edge points that way |
+|---|---|---|
+| `<IO / parsing / transport / policy>` | `<crate>` | `<the layering reason>` |
+
+**The "do-not-depend-on" list:** `<dependencies this crate must never grow, and the architectural
+guarantee that forbids them>`.
+
+---
+
+## 5. Invariants & Contract Rules &nbsp;·&nbsp; CORE
+
+> Rules that must hold for every consumer in every reachable state. State the rule, then the layer
+> that enforces it (type system / construction / runtime) — an unplaced invariant is unenforced.
+
+| # | Invariant | Enforced at | On violation |
+|---|---|---|---|
+| I1 | `<rule that must always hold>` | `<type system / ctor / runtime check>` | `<error code / panic / compile error>` |
+
+<!-- Where a test proves an invariant, name it: "I1 — proven by tests::rejects_x". -->
+
+---
+
+## 6. Control Flow & Lifecycle &nbsp;·&nbsp; DEEP
+
+> How the mechanism runs at runtime: the boot sequence, the hot path, the background loop, the
+> hot-reload swap, or the per-message state machine. Distinguish the **hot path** (per-call, must be
+> cheap) from **background / boot** work. Collapse to one line for a pure contract crate.
+
+**`<flow name>`**
+
+1. `<trigger>` → `<step>` (`<hot path \| boot \| background>`)
+2. …
+
+---
+
+## 7. Crate Coupling (dependency-graph slice) &nbsp;·&nbsp; DEEP
+
+> This crate's edges in the workspace dependency graph, stated with the coupling pattern so the
+> direction is explicit. Upstream = crates it links; downstream = crates that link it.
+
+| Neighbour crate | Direction | Pattern | Mechanism | What breaks if it changes |
+|---|---|---|---|---|
+| `<crate>` | upstream (we depend) | `<Separated Interface \| Conformist \| ACL>` | `<trait / type>` | `<impact on us>` |
+| `<crate>` | downstream (depends on us) | `<Published Contract \| OHS>` | `<our trait / type>` | `<impact on them>` |
+
+> **Stability seam:** `<the type/trait that is public API and whose change is a breaking change>`.
+
+---
+
+## 8. Emitted Signals & Side-Effects &nbsp;·&nbsp; DEEP
+
+> A shared crate emits no *domain* events. State what it DOES emit: `tracing` events, metrics, Kafka
+> envelopes it relays (not owns), or "none — pure". Answers "what observable trace does using this
+> crate leave?".
+
+| Signal | Kind | Emitted when | Who observes |
+|---|---|---|---|
+| `<event / metric>` | `<tracing \| metric \| relayed Kafka>` | `<trigger>` | `<dashboards / alerts>` |
+
+---
+
+## 9. Decisions & Rationale &nbsp;·&nbsp; DEEP
+
+> Why the boundary is where it is. Foundation/platform crates have no dedicated ADRs — link the
+> README §Architecture (the authoritative rationale) and any cross-cutting memory; never fabricate
+> an ADR number.
+
+| Decision | Where recorded | Status |
+|---|---|---|
+| `<the locked architectural choice>` | [`README §Architecture`](../README.md) | Accepted |
+
+---
+
+## 10. Classification & Evolution &nbsp;·&nbsp; DEEP
+
+- **Classification:** `<Generic \| Supporting>` — `<investment implication: commodity vs leverage>`.
+- **Stability:** `<stable contract \| evolving>` — `<what a breaking change here would cost the fleet>`.
+- **Volatility:** `<how often the surface changes, and why>`.
+- **Deferred capabilities:** `<modeled-for but not built; the seam left for them>`.


### PR DESCRIPTION
## What

Completes the `DOMAIN.md` initiative beyond the 17 services by documenting the **shared infrastructure layers** — `crates/foundation/` (6 crates) and `crates/platform/` (8 crates).

## Why a new template

The service `DOMAIN.template.md` is bounded-context-shaped (aggregates, Kafka events, data ownership). The foundation/platform crates own no business data and emit no domain events — they own a **technical capability** (a mechanism, a contract, a boot sequence). So this adds a **library variant**, `docs/templates/DOMAIN.lib.template.md`:

- same 10-section skeleton + CORE/DEEP tiering (keeps the catalog uniform & grep-able);
- *Data Ownership* → **dependency-direction / purity boundary** (the "do-not-depend-on" rule);
- *Domain Events* → **emitted signals** (`tracing` / metrics / none);
- rationale links `README §Architecture` — these crates have **no dedicated ADRs**, and the template forbids fabricating ADR numbers.

## Documented crates (28 files: EN + FR each)

**foundation:** `error`, `health`, `infra-config`, `resilience`, `traffic`, `validate-core`
**platform:** `auth-context`, `cqrs`, `service-runtime`, `telemetry`, `test-support`, `traffic-redis`, `transport`, `validation`

Every statement derived from the code — `lib.rs`, public types, `Cargo.toml` dependency edges, feature flags. No stubs; thin leaf crates honestly collapse DEEP sections to one line per the TIER rule rather than padding.

## Index wiring

Added a **"Shared infrastructure library contracts"** section (foundation + platform subtables, all linked) to `docs/domain/README.md` and its French mirror, plus a pointer to the new library template.

## CI / i18n

`tools/i18n/i18n-drift.sh check` → **green**. All 14 `DOMAIN.fr.md` hashes stamped; both index mirrors re-stamped after edits. Also fixed 6 wrong-depth relative cross-links and verified every cross-reference resolves on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)