### PR TITLE
fix(architecture): make workspace.dsl parse under Structurizr Lite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ rust-project.json
 # Structurizr
 .structurizr/
 **/structurizr-*-key.json
+# Workspace state Lite regenerates from workspace.dsl (derived, not source)
+docs/architecture/workspace.json
 
 # Fichiers et dossiers générés par Terraform
 .terraform.lock.hcl

--- a/docs/architecture/README.fr.md
+++ b/docs/architecture/README.fr.md
@@ -1,8 +1,8 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: fbc0f03fb12485e283da98ceeac6b1fb7eb32bf8bcc056284974e6da6d29774c
-  translated_at: 2026-06-28
+  source_sha256: 1438dc450817ea3927ef2df20386163bbfeb39c6f545abfdd88a269a55e87877
+  translated_at: 2026-06-29
   status: complete
 ---
 > 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
@@ -39,11 +39,18 @@ livrée — services fantômes, mauvaise stack, 7 services manquants.
 ## Rendu
 
 Rendre avec le [Structurizr CLI](https://structurizr.com/help/cli) ou en important `workspace.dsl`
-dans [Structurizr Lite](https://structurizr.com/lite) :
+dans [Structurizr Lite](https://structurizr.com/lite). Lancer depuis la racine du dépôt :
 
 ```bash
-docker run -it --rm -p 8080:8080 -v "$PWD/docs/architecture:/usr/local/structurizr" structurizr/lite
+docker run --rm -it -p 8080:8080 \
+  -v "$PWD/docs/architecture:/usr/local/structurizr" \
+  structurizr/lite:2025.05.28
 ```
+
+Puis ouvrir <http://localhost:8080/>. Lite re-parse `workspace.dsl` à chaque requête : les
+modifications apparaissent au rafraîchissement, sans redémarrage. Sur Apple Silicon, ajouter
+`--platform linux/amd64` si le tag d'image récupéré est amd64 uniquement. Lite écrit un
+`workspace.json` dérivé (gitignoré) à côté du DSL.
 
 ## Le garder vrai
 
@@ -51,5 +58,11 @@ Quand `CONTEXT_MAP.md` ou une Domain Card change une relation, un store ou une c
 sous-domaine, mettre à jour `workspace.dsl` dans le même changement. Le modèle est petit et
 maintenu à la main à dessein ; un futur générateur pourrait l'émettre depuis les Domain Cards + la
 garde de registre de topologie d'événements.
+
+> **Piège de syntaxe DSL.** Le DSL Structurizr est orienté ligne : **une instruction par ligne**,
+> et les blocs (`element "Tag" { … }`, relations) s'étendent sur plusieurs lignes. Il n'y a pas de
+> séparateur `;`. Empiler deux relations sur une ligne avec `;`, ou réduire un bloc de style à une
+> seule ligne, fait échouer le parseur avec `Too many tokens`. Garder chaque instruction sur sa
+> propre ligne.
 
 > 🇬🇧 Source anglaise : [`README.md`](./README.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -28,16 +28,27 @@ shipped — phantom services, wrong stack, 7 missing services.
 ## Rendering
 
 Render with the [Structurizr CLI](https://structurizr.com/help/cli) or by importing `workspace.dsl`
-into [Structurizr Lite](https://structurizr.com/lite):
+into [Structurizr Lite](https://structurizr.com/lite). Run from the repo root:
 
 ```bash
-docker run -it --rm -p 8080:8080 -v "$PWD/docs/architecture:/usr/local/structurizr" structurizr/lite
+docker run --rm -it -p 8080:8080 \
+  -v "$PWD/docs/architecture:/usr/local/structurizr" \
+  structurizr/lite:2025.05.28
 ```
+
+Then open <http://localhost:8080/>. Lite re-parses `workspace.dsl` on each request, so edits show
+up on refresh — no restart needed. On Apple Silicon, add `--platform linux/amd64` if the image tag
+you pull is amd64-only. Lite writes a derived `workspace.json` (gitignored) next to the DSL.
 
 ## Keeping it true
 
 When `CONTEXT_MAP.md` or a Domain Card changes a relationship, store, or subdomain class, update
 `workspace.dsl` in the same change. The model is small and hand-maintained on purpose; a future
 generator could emit it from the Domain Cards + the event-topology registry guard.
+
+> **DSL syntax gotcha.** Structurizr DSL is line-based: **one statement per line**, and blocks
+> (`element "Tag" { … }`, relationships) span multiple lines. There is no `;` separator. Packing
+> two relationships onto one line with `;`, or collapsing a style block onto a single line, makes
+> the parser fail with `Too many tokens`. Keep each statement on its own line.
 
 > 🇫🇷 Miroir français : [`README.fr.md`](./README.fr.md).

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -71,20 +71,33 @@ workspace "Core Platform" "Social platform backend — corrected C4, derived fro
 
             # === Service ↔ datastore =============================================================
             account -> postgres "reads/writes"
-            auth -> postgres "reads/writes" ; auth -> redis "session/revocation cache"
-            profile -> scylla "reads/writes" ; profile -> redis "L1 entity cache"
+            auth -> postgres "reads/writes"
+            auth -> redis "session/revocation cache"
+            profile -> scylla "reads/writes"
+            profile -> redis "L1 entity cache"
             post -> scylla "reads/writes (by id + by author)"
             comment -> scylla "reads/writes (LCS + TWCS)"
-            chat -> scylla "message log (bucketed)" ; chat -> redis "sharded pub/sub"
-            engagement -> redis "Lua-atomic edges" ; engagement -> scylla "durable write-behind"
-            socialGraph -> scylla "4-table relations" ; socialGraph -> redis "hot relation Sets"
-            timeline -> redis "feed ZSETs" ; timeline -> scylla "materialized feeds"
+            chat -> scylla "message log (bucketed)"
+            chat -> redis "sharded pub/sub"
+            engagement -> redis "Lua-atomic edges"
+            engagement -> scylla "durable write-behind"
+            socialGraph -> scylla "4-table relations"
+            socialGraph -> redis "hot relation Sets"
+            timeline -> redis "feed ZSETs"
+            timeline -> scylla "materialized feeds"
             search -> opensearch "index + query"
-            geo -> redis "H3 ZSET + cardinality" ; geo -> scylla "map_post_cards"
-            counter -> redis "hot counters" ; counter -> postgres "warm SoRef + ledger" ; counter -> scylla "cold TWCS"
-            notification -> scylla "TWCS activity feed" ; notification -> redis "write-collapse counters"
-            moderation -> postgres "decision/case SoR" ; moderation -> scylla "signal history" ; moderation -> redis "enforcement projection + Screen corpus"
-            media -> postgres "asset SoR" ; media -> redis "cache"
+            geo -> redis "H3 ZSET + cardinality"
+            geo -> scylla "map_post_cards"
+            counter -> redis "hot counters"
+            counter -> postgres "warm SoRef + ledger"
+            counter -> scylla "cold TWCS"
+            notification -> scylla "TWCS activity feed"
+            notification -> redis "write-collapse counters"
+            moderation -> postgres "decision/case SoR"
+            moderation -> scylla "signal history"
+            moderation -> redis "enforcement projection + Screen corpus"
+            media -> postgres "asset SoR"
+            media -> redis "cache"
             audit -> postgres "append-only ledger"
             realtimeGateway -> redis "connection/presence registry + node-hop pub/sub"
             realtimeDispatcher -> redis "resolve + publish (node-hop)"
@@ -175,18 +188,54 @@ workspace "Core Platform" "Social platform backend — corrected C4, derived fro
         }
 
         styles {
-            element "User" { shape Person background #2c3e50 color #ffffff }
-            element "External" { background #95a5a6 color #ffffff }
+            element "User" {
+                shape Person
+                background #2c3e50
+                color #ffffff
+            }
+            element "External" {
+                background #95a5a6
+                color #ffffff
+            }
             # shape from role, colour from subdomain class (Core vs Supporting)
-            element "Service" { shape RoundedBox color #ffffff }
-            element "Worker" { shape Hexagon color #ffffff }
-            element "Edge" { shape RoundedBox color #ffffff }
-            element "Supporting" { background #1168bd color #ffffff }
-            element "Core" { background #b8341b color #ffffff }
-            element "Datastore" { shape Cylinder background #6b4f9e color #ffffff }
-            element "MessageBroker" { shape Pipe background #d98c00 color #ffffff }
-            relationship "Async" { dashed true color #d98c00 }
-            relationship "Sync" { dashed false color #2c3e50 }
+            element "Service" {
+                shape RoundedBox
+                color #ffffff
+            }
+            element "Worker" {
+                shape Hexagon
+                color #ffffff
+            }
+            element "Edge" {
+                shape RoundedBox
+                color #ffffff
+            }
+            element "Supporting" {
+                background #1168bd
+                color #ffffff
+            }
+            element "Core" {
+                background #b8341b
+                color #ffffff
+            }
+            element "Datastore" {
+                shape Cylinder
+                background #6b4f9e
+                color #ffffff
+            }
+            element "MessageBroker" {
+                shape Pipe
+                background #d98c00
+                color #ffffff
+            }
+            relationship "Async" {
+                dashed true
+                color #d98c00
+            }
+            relationship "Sync" {
+                dashed false
+                color #2c3e50
+            }
         }
     }
 


### PR DESCRIPTION
## What

The C4 Structurizr workspace (`docs/architecture/workspace.dsl`) failed to load in Structurizr Lite. Two grammar violations crashed the parser; this fixes both and refreshes the render docs.

## Why it failed

Structurizr DSL is **line-based** — one statement per line, and blocks span multiple lines. The file had:

1. **Service↔datastore relationships joined with `;`** on one line (11 lines) → parser threw `Too many tokens` at the first one (line 74).
2. **`styles` `element`/`relationship` blocks collapsed onto single lines** (`element "User" { shape Person … }`) → `Too many tokens, expected: element <tag> {` at line 191.

There is no `;` separator in the DSL, and a block's `{` must end the line.

## Changes

- Split every `;`-joined relationship into one statement per line.
- Expanded all 10 `element` + 2 `relationship` style blocks to multi-line form.
- `.gitignore`: ignore `docs/architecture/workspace.json` (derived state Lite regenerates; `.structurizr/` was already ignored).
- README (EN + FR): pin the Lite image tag, run-from-repo-root note, Apple Silicon `--platform` caveat, on-refresh reparse, and a **line-based DSL gotcha** box. Re-stamped FR i18n source hash.

## Verification

Ran Structurizr Lite against the fixed workspace on real Docker:

```
Started StructurizrLite in 8.5s
GET /workspace/diagrams -> HTTP 200
no StructurizrDslParserException, no errors
```

`tools/i18n/i18n-drift.sh check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)