### PR TITLE
fix(karpenter): correct NodePool cpu limits (cores, not millicores)

### DIFF
--- a/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/templates/nodepools.yaml
+++ b/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/templates/nodepools.yaml
@@ -45,7 +45,10 @@ spec:
       expireAfter: 720h # Sécurité pour recycler les nœuds tous les 30 jours
   
   limits:
-    cpu: {{ $config.cpuLimit | default 1000 }} # 1cpu par defaut
+    # Karpenter limits.cpu is a CORE COUNT (a pool-wide vCPU ceiling), not
+    # millicores. Default 16 vCPUs if a pool omits cpuLimit — a real guardrail,
+    # never the old `1000` (which meant 1000 cores, effectively unlimited).
+    cpu: {{ $config.cpuLimit | default 16 }}
   
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized

--- a/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/values.yaml
+++ b/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/values.yaml
@@ -4,23 +4,29 @@ clusterName: "core-platform-dev"
 env: "dev"
 
 nodepools:
+  # IMPORTANT: Karpenter `limits.cpu` is a CORE COUNT, not millicores.
+  # `cpuLimit: 16` means this pool may provision at most 16 vCPUs in total
+  # across all its nodes. (One vCPU would be "1000m"/"1", NOT 1000.)
+  # These are the cost/blast-radius ceilings: a runaway HPA or crash-loop
+  # fan-out cannot scale the pool past these totals.
+
   # (ArgoCD, Monitoring, Controllers)
   system:
     capacityType: ["on-demand"] # Stabilité maximale
     categories: ["t", "c", "m"]
     sizes: ["medium", "large"]
-    cpuLimit: 1000 # 1000 = 1 vCPU.
+    cpuLimit: 16 # 16 vCPUs total for the pool.
 
   # (Profile, Auth, etc.)
   apps:
     capacityType: ["spot"]      # Économies (jusqu'à -70%)
     categories: ["t", "c", "m"]
     sizes: ["medium", "large"]
-    cpuLimit: 5000 # 5000 = 5 vCPUs.
+    cpuLimit: 64 # 64 vCPUs total for the pool.
 
   # (Postgres, Scylla, Redis)
   database:
     capacityType: ["on-demand"]
     categories: ["m", "r"]      # Instances optimisées pour la mémoire
     sizes: ["large", "xlarge"]
-    cpuLimit: 2000 # 2000 = 2 vCPUs.
+    cpuLimit: 32 # 32 vCPUs total for the pool.


### PR DESCRIPTION
## What
Karpenter `limits.cpu` is a **core count**, but the NodePool limits were set to `1000/5000/2000` with comments claiming "1000 = 1 vCPU". Karpenter read those as **1000/5000/2000 cores**, so the intended pool-wide cost ceiling (~8 vCPUs) was actually **~8,000 vCPUs** — effectively no cap.

## Fix
- `system=16`, `apps=64`, `database=32` vCPUs (validated with the user).
- Template fallback `default 1000` → `default 16`.
- Documented the unit so it can't regress.

## Risk
Lowers a ceiling only. Verified with `helm template`: renders `cpu: 16/64/32`.

## Audit ref
**C3 (Critical)** — runaway-scale money landmine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)