### PR TITLE
fix(vpc): honor single_nat_gateway + add VPC endpoints to cut NAT cost

### DIFF
--- a/infrastructure/live/dev/us-east-1/networking/vpc/terragrunt.hcl
+++ b/infrastructure/live/dev/us-east-1/networking/vpc/terragrunt.hcl
@@ -22,4 +22,6 @@ inputs = {
   cluster_name       = "core-platform-${local.env_vars.locals.env}"
   vpc_cidr           = local.env_vars.locals.vpc_cidr
   availability_zones = ["${local.region_vars.locals.aws_region}a", "${local.region_vars.locals.aws_region}b"]
+  # Honor the env.hcl flag (was previously dead config). dev stays single-NAT.
+  single_nat_gateway = local.env_vars.locals.single_nat_gateway
 }

--- a/infrastructure/live/staging/us-east-1/networking/vpc/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/networking/vpc/terragrunt.hcl
@@ -19,4 +19,7 @@ inputs = {
   cluster_name       = "core-platform-${local.env_vars.locals.env}"
   vpc_cidr           = local.env_vars.locals.vpc_cidr
   availability_zones = ["${local.region_vars.locals.aws_region}a", "${local.region_vars.locals.aws_region}b"]
+  # Honor the env.hcl flag (was previously dead config). staging stays single-NAT
+  # by choice (env.hcl); flip env.hcl to false for NAT-per-AZ HA.
+  single_nat_gateway = local.env_vars.locals.single_nat_gateway
 }

--- a/infrastructure/modules/networking/vpc/main.tf
+++ b/infrastructure/modules/networking/vpc/main.tf
@@ -20,8 +20,8 @@ resource "aws_internet_gateway" "main" {
 # --- SUBNETS PUBLICS ---
 # Utilisés pour les Load Balancers et NAT Gateways
 resource "aws_subnet" "public" {
-  count                   = length(var.availability_zones)
-  vpc_id                  = aws_vpc.main.id
+  count  = length(var.availability_zones)
+  vpc_id = aws_vpc.main.id
   # Plage : 10.0.0.0/24, 10.0.1.0/24, 10.0.2.0/24
   cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
   availability_zone       = var.availability_zones[count.index]
@@ -37,8 +37,8 @@ resource "aws_subnet" "public" {
 # --- SUBNETS PRIVÉS APPS (EKS) ---
 # GRANDS subnets pour supporter des milliers de Pods
 resource "aws_subnet" "private_apps" {
-  count             = length(var.availability_zones)
-  vpc_id            = aws_vpc.main.id
+  count  = length(var.availability_zones)
+  vpc_id = aws_vpc.main.id
   # Plage : 10.0.16.0/20, 10.0.32.0/20, 10.0.48.0/20
   # On commence à l'index 1 (saut de 16) pour éviter le conflit avec les publics
   cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + 1)
@@ -55,8 +55,8 @@ resource "aws_subnet" "private_apps" {
 # --- SUBNETS PRIVÉS DATA (Bases de données) ---
 # Isolés et petits
 resource "aws_subnet" "private_data" {
-  count             = length(var.availability_zones)
-  vpc_id            = aws_vpc.main.id
+  count  = length(var.availability_zones)
+  vpc_id = aws_vpc.main.id
   # Plage : 10.0.200.0/24, 10.0.201.0/24, etc.
   cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 200)
   availability_zone = var.availability_zones[count.index]
@@ -67,16 +67,34 @@ resource "aws_subnet" "private_data" {
   }
 }
 
-# --- NAT GATEWAY (Sortie Internet pour les Apps) ---
+# --- NAT GATEWAYS (egress for the private app subnets) ---
+# single_nat_gateway = true  -> one shared NAT (cheapest; fine for dev/staging).
+# single_nat_gateway = false -> one NAT per AZ (HA): an AZ outage no longer kills
+# fleet-wide egress, and each AZ egresses through its LOCAL NAT, so pod->NAT
+# traffic stays in-AZ (no cross-AZ data-transfer charges). The env.hcl flag is
+# now actually honored — previously it was dead config and NAT was always single.
+locals {
+  nat_count = var.single_nat_gateway ? 1 : length(var.availability_zones)
+}
+
 resource "aws_eip" "nat" {
-  count = 1 # Pour la DEV on en met un seul, en PROD on en mettrait un par AZ
+  count  = local.nat_count
   domain = "vpc"
+  tags   = { Name = "${var.project_name}-${var.env}-nat-${count.index}" }
 }
 
 resource "aws_nat_gateway" "main" {
-  allocation_id = aws_eip.nat[0].id
-  subnet_id     = aws_subnet.public[0].id
-  tags          = { Name = "${var.project_name}-nat" }
+  count         = local.nat_count
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+  tags          = { Name = "${var.project_name}-${var.env}-nat-${count.index}" }
+  depends_on    = [aws_internet_gateway.main]
+}
+
+# Preserve the previously-unindexed NAT on already-applied (single-NAT) envs.
+moved {
+  from = aws_nat_gateway.main
+  to   = aws_nat_gateway.main[0]
 }
 
 # --- ROUTAGE ---
@@ -94,18 +112,27 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public.id
 }
 
+# One private route table per NAT; each private-app subnet routes to the NAT in
+# its AZ (or all share the single NAT when single_nat_gateway = true).
 resource "aws_route_table" "private" {
+  count  = local.nat_count
   vpc_id = aws_vpc.main.id
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main.id
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
   }
+  tags = { Name = "${var.project_name}-${var.env}-rt-private-${count.index}" }
+}
+
+moved {
+  from = aws_route_table.private
+  to   = aws_route_table.private[0]
 }
 
 resource "aws_route_table_association" "private_apps" {
   count          = length(var.availability_zones)
   subnet_id      = aws_subnet.private_apps[count.index].id
-  route_table_id = aws_route_table.private.id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
 }
 
 resource "aws_route_table" "data" {
@@ -117,4 +144,61 @@ resource "aws_route_table_association" "private_data" {
   count          = length(var.availability_zones)
   subnet_id      = aws_subnet.private_data[count.index].id
   route_table_id = aws_route_table.data.id
+}
+
+# --- VPC ENDPOINTS (keep AWS-service traffic off the NAT) ---------------------
+# S3 Gateway endpoint is FREE and removes all S3 traffic from the NAT data-
+# processing meter — significant for the media (presigned objects), audit (WORM
+# checkpoints) and ECR-layer (image pulls) paths. Associated with the private-app
+# and data route tables; routing through the endpoint instead of the NAT.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = concat(aws_route_table.private[*].id, [aws_route_table.data.id])
+  tags              = { Name = "${var.project_name}-${var.env}-s3-gw" }
+}
+
+# Interface endpoints for the AWS APIs the fleet hits on the hot path (ECR pulls,
+# STS for IRSA, Secrets Manager for ESO, KMS for audit/MSK). Off by default
+# (each endpoint bills per-AZ-hour); enable in staging/prod where the NAT data-
+# processing they offload exceeds their cost. dev keeps NAT-only.
+resource "aws_security_group" "vpc_endpoints" {
+  count       = var.enable_interface_endpoints ? 1 : 0
+  name_prefix = "${var.project_name}-${var.env}-vpce-"
+  description = "HTTPS from the VPC to interface endpoints"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTPS from the VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-${var.env}-vpce" }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_endpoint" "interface" {
+  for_each = var.enable_interface_endpoints ? toset(var.interface_endpoint_services) : []
+
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.${each.value}"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private_apps[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
+  private_dns_enabled = true
+  tags                = { Name = "${var.project_name}-${var.env}-vpce-${replace(each.value, ".", "-")}" }
 }

--- a/infrastructure/modules/networking/vpc/variables.tf
+++ b/infrastructure/modules/networking/vpc/variables.tf
@@ -24,3 +24,28 @@ variable "availability_zones" {
   type    = list(string)
   default = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
+
+variable "aws_region" {
+  type        = string
+  description = "Region for VPC-endpoint service names (e.g. us-east-1)."
+  # Provided globally via root.hcl inputs; default keeps the module usable standalone.
+  default = "us-east-1"
+}
+
+variable "single_nat_gateway" {
+  type        = bool
+  description = "true = one shared NAT (cheap); false = one NAT per AZ (HA, in-AZ egress)."
+  default     = true
+}
+
+variable "enable_interface_endpoints" {
+  type        = bool
+  description = "Provision interface endpoints (ECR/STS/SecretsManager/KMS) to keep AWS-API calls off the NAT. Bills per-AZ-hour; enable in staging/prod."
+  default     = false
+}
+
+variable "interface_endpoint_services" {
+  type        = list(string)
+  description = "Short service names for the interface endpoints (region prefix added in main.tf)."
+  default     = ["ecr.api", "ecr.dkr", "sts", "secretsmanager", "kms"]
+}


### PR DESCRIPTION
## W1 — NAT HA (the dead flag)
`single_nat_gateway` in every `env.hcl` was **dead config**: the module hardcoded one NAT (`count=1`), so prod's `single_nat_gateway = false` ("Une NAT par AZ pour la haute disponibilité") was silently dropped and the NAT was a single-AZ **SPOF**.

- Module now honors the flag: `false` → one NAT per AZ, with a per-AZ private route table so each AZ egresses through its **local** NAT (no cross-AZ data-transfer charges, no fleet-wide egress outage on a single-AZ failure).
- dev/staging stay single-NAT by their `env.hcl`.
- `moved` blocks keep already-applied single-NAT envs **in place** (no NAT/route-table recreation).
- Wired through dev + staging VPC terragrunt.

## W2 — VPC endpoints (recurring NAT savings)
No VPC endpoints existed → all S3/ECR/STS/SecretsManager/KMS traffic billed through the NAT data-processing meter.

- **S3 Gateway endpoint (FREE)** on the private-app + data route tables — removes media/audit object I/O and ECR layer pulls from the NAT.
- **Optional** interface endpoints (ECR api/dkr, STS, Secrets Manager, KMS), **off by default** (they bill per-AZ-hour); enable in staging/prod where the offloaded NAT processing exceeds their cost.

## Notes
- prod's networking unit is separately broken (wrong module path — tracked as W13) and is **not** touched here.
- `fmt` clean. `terraform validate` requires provider download (network) and was not run offline — resource shapes are standard.

## Audit ref
**W1 + W2 (Warning)** — SPOF + recurring money leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)