### PR TITLE
fix(db): schedule stateful DBs on the dedicated tier + add CNPG backups (C5+C6)

### DIFF
--- a/infrastructure/live/staging/us-east-1/data/cnpg-backups/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/data/cnpg-backups/terragrunt.hcl
@@ -1,0 +1,33 @@
+# infrastructure/live/staging/us-east-1/data/cnpg-backups/terragrunt.hcl
+#
+# Shared CNPG backup target: base backups + WAL for every CNPG cluster, one path
+# prefix per cluster (s3://<bucket>/<cluster>). Versioned, SSE-S3, private. The
+# CNPG pods write via the cnpg-backup IRSA role (Block: security/irsa-roles).
+# Bucket name is account-scoped for S3 global uniqueness.
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../../../modules/s3-bucket"
+}
+
+locals {
+  env_vars   = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  account_id = get_aws_account_id()
+}
+
+inputs = {
+  name               = "core-platform-${local.env_vars.locals.env}-cnpg-backups-${local.account_id}"
+  versioning_enabled = true
+  # Object-store WAL/base backups; no Object-Lock (retention is managed by CNPG's
+  # barman retentionPolicy, which must be able to prune).
+  cors_enabled = false
+
+  tags = {
+    Environment = local.env_vars.locals.env
+    ManagedBy   = "terragrunt"
+    Service     = "cnpg-backups"
+  }
+}

--- a/infrastructure/live/staging/us-east-1/security/irsa-roles/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/security/irsa-roles/terragrunt.hcl
@@ -30,6 +30,12 @@ dependency "media_bucket" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
 
+dependency "cnpg_backups" {
+  config_path                             = "../../data/cnpg-backups"
+  mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-cnpg-backups" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
 terraform {
   source = "../../../../../modules/security/irsa-roles"
 }
@@ -55,6 +61,17 @@ inputs = {
   ]
   media_bucket_arn       = dependency.media_bucket.outputs.bucket_arn
   media_service_accounts = ["default:staging-media-server"]
+
+  # CNPG backup role — each cluster's pod SA (name == cluster name) assumes it.
+  cnpg_backup_bucket_arn = dependency.cnpg_backups.outputs.bucket_arn
+  cnpg_service_accounts = [
+    "default:staging-account-postgres",
+    "default:staging-counter-postgres",
+    "default:staging-audit-postgres",
+    "default:staging-moderation-postgres",
+    "default:staging-auth-postgres",
+    "default:staging-media-postgres",
+  ]
 
   tags = {
     Environment = "staging"

--- a/infrastructure/modules/security/irsa-roles/main.tf
+++ b/infrastructure/modules/security/irsa-roles/main.tf
@@ -456,3 +456,49 @@ resource "aws_iam_role_policy" "karpenter_interruption" {
     }]
   })
 }
+
+# --- 11. CNPG BACKUPS (barmanObjectStore -> S3) ------------------------------
+# Each CNPG cluster's pods assume this role (via serviceAccountTemplate) to write
+# base backups + WAL to the shared backups bucket (path-prefixed per cluster).
+# Created only when the bucket ARN is supplied (staging/prod).
+module "cnpg_backup_irsa_role" {
+  count = var.cnpg_backup_bucket_arn != "" ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+
+  role_name = "${var.cluster_name}-cnpg-backup-role"
+
+  oidc_providers = {
+    main = {
+      provider_arn               = var.oidc_provider_arn
+      namespace_service_accounts = var.cnpg_service_accounts
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "cnpg_backup" {
+  count = var.cnpg_backup_bucket_arn != "" ? 1 : 0
+
+  name = "CnpgBackupReadWrite"
+  role = module.cnpg_backup_irsa_role[0].iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Barman needs read+write+delete (retention prunes old backups/WAL).
+        Sid      = "ObjectReadWrite"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = ["${var.cnpg_backup_bucket_arn}/*"]
+      },
+      {
+        Sid      = "ListAndLocate"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket", "s3:GetBucketLocation"]
+        Resource = [var.cnpg_backup_bucket_arn]
+      }
+    ]
+  })
+}

--- a/infrastructure/modules/security/irsa-roles/output.tf
+++ b/infrastructure/modules/security/irsa-roles/output.tf
@@ -43,6 +43,11 @@ output "media_app_role_arn" {
   value       = try(module.media_app_irsa_role[0].iam_role_arn, null)
 }
 
+output "cnpg_backup_role_arn" {
+  description = "IRSA role ARN for CNPG backups (null unless cnpg_backup_bucket_arn set)."
+  value       = try(module.cnpg_backup_irsa_role[0].iam_role_arn, null)
+}
+
 output "iam_role_arns" {
   value = {
     lb_controller    = module.lb_controller_irsa_role.iam_role_arn

--- a/infrastructure/modules/security/irsa-roles/variables.tf
+++ b/infrastructure/modules/security/irsa-roles/variables.tf
@@ -73,3 +73,16 @@ variable "media_service_accounts" {
   type        = list(string)
   default     = []
 }
+
+# ── CNPG backups (barmanObjectStore -> S3) ────────────────────────────────────
+variable "cnpg_backup_bucket_arn" {
+  description = "ARN of the CNPG backups bucket. Empty disables the CNPG backup IRSA role."
+  type        = string
+  default     = ""
+}
+
+variable "cnpg_service_accounts" {
+  description = "Trust subjects (<ns>:<sa>) for the CNPG cluster pods that write backups (one per cluster, SA name == cluster name)."
+  type        = list(string)
+  default     = []
+}

--- a/k8s/base/infra/scylla-cluster/scylla-cluster.yaml
+++ b/k8s/base/infra/scylla-cluster/scylla-cluster.yaml
@@ -15,6 +15,20 @@ spec:
     racks:
       - name: rack1
         members: 3
+        # Pin to the database node tier and tolerate its taint, so Scylla lands on
+        # the dedicated DB nodes instead of general/spot capacity.
+        placement:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: intent
+                      operator: In
+                      values: ["database"]
+          tolerations:
+            - key: dedicated
+              value: database
+              effect: NoSchedule
         storage:
           capacity: 20Gi
           storageClassName: gp3

--- a/k8s/overlays/staging/account-postgres.yaml
+++ b/k8s/overlays/staging/account-postgres.yaml
@@ -15,3 +15,15 @@ spec:
   storage:
     size: 10Gi
     storageClass: gp3
+  # Pin to the database node tier and tolerate its taint, so the cluster lands on
+  # the dedicated DB nodes instead of spilling onto general/spot capacity.
+  # enablePodAntiAffinity spreads the two instances across AZs.
+  affinity:
+    nodeSelector:
+      intent: database
+    tolerations:
+      - key: dedicated
+        value: database
+        effect: NoSchedule
+    enablePodAntiAffinity: true
+    topologyKey: topology.kubernetes.io/zone

--- a/k8s/overlays/staging/account-postgres.yaml
+++ b/k8s/overlays/staging/account-postgres.yaml
@@ -27,3 +27,17 @@ spec:
         effect: NoSchedule
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone
+  # Backups: the pod SA assumes the CNPG backup IRSA role and writes base backups
+  # + WAL to the shared backups bucket under this cluster's prefix. Pruned by the
+  # 30d retention policy. A nightly ScheduledBackup triggers base backups
+  # (see scheduledbackups.yaml); WAL is archived continuously.
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::724772065879:role/core-platform-staging-cnpg-backup-role
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://core-platform-staging-cnpg-backups-724772065879/account
+      s3Credentials:
+        inheritFromIAMRole: true
+    retentionPolicy: "30d"

--- a/k8s/overlays/staging/audit-postgres.yaml
+++ b/k8s/overlays/staging/audit-postgres.yaml
@@ -20,3 +20,15 @@ spec:
   storage:
     size: 10Gi
     storageClass: gp3
+  # Pin to the database node tier and tolerate its taint, so the cluster lands on
+  # the dedicated DB nodes instead of spilling onto general/spot capacity.
+  # enablePodAntiAffinity spreads the two instances across AZs.
+  affinity:
+    nodeSelector:
+      intent: database
+    tolerations:
+      - key: dedicated
+        value: database
+        effect: NoSchedule
+    enablePodAntiAffinity: true
+    topologyKey: topology.kubernetes.io/zone

--- a/k8s/overlays/staging/audit-postgres.yaml
+++ b/k8s/overlays/staging/audit-postgres.yaml
@@ -32,3 +32,19 @@ spec:
         effect: NoSchedule
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone
+  # Backups: the pod SA assumes the CNPG backup IRSA role and writes base backups
+  # + WAL to the shared backups bucket under this cluster's prefix. Pruned by the
+  # 30d retention policy. A nightly ScheduledBackup triggers base backups
+  # (see scheduledbackups.yaml); WAL is archived continuously.
+  # NB: this is the live SoR for the TIER-0 hash-chained ledger — the WORM bucket
+  # only holds periodic Merkle checkpoints, so PITR of this cluster matters most.
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::724772065879:role/core-platform-staging-cnpg-backup-role
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://core-platform-staging-cnpg-backups-724772065879/audit
+      s3Credentials:
+        inheritFromIAMRole: true
+    retentionPolicy: "30d"

--- a/k8s/overlays/staging/auth-postgres.yaml
+++ b/k8s/overlays/staging/auth-postgres.yaml
@@ -19,3 +19,15 @@ spec:
   storage:
     size: 10Gi
     storageClass: gp3
+  # Pin to the database node tier and tolerate its taint, so the cluster lands on
+  # the dedicated DB nodes instead of spilling onto general/spot capacity.
+  # enablePodAntiAffinity spreads the two instances across AZs.
+  affinity:
+    nodeSelector:
+      intent: database
+    tolerations:
+      - key: dedicated
+        value: database
+        effect: NoSchedule
+    enablePodAntiAffinity: true
+    topologyKey: topology.kubernetes.io/zone

--- a/k8s/overlays/staging/auth-postgres.yaml
+++ b/k8s/overlays/staging/auth-postgres.yaml
@@ -31,3 +31,17 @@ spec:
         effect: NoSchedule
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone
+  # Backups: the pod SA assumes the CNPG backup IRSA role and writes base backups
+  # + WAL to the shared backups bucket under this cluster's prefix. Pruned by the
+  # 30d retention policy. A nightly ScheduledBackup triggers base backups
+  # (see scheduledbackups.yaml); WAL is archived continuously.
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::724772065879:role/core-platform-staging-cnpg-backup-role
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://core-platform-staging-cnpg-backups-724772065879/auth
+      s3Credentials:
+        inheritFromIAMRole: true
+    retentionPolicy: "30d"

--- a/k8s/overlays/staging/cnpg-refs-config.yaml
+++ b/k8s/overlays/staging/cnpg-refs-config.yaml
@@ -1,0 +1,18 @@
+# k8s/overlays/staging/cnpg-refs-config.yaml
+#
+# Kustomize nameReference extension for CloudNativePG.
+#
+# Same class of gap as the KEDA ScaledObject (see scaledobject-refs-config.yaml):
+# kustomize's built-in name-reference config doesn't know that a ScheduledBackup's
+# spec.cluster.name points at a CNPG Cluster, so without this the namePrefix would
+# rename the Cluster to `staging-audit-postgres` while the ScheduledBackup kept
+# referencing `audit-postgres` — silently backing up nothing. This teaches kustomize
+# the reference so the prefix flows to both sides.
+#
+# Referenced from kustomization.yaml `configurations:`.
+nameReference:
+  - kind: Cluster
+    group: postgresql.cnpg.io
+    fieldSpecs:
+      - path: spec/cluster/name
+        kind: ScheduledBackup

--- a/k8s/overlays/staging/counter-postgres.yaml
+++ b/k8s/overlays/staging/counter-postgres.yaml
@@ -32,3 +32,17 @@ spec:
         effect: NoSchedule
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone
+  # Backups: the pod SA assumes the CNPG backup IRSA role and writes base backups
+  # + WAL to the shared backups bucket under this cluster's prefix. Pruned by the
+  # 30d retention policy. A nightly ScheduledBackup triggers base backups
+  # (see scheduledbackups.yaml); WAL is archived continuously.
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::724772065879:role/core-platform-staging-cnpg-backup-role
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://core-platform-staging-cnpg-backups-724772065879/counter
+      s3Credentials:
+        inheritFromIAMRole: true
+    retentionPolicy: "30d"

--- a/k8s/overlays/staging/counter-postgres.yaml
+++ b/k8s/overlays/staging/counter-postgres.yaml
@@ -20,3 +20,15 @@ spec:
   storage:
     size: 10Gi
     storageClass: gp3
+  # Pin to the database node tier and tolerate its taint, so the cluster lands on
+  # the dedicated DB nodes instead of spilling onto general/spot capacity.
+  # enablePodAntiAffinity spreads the two instances across AZs.
+  affinity:
+    nodeSelector:
+      intent: database
+    tolerations:
+      - key: dedicated
+        value: database
+        effect: NoSchedule
+    enablePodAntiAffinity: true
+    topologyKey: topology.kubernetes.io/zone

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -14,6 +14,8 @@ namePrefix: staging-
 # (built-in name-reference covers HPA but not the keda.sh CRD). See the file.
 configurations:
   - scaledobject-refs-config.yaml
+  # Flow namePrefix into ScheduledBackup.spec.cluster.name -> CNPG Cluster.
+  - cnpg-refs-config.yaml
 resources:
   # ── Services ─────────────────────────────────────────────────────────────────
   - ../../base/services/chat/server
@@ -48,6 +50,8 @@ resources:
   - moderation-postgres.yaml
   - auth-postgres.yaml
   - media-postgres.yaml
+  # Nightly base backups for the CNPG clusters (barmanObjectStore -> S3).
+  - scheduledbackups.yaml
   # IRSA-annotated ServiceAccounts (audit-server/-worker, media-server).
   - service-accounts.yaml
   # KEDA SASL auth for the MSK lag scalers (counter/realtime/audit workers).

--- a/k8s/overlays/staging/media-postgres.yaml
+++ b/k8s/overlays/staging/media-postgres.yaml
@@ -32,3 +32,17 @@ spec:
         effect: NoSchedule
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone
+  # Backups: the pod SA assumes the CNPG backup IRSA role and writes base backups
+  # + WAL to the shared backups bucket under this cluster's prefix. Pruned by the
+  # 30d retention policy. A nightly ScheduledBackup triggers base backups
+  # (see scheduledbackups.yaml); WAL is archived continuously.
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::724772065879:role/core-platform-staging-cnpg-backup-role
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://core-platform-staging-cnpg-backups-724772065879/media
+      s3Credentials:
+        inheritFromIAMRole: true
+    retentionPolicy: "30d"

--- a/k8s/overlays/staging/media-postgres.yaml
+++ b/k8s/overlays/staging/media-postgres.yaml
@@ -20,3 +20,15 @@ spec:
   storage:
     size: 10Gi
     storageClass: gp3
+  # Pin to the database node tier and tolerate its taint, so the cluster lands on
+  # the dedicated DB nodes instead of spilling onto general/spot capacity.
+  # enablePodAntiAffinity spreads the two instances across AZs.
+  affinity:
+    nodeSelector:
+      intent: database
+    tolerations:
+      - key: dedicated
+        value: database
+        effect: NoSchedule
+    enablePodAntiAffinity: true
+    topologyKey: topology.kubernetes.io/zone

--- a/k8s/overlays/staging/moderation-postgres.yaml
+++ b/k8s/overlays/staging/moderation-postgres.yaml
@@ -32,3 +32,17 @@ spec:
         effect: NoSchedule
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone
+  # Backups: the pod SA assumes the CNPG backup IRSA role and writes base backups
+  # + WAL to the shared backups bucket under this cluster's prefix. Pruned by the
+  # 30d retention policy. A nightly ScheduledBackup triggers base backups
+  # (see scheduledbackups.yaml); WAL is archived continuously.
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::724772065879:role/core-platform-staging-cnpg-backup-role
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://core-platform-staging-cnpg-backups-724772065879/moderation
+      s3Credentials:
+        inheritFromIAMRole: true
+    retentionPolicy: "30d"

--- a/k8s/overlays/staging/moderation-postgres.yaml
+++ b/k8s/overlays/staging/moderation-postgres.yaml
@@ -20,3 +20,15 @@ spec:
   storage:
     size: 10Gi
     storageClass: gp3
+  # Pin to the database node tier and tolerate its taint, so the cluster lands on
+  # the dedicated DB nodes instead of spilling onto general/spot capacity.
+  # enablePodAntiAffinity spreads the two instances across AZs.
+  affinity:
+    nodeSelector:
+      intent: database
+    tolerations:
+      - key: dedicated
+        value: database
+        effect: NoSchedule
+    enablePodAntiAffinity: true
+    topologyKey: topology.kubernetes.io/zone

--- a/k8s/overlays/staging/scheduledbackups.yaml
+++ b/k8s/overlays/staging/scheduledbackups.yaml
@@ -1,0 +1,72 @@
+# k8s/overlays/staging/scheduledbackups.yaml
+#
+# Nightly base backups for each CNPG cluster (WAL is archived continuously by the
+# cluster's barmanObjectStore; this triggers the periodic base backup the WAL
+# replays from). schedule is CNPG's 6-field cron (sec min hour dom mon dow):
+# "0 0 2 * * *" = 02:00 UTC daily. cluster.name is the BASE name — kustomize
+# rewrites it to the staging- prefix via cnpg-refs-config.yaml.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: account-postgres-backup
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: account-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: counter-postgres-backup
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: counter-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: audit-postgres-backup
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: audit-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: moderation-postgres-backup
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: moderation-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: auth-postgres-backup
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: auth-postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: media-postgres-backup
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: media-postgres


### PR DESCRIPTION
Two cohesive DB-tier fixes (separate commits — splittable if preferred).

## C5 — stateful workloads couldn't use their own node tier
The Karpenter `database` NodePool taints nodes `dedicated=database:NoSchedule`, but neither the operator `ScyllaCluster` nor any of the 6 CNPG Postgres clusters tolerated it or selected the tier — so the primary SoR and every Postgres sat `Pending` or spilled onto general/**spot** capacity (spot reclaim → evicted stateful node). The dedicated DB tier was decorative.

- All staging stateful workloads now set `nodeSelector intent=database` + a toleration for `dedicated=database:NoSchedule`.
- CNPG clusters add `enablePodAntiAffinity` across `topology.kubernetes.io/zone` (spreads the 2 instances across AZs — also closes the co-location risk from W9).

## C6 — zero backups on any Postgres (incl. the TIER-0 audit ledger)
No base backups, no WAL archiving, no PITR. Lose the audit PVC and the hash chain is gone (the WORM bucket holds only periodic Merkle checkpoints).

- **Terraform:** a shared CNPG backups bucket (versioned, SSE-S3, private) + a `cnpg-backup` IRSA role granting each cluster's pod SA RW to it. Both gated on the bucket ARN (dev unaffected). Wired through the staging irsa unit.
- **Manifests:** each cluster gets `serviceAccountTemplate` (assumes the role), a `barmanObjectStore` destination (one S3 prefix per cluster), `retentionPolicy: 30d`, continuous WAL archiving + a nightly base `ScheduledBackup` (02:00 UTC). A `cnpg-refs-config` flows the `staging-` prefix into `ScheduledBackup.spec.cluster.name`.

**Defaults (easily tuned):** 30-day retention, nightly base backup, one shared path-prefixed bucket. Storage left at 10Gi — a **prod follow-up** (the audit 7-year ledger needs real capacity planning).

## Validation (offline)
- Overlay builds: **92 objects**; the 6 ScheduledBackups resolve `cluster.name` to the `staging-` prefix on both sides; 6 distinct backup paths.
- `terraform fmt` clean. `terraform validate` needs provider download (network) — not run offline.

## ⚠️ Reviewer caveats
- Apply order: `data/cnpg-backups` → `security/irsa-roles` → workloads (so the role + bucket exist before CNPG starts backing up).
- IRSA trust assumes the CNPG pod SA name == cluster name (`staging-<svc>-postgres`); confirm on first apply.

## Audit refs
**C5 (Critical)** scheduling · **C6 (Critical)** durability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)