### PR TITLE
fix(karpenter): enable spot-interruption handling (W5)

### DIFF
--- a/infrastructure/argocd/bootstrap/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/root-infra-platform.yaml
@@ -51,8 +51,10 @@ spec:
                 value: "{{ .global.clusterEndpoint }}"
               - name: "karpenter.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
                 value: "{{ .global.karpenterRoleArn }}"
+              # Spot-interruption queue (Terraform names it == cluster name), so
+              # Karpenter drains reclaimed nodes gracefully instead of abrupt kills.
               - name: "karpenter.settings.interruptionQueue"
-                value: ""
+                value: "{{ .global.clusterName }}"
               # {{ end }}
 
               # {{ if eq .name "aws-load-balancer-controller" }}

--- a/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
@@ -51,8 +51,10 @@ spec:
                 value: "{{ .global.clusterEndpoint }}"
               - name: "karpenter.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
                 value: "{{ .global.karpenterRoleArn }}"
+              # Spot-interruption queue (Terraform names it == cluster name), so
+              # Karpenter drains reclaimed nodes gracefully instead of abrupt kills.
               - name: "karpenter.settings.interruptionQueue"
-                value: ""
+                value: "{{ .global.clusterName }}"
               # {{ end }}
 
               # {{ if eq .name "aws-load-balancer-controller" }}

--- a/infrastructure/modules/security/irsa-roles/main.tf
+++ b/infrastructure/modules/security/irsa-roles/main.tf
@@ -372,3 +372,87 @@ resource "aws_iam_role_policy" "media_app" {
     ]
   })
 }
+
+# --- 10. KARPENTER SPOT-INTERRUPTION QUEUE -----------------------------------
+# Without this, Karpenter cannot receive the 2-minute spot interruption /
+# rebalance / scheduled-maintenance notices, so it can't cordon+drain a reclaimed
+# node gracefully — pods (incl. the realtime gateway's live WebSocket
+# connections) are killed abruptly. EventBridge routes those events to this SQS
+# queue; Karpenter polls it and starts a graceful drain on the warning. The queue
+# NAME == cluster name (Karpenter convention; the platform appset sets
+# settings.interruptionQueue from .global.clusterName).
+resource "aws_sqs_queue" "karpenter_interruption" {
+  name                      = var.cluster_name
+  message_retention_seconds = 300
+  sqs_managed_sse_enabled   = true
+  tags                      = var.tags
+}
+
+data "aws_iam_policy_document" "karpenter_interruption_queue" {
+  statement {
+    sid       = "EventBridgeAndSpotToQueue"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.karpenter_interruption.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com", "sqs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "karpenter_interruption" {
+  queue_url = aws_sqs_queue.karpenter_interruption.id
+  policy    = data.aws_iam_policy_document.karpenter_interruption_queue.json
+}
+
+# The four event sources Karpenter consumes, each routed to the queue.
+locals {
+  karpenter_interruption_events = {
+    spot_interruption = {
+      source      = ["aws.ec2"]
+      detail_type = ["EC2 Spot Instance Interruption Warning"]
+    }
+    rebalance = {
+      source      = ["aws.ec2"]
+      detail_type = ["EC2 Instance Rebalance Recommendation"]
+    }
+    instance_state_change = {
+      source      = ["aws.ec2"]
+      detail_type = ["EC2 Instance State-change Notification"]
+    }
+    scheduled_change = {
+      source      = ["aws.health"]
+      detail_type = ["AWS Health Event"]
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "karpenter_interruption" {
+  for_each = local.karpenter_interruption_events
+
+  name          = "${var.cluster_name}-karpenter-${each.key}"
+  event_pattern = jsonencode({ "source" = each.value.source, "detail-type" = each.value.detail_type })
+  tags          = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_interruption" {
+  for_each = local.karpenter_interruption_events
+
+  rule = aws_cloudwatch_event_rule.karpenter_interruption[each.key].name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}
+
+# Let the Karpenter controller drain the interruption queue.
+resource "aws_iam_role_policy" "karpenter_interruption" {
+  name = "KarpenterInterruptionQueue"
+  role = module.karpenter_irsa_role.iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:DeleteMessage", "sqs:GetQueueUrl", "sqs:GetQueueAttributes", "sqs:ReceiveMessage"]
+      Resource = aws_sqs_queue.karpenter_interruption.arn
+    }]
+  })
+}


### PR DESCRIPTION
## Problem
The platform appset hardcoded `karpenter.settings.interruptionQueue: ""`, so Karpenter never received the 2-minute spot interruption / rebalance / scheduled-maintenance notices and **could not gracefully drain a reclaimed node**. With the spot-only `apps` pool, that means abrupt pod kills — directly undermining the realtime gateway's stateful-edge design (its 120s drain + broadcast `RECONNECT` only runs if the node is *drained*, not hard-killed).

## Fix
Provision the standard Karpenter interruption path in the platform/identity module:
- an **SQS queue** (name == cluster name, Karpenter convention) with SSE + a queue policy allowing EventBridge/Spot to enqueue;
- **four EventBridge rules** (spot interruption, rebalance recommendation, instance state-change, scheduled health) → the queue;
- an IAM policy letting the Karpenter controller drain it.

Point both platform appsets (dev + staging) at it: `interruptionQueue: "" → "{{ .global.clusterName }}"`.

Now a spot reclaim triggers a graceful drain, so the gateway's `terminationGracePeriod` + `broadcast_drain` runs and clients re-handshake with jitter instead of dropping.

## Validation (offline)
- `terraform fmt` clean; both appsets parse; queue + 4 rules + target + controller policy added.
- `terraform validate` needs provider download (network) — not run offline.

## Note
Pinning the realtime gateway *specifically* off spot is a separate nodepool-design item (**W11**); graceful drain makes spot tolerable for it in the meantime.

## Audit ref
**W5 (Warning)** — abrupt spot kills vs. the realtime guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)