### PR TITLE
fix(counter): KEDA offsetResetPolicy earliest so cold groups drain (W10)

### DIFF
--- a/k8s/base/services/counter/worker/scaledobject.yaml
+++ b/k8s/base/services/counter/worker/scaledobject.yaml
@@ -36,4 +36,10 @@ spec:
         # Omitting `topic` monitors lag across ALL topics the group subscribes to
         # (view/impression/click.v1.events). Scale when avg lag/pod exceeds:
         lagThreshold: "5000"
-        offsetResetPolicy: latest
+        # `earliest` so a cold/reset consumer group counts the FULL unconsumed
+        # backlog as lag and KEDA scales up to drain it — the right policy for an
+        # analytics counter that must process every event. With `latest`, an
+        # uncommitted group reads lag as ~0 and the worker silently under-scales.
+        # (Matches the audit worker; the app consumer's own auto.offset.reset is
+        # separate and lives in counter's runtime config.)
+        offsetResetPolicy: earliest


### PR DESCRIPTION
## What
`counter-worker`'s KEDA Kafka trigger used `offsetResetPolicy: latest`. For an uncommitted/reset consumer group KEDA reads lag as ~0 (`latest` == current end), so it **under-scales** and the unconsumed backlog drains slowly. For an analytics counter that must process every `view/impression/click` event, `earliest` is correct — the full backlog counts as lag and KEDA scales to drain it. Matches the `audit-worker`, which already uses `earliest`.

## Scope note
This is the **KEDA scaler** lag policy. The actual consumed offset is governed by the app consumer's `auto.offset.reset` in counter's runtime config (separate, app-side) — worth confirming there too, but out of scope for this manifest.

## Validation
Staging overlay builds.

## Audit ref
**W10 (Warning)** — under-scaling / undercount risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)