### PR TITLE
fix(k8s): baseline pod-security hardening on every Deployment (W7)

### DIFF
--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -157,6 +157,10 @@ images:
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
     newTag: staging
 patches:
+  # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
+  - path: patch-securitycontext.yaml
+    target:
+      kind: Deployment
   # Inject the synced MSK/Redis creds into every service container.
   - path: patch-backend-creds.yaml
     target:

--- a/k8s/overlays/staging/patch-securitycontext.yaml
+++ b/k8s/overlays/staging/patch-securitycontext.yaml
@@ -1,0 +1,29 @@
+# k8s/overlays/staging/patch-securitycontext.yaml
+#
+# Baseline pod-security hardening applied to EVERY Deployment in the fleet (none
+# set a securityContext, so all containers ran as root with full capabilities —
+# including the TIER-0 auth/audit services). The runtime image (deploy/Dockerfile)
+# already runs as UID 10001; this enforces it at the kubelet and adds the standard
+# guards.
+#
+# Applied as a JSON6902 patch targeting kind: Deployment (all 20 fleet Deployments
+# are single-container, so containers/0 is always the app container).
+#
+# readOnlyRootFilesystem is intentionally NOT set fleet-wide: it needs per-service
+# validation of scratch/temp writes and would risk crash-looping a service that
+# writes to disk. Tracked as a follow-up. Init containers (migrator) get the
+# pod-level guards but not the container-level ones (the index-0 patch targets the
+# app container only).
+- op: add
+  path: /spec/template/spec/securityContext
+  value:
+    runAsNonRoot: true
+    runAsUser: 10001
+    seccompProfile:
+      type: RuntimeDefault
+- op: add
+  path: /spec/template/spec/containers/0/securityContext
+  value:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]


### PR DESCRIPTION
## Problem
No Deployment set a `securityContext`, so all 20 fleet services — **including the TIER-0 auth/audit planes** — ran as **root** with full Linux capabilities and no seccomp profile. A single RCE was a root container. The runtime image already runs as UID 10001, but nothing enforced it.

## Fix
A JSON6902 patch applied to every Deployment (all single-container, so `containers/0` is the app container):
- **pod:** `runAsNonRoot`, `runAsUser: 10001`, `seccompProfile: RuntimeDefault`;
- **container:** `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`.

## Deliberately scoped out
- `readOnlyRootFilesystem` is **not** set fleet-wide — it needs per-service validation of scratch/temp writes and could crash-loop a service that writes to disk. Follow-up.
- Init containers (migrator) get the pod-level guards only (the index-0 patch targets the app container).
- Applied at the staging overlay; promoting to base (so dev inherits) is a follow-up.

## Validation
Staging overlay builds; **all 20 Deployments** carry both the pod- and container-level hardening (verified by parsing the rendered output).

## Audit ref
**W7 (Warning)** — root containers fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)