### PR TITLE
fix(eks): private endpoint + public allowlist knob; correct node SG CIDR (W3/W4)

### DIFF
--- a/infrastructure/live/dev/us-east-1/eks/terragrunt.hcl
+++ b/infrastructure/live/dev/us-east-1/eks/terragrunt.hcl
@@ -36,6 +36,10 @@ inputs = {
   cluster_name       = "core-platform-${local.env_vars.locals.env}"
   vpc_id             = dependency.vpc.outputs.vpc_id
   private_subnet_ids = dependency.vpc.outputs.private_app_subnet_ids
+  vpc_cidr           = dependency.vpc.outputs.vpc_cidr_block
+
+  # Tighten the public API endpoint to your admin/CI ranges when ready, e.g.:
+  # endpoint_public_access_cidrs = ["203.0.113.4/32"]
 
   # Injecte la map dynamique définie dans env.hcl (Node Groups système)
   node_groups = local.env_vars.locals.node_groups

--- a/infrastructure/live/staging/us-east-1/eks/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/eks/terragrunt.hcl
@@ -21,7 +21,11 @@ inputs = {
   cluster_name       = "core-platform-${local.env_vars.locals.env}"
   vpc_id             = dependency.vpc.outputs.vpc_id
   private_subnet_ids = dependency.vpc.outputs.private_app_subnet_ids
+  vpc_cidr           = dependency.vpc.outputs.vpc_cidr_block
   node_groups        = local.env_vars.locals.node_groups
+
+  # Tighten the public API endpoint to your admin/CI ranges when ready, e.g.:
+  # endpoint_public_access_cidrs = ["203.0.113.4/32"]
 
   project_name = "core-platform"
   env          = local.env_vars.locals.env

--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -8,7 +8,12 @@ module "eks" {
   cluster_name    = var.cluster_name
   cluster_version = "1.31"
 
-  cluster_endpoint_public_access = true
+  # Private access is always on (in-VPC/node traffic stays off the public path).
+  # Public access stays on so kubectl/Terraform reach the API, but the allow-list
+  # is now a knob (W3): default 0.0.0.0/0 — tighten per-env to your admin/CI CIDRs.
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_private_access      = true
+  cluster_endpoint_public_access_cidrs = var.endpoint_public_access_cidrs
 
   vpc_id     = var.vpc_id
   subnet_ids = var.private_subnet_ids
@@ -16,11 +21,11 @@ module "eks" {
   enable_cluster_creator_admin_permissions = true
   enable_irsa                              = true
 
-# --- MANAGED NODE GROUPS DYNAMIQUES ---
+  # --- MANAGED NODE GROUPS DYNAMIQUES ---
   # Ici, on passe directement la map configurée dans Terragrunt.
   # Cela permet de varier le nombre et le type de groupes selon l'environnement.
   eks_managed_node_groups = var.node_groups
-  
+
   # Tag crucial pour que Karpenter identifie le Security Group à utiliser pour les nouveaux nodes
   node_security_group_tags = {
     "karpenter.sh/discovery" = var.cluster_name
@@ -33,8 +38,11 @@ module "eks" {
       from_port   = 8080
       to_port     = 8080
       type        = "ingress"
-      # On autorise le trafic venant de l'ALB (via le CIDR du VPC)
-      cidr_blocks = ["10.0.0.0/16"] # Utilise ton CIDR VPC ici
+      # The ALB lives in the VPC; allow from the actual VPC CIDR (W4 — was
+      # hardcoded to 10.0.0.0/16, wrong for any env not on that CIDR, e.g. staging
+      # 10.20.0.0/16). TODO: tighten to the ALB security group once the LB
+      # controller has created it.
+      cidr_blocks = [var.vpc_cidr]
     }
   }
 }

--- a/infrastructure/modules/eks/variables.tf
+++ b/infrastructure/modules/eks/variables.tf
@@ -27,6 +27,17 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+variable "vpc_cidr" {
+  description = "VPC CIDR — used to scope the node SG rule that lets the ALB reach ArgoCD (8080)."
+  type        = string
+}
+
+variable "endpoint_public_access_cidrs" {
+  description = "CIDRs allowed to reach the EKS public API endpoint. Default 0.0.0.0/0 — TIGHTEN per-env to your admin/CI ranges."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 # --- CONFIGURATION DES NOEUDS ---
 variable "node_groups" {
   description = "Map complète des Managed Node Groups (passée par Terragrunt)"


### PR DESCRIPTION
## W3 — EKS API endpoint exposure
The endpoint was public to `0.0.0.0/0` with no allow-list and no private access.
- Enable `cluster_endpoint_private_access` — in-VPC/node traffic stays off the public path (free hardening).
- Expose `cluster_endpoint_public_access_cidrs` as a variable (**default `0.0.0.0/0`**) so each env can tighten to its admin/CI ranges without a code change. Public access stays open by default (your call) so kubectl/Terraform keep working; the live configs document where to tighten.

## W4 — node SG rule had the wrong CIDR
The rule letting the ALB reach ArgoCD on `8080` was hardcoded to `cidr_blocks ["10.0.0.0/16"]` — broad **and wrong** for any env not on that CIDR (staging is `10.20.0.0/16`, so the rule didn't even match). Parameterized to the actual VPC CIDR (`var.vpc_cidr`, passed from the `vpc` dependency in dev + staging). TODO left to tighten to the ALB security group once the LB controller creates it.

## Follow-up to actually close W3
This ships the *mechanism* (private access + the allow-list knob). To reduce public exposure, set `endpoint_public_access_cidrs` per-env to your real admin/CI ranges — there's a commented example in each EKS terragrunt.

## Validation
`terraform fmt` clean on the changed files. `terraform validate` needs provider download (network) — not run offline.

## Audit refs
**W3 + W4 (Warning)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)