### PR TITLE
fix(k8s): NetworkPolicy namespace-isolation baseline + enable CNI enforcement (W8)

### DIFF
--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -21,6 +21,19 @@ module "eks" {
   enable_cluster_creator_admin_permissions = true
   enable_irsa                              = true
 
+  # Enable NetworkPolicy enforcement in the AWS VPC CNI — without this the CNI
+  # silently ignores NetworkPolicy objects, so the fleet's namespace-isolation
+  # baseline (k8s/overlays/staging/networkpolicies.yaml) would be a no-op. The CNI
+  # network-policy agent permits the node->pod kubelet health-probe path, so
+  # default-deny ingress does not break liveness/readiness probes.
+  cluster_addons = {
+    vpc-cni = {
+      configuration_values = jsonencode({
+        enableNetworkPolicy = "true"
+      })
+    }
+  }
+
   # --- MANAGED NODE GROUPS DYNAMIQUES ---
   # Ici, on passe directement la map configurée dans Terragrunt.
   # Cela permet de varier le nombre et le type de groupes selon l'environnement.

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -57,6 +57,8 @@ resources:
   # KEDA SASL auth for the MSK lag scalers (counter/realtime/audit workers).
   - keda-trigger-auth.yaml
   - external-secrets.yaml
+  # Baseline namespace isolation (default-deny ingress + same-ns allow + public WSS).
+  - networkpolicies.yaml
 configMapGenerator:
   - name: chat-config
     envs: [chat.env]

--- a/k8s/overlays/staging/networkpolicies.yaml
+++ b/k8s/overlays/staging/networkpolicies.yaml
@@ -1,0 +1,68 @@
+# k8s/overlays/staging/networkpolicies.yaml
+#
+# Baseline namespace isolation for the fleet (default namespace). Before this,
+# every pod was reachable by every other pod from any namespace.
+#
+# v1 posture (INGRESS only — egress is left fully open on purpose):
+#   * default-deny all ingress;
+#   * allow ingress only from pods in the SAME namespace — this keeps the entire
+#     gRPC mesh + app->CNPG traffic working without having to enumerate the (partly
+#     code-level) call graph, while blocking cross-namespace and external direct
+#     ingress (observability / external-secrets / kube-system pods can no longer
+#     reach app pods directly);
+#   * the realtime gateway's public WSS port (8443) is internet-facing via the NLB,
+#     so it explicitly accepts ingress there.
+#
+# Egress is deliberately NOT restricted yet: locking it down needs the managed
+# data-store CIDRs (MSK/ElastiCache/OpenSearch ENIs), CoreDNS, the OTel collector
+# and S3 endpoints mapped first — doing it blind would break the fleet.
+#
+# NEXT (v2, needs the code-level gRPC call graph): per-service ingress so a
+# compromised peer can't reach TIER-0 audit/auth — e.g. the workers
+# (audit/counter/realtime-dispatcher) take no mesh ingress at all, audit-server's
+# sync RPC is break-glass only.
+#
+# PREREQUISITE: NetworkPolicy enforcement. The AWS VPC CNI ignores these objects
+# unless enableNetworkPolicy=true (set on the vpc-cni addon in modules/eks). The
+# VPC CNI permits the node->pod kubelet health-probe path, so default-deny does
+# not break liveness/readiness probes.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+# The realtime gateway terminates client WebSockets on :8443 (public, via the NLB).
+# Its internal gRPC/health (:50066) is covered by allow-same-namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: realtime-gateway-public-wss
+spec:
+  podSelector:
+    matchLabels:
+      app: realtime-gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 8443


### PR DESCRIPTION
## Problem
Flat pod network — every pod reachable by every other pod from any namespace (a compromised `geo-discovery` pod could hit TIER-0 `audit`/`auth`). And the **AWS VPC CNI ignores NetworkPolicy objects unless enforcement is enabled**, so any policy would have been a no-op.

## Fix (two parts)
1. **EKS:** `enableNetworkPolicy=true` on the `vpc-cni` addon so policies are enforced. The CNI agent permits node→pod kubelet probes, so default-deny ingress doesn't break liveness/readiness.
2. **Staging overlay — ingress-only baseline:**
   - default-deny all ingress;
   - allow ingress only from the **same namespace** (keeps the whole gRPC mesh + app→CNPG working without enumerating the partly-code-level call graph, while blocking cross-namespace + external direct ingress);
   - the realtime gateway's public WSS `:8443` explicitly allowed (NLB).

## Deliberately scoped out (why this is the *safe* v1)
- **Egress left fully open** — locking it needs the managed-store ENIs (MSK/ElastiCache/OpenSearch), CoreDNS, OTel and S3 mapped first; blind egress-deny would break the fleet.
- **Per-service micro-segmentation** (isolate `audit`/`auth` from peers; workers take no mesh ingress; audit sync RPC is break-glass only) is **v2** — it needs the code-level gRPC call graph. The env files only declare 6 mesh edges; the rest is in code, and many services are Kafka-fed. Aggressive rules on partial info would sever live traffic.

## ⚠️ Reviewer caveats
- NetworkPolicy correctness can't be fully validated offline. **Roll out the CNI enablement first, then the policies**, and watch for dropped flows — especially anything cross-namespace that legitimately needs ingress (e.g. Prometheus scraping, if metrics aren't push-based; this fleet uses push-based OTel, so likely fine).
- `modules/eks/main.tf` is also touched by #516 (W3/W4) in a different section — trivial merge interaction at most.

## Validation
Staging overlay builds (89 objects incl. 3 policies); `terraform fmt` clean.

## Audit ref
**W8 (Warning)** — flat pod network / no segmentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)