### PR TITLE
fix(k8s): per-service mesh NetworkPolicies — isolate TIER-0 + workers (W8 v2, safe subset)

### DIFF
--- a/docs/security/network-policy-call-graph.md
+++ b/docs/security/network-policy-call-graph.md
@@ -1,0 +1,205 @@
+# W8 v2 — Per-Service NetworkPolicy Call Graph
+
+Basis for tightening the namespace-isolation baseline (#519) into per-service
+micro-segmentation that isolates TIER-0 `audit`/`auth` from arbitrary peers.
+Derived from code + config, not guesswork:
+
+- **gRPC ports** — `k8s/base/services/*/.../{deployment,service}.yaml`.
+- **gRPC mesh edges** — the tonic `*Client` types actually instantiated under
+  `crates/services/*/src` (the *complete* set is 6 — see below) cross-checked with
+  the `*_GRPC_ENDPOINT` config in `k8s/overlays/staging/*.env`.
+- **Kafka event plane** — the generated topic-wiring in
+  `docs/domain/EVENT_CATALOG.md` (authoritative: `crates/contracts/event-topology`).
+- **Datastore egress** — the `*.env` per service.
+
+> **Key result:** the intra-fleet gRPC mesh is **tiny** — only **6 services** receive
+> calls from another fleet service. The rest is Kafka (egress to MSK, not pod→pod)
+> or client-facing. That makes ingress micro-segmentation low-risk; egress lockdown
+> is the harder half (managed AWS ENIs).
+
+---
+
+## 1. gRPC server ports
+
+| Port | Service | Role |
+|---|---|---|
+| 50051 | chat | client-facing |
+| 50052 | profile | **mesh callee** |
+| 50053 | social-graph | **mesh callee** |
+| 50054 | geo-discovery | client-facing |
+| 50055 | notification | client-facing |
+| 50056 | post | **mesh callee** |
+| 50057 | comment | client-facing |
+| 50058 | engagement | client-facing |
+| 50059 | account | **mesh callee** |
+| 50060 | auth | **mesh callee** (JWKS) |
+| 50060 | timeline | client-facing (read) |
+| 50061 | moderation | **mesh callee** (Screen) |
+| 50062 | search | client-facing (read) |
+| 50063 | media | client-facing |
+| 50064 | counter-server | client-facing (read) |
+| 50065 | counter-worker | worker (health only) |
+| 50066 / 8443 | realtime-gateway | internal health / **public WSS** |
+| 50067 | realtime-dispatcher | worker (health only) |
+| 50068 | audit-server | TIER-0 (break-glass RecordPrivileged + Query) |
+| 50069 | audit-worker | worker (health only) |
+
+> ⚠️ **Side-finding — port collision:** `auth` and `timeline` both listen on **50060**.
+> They're distinct ClusterIP services (different DNS/IPs), so k8s tolerates it and
+> NetworkPolicy still works per-pod — but it's almost certainly a copy-paste slip
+> (`timeline` should have its own port). Worth fixing independently of W8.
+
+---
+
+## 2. Inbound gRPC mesh (the complete set — 6 edges)
+
+The only `*Client` types instantiated anywhere in `crates/services/*`:
+
+| Caller | Client type | → Callee : port | Purpose |
+|---|---|---|---|
+| `auth` | `AccountServiceClient` | `account:50059` | account lookup during issuance |
+| `moderation` | `AccountServiceClient` | `account:50059` | subject resolution |
+| `counter` | `SocialGraphServiceClient` | `social-graph:50053` | follower/following reconcile |
+| `timeline` | `SocialGraphServiceClient` / `SocialGraphGrpcClient` | `social-graph:50053` | fan-out + cold rebuild |
+| `search` | `PostServiceClient` | `post:50056` | hydrate post docs |
+| `search` | `ProfileServiceClient` | `profile:50052` | hydrate profile docs |
+| `media` | `ModerationServiceClient` | `moderation:50061` | **fail-closed Screen gate** |
+| `realtime` | `JwksClient` | `auth:50060` | fetch JWKS to verify edge tokens |
+
+### Inbound matrix (who a policy must allow)
+
+| Callee | Allowed in-mesh callers | Port |
+|---|---|---|
+| `account` | `auth`, `moderation` | 50059 |
+| `social-graph` | `counter`, `timeline` | 50053 |
+| `post` | `search` | 50056 |
+| `profile` | `search` | 50052 |
+| `moderation` | `media` | 50061 |
+| `auth` | `realtime` | 50060 |
+
+**No in-mesh inbound at all** (→ ingress = health probe only, + the client entry
+point if/when one exists): `chat`, `geo-discovery`, `notification`, `comment`,
+`engagement`, `timeline`, `search`, `media`, `counter-server`, and the workers
+`counter-worker`, `realtime-dispatcher`, `audit-worker`. `audit-server` takes only
+the break-glass `RecordPrivileged`/`Query` path (no normal-flow mesh caller).
+`realtime-gateway` takes public WSS on 8443 (already allowed in #519).
+
+---
+
+## 3. ⚠️ Open decision — the client-facing entry point
+
+The "client-facing" services above are read/command APIs meant to be called by a
+gateway/BFF, **not** by other fleet services. But:
+
+- there is **no in-cluster BFF/gateway** in this repo or the staging overlay (only a
+  `gateway-bff-deploy.yml` workflow — the BFF lives off-fleet);
+- staging has **no ALB ingress** (only the realtime NLB).
+
+So today those services have **no in-cluster inbound** beyond health probes — they
+could be locked down hard right now. But that would block the BFF/edge the moment
+it's introduced. **Decision needed before writing their ingress policies:**
+
+1. **Where does client traffic enter?** An in-cluster BFF pod (→ allow by its label),
+   an ALB (→ allow from the ALB/VPC ipBlock), or stays external-only for now (→ lock
+   to health probes + revisit when the BFF lands)?
+
+Until that's answered, the safe move is to keep the **same-namespace baseline**
+(#519) for the client-facing set and only tighten the **6 mesh callees** + the
+**TIER-0/worker** services, whose inbound is fully known.
+
+---
+
+## 4. Kafka event plane (egress to MSK, not pod→pod)
+
+From `EVENT_CATALOG.md` — these are producer→consumer over MSK, so they are
+**egress to the broker ENIs**, never pod-to-pod ingress. They do NOT need ingress
+allows; they inform the **egress** policy (who needs MSK :9096).
+
+| Topic | Producer | Consumers |
+|---|---|---|
+| `account.v1.events` | account | audit, profile |
+| `profile.v1.events` | profile | search, post |
+| `post.v1.events` | post | timeline, search, realtime |
+| `post.published` / `post.deleted` | post | geo-discovery, notification / timeline |
+| `comment.created` / `comment.deleted` | comment | notification, engagement / engagement |
+| `engagement.reactions` | engagement | counter, notification, engagement |
+| `social-graph.*` (followed/unfollowed/tier) | social-graph | timeline, profile |
+| `counter.v1.popularity` | counter | realtime, geo-discovery |
+| `moderation.v1.events` | moderation | audit, search, media |
+| `auth.v1.events` | auth | audit |
+| `media.v1.events` | media | media |
+| `chat.*` | chat | chat (rest orphan) |
+
+**MSK producers/consumers** (need egress :9096): account, profile, post, comment,
+engagement, social-graph, counter (+worker), moderation, auth, media, chat,
+geo-discovery, notification, timeline, search, realtime (+dispatcher), audit (+worker).
+(≈ everyone except the pure read paths.)
+
+---
+
+## 5. Egress map (per service) — for the v2 egress lockdown
+
+Every pod also needs: **DNS** → `kube-system` CoreDNS :53 (UDP/TCP), and **OTel** →
+`otel-collector.observability.svc` :4317.
+
+| Service | Datastores / object store (egress) | gRPC callees | Kafka |
+|---|---|---|---|
+| account | CNPG `account` | — | producer |
+| auth | CNPG `auth`, Redis | account:50059 | producer |
+| profile | CNPG, Redis, Scylla | — | both |
+| social-graph | CNPG, Redis, Scylla | — | both |
+| post | CNPG, Scylla | — | both |
+| comment | CNPG, Scylla | — | both |
+| engagement | CNPG, Redis, Scylla | — | both |
+| counter (server+worker) | CNPG, Redis, Scylla | social-graph:50053 | both |
+| geo-discovery | CNPG, Redis, Scylla | — | consumer |
+| notification | CNPG, Redis, Scylla | — | consumer |
+| timeline | CNPG, Redis, Scylla | social-graph:50053 | consumer |
+| chat | CNPG, Redis, Scylla | — | producer |
+| moderation | CNPG, Redis, Scylla | account:50059 | both |
+| media (server) | CNPG, Redis, **S3** (asset + object-store) | moderation:50061 | both |
+| search | **OpenSearch** | post:50056, profile:50052 | consumer |
+| audit (server+worker) | CNPG, **S3** (WORM/witness), KMS | — | consumer |
+| realtime (gateway+dispatcher) | Redis | auth:50060 (JWKS) | consumer |
+
+**Managed-AWS egress targets** (no pod IP — use ipBlock of the **private-data subnet
+CIDRs**): MSK :9096, ElastiCache :6379, OpenSearch :443. **S3** → via the S3 gateway
+endpoint (NetworkPolicy can't name a prefix list; allow :443 to the VPC/`0.0.0.0/0`
+or rely on the gateway-endpoint route). **Scylla** → `scylla` ns :9042 (namespace
+selector). **CNPG** → same-ns :5432 (pod selector `cnpg.io/cluster`).
+
+---
+
+## 6. Proposed policy shape (v2)
+
+Layered on top of the #519 baseline:
+
+**Ingress (do now — fully known):**
+- Per mesh callee (`account`, `social-graph`, `post`, `profile`, `moderation`,
+  `auth`): replace the broad same-ns allow with an allow **only** from the specific
+  caller pods on the specific port (table §2).
+- Workers (`counter-worker`, `realtime-dispatcher`, `audit-worker`) and `audit-server`:
+  deny all mesh ingress (health probes are node→pod, permitted by the VPC CNI).
+- `realtime-gateway`: keep the public-WSS allow (#519); 50066 health only.
+- Client-facing set: **hold at same-ns** until §3 is decided.
+
+**Egress (do after ingress proves stable — riskier):**
+- Namespace-wide allow: DNS (kube-system :53), OTel (observability :4317).
+- Per service: its datastores (Scylla ns / same-ns CNPG / data-subnet ipBlock for
+  ElastiCache+OpenSearch+MSK / S3 :443) + its gRPC callee(s) from §5.
+- Flip on `default-deny-egress` **last**, per service, watching for drops.
+
+---
+
+## 7. Open decisions before implementing
+
+1. **Client entry point** (§3) — BFF pod label, ALB ipBlock, or lock-to-probes-for-now?
+2. **Egress scope** — do we want full egress lockdown now, or ingress-only v2 first?
+   (Egress needs the live data-subnet CIDRs + S3 handling; higher breakage risk.)
+3. **Port collision** — fix `auth`/`timeline` both on 50060 first (independent of W8).
+4. **CNI** — confirm `enableNetworkPolicy=true` (shipped in #519) is live before any
+   of this enforces.
+
+Once 1–2 are answered, the per-service policies are mechanical to generate from the
+matrices above. Rollout slots into Phase 3c of
+`docs/runbooks/audit-remediation-rollout.md` (apply allows first, deny last, watch).

--- a/k8s/overlays/staging/networkpolicies.yaml
+++ b/k8s/overlays/staging/networkpolicies.yaml
@@ -3,24 +3,25 @@
 # Baseline namespace isolation for the fleet (default namespace). Before this,
 # every pod was reachable by every other pod from any namespace.
 #
-# v1 posture (INGRESS only — egress is left fully open on purpose):
+# Posture (INGRESS only — egress is left fully open on purpose):
 #   * default-deny all ingress;
-#   * allow ingress only from pods in the SAME namespace — this keeps the entire
-#     gRPC mesh + app->CNPG traffic working without having to enumerate the (partly
-#     code-level) call graph, while blocking cross-namespace and external direct
-#     ingress (observability / external-secrets / kube-system pods can no longer
-#     reach app pods directly);
-#   * the realtime gateway's public WSS port (8443) is internet-facing via the NLB,
-#     so it explicitly accepts ingress there.
+#   * SAME-NAMESPACE allow for the CLIENT-FACING set only (excludes the tightened
+#     services below) — a safe default that keeps their traffic working until the
+#     client entry point (BFF/ALB) is decided;
+#   * the 6 mesh callees (account/social-graph/post/profile/moderation/auth) accept
+#     ONLY their specific in-fleet caller(s) on their gRPC port — the complete mesh,
+#     derived from the tonic *Client types in crates/services/*;
+#   * the TIER-0 audit + the three Kafka-consumer workers (audit/counter/realtime-
+#     dispatcher) get NO mesh ingress at all (default-deny; health probes are
+#     node->pod, permitted by the CNI) — a compromised peer can no longer reach them;
+#   * the realtime gateway's public WSS port (8443) is internet-facing via the NLB.
 #
 # Egress is deliberately NOT restricted yet: locking it down needs the managed
 # data-store CIDRs (MSK/ElastiCache/OpenSearch ENIs), CoreDNS, the OTel collector
 # and S3 endpoints mapped first — doing it blind would break the fleet.
 #
-# NEXT (v2, needs the code-level gRPC call graph): per-service ingress so a
-# compromised peer can't reach TIER-0 audit/auth — e.g. the workers
-# (audit/counter/realtime-dispatcher) take no mesh ingress at all, audit-server's
-# sync RPC is break-glass only.
+# DEFERRED: client-facing services stay on same-ns until the BFF/ALB entry point is
+# decided; egress lockdown. See docs/security/network-policy-call-graph.md.
 #
 # PREREQUISITE: NetworkPolicy enforcement. The AWS VPC CNI ignores these objects
 # unless enableNetworkPolicy=true (set on the vpc-cni addon in modules/eks). The
@@ -35,12 +36,31 @@ spec:
   policyTypes:
     - Ingress
 ---
+# Same-namespace allow — for the CLIENT-FACING set only. The tightened services
+# (6 mesh callees + TIER-0/workers) are EXCLUDED here and get explicit, caller-
+# scoped ingress below; everything else (and any future service) keeps the broad
+# same-ns allow as a safe default. NetworkPolicies are additive, so this MUST
+# exclude the tightened set or their narrow rules wouldn't actually restrict.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-same-namespace
 spec:
-  podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+          - account-server      # mesh callee  (auth, moderation)
+          - social-graph-server # mesh callee  (counter-worker, timeline)
+          - post-server         # mesh callee  (search)
+          - profile-server      # mesh callee  (search)
+          - moderation-server   # mesh callee  (media Screen)
+          - auth-server         # mesh callee  (realtime JWKS)
+          - audit-server        # TIER-0 — no normal-flow mesh ingress
+          - audit-worker        # worker — Kafka consumer, health only
+          - counter-worker      # worker — Kafka consumer, health only
+          - realtime-dispatcher # worker — Kafka consumer, health only
   policyTypes:
     - Ingress
   ingress:
@@ -66,3 +86,115 @@ spec:
       ports:
         - protocol: TCP
           port: 8443
+---
+# ── Per-service mesh ingress (caller-scoped) ─────────────────────────────────
+# The 6 services that receive intra-fleet gRPC. Each accepts ONLY its known
+# caller(s) on its gRPC port (the complete mesh — derived from the tonic *Client
+# types in crates/services/*; see docs/security/network-policy-call-graph.md).
+# Kubelet health probes are node->pod, permitted by the VPC CNI.
+#
+# NOTE: when a client gateway/BFF is introduced, add it as an allowed source to
+# whichever of these it fronts (account/post/profile/... are also read APIs).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-account-from-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: account-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - { key: app, operator: In, values: [auth-server, moderation-server] }
+      ports:
+        - { protocol: TCP, port: 50059 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-social-graph-from-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: social-graph-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - { key: app, operator: In, values: [counter-worker, timeline-server] }
+      ports:
+        - { protocol: TCP, port: 50053 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-post-from-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: post-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: search-server
+      ports:
+        - { protocol: TCP, port: 50056 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-profile-from-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: profile-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: search-server
+      ports:
+        - { protocol: TCP, port: 50052 }
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-moderation-from-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: moderation-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: media-server
+      ports:
+        - { protocol: TCP, port: 50061 }
+---
+# realtime-gateway fetches JWKS from auth to verify edge tokens. auth serves both
+# gRPC and JWKS on 50060 (its only port).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-auth-from-mesh
+spec:
+  podSelector:
+    matchLabels:
+      app: auth-server
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: realtime-gateway
+      ports:
+        - { protocol: TCP, port: 50060 }


### PR DESCRIPTION
Tightens the #519 namespace-isolation baseline into per-service ingress for the **fully-known** part of the call graph. Ships the call-graph mapping (`docs/security/network-policy-call-graph.md`) alongside.

## What's known (and now enforced)
The intra-fleet gRPC mesh is exactly **6 edges** — the only tonic `*Client` types in `crates/services/*`. Because NetworkPolicies are additive, the blanket same-ns allow is scoped to **exclude** the tightened set (otherwise the narrow rules wouldn't restrict anything). Then:

**6 mesh callees — accept only their caller(s) on their gRPC port:**
| Callee:port | From |
|---|---|
| account:50059 | auth, moderation |
| social-graph:50053 | counter-worker, timeline |
| post:50056 | search |
| profile:50052 | search |
| moderation:50061 | media (Screen) |
| auth:50060 | realtime (JWKS) |

**TIER-0 + workers — no mesh ingress at all:** `audit-server`, `audit-worker`, `counter-worker`, `realtime-dispatcher` are excluded from same-ns and have no allow policy → default-deny only (kubelet probes are node→pod, CNI-permitted). **This closes the audit's headline concern** — audit was reachable from any pod.

## Deliberately deferred (safe subset)
- **Client-facing services stay on same-ns** until the client entry point (BFF/ALB) is decided — there's no in-cluster BFF today, so locking them now risks future breakage. (When the BFF lands, add it as an allowed source to the services it fronts.)
- **Egress lockdown** still deferred (needs managed-store ENI CIDRs + S3 handling).

## Side-finding (separate fix)
`auth` and `timeline` both listen on **50060** — distinct ClusterIPs so it works, but almost certainly a copy-paste slip.

## Validation
Overlay builds (101 objects). A semantic parse confirms each callee is scoped to its exact callers+port and the TIER-0/worker set is locked. Full enforcement is only provable on a live cluster (CNI) — roll out per Phase 3c of the rollout runbook (allows first, watch).

## Refs
**W8 v2 (safe subset).** Builds on #519. Mapping: `docs/security/network-policy-call-graph.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)