### PR TITLE
fix(timeline): move gRPC port 50060 -> 50070 to clear collision with auth

### DIFF
--- a/crates/apps/timeline-server/src/main.rs
+++ b/crates/apps/timeline-server/src/main.rs
@@ -7,7 +7,7 @@ use timeline::service::TimelineService;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = std::env::var("TIMELINE_GRPC_ADDR")
-        .unwrap_or_else(|_| "0.0.0.0:50060".to_owned())
+        .unwrap_or_else(|_| "0.0.0.0:50070".to_owned())
         .parse()?;
 
     service_runtime::serve::<TimelineService>(addr).await

--- a/crates/services/timeline/README.fr.md
+++ b/crates/services/timeline/README.fr.md
@@ -1,8 +1,8 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 0069353afdfe2430520f4d00722c2461ffb443cb7927f5deb5c3e41bad803a0a
-  translated_at: 2026-06-25
+  source_sha256: 6737910e3ddf997c4e171bc96166cfc3324613b06eb22f1a3605a5628d51382e
+  translated_at: 2026-06-29
   status: complete
 ---
 > 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
@@ -223,7 +223,7 @@ use timeline::service::TimelineService;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = std::env::var("TIMELINE_GRPC_ADDR")
-        .unwrap_or_else(|_| "0.0.0.0:50060".to_owned())
+        .unwrap_or_else(|_| "0.0.0.0:50070".to_owned())
         .parse()?;
     service_runtime::serve::<TimelineService>(addr).await
 }
@@ -250,7 +250,7 @@ async fn main() -> anyhow::Result<()> {
 | `TIMELINE_KAFKA_GROUP_*` | `timeline-*` | Consumer group IDs (post-published/deleted, sg-followed/unfollowed). |
 
 > Les variables de connexion ScyllaDB / Redis / Kafka standard des crates de stockage partagés
-> s'appliquent. `TIMELINE_GRPC_ADDR` vaut par défaut `0.0.0.0:50060`.
+> s'appliquent. `TIMELINE_GRPC_ADDR` vaut par défaut `0.0.0.0:50070`.
 
 ---
 

--- a/crates/services/timeline/README.md
+++ b/crates/services/timeline/README.md
@@ -207,7 +207,7 @@ use timeline::service::TimelineService;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = std::env::var("TIMELINE_GRPC_ADDR")
-        .unwrap_or_else(|_| "0.0.0.0:50060".to_owned())
+        .unwrap_or_else(|_| "0.0.0.0:50070".to_owned())
         .parse()?;
     service_runtime::serve::<TimelineService>(addr).await
 }
@@ -234,7 +234,7 @@ async fn main() -> anyhow::Result<()> {
 | `TIMELINE_KAFKA_GROUP_*` | `timeline-*` | Consumer group IDs (post-published/deleted, sg-followed/unfollowed). |
 
 > Standard ScyllaDB / Redis / Kafka connection variables from the shared storage crates apply.
-> `TIMELINE_GRPC_ADDR` defaults to `0.0.0.0:50060`.
+> `TIMELINE_GRPC_ADDR` defaults to `0.0.0.0:50070`.
 
 ---
 

--- a/docs/infrastructure/README.fr.md
+++ b/docs/infrastructure/README.fr.md
@@ -1,8 +1,8 @@
 ---
 i18n:
   source: ./README.md
-  source_sha256: 05696c66bc43d3b744fe31dcced5db44ac17a40561bbe392bf169e271187f3b9
-  translated_at: 2026-06-28
+  source_sha256: 63ac1bbdccbe90b81b852611050d76d4a0ccd919f16e9ff418dc89c2e3384fe5
+  translated_at: 2026-06-29
   status: complete
 ---
 > 🇫🇷 Traduction française — la version **anglaise** [`README.md`](./README.md) fait foi.
@@ -35,9 +35,9 @@ Le niveau (« tier ») est un contrat d'exécution explicite (label de pod `tier
 |---|---|---|---|
 | **TIER-0** | **Fail-closed** | `auth` (50060), `moderation` (50061), `audit-server` (50068), `audit-worker` (50069) | Identité, confiance/sécurité, conformité infalsifiable. Exactitude prioritaire sur disponibilité — p. ex. audit refuse une écriture privilégiée non enregistrable (« break-glass »). |
 | **TIER-1** | **Fail-open** | `counter-server/worker` (50064/50065), `media` (50063), `search` (50062), `realtime-gateway` (8443/50066), `realtime-dispatcher` (50067) | Systèmes-de-Référence / -de-Connexion / -de-Livraison. Disponibilité prioritaire — dégradation gracieuse, re-dérivation depuis les SoR amont. |
-| **Cœur (implicite)** | Mixte | `account` (50059), `profile` (50052), `social-graph` (50053), `post` (50056), `comment` (50057), `engagement` (50058), `geo-discovery` (50054), `notification` (50055), `timeline` (50060*), `chat` (50051) | Les Systèmes-d'Enregistrement du graphe social et les modèles de lecture. |
+| **Cœur (implicite)** | Mixte | `account` (50059), `profile` (50052), `social-graph` (50053), `post` (50056), `comment` (50057), `engagement` (50058), `geo-discovery` (50054), `notification` (50055), `timeline` (50070), `chat` (50051) | Les Systèmes-d'Enregistrement du graphe social et les modèles de lecture. |
 
-\* Les ports internes sont des ClusterIP par service ; la réutilisation numérique (p. ex. `timeline` et `auth` en 50060) est sans effet entre Services distincts.
+Les ports internes sont des ClusterIP par service ; chaque service possède désormais un port distinct (`timeline` déplacé de 50060 → 50070 pour lever sa réutilisation du port d'`auth`).
 
 ### 1.3 Archétypes de déploiement
 
@@ -167,7 +167,7 @@ Les substituts d'endpoint (`<<…>>`) sont remplacés à partir des sorties Terr
 
 ## Annexe A — Allocation des ports
 
-`chat` 50051 · `profile` 50052 · `social-graph` 50053 · `geo-discovery` 50054 · `notification` 50055 · `post` 50056 · `comment` 50057 · `engagement` 50058 · `account` 50059 · `auth` 50060 · `timeline` 50060 · `moderation` 50061 · `search` 50062 · `media` 50063 · `counter-server` 50064 · `counter-worker` 50065 · `realtime-gateway` 50066 (gRPC) + 8443 (WSS) · `realtime-dispatcher` 50067 · `audit-server` 50068 · `audit-worker` 50069.
+`chat` 50051 · `profile` 50052 · `social-graph` 50053 · `geo-discovery` 50054 · `notification` 50055 · `post` 50056 · `comment` 50057 · `engagement` 50058 · `account` 50059 · `auth` 50060 · `timeline` 50070 · `moderation` 50061 · `search` 50062 · `media` 50063 · `counter-server` 50064 · `counter-worker` 50065 · `realtime-gateway` 50066 (gRPC) + 8443 (WSS) · `realtime-dispatcher` 50067 · `audit-server` 50068 · `audit-worker` 50069.
 
 ## Annexe B — Catalogue des topics
 

--- a/docs/infrastructure/README.md
+++ b/docs/infrastructure/README.md
@@ -23,9 +23,9 @@ Tier is an explicit runtime contract (`tier:` pod label) that dictates failure p
 |---|---|---|---|
 | **TIER-0** | **Fail-closed** | `auth` (50060), `moderation` (50061), `audit-server` (50068), `audit-worker` (50069) | Identity, trust/safety, and tamper-evident compliance. Correctness over availability — e.g. audit denies an unrecordable privileged write (break-glass). |
 | **TIER-1** | **Fail-open** | `counter-server/worker` (50064/50065), `media` (50063), `search` (50062), `realtime-gateway` (8443/50066), `realtime-dispatcher` (50067) | Systems-of-Reference / -Connection / -Delivery. Availability over completeness — degrade gracefully, re-derive from upstream SoRs. |
-| **Core (implicit)** | Mixed | `account` (50059), `profile` (50052), `social-graph` (50053), `post` (50056), `comment` (50057), `engagement` (50058), `geo-discovery` (50054), `notification` (50055), `timeline` (50060*), `chat` (50051) | The social-graph Systems-of-Record and read-models. |
+| **Core (implicit)** | Mixed | `account` (50059), `profile` (50052), `social-graph` (50053), `post` (50056), `comment` (50057), `engagement` (50058), `geo-discovery` (50054), `notification` (50055), `timeline` (50070), `chat` (50051) | The social-graph Systems-of-Record and read-models. |
 
-\* Internal ports are per-service ClusterIPs; numeric reuse (e.g. `timeline` and `auth` both at 50060) is harmless across distinct Services.
+Internal ports are per-service ClusterIPs; each service now owns a distinct port (`timeline` moved 50060 → 50070 to clear its reuse of `auth`'s port).
 
 ### 1.3 Deployment archetypes
 
@@ -155,7 +155,7 @@ Endpoint placeholders (`<<…>>`) are substituted from Terragrunt outputs at dep
 
 ## Appendix A — Port allocation
 
-`chat` 50051 · `profile` 50052 · `social-graph` 50053 · `geo-discovery` 50054 · `notification` 50055 · `post` 50056 · `comment` 50057 · `engagement` 50058 · `account` 50059 · `auth` 50060 · `timeline` 50060 · `moderation` 50061 · `search` 50062 · `media` 50063 · `counter-server` 50064 · `counter-worker` 50065 · `realtime-gateway` 50066 (gRPC) + 8443 (WSS) · `realtime-dispatcher` 50067 · `audit-server` 50068 · `audit-worker` 50069.
+`chat` 50051 · `profile` 50052 · `social-graph` 50053 · `geo-discovery` 50054 · `notification` 50055 · `post` 50056 · `comment` 50057 · `engagement` 50058 · `account` 50059 · `auth` 50060 · `timeline` 50070 · `moderation` 50061 · `search` 50062 · `media` 50063 · `counter-server` 50064 · `counter-worker` 50065 · `realtime-gateway` 50066 (gRPC) + 8443 (WSS) · `realtime-dispatcher` 50067 · `audit-server` 50068 · `audit-worker` 50069.
 
 ## Appendix B — Topic catalog
 

--- a/docs/security/network-policy-call-graph.md
+++ b/docs/security/network-policy-call-graph.md
@@ -33,7 +33,7 @@ Derived from code + config, not guesswork:
 | 50058 | engagement | client-facing |
 | 50059 | account | **mesh callee** |
 | 50060 | auth | **mesh callee** (JWKS) |
-| 50060 | timeline | client-facing (read) |
+| 50070 | timeline | client-facing (read) |
 | 50061 | moderation | **mesh callee** (Screen) |
 | 50062 | search | client-facing (read) |
 | 50063 | media | client-facing |
@@ -44,10 +44,10 @@ Derived from code + config, not guesswork:
 | 50068 | audit-server | TIER-0 (break-glass RecordPrivileged + Query) |
 | 50069 | audit-worker | worker (health only) |
 
-> ⚠️ **Side-finding — port collision:** `auth` and `timeline` both listen on **50060**.
-> They're distinct ClusterIP services (different DNS/IPs), so k8s tolerates it and
-> NetworkPolicy still works per-pod — but it's almost certainly a copy-paste slip
-> (`timeline` should have its own port). Worth fixing independently of W8.
+> ✅ **Resolved (side-finding):** `auth` and `timeline` previously both listened on
+> `50060`. Distinct ClusterIPs so it worked, but it broke the one-port-per-service
+> convention — `timeline` moved to **50070** (it has no in-fleet caller, so nothing
+> dialed it). auth keeps 50060.
 
 ---
 
@@ -196,7 +196,7 @@ Layered on top of the #519 baseline:
 1. **Client entry point** (§3) — BFF pod label, ALB ipBlock, or lock-to-probes-for-now?
 2. **Egress scope** — do we want full egress lockdown now, or ingress-only v2 first?
    (Egress needs the live data-subnet CIDRs + S3 handling; higher breakage risk.)
-3. **Port collision** — fix `auth`/`timeline` both on 50060 first (independent of W8).
+3. ~~**Port collision** — fix `auth`/`timeline` both on 50060.~~ ✅ Done — `timeline` → 50070.
 4. **CNI** — confirm `enableNetworkPolicy=true` (shipped in #519) is live before any
    of this enforces.
 

--- a/k8s/base/services/timeline/server/deployment.yaml
+++ b/k8s/base/services/timeline/server/deployment.yaml
@@ -39,9 +39,13 @@ spec:
             # The runtime is fail-closed on this file; mounted from infra-config.
             - name: INFRA_CONFIG_PATH
               value: /etc/infra/infrastructure.toml
+            # Own port (was 50060, which collided with auth — distinct ClusterIPs
+            # so it worked, but broke the one-port-per-service convention).
+            - name: TIMELINE_GRPC_ADDR
+              value: "0.0.0.0:50070"
           ports:
             - name: grpc
-              containerPort: 50060
+              containerPort: 50070
           volumeMounts:
             - name: infra-config
               mountPath: /etc/infra
@@ -51,7 +55,7 @@ spec:
           # so a pod leaves rotation when a dependency is unreachable.
           readinessProbe:
             grpc:
-              port: 50060
+              port: 50070
               service: timeline.v1.TimelineService
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -59,7 +63,7 @@ spec:
           # backend blip drops readiness without triggering a restart loop.
           livenessProbe:
             grpc:
-              port: 50060
+              port: 50070
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:

--- a/k8s/base/services/timeline/server/service.yaml
+++ b/k8s/base/services/timeline/server/service.yaml
@@ -11,7 +11,7 @@ spec:
   ports:
     - name: grpc
       protocol: TCP
-      port: 50060
+      port: 50070
       targetPort: grpc
       appProtocol: grpc
   type: ClusterIP


### PR DESCRIPTION
`timeline-server` and `auth-server` both listened on **50060**. Distinct ClusterIPs so k8s tolerated it (the docs even called the reuse "harmless"), but it broke the one-port-per-service convention and is a latent trap for tooling that assumes uniqueness.

## Which one moved, and why timeline
- **timeline → 50070.** It has **no in-fleet gRPC caller** (client-facing; it only *dials* social-graph), so nothing breaks.
- **auth stays 50060** — TIER-0, dialed by `realtime` (JWKS), and documented across the fleet (incl. the W8 netpol `allow-auth-from-mesh`).

## Changes
- `crates/apps/timeline-server`: default `TIMELINE_GRPC_ADDR` → `0.0.0.0:50070`.
- timeline base `deployment.yaml`/`service.yaml`: container/probe/service ports → 50070, plus an explicit `TIMELINE_GRPC_ADDR` env (self-documenting, matches the new-fleet pattern).
- docs: timeline README (EN+FR), infrastructure README port registry (EN+FR — dropped the obsolete "harmless reuse" footnote), and the W8 call-graph doc side-finding marked resolved. **FR translations re-stamped** so the i18n drift gate stays green.

## Validation
- Staging overlay builds (101 objects); `staging-timeline-server` service on **50070**.
- `tools/i18n/i18n-drift.sh check` passes.
- The remaining `50060` mentions are intentional historical prose ("moved 50060 → 50070"); all config/code is 50070.

## Ref
Side-finding from `docs/security/network-policy-call-graph.md` §1/§7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)