### PR TITLE
fix(msk): staging broker count 2 = multiple of its 2 AZs (C7)

### DIFF
--- a/infrastructure/live/staging/us-east-1/data/msk/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/data/msk/terragrunt.hcl
@@ -17,10 +17,14 @@ locals {
 }
 
 inputs = {
-  name                = "core-platform-${local.env_vars.locals.env}"
-  vpc_id              = dependency.vpc.outputs.vpc_id
-  subnet_ids          = dependency.vpc.outputs.private_data_subnet_ids
-  allowed_cidr_blocks = [dependency.vpc.outputs.vpc_cidr_block]
+  name       = "core-platform-${local.env_vars.locals.env}"
+  vpc_id     = dependency.vpc.outputs.vpc_id
+  subnet_ids = dependency.vpc.outputs.private_data_subnet_ids
+  # Broker count MUST be a multiple of the AZ/subnet count. Staging's VPC has 2
+  # data-subnet AZs, so 2 brokers (the module default is 3, which would fail to
+  # provision here). C7.
+  number_of_broker_nodes = 2
+  allowed_cidr_blocks    = [dependency.vpc.outputs.vpc_cidr_block]
 
   tags = {
     Environment = local.env_vars.locals.env


### PR DESCRIPTION
The MSK module defaults to `number_of_broker_nodes=3`, but staging's VPC has only **2 data-subnet AZs**, and MSK requires the broker count to be a **multiple of the AZ count** — so the apply fails (`The number of broker nodes must be a multiple of Availability Zones`).

Pin staging to **2 brokers** (1 per AZ).

**Caught live during the staging rollout**, immediately before the MSK apply (VPC + EKS already applied successfully). This is audit finding **C7** — it had not been remediated in the earlier batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)