### PR TITLE
fix(terragrunt): make ecr-public login hook non-fatal

### DIFF
--- a/infrastructure/root.hcl
+++ b/infrastructure/root.hcl
@@ -141,7 +141,10 @@ terraform {
     execute  = [
       "sh", 
       "-c", 
-      "aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws"
+      # Non-fatal: this is only a Helm pull-rate-limit convenience (and is a no-op
+      # for non-Helm units), so a flaky/rate-limited public.ecr.aws login must not
+      # abort the apply.
+      "aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws || true"
     ]
   }
 }


### PR DESCRIPTION
The `before_hook` that logs into `public.ecr.aws` (a Helm pull-rate-limit convenience) runs on **every** unit's plan/apply — even non-Helm ones — and intermittently fails (rate-limited / flaky public-ECR auth), **aborting the whole apply**. Append `|| true` so a failed login no longer blocks unrelated units.

Caught live during the staging data-layer apply, where it spuriously failed 3 already-applied units (audit-kms/media-bucket/msk) while ElastiCache + OpenSearch actually succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)