### PR TITLE
fix(ecr): correct global artifacts/ecr module source path

### DIFF
--- a/infrastructure/live/global/artifacts/ecr/terragrunt.hcl
+++ b/infrastructure/live/global/artifacts/ecr/terragrunt.hcl
@@ -5,7 +5,10 @@ include "root" {
 }
 
 terraform {
-  source = "../../../../../modules/artifacts/ecr"
+  # 4 levels up reaches infrastructure/ (this unit lives at live/global/artifacts/ecr).
+  # NB: a get_repo_root()//… source would try to copy the whole repo and trips over
+  # the broken bazel-* symlinks at the root.
+  source = "../../../../modules/artifacts/ecr"
 }
 
 inputs = {


### PR DESCRIPTION
The `live/global/artifacts/ecr` unit sourced the module at `../../../../../modules/...` (**5** levels = repo root), but it lives one level shallower than the `us-east-1` units, so it needs **4** levels to reach `infrastructure/modules/`. Never applied, so the broken path went unnoticed until the staging rollout needed the ECR repos.

Use 4 levels. (A `get_repo_root()//…` source instead tries to copy the whole repo and trips over the broken `bazel-*` symlinks at the root.) Plans clean: **46 to add**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)