### PR TITLE
feat(ci): build + push all 20 fleet services, not just the new 10

### DIFF
--- a/.github/workflows/fleet-images-deploy.yml
+++ b/.github/workflows/fleet-images-deploy.yml
@@ -1,6 +1,6 @@
 # .github/workflows/fleet-images-deploy.yml
 #
-# Build + push the new-fleet binaries (10 services) + the shared migrator to ECR,
+# Build + push every fleet binary (20 services + the shared migrator) to ECR,
 # one image per binary via the generic deploy/Dockerfile (`--build-arg BIN`). This
 # replaces the legacy per-service Bazel deploy workflows for the Rust crates/ fleet
 # (those target the old backend/ tree). Add a BIN to the matrix to ship a new one.
@@ -56,6 +56,18 @@ jobs:
           - search-server
           - realtime-gateway
           - realtime-dispatcher
+          # ── Core services (same Rust workspace; the staging overlay deploys these too) ──
+          - account-server
+          - chat-server
+          - comment-server
+          - engagement-server
+          - geo-discovery-server
+          - notification-server
+          - post-server
+          - profile-server
+          - social-graph-server
+          - timeline-server
+          # ── Shared ──
           - migrator
     steps:
       - name: Checkout code
@@ -119,7 +131,11 @@ jobs:
           for bin in \
             counter-server counter-worker audit-server audit-worker \
             auth-server media-server moderation-server search-server \
-            realtime-gateway realtime-dispatcher migrator; do
+            realtime-gateway realtime-dispatcher \
+            account-server chat-server comment-server engagement-server \
+            geo-discovery-server notification-server post-server profile-server \
+            social-graph-server timeline-server \
+            migrator; do
             NAME="core-platform-$bin" NEWTAG="$TAG" \
               yq -i '(.images[] | select(.name == strenv(NAME)).newTag) = strenv(NEWTAG)' \
               k8s/overlays/staging/kustomization.yaml


### PR DESCRIPTION
The staging overlay deploys **all 20 services**, but `fleet-images-deploy.yml` only built the **10 new-fleet binaries + migrator** — the 10 core services (chat, social-graph, profile, geo-discovery, notification, post, comment, engagement, account, timeline) were never built, so their pods would `ImagePullBackOff`.

They live in the **same `crates/` workspace** (`crates/apps/<svc>-server`) and build via the same `deploy/Dockerfile` — so add them to the build matrix **and** the C4 pin list. Matrix is now **21 bins** (20 services + migrator).

Needed to bring up the staging fleet (Phase 3 of the live rollout). Heads-up: the first run is a cold cargo-chef build per binary (per-BIN cache), so ~21 parallel jobs each compiling the dep graph once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)