### PR TITLE
fix(argocd): reference CMP plugin as envsubst-v1.0

### DIFF
--- a/infrastructure/argocd/apps/deployments/staging/fleet.yaml
+++ b/infrastructure/argocd/apps/deployments/staging/fleet.yaml
@@ -27,7 +27,9 @@ spec:
     targetRevision: develop
     path: k8s/overlays/staging
     plugin:
-      name: envsubst
+      # ArgoCD names a versioned sidecar CMP "<metadata.name>-<spec.version>", so the
+      # plugin defined as envsubst / v1.0 is referenced as "envsubst-v1.0".
+      name: envsubst-v1.0
   destination:
     server: https://kubernetes.default.svc
     namespace: default


### PR DESCRIPTION
ArgoCD names a **sidecar** Config Management Plugin `<metadata.name>-<spec.version>`. The C1 plugin is `name: envsubst` + `version: v1.0`, so its resolvable name is **`envsubst-v1.0`** — but `staging-fleet` referenced `envsubst`, so the repo-server `ComparisonError`'d:

```
Manifest generation error: couldn't find cmp-server plugin with name "envsubst" supporting the given repository
```
(the sidecar log literally says: 'specify "envsubst-v1.0" in the Application's spec.source.plugin.name field.')

Reference the versioned name. **Surfaced live** — C1 was offline-validated (sed render + `helm template`), but ArgoCD's plugin-name resolution is runtime-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)