### PR TITLE
fix(scylla-operator): self-sign webhook cert

### DIFF
--- a/infrastructure/argocd/apps/infrastructure/operators/scylla-operator/values.yaml
+++ b/infrastructure/argocd/apps/infrastructure/operators/scylla-operator/values.yaml
@@ -1,5 +1,8 @@
 # infrastructure/argocd/apps/infrastructure/operators/scylla-operator/values.yaml
 scylla-operator:
-  # cert-manager (installed via the security ArgoCD app) issues the webhook certs.
+  # Let the chart self-sign its (internal, cluster-only) webhook cert. With
+  # createSelfSignedCertificate=false the chart expects an externally-provided cert
+  # secret, but none was wired (no cert-manager Certificate for it), so the
+  # webhook-server Deployment rendered with an empty secretName and was invalid.
   webhook:
-    createSelfSignedCertificate: false
+    createSelfSignedCertificate: true


### PR DESCRIPTION
`createSelfSignedCertificate=false` made the scylla-operator chart expect an externally-provided webhook cert secret, but none was wired (no cert-manager Certificate created for it) — so `webhook-server` rendered with an empty `secretName` and failed to apply:

```
Deployment.apps "webhook-server" is invalid: [spec.template.spec.volumes[0].secret.secretName: Required value, spec.template.spec.containers[0].volumeMounts[0].name: Not found: "cert"]
```
Flip to `true` so the chart self-signs its internal (cluster-only) webhook cert. Unblocks the operator-managed ScyllaCluster (Scylla backs post/social-graph/comment/geo/chat + counter timeseries). **Surfaced during the staging rollout.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)