### PR TITLE
fix(eks): allow control plane to reach pod webhooks on any port

### DIFF
--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -57,5 +57,16 @@ module "eks" {
       # controller has created it.
       cidr_blocks = [var.vpc_cidr]
     }
+    # Let the (trusted) EKS control plane reach admission/conversion webhooks on
+    # ANY pod port. The module's defaults only cover 443/10250, so webhooks on
+    # other ports (e.g. scylla-operator on 5000) time out from the apiserver.
+    ingress_cluster_to_node_webhooks = {
+      description                   = "EKS control plane to node/pod webhooks (any port)"
+      protocol                      = "tcp"
+      from_port                     = 1025
+      to_port                       = 65535
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
   }
 }


### PR DESCRIPTION
The scylla-operator validating webhook (pod port **5000**) timed out from the apiserver (`context deadline exceeded`) — the EKS module's default node SG rules only admit the control plane on 443/10250, so webhooks on other ports are unreachable and **any ScyllaCluster create fails**.

Add a node SG ingress rule allowing the (trusted) cluster security group → nodes on `1025-65535`. **Surfaced applying the ScyllaCluster during the staging rollout** (webhook-server 2/2 Ready with registered endpoints, but unreachable from the control plane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)