### PR TITLE
fix(docker): provide protobuf well-known types to protoc in the build image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -50,11 +50,17 @@ RUN cargo chef prepare --recipe-path recipe.json
 # ── Builder ───────────────────────────────────────────────────────────────────
 FROM chef AS builder
 
-# protoc: the `*-api` crates' build.rs run tonic-prost-build.
-# cmake + zlib: rdkafka builds librdkafka (bundled) from source.
+# protoc: the `*-api` crates' build.rs run tonic-prost-build. libprotobuf-dev ships
+# the well-known types (/usr/include/google/protobuf/*.proto) that several .proto
+# files import (e.g. google/protobuf/timestamp.proto) — without it protoc fails
+# "File not found". cmake + zlib: rdkafka builds librdkafka (bundled) from source.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    protobuf-compiler cmake zlib1g-dev \
+    protobuf-compiler libprotobuf-dev cmake zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Tell prost-build where the well-known types live so it adds them to protoc's
+# include path (the *-api build.rs only pass their own ../proto/ as an include).
+ENV PROTOC_INCLUDE=/usr/include
 
 # 1+2: cook the third-party graph. Baked into THIS layer (no target cache mount),
 # so it is reused via Docker/BuildKit layer cache until recipe.json changes. The


### PR DESCRIPTION
**14 of 21 fleet images failed to build:** the `*-api` crates' `build.rs` import `google/protobuf/timestamp.proto` (and other well-known types), but the builder stage installed only `protobuf-compiler` — **not `libprotobuf-dev`**, which ships the well-known `.proto` files at `/usr/include/google/protobuf/` — and prost-build wasn't told where they are (the build.rs only pass their own `../proto/` include). So protoc failed `google/protobuf/timestamp.proto: File not found` for every contract importing a well-known type.

Fix: install `libprotobuf-dev` + set `PROTOC_INCLUDE=/usr/include`. The 7 images that built don't import well-known types; this unblocks the other 14.

**Surfaced live** — the earlier workflow runs always failed earlier (missing buildcache repo), so this protoc gap was never reached until now. Merging triggers a rebuild (Dockerfile is in the trigger paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)