### PR TITLE
fix(s3): add force_destroy to the bucket module; enable for ephemeral staging buckets

### DIFF
--- a/infrastructure/live/staging/us-east-1/data/cnpg-backups/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/data/cnpg-backups/terragrunt.hcl
@@ -24,6 +24,9 @@ inputs = {
   # Object-store WAL/base backups; no Object-Lock (retention is managed by CNPG's
   # barman retentionPolicy, which must be able to prune).
   cors_enabled = false
+  # Backups are re-derivable; let destroy empty + delete the bucket (CNPG starts
+  # WAL-archiving immediately, so it is never empty at teardown).
+  force_destroy = true
 
   tags = {
     Environment = local.env_vars.locals.env

--- a/infrastructure/live/staging/us-east-1/data/media-bucket/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/data/media-bucket/terragrunt.hcl
@@ -22,6 +22,9 @@ inputs = {
   cors_enabled       = true
   # Tighten to the real web origins before prod; '*' is acceptable for staging.
   cors_allowed_origins = ["*"]
+  # Staging media is ephemeral test data — let destroy clean the bucket. (Prod
+  # would keep this false.)
+  force_destroy = true
 
   tags = {
     Environment = local.env_vars.locals.env

--- a/infrastructure/modules/s3-bucket/main.tf
+++ b/infrastructure/modules/s3-bucket/main.tf
@@ -18,6 +18,10 @@ resource "aws_s3_bucket" "this" {
   # Object Lock can ONLY be enabled at creation time and forces versioning on.
   object_lock_enabled = var.object_lock_mode != ""
 
+  # Let destroy empty an ephemeral bucket first. Off by default; never enabled
+  # for the WORM audit bucket (Object-Lock COMPLIANCE blocks deletion regardless).
+  force_destroy = var.force_destroy
+
   tags = var.tags
 }
 

--- a/infrastructure/modules/s3-bucket/variables.tf
+++ b/infrastructure/modules/s3-bucket/variables.tf
@@ -45,6 +45,12 @@ variable "cors_allowed_origins" {
   default     = ["*"]
 }
 
+variable "force_destroy" {
+  type        = bool
+  description = "Allow `terraform destroy` to delete a non-empty bucket (deletes all objects + versions first). Safe default off; enable only for ephemeral/re-derivable buckets (NOT WORM/compliance)."
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags applied to the bucket."


### PR DESCRIPTION
`terragrunt destroy` of the staging stack failed on the **cnpg-backups** bucket (`BucketNotEmpty`) — CNPG starts WAL-archiving the moment a cluster boots, so the versioned bucket had 18 objects and terraform had no way to empty it (the `s3-bucket` module had no `force_destroy`). Required a manual `delete-objects` + `delete-bucket` to finish the teardown.

- Add a `force_destroy` variable to `modules/s3-bucket` (**default `false`** — safe).
- Enable it on the two **ephemeral / re-derivable** staging buckets: **cnpg-backups** and **media** (test data).
- The **WORM audit bucket stays `false`** (Object-Lock COMPLIANCE blocks deletion regardless — by design).

Surfaced during the staging teardown — this is the **13th** issue the rollout/teardown caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)