### PR TITLE
chore(infra): safe-teardown hooks + disposable staging audit-worm

### DIFF
--- a/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
+++ b/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# infrastructure/assets/teardown/k8s-graceful-cleanup.sh
+#
+# `before_hook` (destroy) for the kubernetes/argocd Terragrunt unit. Drains the
+# AWS resources that in-cluster controllers provision — and that Terraform does
+# NOT own — BEFORE Terraform deletes the cluster and VPC. Without this:
+#   * ALBs (Ingress) / NLBs (Service type=LoadBalancer) leak, and their leftover
+#     ENIs block `aws_vpc` destroy with DependencyViolation;
+#   * EBS volumes behind CNPG/Scylla PVCs leak (reclaimPolicy=Delete only fires
+#     on orderly PVC deletion, which a blind destroy skips);
+#   * Karpenter EC2 nodes leak (not in the managed node group Terraform deletes).
+#
+# Usage: k8s-graceful-cleanup.sh <cluster_name> <aws_region>
+# Every step is best-effort (|| true): a partially-broken cluster must never block
+# the destroy. Idempotent — safe to re-run.
+
+set -uo pipefail
+
+CLUSTER_NAME="${1:?cluster name required}"
+AWS_REGION="${2:?aws region required}"
+
+echo "--- Graceful Cleanup Start (${CLUSTER_NAME}) ---"
+
+# Point kubectl at the target cluster (idempotent). If the cluster/API is already
+# gone, every kubectl below no-ops via || true and we fall through to Terraform.
+aws eks update-kubeconfig --name "${CLUSTER_NAME}" --region "${AWS_REGION}" >/dev/null 2>&1 \
+  || echo "update-kubeconfig failed (cluster may already be gone); continuing..."
+
+# 1. Stop ArgoCD reconciliation so it cannot recreate what we delete below.
+echo "Disabling ArgoCD self-heal..."
+kubectl patch app root-bootstrap -n argocd --type merge \
+  -p '{"spec":{"syncPolicy":null}}' || true
+kubectl delete appsets --all -A --timeout=60s || true
+
+# 2. Load balancers FIRST — frees the ALB (Ingress) and NLB (Service) ENIs that
+#    otherwise block VPC destroy. Wait for the AWS LB controller to deprovision.
+echo "Deleting Ingresses (ALBs)..."
+kubectl delete ingress --all -A --timeout=180s \
+  || echo "Ingress deletion timed out; continuing..."
+
+echo "Deleting type=LoadBalancer Services (NLBs)..."
+# `spec.type` is not a supported field selector for Services, so enumerate.
+kubectl get svc -A \
+  -o go-template='{{range .items}}{{if eq .spec.type "LoadBalancer"}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}{{end}}' \
+  2>/dev/null | while read -r ns name; do
+  [ -n "${name:-}" ] && kubectl delete svc -n "$ns" "$name" --timeout=180s || true
+done
+
+# 3. Stateful workloads: delete the CRs (removes pods that hold the volumes), then
+#    PVCs, so ebs-csi issues DeleteVolume for the backing EBS volumes.
+echo "Deleting CNPG / ScyllaDB clusters..."
+kubectl delete clusters.postgresql.cnpg.io --all -A --timeout=180s || true
+kubectl delete scyllaclusters.scylla.scylladb.com --all -A --timeout=300s || true
+
+echo "Deleting PVCs (EBS volumes)..."
+kubectl delete pvc --all -A --timeout=180s \
+  || echo "PVC deletion timed out; continuing..."
+
+# 4. Stop the remaining ArgoCD apps EXCEPT Karpenter (kept alive for step 5) so
+#    nothing re-syncs. ArgoCD tracks by label (not ownerRefs), so this halts drift;
+#    the real cloud cleanup is steps 2-3 and 5.
+echo "Deleting ArgoCD apps (excluding bootstrap + karpenter)..."
+kubectl delete app -n argocd \
+  -l "argocd.argoproj.io/instance!=root-bootstrap,app.kubernetes.io/name!=karpenter" \
+  --cascade=foreground --timeout=180s || true
+
+# 5. Drain Karpenter nodes WHILE Karpenter still runs, so it terminates the EC2
+#    instances (and their ENIs/EBS) via the EC2 API.
+echo "Draining Karpenter nodes (EC2)..."
+kubectl delete nodeclaims --all --timeout=300s || true
+kubectl delete nodes -l karpenter.sh/nodepool --timeout=180s || true
+
+echo "--- Cleanup finished, proceeding to Terraform Destroy ---"

--- a/infrastructure/live/dev/us-east-1/kubernetes/argocd/terragrunt.hcl
+++ b/infrastructure/live/dev/us-east-1/kubernetes/argocd/terragrunt.hcl
@@ -6,7 +6,7 @@ include "root" {
 
 locals {
   region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
-  aws_region = local.region_vars.locals.aws_region
+  aws_region  = local.region_vars.locals.aws_region
 }
 
 dependency "vpc" {
@@ -18,41 +18,23 @@ dependency "eks" {
 }
 
 dependency "security" {
-  config_path = "../../security/irsa-roles" 
+  config_path = "../../security/irsa-roles"
 }
 
 terraform {
   source = "../../../../../modules//kubernetes/argocd"
 
+  # Drain operator-managed AWS resources (ALBs/NLBs, CNPG/Scylla EBS, Karpenter
+  # EC2) from inside the live cluster BEFORE Terraform deletes the cluster/VPC —
+  # otherwise they leak and leftover LB ENIs block VPC destroy. Shared script so
+  # dev and staging stay in lockstep. See the script header for the rationale.
   before_hook "graceful_cleanup" {
-    commands     = ["destroy"]
-    execute      = ["/bin/bash", "-c", <<-EOT
-      echo "--- Graceful Cleanup Start ---"
-      
-      # 1. Bloquer la réconciliation pour éviter les "zombies"
-      kubectl patch app root-bootstrap -n argocd --type merge -p '{"spec":{"syncPolicy":null}}' || true
-      
-      # 2. Supprimer les Ingress EN PREMIER (Crucial pour libérer les ALB)
-      # On attend que l'AWS Load Balancer Controller fasse son job
-      echo "Deleting all Ingresses..."
-      kubectl delete ingress --all -A --timeout=120s || echo "Ingress deletion timed out, continuing..."
-      
-      # 3. Supprimer les ApplicationSets
-      kubectl delete appsets --all -A || true
-      
-      # 4. Supprimer les Apps enfants avec cascade FOREGROUND
-      # On exclut le bootstrap et KARPENTER. Pourquoi ? 
-      # On a besoin que Karpenter soit vivant pour terminer la suppression des noeuds.
-      echo "Deleting Apps (excluding core controllers)..."
-      kubectl delete app -n argocd -l "argocd.argoproj.io/instance!=root-bootstrap,app.kubernetes.io/name!=karpenter" --cascade=foreground --timeout=180s || true
-      
-      # 5. Enfin, supprimer les nodes Karpenter proprement
-      # Cela force Karpenter à appeler l'API EC2 pour terminer les instances
-      echo "Draining Karpenter nodes..."
-      kubectl delete nodes -l karpenter.sh/nodepool --timeout=120s || true
-      
-      echo "--- Cleanup finished, proceeding to Terraform Destroy ---"
-    EOT
+    commands = ["destroy"]
+    execute = [
+      "/bin/bash",
+      "${get_repo_root()}/infrastructure/assets/teardown/k8s-graceful-cleanup.sh",
+      dependency.eks.outputs.cluster_name,
+      local.aws_region,
     ]
   }
 }
@@ -73,7 +55,7 @@ inputs = {
 
   # --- Sécurité & Certificats ---
   ssl_certificate_arn = dependency.security.outputs.certificate_arn
-  
+
   addons_iam_roles = {
     karpenter     = dependency.security.outputs.karpenter_role_arn
     lb_controller = dependency.security.outputs.lb_controller_role_arn

--- a/infrastructure/live/staging/us-east-1/data/audit-worm/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/data/audit-worm/terragrunt.hcl
@@ -1,9 +1,19 @@
 # infrastructure/live/staging/us-east-1/data/audit-worm/terragrunt.hcl
 #
-# Audit WORM anchor bucket: Object-Lock COMPLIANCE (true write-once — not even
-# root can delete/overwrite before retention), SSE-KMS under the audit KEK. This
-# is the external-witness sink for the signed Merkle checkpoints. audit-server is
-# the only principal granted write (no delete) — see Block 4 IRSA.
+# Audit WORM anchor bucket: Object-Lock + SSE-KMS under the audit KEK. This is the
+# external-witness sink for the signed Merkle checkpoints. audit-server is the
+# only principal granted write (no delete) — see Block 4 IRSA.
+#
+# STAGING POSTURE: GOVERNANCE (not COMPLIANCE) + force_destroy. Staging is an
+# ephemeral, frequently-rebuilt environment; COMPLIANCE makes the bucket literally
+# undeletable for the full retention (7y) even by root, which hard-stalls
+# `terragrunt run --all destroy`. GOVERNANCE preserves WORM semantics for the
+# audit service at runtime (audit's IRSA role has NO bypass permission, so it
+# still cannot delete/overwrite checkpoints) while letting the teardown principal
+# empty + delete the bucket via force_destroy — the AWS provider sets
+# BypassGovernanceRetention on the delete calls, which requires the destroying
+# principal to hold s3:BypassGovernanceRetention. PROD must flip this back to
+# COMPLIANCE + force_destroy=false (true tamper-evidence; never disposable).
 
 include "root" {
   path = find_in_parent_folders("root.hcl")
@@ -32,9 +42,15 @@ inputs = {
   name = "core-platform-${local.env_vars.locals.env}-audit-worm-${local.account_id}"
 
   # WORM: versioning is forced on by the module when object_lock_mode is set.
-  object_lock_mode           = "COMPLIANCE"
+  # GOVERNANCE so staging stays disposable (see header); PROD => COMPLIANCE.
+  object_lock_mode           = "GOVERNANCE"
   object_lock_retention_days = 2555 # ~7 years
   kms_key_arn                = dependency.audit_kms.outputs.key_arn
+
+  # Let teardown empty + delete the bucket. With GOVERNANCE this works because the
+  # provider passes BypassGovernanceRetention on object deletes (the destroying
+  # principal needs s3:BypassGovernanceRetention). PROD => false.
+  force_destroy = true
 
   tags = {
     Environment = local.env_vars.locals.env

--- a/infrastructure/live/staging/us-east-1/kubernetes/argocd/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/kubernetes/argocd/terragrunt.hcl
@@ -49,6 +49,21 @@ dependency "opensearch" {
 
 terraform {
   source = "../../../../../modules//kubernetes/argocd"
+
+  # Drain operator-managed AWS resources (ALBs/NLBs, CNPG/Scylla EBS, Karpenter
+  # EC2) from inside the live cluster BEFORE Terraform deletes the cluster/VPC —
+  # otherwise they leak and leftover LB ENIs block VPC destroy. Staging is the
+  # one that actually carries the public NLB + 6 CNPG clusters + Scylla, so this
+  # is load-bearing here. Shared script keeps dev and staging in lockstep.
+  before_hook "graceful_cleanup" {
+    commands = ["destroy"]
+    execute = [
+      "/bin/bash",
+      "${get_repo_root()}/infrastructure/assets/teardown/k8s-graceful-cleanup.sh",
+      dependency.eks.outputs.cluster_name,
+      local.aws_region,
+    ]
+  }
 }
 
 inputs = {


### PR DESCRIPTION
Makes `terragrunt run --all destroy` **leak-free and stall-free** for both `dev` and `staging`. Addresses the two highest-impact gaps from the teardown audit.

## #1 — Graceful-cleanup `before_hook` on the argocd unit (both envs)

The cloud resources that leak on a blind destroy are all **created by in-cluster controllers, not Terraform** — so Terraform deleting the cluster/VPC never calls `Delete*` for them. Previously only **dev** had a cleanup hook; **staging had none**, despite being the env that actually carries the public NLB, 6 CNPG Postgres clusters, ScyllaDB, and Karpenter nodes.

- Extracted the dev inline hook into a shared script — `infrastructure/assets/teardown/k8s-graceful-cleanup.sh` — and wired **both** dev and staging to it (single source of truth, no drift).
- **Extended coverage** beyond the old dev hook, which only handled Ingress ALBs + Karpenter nodes. It now also:
  - deletes `Service type=LoadBalancer` → the realtime **NLB** (was leaking + blocking VPC destroy with `DependencyViolation`);
  - deletes CNPG `Cluster` + `ScyllaCluster` CRs, then all PVCs → ebs-csi issues `DeleteVolume` for the backing **EBS** volumes;
  - deletes Karpenter `NodeClaims` (+ nodes) while Karpenter is still alive → **EC2** terminated via the API.
- Runs `aws eks update-kubeconfig <cluster> <region>` first, so it works during an automated run regardless of the caller's current kube context (the old hook silently assumed the right context).
- Every step is best-effort (`|| true`) and idempotent; a partially-broken cluster can't block the destroy.

Order: stop ArgoCD self-heal → LBs → stateful/PVCs → other apps (keep Karpenter) → drain Karpenter nodes → Terraform.

## #2 — Staging `audit-worm`: GOVERNANCE + `force_destroy` (was COMPLIANCE)

COMPLIANCE Object-Lock makes the bucket **undeletable for the full 7-year retention even by root** — and `force_destroy` cannot override it — so any written checkpoint **hard-stalls** the staging `data` tier destroy forever.

- Staging (ephemeral) now uses **GOVERNANCE + `force_destroy = true`**: WORM is still enforced at runtime (audit's IRSA role has no bypass permission, so it still cannot delete/overwrite checkpoints), but the teardown principal can empty+delete the bucket. The AWS provider sets `BypassGovernanceRetention` on the object deletes.
- **PROD must keep COMPLIANCE + `force_destroy = false`** — documented inline in the unit header.

### Operator note
The teardown principal needs `s3:BypassGovernanceRetention` on the audit-worm bucket for the GOVERNANCE force_destroy to succeed. The current admin CLI user has it; CI teardown roles need it added.

## Not in this PR
Recommendation #3 (add `resources-finalizer.argocd.argoproj.io` for native ArgoCD cascade delete) — left out deliberately; the imperative hook is sufficient and avoids finalizer-hang risk.

## Validation
- `terragrunt hcl fmt --check` clean on all edited units; `bash -n` clean on the script.
- Not applied (no live teardown run) — logic-reviewed against the audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)