### PR TITLE
feat(infra): seed app secrets (media/audit/auth) via data/app-secrets

### DIFF
--- a/infrastructure/live/staging/us-east-1/data/app-secrets/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/data/app-secrets/terragrunt.hcl
@@ -1,0 +1,53 @@
+# infrastructure/live/staging/us-east-1/data/app-secrets/terragrunt.hcl
+#
+# Seeds the 3 app secrets the workload ExternalSecrets need but no other unit
+# created (media-s3 / audit-crypto / auth-secrets) — closing the "create
+# out-of-band" gap that left media/audit/auth pods in CreateContainerConfigError.
+# STAGING v1: static IAM keys + generated KEK/signing/ES256 in TF state. Prod uses
+# real KMS/HSM custody (deferred — see audit blueprint). secret_recovery_window=0
+# keeps staging disposable (same posture as the data-store secrets).
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../../../modules/app-secrets"
+}
+
+dependency "media_bucket" {
+  config_path                             = "../media-bucket"
+  mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-media" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "audit_worm" {
+  config_path                             = "../audit-worm"
+  mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-audit-worm" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+dependency "audit_kms" {
+  config_path                             = "../audit-kms"
+  mock_outputs                            = { key_arn = "arn:aws:kms:us-east-1:000000000000:key/mock" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+locals {
+  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+}
+
+inputs = {
+  name                  = "core-platform-${local.env_vars.locals.env}"
+  media_bucket_arn      = dependency.media_bucket.outputs.bucket_arn
+  audit_worm_bucket_arn = dependency.audit_worm.outputs.bucket_arn
+  audit_kms_key_arn     = dependency.audit_kms.outputs.key_arn
+
+  # Disposable staging: free the secret names immediately on destroy.
+  secret_recovery_window_days = 0
+
+  tags = {
+    Environment = local.env_vars.locals.env
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/infrastructure/live/staging/us-east-1/kubernetes/argocd/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/kubernetes/argocd/terragrunt.hcl
@@ -47,6 +47,14 @@ dependency "opensearch" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
 }
 
+# Ordering-only: the workload ExternalSecrets (synced by ArgoCD) pull the app
+# secrets this unit seeds, so it must apply before ArgoCD brings up the fleet.
+# No outputs consumed here.
+dependency "app_secrets" {
+  config_path  = "../../data/app-secrets"
+  skip_outputs = true
+}
+
 terraform {
   source = "../../../../../modules//kubernetes/argocd"
 }

--- a/infrastructure/modules/app-secrets/main.tf
+++ b/infrastructure/modules/app-secrets/main.tf
@@ -1,0 +1,171 @@
+# infrastructure/modules/app-secrets/main.tf
+#
+# Seeds the application secrets that the workload overlay's ExternalSecrets pull
+# from AWS Secrets Manager but that NO other Terraform unit creates (previously
+# "create out-of-band" — the gap that left media/audit/auth pods in
+# CreateContainerConfigError). Generates everything so a from-scratch env needs
+# zero manual steps:
+#   * <name>-media-s3     {access_key, secret_key}                 (rusty-s3 static keys)
+#   * <name>-audit-crypto {object/witness S3 keys, kek_base64, signing_key_base64}
+#   * <name>-auth-secrets {ES256 signing PEM pair, keycloak_client_secret}
+#
+# STAGING v1 PATH: static IAM keys (rusty-s3 cannot use IRSA web-identity) and the
+# env-KEK / signing key are GENERATED HERE and live in Terraform state. Prod's
+# tamper-evidence story (real KMS/HSM custody, cross-account WORM witness) is the
+# documented external deferral — see the audit blueprint; do NOT use this path for
+# prod. The ESO read policy already covers <name>-* (modules/security/irsa-roles).
+#
+# NB: the tls (auth_signing) and random (KEK/signing/keycloak) providers are
+# resolved implicitly by Terraform from the resource prefixes. They are NOT
+# declared in a required_providers block here on purpose: Terragrunt generates the
+# module's only versions.tf (aws + time, overwrite_terragrunt) and a module may
+# have just one required_providers block.
+
+# ── media: static S3 keys ─────────────────────────────────────────────────────
+resource "aws_iam_user" "media" {
+  name = "${var.name}-media-s3"
+  tags = var.tags
+}
+
+resource "aws_iam_user_policy" "media" {
+  name = "media-s3-rw"
+  user = aws_iam_user.media.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ListBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.media_bucket_arn]
+      },
+      {
+        Sid      = "ObjectRW"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
+        Resource = ["${var.media_bucket_arn}/*"]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "media" {
+  user = aws_iam_user.media.name
+}
+
+resource "aws_secretsmanager_secret" "media_s3" {
+  name                    = "${var.name}-media-s3"
+  recovery_window_in_days = var.secret_recovery_window_days
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "media_s3" {
+  secret_id = aws_secretsmanager_secret.media_s3.id
+  secret_string = jsonencode({
+    access_key = aws_iam_access_key.media.id
+    secret_key = aws_iam_access_key.media.secret
+  })
+}
+
+# ── audit: static S3 keys (object store + witness) + crypto custody (v1) ───────
+# Two independent users so object-store and witness credentials rotate separately.
+# Both scoped to the WORM bucket, append-only (Object-Lock blocks deletes anyway),
+# plus KMS to write/read the SSE-KMS objects under the audit KEK.
+resource "aws_iam_user" "audit_object" {
+  name = "${var.name}-audit-object"
+  tags = var.tags
+}
+
+resource "aws_iam_user" "audit_witness" {
+  name = "${var.name}-audit-witness"
+  tags = var.tags
+}
+
+resource "aws_iam_user_policy" "audit_object" {
+  name   = "audit-worm-append"
+  user   = aws_iam_user.audit_object.name
+  policy = local.audit_worm_policy
+}
+
+resource "aws_iam_user_policy" "audit_witness" {
+  name   = "audit-worm-append"
+  user   = aws_iam_user.audit_witness.name
+  policy = local.audit_worm_policy
+}
+
+locals {
+  # Append-only write + read to the WORM bucket; GenerateDataKey/Decrypt on the
+  # audit KEK for SSE-KMS. No s3:DeleteObject (the ledger never deletes).
+  audit_worm_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      { Sid = "ListBucket", Effect = "Allow", Action = ["s3:ListBucket"], Resource = [var.audit_worm_bucket_arn] },
+      { Sid = "ObjectAppend", Effect = "Allow", Action = ["s3:GetObject", "s3:PutObject"], Resource = ["${var.audit_worm_bucket_arn}/*"] },
+      { Sid = "KmsForSse", Effect = "Allow", Action = ["kms:GenerateDataKey", "kms:Decrypt"], Resource = [var.audit_kms_key_arn] },
+    ]
+  })
+}
+
+resource "aws_iam_access_key" "audit_object" {
+  user = aws_iam_user.audit_object.name
+}
+
+resource "aws_iam_access_key" "audit_witness" {
+  user = aws_iam_user.audit_witness.name
+}
+
+# App-level env KEK (wraps per-subject DEKs for crypto-shred) + checkpoint signing
+# key. 32 random bytes each, base64. v1 only — prod custody = real KMS/HSM.
+resource "random_bytes" "audit_kek" {
+  length = 32
+}
+
+resource "random_bytes" "audit_signing_key" {
+  length = 32
+}
+
+resource "aws_secretsmanager_secret" "audit_crypto" {
+  name                    = "${var.name}-audit-crypto"
+  recovery_window_in_days = var.secret_recovery_window_days
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "audit_crypto" {
+  secret_id = aws_secretsmanager_secret.audit_crypto.id
+  secret_string = jsonencode({
+    object_access_key  = aws_iam_access_key.audit_object.id
+    object_secret_key  = aws_iam_access_key.audit_object.secret
+    witness_access_key = aws_iam_access_key.audit_witness.id
+    witness_secret_key = aws_iam_access_key.audit_witness.secret
+    kek_base64         = random_bytes.audit_kek.base64
+    signing_key_base64 = random_bytes.audit_signing_key.base64
+  })
+}
+
+# ── auth: ES256 signing keypair + Keycloak client secret (placeholder) ────────
+# Keycloak is not yet provisioned (auth prerequisite), so the client secret is a
+# generated placeholder until it lands.
+resource "tls_private_key" "auth_signing" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+resource "random_password" "keycloak_client_secret" {
+  length  = 40
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "auth_secrets" {
+  name                    = "${var.name}-auth-secrets"
+  recovery_window_in_days = var.secret_recovery_window_days
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "auth_secrets" {
+  secret_id = aws_secretsmanager_secret.auth_secrets.id
+  secret_string = jsonencode({
+    signing_private_pem    = tls_private_key.auth_signing.private_key_pem
+    signing_public_pem     = tls_private_key.auth_signing.public_key_pem
+    keycloak_client_secret = random_password.keycloak_client_secret.result
+  })
+}

--- a/infrastructure/modules/app-secrets/outputs.tf
+++ b/infrastructure/modules/app-secrets/outputs.tf
@@ -1,0 +1,16 @@
+# infrastructure/modules/app-secrets/outputs.tf
+
+output "media_s3_secret_arn" {
+  description = "ARN of the media static-key secret."
+  value       = aws_secretsmanager_secret.media_s3.arn
+}
+
+output "audit_crypto_secret_arn" {
+  description = "ARN of the audit crypto/custody secret."
+  value       = aws_secretsmanager_secret.audit_crypto.arn
+}
+
+output "auth_secrets_secret_arn" {
+  description = "ARN of the auth signing/Keycloak secret."
+  value       = aws_secretsmanager_secret.auth_secrets.arn
+}

--- a/infrastructure/modules/app-secrets/variables.tf
+++ b/infrastructure/modules/app-secrets/variables.tf
@@ -1,0 +1,37 @@
+# infrastructure/modules/app-secrets/variables.tf
+
+variable "name" {
+  type        = string
+  description = "Env-scoped prefix, e.g. core-platform-staging. Secret names are <name>-{media-s3,audit-crypto,auth-secrets}; the ExternalSecrets in k8s/overlays/<env> reference these literal names."
+}
+
+variable "media_bucket_arn" {
+  type        = string
+  description = "ARN of the media object-store bucket. The media static-key IAM user is scoped to read/write here (rusty-s3 SigV4 needs static keys, not IRSA)."
+}
+
+variable "audit_worm_bucket_arn" {
+  type        = string
+  description = "ARN of the audit WORM bucket. The audit object-store + witness static-key IAM users are scoped to write here (append-only; Object-Lock blocks deletes regardless)."
+}
+
+variable "audit_kms_key_arn" {
+  type        = string
+  description = "ARN of the audit KEK (KMS). The audit static-key users need GenerateDataKey/Decrypt to write/read the SSE-KMS WORM objects. NOTE: distinct from the app-level env KEK (kek_base64) this module generates for crypto-shred."
+}
+
+variable "secret_recovery_window_days" {
+  type        = number
+  description = "Secrets Manager recovery window (days). 0 = delete immediately on destroy (disposable/staging); 7-30 = recoverable (prod)."
+  default     = 30
+  validation {
+    condition     = var.secret_recovery_window_days == 0 || (var.secret_recovery_window_days >= 7 && var.secret_recovery_window_days <= 30)
+    error_message = "secret_recovery_window_days must be 0 or between 7 and 30."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to created resources."
+  default     = {}
+}

--- a/k8s/overlays/staging/external-secrets.yaml
+++ b/k8s/overlays/staging/external-secrets.yaml
@@ -61,8 +61,9 @@ spec:
       remoteRef: { key: "core-platform-staging-opensearch-master", property: password }
 ---
 # media S3 static keys (rusty-s3 SigV4). These are an IAM user's access key —
-# the media code does NOT use the IRSA role on its SA (see Block 5 notes). Create
-# the SM secret core-platform-staging-media-s3 {access_key, secret_key} out-of-band.
+# the media code does NOT use the IRSA role on its SA (see Block 5 notes). The SM
+# secret core-platform-staging-media-s3 {access_key, secret_key} is provisioned by
+# the data/app-secrets Terraform unit (was previously create-out-of-band).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -80,10 +81,11 @@ spec:
     - secretKey: MEDIA_S3_SECRET_KEY
       remoteRef: { key: "core-platform-staging-media-s3", property: secret_key }
 ---
-# audit crypto/custody material. Static S3 keys (object-store + witness), KMS keys,
-# the v1 ENV-KEK and the checkpoint signing key. Real AWS KMS + cross-account WORM
-# witness are the documented external deferral; this wires the v1 path. Create the
-# SM secret core-platform-staging-audit-crypto with the properties below.
+# audit crypto/custody material. Static S3 keys (object-store + witness), the v1
+# ENV-KEK and the checkpoint signing key. Real AWS KMS/HSM custody + cross-account
+# WORM witness are the documented external deferral; this wires the v1 path. The SM
+# secret core-platform-staging-audit-crypto is provisioned by the data/app-secrets
+# Terraform unit (was previously create-out-of-band).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -109,9 +111,10 @@ spec:
     - secretKey: AUDIT_CHECKPOINT_SIGNING_KEY_BASE64
       remoteRef: { key: "core-platform-staging-audit-crypto", property: signing_key_base64 }
 ---
-# auth ES256 signing keys + Keycloak client secret. Create the SM secret
-# core-platform-staging-auth-secrets out-of-band. Keycloak itself is NOT yet
-# provisioned (auth-prerequisite); the client secret here is a placeholder until it is.
+# auth ES256 signing keys + Keycloak client secret. The SM secret
+# core-platform-staging-auth-secrets is provisioned by the data/app-secrets
+# Terraform unit (was previously create-out-of-band). Keycloak itself is NOT yet
+# provisioned (auth-prerequisite); the client secret is a generated placeholder.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:


### PR DESCRIPTION
Closes the **SecretStore seeding gap** found during the full staging E2E test. The `SecretStore` itself was fine — the problem was that **3 of the 6 workload ExternalSecrets pointed at AWS Secrets Manager secrets that no Terraform unit created** (they were commented "create out-of-band"). Result: `media`/`audit`/`auth` pods stuck in `CreateContainerConfigError`, blocking fleet convergence.

## What this adds
A `modules/app-secrets` module + `live/staging/.../data/app-secrets` unit that generate all three, so a from-scratch env needs **zero manual steps**:

| Secret | Contents | How generated |
|---|---|---|
| `…-media-s3` | `access_key`, `secret_key` | IAM user + access key, scoped to the media bucket (rusty-s3 needs static keys — can't use IRSA web-identity) |
| `…-audit-crypto` | object/witness S3 keys, `kek_base64`, `signing_key_base64` | 2 IAM users (append-only on the WORM bucket + KMS GenerateDataKey/Decrypt for SSE-KMS) + `random_bytes` env-KEK & signing key |
| `…-auth-secrets` | ES256 `signing_private/public_pem`, `keycloak_client_secret` | `tls_private_key` (ECDSA P-256) + placeholder (Keycloak not yet provisioned) |

- Property names match the ExternalSecrets exactly; the **ESO read policy already covers `…-*`**, so no IAM read change.
- Staging sets `secret_recovery_window_days = 0` (disposable).
- The `argocd` unit gains an **ordering-only dependency** (`skip_outputs`) on `app-secrets`, so the secrets exist before ESO syncs the fleet.
- `external-secrets.yaml` comments updated to drop the stale "create out-of-band" notes.

## Security posture (important)
**STAGING v1 path:** static IAM keys + the env-KEK/signing/ES256 material are generated here and live in **Terraform state** (encrypted S3). This is the documented v1 approach. **Prod's tamper-evidence custody — real KMS/HSM, cross-account WORM witness — remains the external deferral and must NOT use this path** (see the audit blueprint). IAM user policies are least-privilege (bucket-scoped, audit users append-only).

## Relationship to other PRs
- Independent of **#537** (safe-teardown) and **#538** (gp3 StorageClass + secret recovery window) — no file overlap. **All three are needed for a fully-Healthy staging fleet**: #538 unblocks storage, this unblocks app secrets.
- Minor: this and #537 both edit the staging argocd unit (different sections — a dependency block vs. a before_hook); expect a trivial/no conflict.

## Validation
- `terragrunt validate` green (Terraform auto-installs `tls` v4.3.0 + `random` v3.9.0 implicitly).
- `terraform fmt` + `terragrunt hcl fmt` clean.
- Not applied (no live env up); the secret key-names were cross-checked against the ExternalSecrets in `k8s/overlays/staging/external-secrets.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)