### PR TITLE
fix(infra): unblock fleet convergence — SecretStore ref, ScyllaCluster, teardown LB-wait

### DIFF
--- a/infrastructure/argocd/apps/deployments/staging/scylla-cluster.yaml
+++ b/infrastructure/argocd/apps/deployments/staging/scylla-cluster.yaml
@@ -1,0 +1,34 @@
+# infrastructure/argocd/apps/deployments/staging/scylla-cluster.yaml
+#
+# Deploys the ScyllaCluster (k8s/base/infra/scylla-cluster → name `scylla`, ns
+# `scylla`). SEPARATE from the staging-fleet Application on purpose: the fleet
+# overlay applies `namePrefix: staging-`, which would rename the cluster to
+# `staging-scylla` and make the operator publish `staging-scylla-client.scylla.svc`
+# — but every Scylla-backed service hardcodes `scylla-client.scylla.svc:9042` in
+# its DSN. Syncing the base directly (no prefix) keeps that FQDN intact.
+#
+# Discovered by the staging root-workloads appset (recurse over deployments/staging).
+# Without this, no ScyllaCluster CR is ever created → scylla-migration init
+# containers crash-loop ("could not resolve scylla-client.scylla.svc"). The
+# scylla-operator (root-operators appset, wave -10) installs the CRD first.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: staging-scylla-cluster
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/arnaudmaillet/core-platform
+    targetRevision: develop
+    path: k8s/base/infra/scylla-cluster
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: scylla
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
+++ b/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
@@ -46,6 +46,24 @@ kubectl get svc -A \
   [ -n "${name:-}" ] && kubectl delete svc -n "$ns" "$name" --timeout=180s || true
 done
 
+# 2b. WAIT for the LBs to actually deprovision in AWS. `kubectl delete svc` returns
+#     once the k8s object is gone, but the AWS LB controller then deletes the real
+#     NLB/ALB asynchronously (+ENIs), which can take minutes. If we don't wait, the
+#     later `eks` unit fails to delete its ACM cert (still referenced by the NLB's
+#     TLS listener → ResourceInUseException) and `vpc` early-exits on leftover ENIs.
+#     Poll until no load balancers remain in the cluster VPC (best-effort, ~5 min).
+vpc_id="$(aws eks describe-cluster --name "${CLUSTER_NAME}" --region "${AWS_REGION}" \
+  --query 'cluster.resourcesVpcConfig.vpcId' --output text 2>/dev/null || true)"
+if [ -n "${vpc_id:-}" ] && [ "${vpc_id}" != "None" ]; then
+  echo "Waiting for load balancers in ${vpc_id} to deprovision..."
+  for _ in $(seq 1 30); do
+    remaining="$(aws elbv2 describe-load-balancers --region "${AWS_REGION}" \
+      --query "length(LoadBalancers[?VpcId=='${vpc_id}'])" --output text 2>/dev/null || echo 0)"
+    [ "${remaining:-0}" = "0" ] && { echo "  all load balancers gone"; break; }
+    echo "  ${remaining} still deprovisioning..."; sleep 10
+  done
+fi
+
 # 3. Stateful workloads: delete the CRs (removes pods that hold the volumes), then
 #    PVCs, so ebs-csi issues DeleteVolume for the backing EBS volumes.
 echo "Deleting CNPG / ScyllaDB clusters..."

--- a/k8s/overlays/staging/external-secrets-refs-config.yaml
+++ b/k8s/overlays/staging/external-secrets-refs-config.yaml
@@ -1,0 +1,18 @@
+# k8s/overlays/staging/external-secrets-refs-config.yaml
+#
+# Kustomize nameReference extension for External Secrets Operator.
+#
+# Same class of gap as cnpg-refs-config.yaml / scaledobject-refs-config.yaml:
+# kustomize's built-in name-reference config doesn't know that an ExternalSecret's
+# spec.secretStoreRef.name points at a SecretStore. Without this, `namePrefix:
+# staging-` renames the SecretStore to `staging-aws-secrets-manager` while every
+# ExternalSecret keeps referencing the bare `aws-secrets-manager` — so the store is
+# never found and all ExternalSecrets fail SecretSyncedError ("could not get secret
+# data from provider"). This teaches kustomize the reference so the prefix flows to
+# both sides. Referenced from kustomization.yaml `configurations:`.
+nameReference:
+  - kind: SecretStore
+    group: external-secrets.io
+    fieldSpecs:
+      - path: spec/secretStoreRef/name
+        kind: ExternalSecret

--- a/k8s/overlays/staging/external-secrets.yaml
+++ b/k8s/overlays/staging/external-secrets.yaml
@@ -6,6 +6,11 @@ apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
   name: aws-secrets-manager
+  annotations:
+    # Apply the store before the ExternalSecrets (default wave 0) that reference it,
+    # so the first ExternalSecret reconcile finds it (avoids the initial
+    # SecretSyncedError churn while ESO waits for the store).
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   provider:
     aws:

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -16,6 +16,8 @@ configurations:
   - scaledobject-refs-config.yaml
   # Flow namePrefix into ScheduledBackup.spec.cluster.name -> CNPG Cluster.
   - cnpg-refs-config.yaml
+  # Flow namePrefix into ExternalSecret.spec.secretStoreRef.name -> SecretStore.
+  - external-secrets-refs-config.yaml
 resources:
   # ── Services ─────────────────────────────────────────────────────────────────
   - ../../base/services/chat/server


### PR DESCRIPTION
The full staging validation cycle (12/12 apply; **#538 gp3** and **#539 app-secrets** confirmed working) proved the infra converges but the **fleet does not reach Healthy**. This PR fixes the two workload blockers it surfaced (previously masked by the gp3 issue) and hardens the teardown.

## P0.1 — SecretStore name mismatch → all ExternalSecrets `SecretSyncedError`
`namePrefix: staging-` renames the SecretStore to `staging-aws-secrets-manager`, but kustomize does **not** rewrite `ExternalSecret.spec.secretStoreRef.name` — so every ExternalSecret referenced the bare `aws-secrets-manager`, the store was never found, and `backend-creds`/media/audit/auth secrets never materialized → 15 pods `CreateContainerConfigError`.

- **`external-secrets-refs-config.yaml`** — kustomize `nameReference` (mirrors the existing cnpg/scaledobject configs) so the prefix flows to the ref. **Verified via `kubectl kustomize`: all 5 `secretStoreRef.name` now render as `staging-aws-secrets-manager`, matching the store.**
- Sync-wave on the SecretStore so it applies before the ExternalSecrets.

## P0.2 — ScyllaCluster never deployed → scylla-migration init crash-loops
The overlay comment said the ScyllaCluster is "applied separately" (to avoid `namePrefix` rewriting the `scylla-client` FQDN the services hardcode), but **nothing actually applied it** (render count = 0) → no cluster → `could not resolve scylla-client.scylla.svc`.

- **`deployments/staging/scylla-cluster.yaml`** — a dedicated ArgoCD Application (discovered by the `root-workloads` appset) syncing `k8s/base/infra/scylla-cluster` with **no prefix**, preserving `scylla-client.scylla.svc`. The scylla-operator (wave -10) installs the CRD first.

## P2 — teardown ACM race (reproduced twice)
The graceful-cleanup hook deleted the NLB, but its deprovision + ENI cleanup outlasted Terraform's ACM-delete retry → `eks` failed `ResourceInUseException` → `vpc` early-exit → stale state.

- The hook now **waits for the AWS LBs to actually deprovision** (polls by cluster VPC) after `kubectl delete svc`, so the ACM cert is free when the `eks` unit deletes it.

## Not in this PR (documented follow-ups; neither blocks convergence)
- **Secret-name disposability vs AWS Secrets Manager/KMS deletion-state debt** — the dominant rebuild friction this cycle (needed restore + `terragrunt import` + `kms cancel-key-deletion`). Needs a real strategy (name-uniqueness / cooldown / teardown KMS cleanup) or a documented runbook.
- **`github_repository_file` false-fail (#1)** — confirmed **intermittent** (did not recur on the clean apply); low priority.

## Validation
- `kubectl kustomize k8s/overlays/staging` renders clean; secretStoreRef↔SecretStore names now match.
- `kubectl kustomize k8s/base/infra/scylla-cluster` renders (ScyllaCluster `scylla`/ns `scylla`).
- `bash -n` clean on the hook.
- **Not yet live-retested** — a fresh from-scratch apply is the real confirmation these three land a Healthy fleet. One honest caveat: I couldn't fully root-cause *why the SecretStore CR hadn't applied at all* remotely (it renders correctly); the nameReference is the deterministic mismatch fix, and the sync-wave addresses the most likely ordering/webhook-race — but the live retest should confirm the store now both applies and resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)