### PR TITLE
feat(infra): disposable-env preflight + destroy→rebuild runbook (P1)

### DIFF
--- a/docs/runbooks/staging-disposable-rebuild.md
+++ b/docs/runbooks/staging-disposable-rebuild.md
@@ -1,0 +1,80 @@
+# Runbook: Disposable staging — destroy → rebuild
+
+Staging is a **disposable** environment: it is stood up from scratch, validated,
+and torn down repeatedly. Most of that cycle is clean, but AWS **Secrets Manager**
+and **KMS** carry *deletion state* that outlives a `terragrunt destroy` and can
+block the next `apply`. This runbook captures the gotchas and the exact recovery.
+
+## The core gotcha: name reservation after deletion
+
+- A Secrets Manager secret in **`PendingDeletion`** reserves its name for the whole
+  recovery window. `CreateSecret` with that name fails:
+  `InvalidRequestException: You can't create this secret because a secret with this
+  name is already scheduled for deletion.`
+- **`describe-secret` returns `NotFound` for a `PendingDeletion` secret** — so a
+  naive pre-flight ("does it exist?") reports the name as free when it is not. Use
+  `aws secretsmanager list-secrets --include-planned-deletion`.
+- Modules now set **`recovery_window_in_days = 0`** (PR #538), so teardowns delete
+  secrets *immediately* rather than scheduling a 30-day window. But AWS still
+  **reserves a force-deleted name for a few minutes**, so a rebuild started seconds
+  after a destroy can still collide.
+- **KMS:** MSK's SCRAM secret requires a customer-managed KMS key. Keys have a
+  minimum **7-day** deletion window (no force-immediate). A teardown schedules the
+  key for deletion; a rebuild creates a *fresh* key, so this is orphan cost, not a
+  blocker — **unless** you `terraform import` a stale secret whose key is pending
+  deletion, which then fails `UpdateSecret` with `KMSInvalidStateException`.
+  **Prefer clearing (below) over importing.**
+
+## Standard cycle
+
+```bash
+BASE=infrastructure/live/staging/us-east-1
+# 1. Teardown
+( cd $BASE && AWS_REGION=us-east-1 terragrunt run --all destroy --non-interactive -- -auto-approve )
+
+# 2. Pre-flight the next apply: detect (and optionally clear) leftover name reservations.
+bash infrastructure/assets/teardown/preflight-clean-env.sh staging            # report only
+bash infrastructure/assets/teardown/preflight-clean-env.sh staging --fix      # clear leftovers
+
+# 3. COOLDOWN: if --fix cleared anything, wait ~15 min so AWS releases the names.
+
+# 4. Apply
+( cd $BASE && AWS_REGION=us-east-1 GITHUB_TOKEN=$(gh auth token) \
+    terragrunt run --all apply --non-interactive --backend-bootstrap -- -auto-approve )
+```
+
+> Trust the **Run Summary** (`Succeeded / Failed`), NOT the exit code — `terragrunt
+> run --all` can exit 0 even with failed units.
+
+## Recovery: a data-store unit fails with "already scheduled for deletion"
+
+This means a secret name is still reserved. Two paths:
+
+- **Clear (preferred):** `preflight-clean-env.sh staging --fix`, wait ~15 min, re-apply.
+- **Adopt (no wait, but MSK-risky):** restore the secret and import it so Terraform
+  manages it instead of re-creating:
+  ```bash
+  aws secretsmanager restore-secret --secret-id <name>
+  ( cd $BASE/data/<unit> && terragrunt import aws_secretsmanager_secret.<res> <arn> )
+  ```
+  For **MSK** this hits `KMSInvalidStateException` if the imported secret's KMS key
+  is pending deletion — re-enable it first:
+  `aws kms cancel-key-deletion --key-id <id> && aws kms enable-key --key-id <id>`
+  (then re-schedule its deletion after the apply). Because of this, **prefer Clear
+  for MSK.**
+
+## Teardown stale state (the ACM race)
+
+If `eks` fails deleting its ACM certificate (`ResourceInUseException`, cert still
+held by a not-yet-deprovisioned NLB) and `vpc` early-exits, the AWS resources are
+usually gone but the unit *state* is stale. Reconcile per-unit:
+
+```bash
+( cd $BASE/eks && terragrunt state rm aws_acm_certificate.cert )
+( cd $BASE/networking/vpc && terragrunt state rm $(cd $BASE/networking/vpc && terragrunt state list) )
+```
+
+The graceful-cleanup hook now waits for LBs to deprovision before Terraform reaches
+the cert, so this should be rare. Always confirm zero leaks afterwards:
+`aws ec2 describe-vpcs --filters Name=isDefault,Values=false` (ignore transient
+list-flicker — verify by `--vpc-ids`).

--- a/infrastructure/assets/teardown/preflight-clean-env.sh
+++ b/infrastructure/assets/teardown/preflight-clean-env.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# infrastructure/assets/teardown/preflight-clean-env.sh
+#
+# Pre-apply hygiene check for a DISPOSABLE environment (staging). Detects the
+# AWS Secrets Manager / KMS deletion-state debt that repeatedly blocks a
+# destroy -> rebuild cycle, and (with --fix) clears it so the next apply doesn't
+# collide with "secret ... is already scheduled for deletion".
+#
+# WHY THIS EXISTS (learned the hard way):
+#   * A secret in PendingDeletion RESERVES its name for the whole recovery window
+#     (up to 30 days). `describe-secret` returns NotFound for it — so a naive
+#     pre-flight misses it; you MUST use `list-secrets --include-planned-deletion`.
+#   * Modules now set recovery_window_in_days = 0 (PR #538) so teardowns delete
+#     immediately — but AWS still RESERVES a force-deleted name for a few minutes,
+#     so a rebuild kicked off seconds after a destroy can still collide. Run this
+#     with a short cooldown before re-applying.
+#   * MSK's SCRAM secret is encrypted with a customer KMS key; if you ever import
+#     a stale copy of it whose key is pending deletion, UpdateSecret fails with
+#     KMSInvalidStateException. Prefer clearing (this script) over import.
+#
+# Usage:
+#   preflight-clean-env.sh <env> [--region <r>] [--fix]
+#     (default: report only, read-only. --fix restores+force-deletes the leftovers.)
+
+set -uo pipefail
+
+ENV="${1:?usage: preflight-clean-env.sh <env> [--region <r>] [--fix]}"; shift || true
+REGION="us-east-1"; FIX=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --region) REGION="$2"; shift 2 ;;
+    --fix) FIX=1; shift ;;
+    *) echo "unknown arg: $1"; exit 2 ;;
+  esac
+done
+
+PREFIX="core-platform-${ENV}"
+echo "--- Disposable-env preflight: env=${ENV} region=${REGION} fix=${FIX} ---"
+
+# 1. Secrets in PendingDeletion whose name would collide with a rebuild.
+echo "== Secrets Manager: names reserved by PendingDeletion =="
+pending="$(aws secretsmanager list-secrets --include-planned-deletion --region "${REGION}" \
+  --query "SecretList[?DeletedDate!=null && (starts_with(Name,'${PREFIX}') || starts_with(Name,'AmazonMSK_${PREFIX}'))].Name" \
+  --output text 2>/dev/null || true)"
+
+if [ -z "${pending// }" ]; then
+  echo "  none — names are free."
+else
+  for s in $pending; do echo "  RESERVED: $s"; done
+  if [ "$FIX" -eq 1 ]; then
+    echo "  --fix: restoring then force-deleting to free the names..."
+    for s in $pending; do
+      aws secretsmanager restore-secret --secret-id "$s" --region "${REGION}" >/dev/null 2>&1 || true
+      aws secretsmanager delete-secret --secret-id "$s" --region "${REGION}" \
+        --force-delete-without-recovery >/dev/null 2>&1 \
+        && echo "    freed: $s" || echo "    WARN could not free: $s"
+    done
+    echo "  NOTE: AWS reserves a force-deleted name for ~minutes. Wait ~15 min"
+    echo "        before re-applying, or the CreateSecret will still collide."
+  else
+    echo "  Re-run with --fix to clear (or 'aws secretsmanager restore-secret' +"
+    echo "  'delete-secret --force-delete-without-recovery' per name)."
+  fi
+fi
+
+# 2. KMS keys in PendingDeletion (informational — a rebuild creates fresh keys, so
+#    these are orphan cost, not a blocker; re-scheduling is harmless).
+echo "== KMS: customer keys currently PendingDeletion (orphan-cost check) =="
+keys="$(aws kms list-keys --region "${REGION}" --query "Keys[].KeyId" --output text 2>/dev/null || true)"
+found_kms=0
+for k in $keys; do
+  st="$(aws kms describe-key --key-id "$k" --region "${REGION}" \
+    --query "KeyMetadata.KeyState" --output text 2>/dev/null || echo "")"
+  if [ "$st" = "PendingDeletion" ]; then echo "  PendingDeletion: $k"; found_kms=1; fi
+done
+[ "$found_kms" -eq 0 ] && echo "  none."
+
+echo "--- preflight done ---"


### PR DESCRIPTION
Addresses **P1** — the dominant friction from the staging validation cycles: AWS **Secrets Manager / KMS deletion-state debt** repeatedly blocked destroy→rebuild with `secret ... already scheduled for deletion`, forcing a manual restore/import/`cancel-key-deletion` dance.

## What this adds
- **`infrastructure/assets/teardown/preflight-clean-env.sh`** — a pre-apply hygiene check:
  - Detects secret names still **reserved by `PendingDeletion`** via `list-secrets --include-planned-deletion` (crucial: `describe-secret` returns `NotFound` for these and *lies*).
  - Reports **KMS keys pending deletion** (orphan cost; a rebuild makes fresh keys).
  - `--fix` restores + force-deletes the reserved secret names to free them. Read-only by default; bash 3.2-safe (macOS).
- **`docs/runbooks/staging-disposable-rebuild.md`** — the full cycle (destroy → preflight → **cooldown** → apply), the name-reservation gotcha, the MSK-KMS import caveat, and the ACM-race stale-state reconcile.

## Why not "unique secret names"?
That would eliminate collisions but **break the ExternalSecrets' static `remoteRef.key`** (they hardcode `core-platform-staging-*`). The AWS name-reservation after deletion is inherent; the pragmatic fix is detect + clear + a short cooldown, which is what this delivers. `recovery_window_in_days = 0` (#538) already removed the 30-day PendingDeletion accumulation.

## Smoke-tested live
- Secrets: all free (confirms #538's `recovery_window=0` teardown works).
- KMS: surfaced **11 orphan keys** in PendingDeletion from prior cycles (accumulated ~$/mo) — exactly the kind of debt this is meant to make visible.

## Scope
Operational tooling + docs only — **no code path changed**. Complements the open **#540** (SecretStore/ScyllaCluster convergence fixes). Recommended order: merge #540 → run `preflight-clean-env.sh staging` → one from-scratch validation to confirm a Healthy fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)