### PR TITLE
fix(infra): ClusterSecretStore + scylla memory — the true convergence blockers

### DIFF
--- a/k8s/base/infra/scylla-cluster/scylla-cluster.yaml
+++ b/k8s/base/infra/scylla-cluster/scylla-cluster.yaml
@@ -14,7 +14,9 @@ spec:
     name: datacenter1
     racks:
       - name: rack1
-        members: 3
+        # Single-node for disposable staging: avoids needing 3 dedicated DB nodes
+        # for anti-affinity, and is sufficient to validate the fleet. (Prod: 3.)
+        members: 1
         # Pin to the database node tier and tolerate its taint, so Scylla lands on
         # the dedicated DB nodes instead of general/spot capacity.
         placement:
@@ -32,6 +34,9 @@ spec:
         storage:
           capacity: 20Gi
           storageClassName: gp3
+        # scylla-operator reserves ~1.5Gi/pod (manager-agent + OS), so a 2Gi limit
+        # left only ~476Mi/shard — below Scylla's 1Gi/shard floor → boot failure.
+        # 4Gi leaves ~2.5Gi/shard. Fits the t3.large (8Gi) DB nodes.
         resources:
-          requests: { cpu: "1", memory: 2Gi }
-          limits:   { cpu: "1", memory: 2Gi }
+          requests: { cpu: "1", memory: 4Gi }
+          limits:   { cpu: "1", memory: 4Gi }

--- a/k8s/overlays/staging/external-secrets-refs-config.yaml
+++ b/k8s/overlays/staging/external-secrets-refs-config.yaml
@@ -11,7 +11,7 @@
 # data from provider"). This teaches kustomize the reference so the prefix flows to
 # both sides. Referenced from kustomization.yaml `configurations:`.
 nameReference:
-  - kind: SecretStore
+  - kind: ClusterSecretStore
     group: external-secrets.io
     fieldSpecs:
       - path: spec/secretStoreRef/name

--- a/k8s/overlays/staging/external-secrets.yaml
+++ b/k8s/overlays/staging/external-secrets.yaml
@@ -2,15 +2,19 @@
 # Terraform modules wrote to Secrets Manager into a k8s Secret (backend-creds),
 # which the service pods consume via envFrom (see patch). Auth uses the ESO IRSA
 # role (modules/security/irsa-roles enable_external_secrets).
+# ClusterSecretStore (NOT a namespaced SecretStore): the ESO IRSA ServiceAccount
+# lives in the external-secrets namespace, and a namespaced SecretStore may only
+# reference an SA in its OWN namespace — ESO's admission webhook rejects a
+# cross-namespace serviceAccountRef ("namespace should be empty or match the
+# SecretStore's namespace"). A ClusterSecretStore is cluster-scoped and may
+# reference the operator's SA in external-secrets (the canonical IRSA pattern).
+# No sync-wave: ESO re-reconciles ExternalSecrets once the store exists, so gating
+# the fleet on the store (a prior sync-wave: -1) was unnecessary AND deployed 0
+# pods whenever the store failed to apply.
 apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
+kind: ClusterSecretStore
 metadata:
   name: aws-secrets-manager
-  annotations:
-    # Apply the store before the ExternalSecrets (default wave 0) that reference it,
-    # so the first ExternalSecret reconcile finds it (avoids the initial
-    # SecretSyncedError churn while ESO waits for the store).
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   provider:
     aws:
@@ -30,7 +34,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     name: aws-secrets-manager
-    kind: SecretStore
+    kind: ClusterSecretStore
   # Literal target name (kustomize doesn't prefix fields inside a CR), so the
   # envFrom in the deployment patch matches.
   target:
@@ -55,7 +59,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     name: aws-secrets-manager
-    kind: SecretStore
+    kind: ClusterSecretStore
   target:
     name: search-creds
   # secretKeys ARE the env var names (envFrom) — match what search reads exactly.
@@ -77,7 +81,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     name: aws-secrets-manager
-    kind: SecretStore
+    kind: ClusterSecretStore
   target:
     name: media-s3-creds
   data:
@@ -99,7 +103,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     name: aws-secrets-manager
-    kind: SecretStore
+    kind: ClusterSecretStore
   target:
     name: audit-crypto
   data:
@@ -128,7 +132,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     name: aws-secrets-manager
-    kind: SecretStore
+    kind: ClusterSecretStore
   target:
     name: auth-secrets
   data:


### PR DESCRIPTION
Live cycle-3 validation (12/12 clean apply — preflight #541 worked) exposed the **real** reasons the fleet still didn't reach Healthy. Both were invisible to static analysis / `kubectl kustomize` — only a live **admission webhook** and **pod boot** surface them. This corrects the incomplete SecretStore fix from #540.

## 1. SecretStore was invalid → ESO webhook rejected it
```
validate.secretstore.external-secrets.io denied: invalid Auth.JWT.ServiceAccountRef:
namespace should either be empty or match the namespace of the SecretStore
```
It was a **namespaced** SecretStore (ns `default`) with a **cross-namespace** `serviceAccountRef` (`external-secrets`) — ESO forbids that for namespaced stores. So the store never applied → all ExternalSecrets `SecretSyncedError` → app secrets never materialized → `CreateContainerConfigError`.

- Convert to **`ClusterSecretStore`** (cluster-scoped stores may reference the operator's IRSA SA cross-namespace — the canonical pattern) + update every ExternalSecret `secretStoreRef.kind` + the refs-config `nameReference` kind.
- **Drop the `sync-wave: -1`** I added in #540 — it gated the *whole* staging-fleet behind the failing store (**0 pods** deployed vs. 43). ESO re-reconciles once the store exists, so no gating is needed.

## 2. Scylla pod CrashLoopBackOff
```
Only 476 MiB per shard; below the recommended minimum of 1 GiB/shard; terminating.
```
The ScyllaCluster (deployed via #540's app ✓) couldn't boot: scylla-operator reserves ~1.5 Gi/pod (manager-agent + OS), so the 2 Gi limit left too little.

- Bump memory **2Gi → 4Gi** (leaves ~2.5 Gi/shard; fits the t3.large DB nodes).
- `members` **3 → 1** — disposable staging needs no multi-node quorum and this avoids the 3-dedicated-node anti-affinity requirement.

## Validation
`kubectl kustomize k8s/overlays/staging`: `ClusterSecretStore` renders as `staging-aws-secrets-manager`; **all 5 ExternalSecret refs match it**; **0 namespaced SecretStores**. `kubectl kustomize k8s/base/infra/scylla-cluster`: members:1, memory:4Gi.

## How to validate for real
The staging cluster from cycle-3 is **still up**, so merging this lets **ArgoCD re-sync from develop with no Terraform re-apply** — the fleet should reach Healthy in ~15 min. That's the intended next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)