### PR TITLE
fix(platform): P0 staging hardening — audit caller gate, fleet PDBs/spread, appset deletion guard

### DIFF
--- a/infrastructure/argocd/bootstrap/staging/root-infra-observability.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-observability.yaml
@@ -6,6 +6,15 @@ metadata:
   name: root-observability
   namespace: argocd
 spec:
+  # Guard against generator emptiness cascading into an uninstall: these appsets
+  # gate on global-params-staging.json (Terraform-written, absent when the env is
+  # torn down). Without this, a missing/deleted params file makes the matrix yield
+  # zero elements and the appset DELETES every generated Application — and, with
+  # automated prune, its resources (Karpenter/ESO/KEDA/CNPG/LB controller).
+  # With the guard, deleting an Application orphans (keeps) its resources; only an
+  # explicit terraform destroy tears the platform layer down.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   goTemplate: true
   generators:
     - matrix:

--- a/infrastructure/argocd/bootstrap/staging/root-infra-operators.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-operators.yaml
@@ -14,6 +14,15 @@ metadata:
   name: root-operators
   namespace: argocd
 spec:
+  # Guard against generator emptiness cascading into an uninstall: these appsets
+  # gate on global-params-staging.json (Terraform-written, absent when the env is
+  # torn down). Without this, a missing/deleted params file makes the matrix yield
+  # zero elements and the appset DELETES every generated Application — and, with
+  # automated prune, its resources (Karpenter/ESO/KEDA/CNPG/LB controller).
+  # With the guard, deleting an Application orphans (keeps) its resources; only an
+  # explicit terraform destroy tears the platform layer down.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   goTemplate: true
   generators:
     - matrix:

--- a/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
@@ -5,6 +5,15 @@ metadata:
   name: root-platform
   namespace: argocd
 spec:
+  # Guard against generator emptiness cascading into an uninstall: these appsets
+  # gate on global-params-staging.json (Terraform-written, absent when the env is
+  # torn down). Without this, a missing/deleted params file makes the matrix yield
+  # zero elements and the appset DELETES every generated Application — and, with
+  # automated prune, its resources (Karpenter/ESO/KEDA/CNPG/LB controller).
+  # With the guard, deleting an Application orphans (keeps) its resources; only an
+  # explicit terraform destroy tears the platform layer down.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   goTemplate: true
   generators:
     - matrix:

--- a/infrastructure/argocd/bootstrap/staging/root-infra-security.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-security.yaml
@@ -6,6 +6,15 @@ metadata:
   name: root-security
   namespace: argocd
 spec:
+  # Guard against generator emptiness cascading into an uninstall: these appsets
+  # gate on global-params-staging.json (Terraform-written, absent when the env is
+  # torn down). Without this, a missing/deleted params file makes the matrix yield
+  # zero elements and the appset DELETES every generated Application — and, with
+  # automated prune, its resources (Karpenter/ESO/KEDA/CNPG/LB controller).
+  # With the guard, deleting an Application orphans (keeps) its resources; only an
+  # explicit terraform destroy tears the platform layer down.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   goTemplate: true
   generators:
     - matrix:

--- a/k8s/base/services/account/server/deployment.yaml
+++ b/k8s/base/services/account/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: account-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: account-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: account-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/account/server/kustomization.yaml
+++ b/k8s/base/services/account/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/account/server/pdb.yaml
+++ b/k8s/base/services/account/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/account/server/pdb.yaml
+#
+# Keep at least one account-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: account-server
+  labels:
+    app: account-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: account-server

--- a/k8s/base/services/audit/server/deployment.yaml
+++ b/k8s/base/services/audit/server/deployment.yaml
@@ -30,6 +30,21 @@ spec:
         app: audit-server
         role: server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: audit-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: audit-server
       # IRSA: KEK kms:Decrypt/GenerateDataKey + WORM write. The overlay creates
       # this SA (prefixed) with the eks.amazonaws.com/role-arn annotation.
       serviceAccountName: audit-server

--- a/k8s/base/services/audit/server/kustomization.yaml
+++ b/k8s/base/services/audit/server/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   - hpa.yaml

--- a/k8s/base/services/audit/server/pdb.yaml
+++ b/k8s/base/services/audit/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/audit/server/pdb.yaml
+#
+# Keep at least one audit-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: audit-server
+  labels:
+    app: audit-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: audit-server

--- a/k8s/base/services/audit/worker/deployment.yaml
+++ b/k8s/base/services/audit/worker/deployment.yaml
@@ -31,6 +31,21 @@ spec:
         app: audit-worker
         role: worker
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: audit-worker
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: audit-worker
       # IRSA: same audit role as the server — ingest seals PII via the KEK and the
       # checkpoint loop anchors signed Merkle roots to the WORM bucket.
       serviceAccountName: audit-worker

--- a/k8s/base/services/auth/server/deployment.yaml
+++ b/k8s/base/services/auth/server/deployment.yaml
@@ -22,6 +22,21 @@ spec:
         app: auth-server
         role: server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: auth-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: auth-server
       # Owns the auth Postgres schema via an idempotent migrator init container
       # (reads DATABASE_URL from auth-config).
       initContainers:

--- a/k8s/base/services/auth/server/kustomization.yaml
+++ b/k8s/base/services/auth/server/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   - hpa.yaml

--- a/k8s/base/services/auth/server/pdb.yaml
+++ b/k8s/base/services/auth/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/auth/server/pdb.yaml
+#
+# Keep at least one auth-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-server
+  labels:
+    app: auth-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: auth-server

--- a/k8s/base/services/chat/server/deployment.yaml
+++ b/k8s/base/services/chat/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: chat-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: chat-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: chat-server
       # Apply this service's ScyllaDB migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/chat/server/kustomization.yaml
+++ b/k8s/base/services/chat/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/chat/server/pdb.yaml
+++ b/k8s/base/services/chat/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/chat/server/pdb.yaml
+#
+# Keep at least one chat-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: chat-server
+  labels:
+    app: chat-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: chat-server

--- a/k8s/base/services/comment/server/deployment.yaml
+++ b/k8s/base/services/comment/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: comment-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: comment-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: comment-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/comment/server/kustomization.yaml
+++ b/k8s/base/services/comment/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/comment/server/pdb.yaml
+++ b/k8s/base/services/comment/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/comment/server/pdb.yaml
+#
+# Keep at least one comment-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: comment-server
+  labels:
+    app: comment-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: comment-server

--- a/k8s/base/services/counter/server/deployment.yaml
+++ b/k8s/base/services/counter/server/deployment.yaml
@@ -27,6 +27,21 @@ spec:
         app: counter-server
         role: server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: counter-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: counter-server
       initContainers:
         # Postgres warm-ledger schema. Idempotent: safe on every rollout.
         - name: migrate-counter

--- a/k8s/base/services/counter/server/kustomization.yaml
+++ b/k8s/base/services/counter/server/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   - hpa.yaml

--- a/k8s/base/services/counter/server/pdb.yaml
+++ b/k8s/base/services/counter/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/counter/server/pdb.yaml
+#
+# Keep at least one counter-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: counter-server
+  labels:
+    app: counter-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: counter-server

--- a/k8s/base/services/counter/worker/deployment.yaml
+++ b/k8s/base/services/counter/worker/deployment.yaml
@@ -29,6 +29,21 @@ spec:
         app: counter-worker
         role: worker
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: counter-worker
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: counter-worker
       terminationGracePeriodSeconds: 60
       containers:
         - name: worker

--- a/k8s/base/services/engagement/server/deployment.yaml
+++ b/k8s/base/services/engagement/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: engagement-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: engagement-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: engagement-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/engagement/server/kustomization.yaml
+++ b/k8s/base/services/engagement/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/engagement/server/pdb.yaml
+++ b/k8s/base/services/engagement/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/engagement/server/pdb.yaml
+#
+# Keep at least one engagement-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: engagement-server
+  labels:
+    app: engagement-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: engagement-server

--- a/k8s/base/services/geo-discovery/server/deployment.yaml
+++ b/k8s/base/services/geo-discovery/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: geo-discovery-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: geo-discovery-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: geo-discovery-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/geo-discovery/server/kustomization.yaml
+++ b/k8s/base/services/geo-discovery/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/geo-discovery/server/pdb.yaml
+++ b/k8s/base/services/geo-discovery/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/geo-discovery/server/pdb.yaml
+#
+# Keep at least one geo-discovery-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: geo-discovery-server
+  labels:
+    app: geo-discovery-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: geo-discovery-server

--- a/k8s/base/services/media/server/deployment.yaml
+++ b/k8s/base/services/media/server/deployment.yaml
@@ -23,6 +23,21 @@ spec:
         app: media-server
         role: server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: media-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: media-server
       # IRSA: S3 object RW on the media bucket (presigned upload/download +
       # takedown delete). The overlay creates this SA with the role-arn annotation.
       serviceAccountName: media-server

--- a/k8s/base/services/media/server/kustomization.yaml
+++ b/k8s/base/services/media/server/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   - hpa.yaml

--- a/k8s/base/services/media/server/pdb.yaml
+++ b/k8s/base/services/media/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/media/server/pdb.yaml
+#
+# Keep at least one media-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: media-server
+  labels:
+    app: media-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: media-server

--- a/k8s/base/services/moderation/server/deployment.yaml
+++ b/k8s/base/services/moderation/server/deployment.yaml
@@ -22,6 +22,21 @@ spec:
         app: moderation-server
         role: server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: moderation-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: moderation-server
       # Dual-store, like counter: Postgres decision/enforcement SoR + Scylla
       # append-only history. One idempotent migrator init container per backend
       # (the migrator reads DATABASE_URL / Scylla config from moderation-config).

--- a/k8s/base/services/moderation/server/kustomization.yaml
+++ b/k8s/base/services/moderation/server/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   - hpa.yaml

--- a/k8s/base/services/moderation/server/pdb.yaml
+++ b/k8s/base/services/moderation/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/moderation/server/pdb.yaml
+#
+# Keep at least one moderation-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: moderation-server
+  labels:
+    app: moderation-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: moderation-server

--- a/k8s/base/services/notification/server/deployment.yaml
+++ b/k8s/base/services/notification/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: notification-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: notification-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: notification-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/notification/server/kustomization.yaml
+++ b/k8s/base/services/notification/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/notification/server/pdb.yaml
+++ b/k8s/base/services/notification/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/notification/server/pdb.yaml
+#
+# Keep at least one notification-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notification-server
+  labels:
+    app: notification-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: notification-server

--- a/k8s/base/services/post/server/deployment.yaml
+++ b/k8s/base/services/post/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: post-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: post-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: post-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/post/server/kustomization.yaml
+++ b/k8s/base/services/post/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/post/server/pdb.yaml
+++ b/k8s/base/services/post/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/post/server/pdb.yaml
+#
+# Keep at least one post-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: post-server
+  labels:
+    app: post-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: post-server

--- a/k8s/base/services/profile/server/deployment.yaml
+++ b/k8s/base/services/profile/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: profile-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: profile-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: profile-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/profile/server/kustomization.yaml
+++ b/k8s/base/services/profile/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/profile/server/pdb.yaml
+++ b/k8s/base/services/profile/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/profile/server/pdb.yaml
+#
+# Keep at least one profile-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: profile-server
+  labels:
+    app: profile-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: profile-server

--- a/k8s/base/services/realtime/dispatcher/deployment.yaml
+++ b/k8s/base/services/realtime/dispatcher/deployment.yaml
@@ -26,6 +26,21 @@ spec:
         app: realtime-dispatcher
         role: worker
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: realtime-dispatcher
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: realtime-dispatcher
       terminationGracePeriodSeconds: 60
       containers:
         - name: dispatcher

--- a/k8s/base/services/realtime/gateway/deployment.yaml
+++ b/k8s/base/services/realtime/gateway/deployment.yaml
@@ -33,6 +33,21 @@ spec:
         app: realtime-gateway
         role: edge
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: realtime-gateway
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: realtime-gateway
       # Generous drain window for jittered client reconnect on rollout/scale-down.
       terminationGracePeriodSeconds: 120
       containers:

--- a/k8s/base/services/search/server/deployment.yaml
+++ b/k8s/base/services/search/server/deployment.yaml
@@ -22,6 +22,21 @@ spec:
         app: search-server
         role: server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: search-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: search-server
       containers:
         - name: server
           image: core-platform-search-server

--- a/k8s/base/services/search/server/kustomization.yaml
+++ b/k8s/base/services/search/server/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml
   - hpa.yaml

--- a/k8s/base/services/search/server/pdb.yaml
+++ b/k8s/base/services/search/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/search/server/pdb.yaml
+#
+# Keep at least one search-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: search-server
+  labels:
+    app: search-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: search-server

--- a/k8s/base/services/social-graph/server/deployment.yaml
+++ b/k8s/base/services/social-graph/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: social-graph-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: social-graph-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: social-graph-server
       # Apply this service's ScyllaDB migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/social-graph/server/kustomization.yaml
+++ b/k8s/base/services/social-graph/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/social-graph/server/pdb.yaml
+++ b/k8s/base/services/social-graph/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/social-graph/server/pdb.yaml
+#
+# Keep at least one social-graph-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: social-graph-server
+  labels:
+    app: social-graph-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: social-graph-server

--- a/k8s/base/services/timeline/server/deployment.yaml
+++ b/k8s/base/services/timeline/server/deployment.yaml
@@ -19,6 +19,21 @@ spec:
       labels:
         app: timeline-server
     spec:
+      # Spread replicas across AZs and nodes (ScheduleAnyway: never blocks
+      # scheduling; the PDB is the hard guard against voluntary co-eviction).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: timeline-server
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: timeline-server
       # Apply this service's schema migrations before the server boots. The
       # migrator is self-contained (migrations embedded) and idempotent, so it is
       # safe to run on every rollout; it exits 0 once schema is up to date.

--- a/k8s/base/services/timeline/server/kustomization.yaml
+++ b/k8s/base/services/timeline/server/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/base/services/timeline/server/pdb.yaml
+++ b/k8s/base/services/timeline/server/pdb.yaml
@@ -1,0 +1,17 @@
+# k8s/base/services/timeline/server/pdb.yaml
+#
+# Keep at least one timeline-server pod serving during voluntary disruptions (node drains,
+# Karpenter consolidation, rollouts). Both replicas can otherwise be evicted
+# simultaneously — the whole fleet runs 2 replicas on consolidating spot nodes.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: timeline-server
+  labels:
+    app: timeline-server
+    role: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: timeline-server

--- a/k8s/overlays/staging/audit.env
+++ b/k8s/overlays/staging/audit.env
@@ -28,6 +28,17 @@ AUDIT_WITNESS_BUCKET=core-platform-staging-audit-worm-724772065879
 AUDIT_WITNESS_ENDPOINT=https://s3.us-east-1.amazonaws.com
 AUDIT_WITNESS_REGION=us-east-1
 
+# ── Caller gate on the audit.v1 surface (PR #546) ─────────────────────────────
+# REQUIRED in every env: without AUDIT_JWKS_URL the gate is DenyAll (fail-closed)
+# — Query/Export/VerifyIntegrity AND RecordPrivileged reject every call. Verify
+# against auth's ES256 JWKS; issuer/audience must match what auth mints (auth.env),
+# same trio realtime uses (REALTIME_JWKS_URL/_ISSUER/_AUDIENCE).
+# NB: callers are authenticated but still need audit:* permissions in the token —
+# auth minting those is a tracked follow-up.
+AUDIT_JWKS_URL=${AUTH_JWKS_URL}
+AUDIT_TOKEN_ISSUER=https://auth.core-platform.click
+AUDIT_TOKEN_AUDIENCE=core-platform
+
 # ── Periodic chain loops ──────────────────────────────────────────────────────
 AUDIT_CHECKPOINT_INTERVAL_S=300
 


### PR DESCRIPTION
Three P0 findings from the infrastructure production-readiness review, all staging-safe config:

## 1. Audit caller-gate variables (unbricks the audit.v1 surface)

`k8s/overlays/staging/audit.env` now sets the PR #546 verification trio:

```
AUDIT_JWKS_URL=${AUTH_JWKS_URL}          # CMP-substituted, same as realtime.env
AUDIT_TOKEN_ISSUER=https://auth.core-platform.click
AUDIT_TOKEN_AUDIENCE=core-platform
```

Without `AUDIT_JWKS_URL` the gate is `DenyAllGate` (fail-closed): Query/Export/VerifyIntegrity **and** the break-glass `RecordPrivileged` reject every call. Values match what auth mints (`auth.env`) and what realtime already verifies. `AUTH_JWKS_URL` is already in the envsubst CMP allow-list, so no Terraform change needed.

> Known follow-up still open: auth must mint `audit:*` permissions into edge tokens, or callers will authenticate and then be denied on permissions.

## 2. Fleet HA posture: PDBs + topology spread

- **PDB `minAvailable: 1`** for all 16 fixed 2-replica servers (realtime-gateway already had one). Before this, Karpenter's `consolidateAfter: 1m` loop could evict both replicas of a TIER-0 service at once — nothing prevented it.
- **`topologySpreadConstraints`** (zone + hostname, `maxSkew: 1`, `ScheduleAnyway`) on all 20 fleet deployments. `ScheduleAnyway` is deliberate: it's a strong scheduler preference that can never make a pod Pending on a small/capped node pool; the PDB is the hard guard for voluntary disruption.
- The three 1-replica KEDA-scaled workers (audit-worker, counter-worker, realtime-dispatcher) get spread constraints but **no PDB**: `minAvailable: 1` at 1 replica blocks node drains indefinitely, and the consumers are restart-tolerant by design (run_consumer manual commit + idempotency).

## 3. ApplicationSet deletion guard

`spec.syncPolicy.preserveResourcesOnDeletion: true` on the 4 staging infra appsets (operators/platform/security/observability). Their matrix generators gate on `infrastructure/argocd/bootstrap/global-params-staging.json` (Terraform-written; deleted on teardown — see b8f66a10): when the file is absent the generator yields zero elements and the appset deletes every generated Application, which with `automated.prune: true` uninstalls Karpenter/ESO/KEDA/CNPG/the LB controller. With the guard, Application deletion orphans (keeps) the resources; only an explicit destroy removes them. The workloads appset is untouched — it uses a plain list generator (not gated on the params file) and intentional app-file removals should still cascade.

## Validation

- `kubectl kustomize k8s/overlays/staging` renders: 17 PDBs, 20 spread constraints, audit vars present with `${AUTH_JWKS_URL}` left intact for the CMP.
- `kubectl kustomize k8s/overlays/dev` still builds (base edits are additive).
- Appset YAML parse-checked; `syncPolicy.preserveResourcesOnDeletion` at ApplicationSet spec level (not the Application template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB