### PR TITLE
fix(transport): recycle gRPC connections so scale-out actually rebalances traffic

### DIFF
--- a/crates/platform/service-runtime/src/lib.rs
+++ b/crates/platform/service-runtime/src/lib.rs
@@ -69,6 +69,16 @@ const DEFAULT_HEALTH_INTERVAL_SECS: u64 = 10;
 const TRAFFIC_PRUNE_INTERVAL_ENV: &str = "TRAFFIC_PRUNE_INTERVAL_SECS";
 /// Default traffic-registry prune cadence.
 const DEFAULT_TRAFFIC_PRUNE_INTERVAL_SECS: u64 = 60;
+/// Environment variable overriding the server-side connection-recycling window
+/// (seconds; `0` disables recycling entirely).
+const MAX_CONNECTION_AGE_ENV: &str = "GRPC_MAX_CONNECTION_AGE_SECS";
+/// Default connection-recycling window. Bounds how long a caller's HTTP/2
+/// channel can stay pinned to this replica: on kube-proxy ClusterIP Services,
+/// scale-out only rebalances traffic when connections are re-established.
+const DEFAULT_MAX_CONNECTION_AGE_SECS: u64 = 300;
+/// Environment variable enabling forced close of streams that outlive the age
+/// deadline (seconds; unset/`0` = never sever in-flight streams).
+const MAX_CONNECTION_AGE_GRACE_ENV: &str = "GRPC_MAX_CONNECTION_AGE_GRACE_SECS";
 
 /// Backend health probes now live in the `health` foundation crate, so storage
 /// crates can expose ready-made probes (`<storage>::health::probe(...)`) without
@@ -162,8 +172,18 @@ pub async fn serve<S: Service>(addr: SocketAddr) -> anyhow::Result<()> {
         .context("register grpc routes")?;
 
     // ── gRPC server: inbound-trace (outer) + traffic (inner) layers ────────────
+    // Connection recycling (GOAWAY after max_connection_age) is on by default:
+    // it is what re-spreads long-lived HTTP/2 channels across replicas after a
+    // scale-out. In-flight streams are never severed unless the grace env is set.
+    let mut grpc_config = GrpcServerConfig::default();
+    if let Some(age) = max_connection_age_from_env() {
+        grpc_config = grpc_config.with_max_connection_age(age);
+    }
+    if let Some(grace) = max_connection_age_grace_from_env() {
+        grpc_config = grpc_config.with_max_connection_age_grace(grace);
+    }
     let traffic = infra.traffic();
-    let mut server_builder = GrpcServerBuilder::new(GrpcServerConfig::default());
+    let mut server_builder = GrpcServerBuilder::new(grpc_config);
     if let Some(registry) = &traffic {
         server_builder = server_builder.with_traffic(Arc::clone(registry));
     }
@@ -279,6 +299,46 @@ fn interval_from_env(env_var: &str, default_secs: u64) -> Duration {
     )
 }
 
+/// Resolves the connection-recycling window from [`MAX_CONNECTION_AGE_ENV`]
+/// (default [`DEFAULT_MAX_CONNECTION_AGE_SECS`], `0` disables).
+fn max_connection_age_from_env() -> Option<Duration> {
+    let raw = std::env::var(MAX_CONNECTION_AGE_ENV).ok();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::from(d.subsec_nanos()))
+        .unwrap_or(0);
+    resolve_connection_age(raw.as_deref(), nanos)
+}
+
+/// Pure core of [`max_connection_age_from_env`]: parses the override and applies
+/// a ±10% per-process jitter (seeded by `entropy`) so replicas started together —
+/// a rollout — don't GOAWAY every caller at the same instant.
+fn resolve_connection_age(raw: Option<&str>, entropy: u64) -> Option<Duration> {
+    let secs: u64 = match raw {
+        Some(v) => v.parse().ok().unwrap_or(DEFAULT_MAX_CONNECTION_AGE_SECS),
+        None => DEFAULT_MAX_CONNECTION_AGE_SECS,
+    };
+    if secs == 0 {
+        return None;
+    }
+    let base_ms = secs.saturating_mul(1000);
+    let span_ms = (base_ms / 5).max(1); // 20% wide band centred on base
+    Some(Duration::from_millis(
+        base_ms - span_ms / 2 + entropy % span_ms,
+    ))
+}
+
+/// Grace is opt-in: only servers whose in-flight streams are safe to sever
+/// should set [`MAX_CONNECTION_AGE_GRACE_ENV`] (chat/notification hold
+/// long-lived server streams that must outlive the GOAWAY).
+fn max_connection_age_grace_from_env() -> Option<Duration> {
+    let secs: u64 = std::env::var(MAX_CONNECTION_AGE_GRACE_ENV)
+        .ok()?
+        .parse()
+        .ok()?;
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
 /// Resolves when the process receives SIGINT (Ctrl-C) or, on Unix, SIGTERM —
 /// the signal Kubernetes sends on pod termination. The tonic server drains
 /// in-flight requests before returning. If neither handler can be installed we
@@ -358,5 +418,48 @@ impl TelemetrySink for TelemetryControlSink {
                 .map_err(|e| ConfigError::validation(format!("telemetry sampling: {e}")))?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_age_defaults_to_five_minutes_within_the_jitter_band() {
+        for entropy in [0, 1, 59_999, 1_000_000_007] {
+            let age = resolve_connection_age(None, entropy).expect("default is enabled");
+            let ms = age.as_millis() as u64;
+            // 300s ±10% ⇒ [270_000, 330_000)
+            assert!((270_000..330_000).contains(&ms), "out of band: {ms}ms");
+        }
+    }
+
+    #[test]
+    fn connection_age_zero_disables_recycling() {
+        assert_eq!(resolve_connection_age(Some("0"), 42), None);
+    }
+
+    #[test]
+    fn connection_age_override_recentres_the_band() {
+        let age = resolve_connection_age(Some("60"), 12_345).expect("enabled");
+        let ms = age.as_millis() as u64;
+        assert!((54_000..66_000).contains(&ms), "out of band: {ms}ms");
+    }
+
+    #[test]
+    fn connection_age_garbage_falls_back_to_the_default() {
+        let age = resolve_connection_age(Some("not-a-number"), 7).expect("enabled");
+        let ms = age.as_millis() as u64;
+        assert!((270_000..330_000).contains(&ms), "out of band: {ms}ms");
+    }
+
+    #[test]
+    fn jitter_is_deterministic_per_entropy_and_varies_across_it() {
+        let a = resolve_connection_age(None, 1000).unwrap();
+        let b = resolve_connection_age(None, 1000).unwrap();
+        let c = resolve_connection_age(None, 999_999).unwrap();
+        assert_eq!(a, b);
+        assert_ne!(a, c);
     }
 }

--- a/crates/platform/transport/src/grpc/server/builder.rs
+++ b/crates/platform/transport/src/grpc/server/builder.rs
@@ -83,6 +83,13 @@ impl GrpcServerBuilder {
         // nests rate-limiting inside the span.
         let mut server = Server::builder().layer(InboundTraceLayer).layer(traffic_layer);
 
+        if let Some(age) = self.config.max_connection_age {
+            server = server.max_connection_age(age);
+        }
+        if let Some(grace) = self.config.max_connection_age_grace {
+            server = server.max_connection_age_grace(grace);
+        }
+
         if let Some(tls) = self.config.tls {
             let identity = TlsIdentity::from_pem(&tls.cert_pem, &tls.key_pem);
             let mut tls_config = ServerTlsConfig::new().identity(identity);

--- a/crates/platform/transport/src/grpc/server/config.rs
+++ b/crates/platform/transport/src/grpc/server/config.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use http::header::HeaderName;
 
@@ -24,6 +25,24 @@ pub struct GrpcServerConfig {
     /// Inbound header the edge mesh injects with the caller identity. Read by the traffic
     /// layer for `per_caller` rate-limit keying. Defaults to [`DEFAULT_IDENTITY_HEADER`].
     pub identity_header: HeaderName,
+
+    /// Maximum lifetime of an accepted connection. At the deadline the server GOAWAYs it:
+    /// in-flight streams keep running (never severed unless [`max_connection_age_grace`]
+    /// is also set) but the caller's *next* stream goes over a fresh connection — which
+    /// re-traverses the ClusterIP and lands on a current backend. This is what re-balances
+    /// long-lived HTTP/2 channels after a scale-out; without it a tonic channel stays
+    /// pinned to one pod for its whole life. `None` (default) = connections live forever.
+    ///
+    /// [`max_connection_age_grace`]: Self::max_connection_age_grace
+    pub max_connection_age: Option<Duration>,
+
+    /// How long in-flight streams may continue after [`max_connection_age`] before the
+    /// connection is forcibly closed. `None` (default) = never force-close, so long-lived
+    /// server streams (chat/notification) outlive the GOAWAY untouched. Only set this on
+    /// servers whose streams are safe to sever.
+    ///
+    /// [`max_connection_age`]: Self::max_connection_age
+    pub max_connection_age_grace: Option<Duration>,
 }
 
 impl Default for GrpcServerConfig {
@@ -33,6 +52,8 @@ impl Default for GrpcServerConfig {
             tls: None,
             enable_reflection: false,
             identity_header: HeaderName::from_static(DEFAULT_IDENTITY_HEADER),
+            max_connection_age: None,
+            max_connection_age_grace: None,
         }
     }
 }
@@ -56,6 +77,18 @@ impl GrpcServerConfig {
     /// Overrides the edge-mesh identity header used for `per_caller` keying.
     pub fn with_identity_header(mut self, header: HeaderName) -> Self {
         self.identity_header = header;
+        self
+    }
+
+    /// Bounds connection lifetime (GOAWAY-based recycling; see the field docs).
+    pub fn with_max_connection_age(mut self, age: Duration) -> Self {
+        self.max_connection_age = Some(age);
+        self
+    }
+
+    /// Force-closes connections whose streams outlive the age deadline by `grace`.
+    pub fn with_max_connection_age_grace(mut self, grace: Duration) -> Self {
+        self.max_connection_age_grace = Some(grace);
         self
     }
 }


### PR DESCRIPTION
Closes the remaining unblocked **P0** from the infra production-readiness review: gRPC connection pinning.

## Problem

Inter-service gRPC runs over ClusterIP Services with long-lived tonic HTTP/2 channels, and the transport crate has no client-side load balancing. kube-proxy balances **only at TCP connect** — so when the HPA scales a callee 2→6 under load, every existing caller keeps hammering the original 2 pods and the 4 new pods idle. Scale-out events don't rebalance anything.

## Fix

Server-side connection recycling (`tonic::transport::Server::max_connection_age`), applied fleet-wide through `service-runtime` — one change, every binary gets it on the next image build:

- **transport** (`GrpcServerConfig`): `max_connection_age` / `max_connection_age_grace` fields + builders, both `None` by default. Mechanism only — the transport tier stays policy-free (same philosophy as no RetryLayer there).
- **service-runtime**: `GRPC_MAX_CONNECTION_AGE_SECS` (default **300**, `0` disables) with a **±10% per-process jitter** so replicas started together (a rollout) don't GOAWAY all their callers at the same instant. At the deadline the server sends GOAWAY; the caller's next RPC transparently reconnects through the ClusterIP and lands on a *current* backend — traffic re-spreads within one window.

### Streaming safety

`GRPC_MAX_CONNECTION_AGE_GRACE_SECS` is **opt-in and unset by default**, which per tonic semantics means in-flight streams are *never* forcibly closed — the GOAWAY only stops *new* streams on the old connection. Verified against the contracts: the only long-lived server streams in the fleet are `chat.StreamConversation/StreamPublic` and `notification.StreamNotifications` (realtime dispatcher→gateway is unary `DeliverToNode`); those streams outlive recycling untouched while their channels' unary/new-stream traffic still rebalances.

## Verification (end-to-end, real `serve()` boot)

Scratch harness: a trivial `Service` booted through the **real** `service_runtime::serve` (telemetry → infra-config → gRPC), plus a client holding **one** tonic Channel doing health RPCs every 250 ms for ~7 s, with `lsof` sampling server-side connections:

| Scenario | RPCs | Distinct server-side connections |
|---|---|---|
| `GRPC_MAX_CONNECTION_AGE_SECS=2` | 28/28 OK, 0 errors | **4** (≈2 s recycling, jittered) |
| `GRPC_MAX_CONNECTION_AGE_SECS=0` | 28/28 OK | 1 (pinned — old behavior) |
| `GRPC_MAX_CONNECTION_AGE_SECS=not-a-number` | 28/28 OK | 1 (falls back to 300 s default; boot doesn't crash) |

The recycling is completely invisible to the caller — zero failed RPCs across the GOAWAY boundaries.

Also: `cargo build`/`clippy --all-targets` clean on both crates; 5 new unit tests on the jitter/parse logic (`resolve_connection_age`).

## Follow-ups (unchanged from the review)

Headless Services + client-side `balance_channel` (finer-grained spreading), or Linkerd for per-request gRPC LB + mTLS. This change is the prerequisite-free 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB