### PR TITLE
fix(infra): add topic-provisioner to the global ECR repo list

### DIFF
--- a/infrastructure/live/global/artifacts/ecr/terragrunt.hcl
+++ b/infrastructure/live/global/artifacts/ecr/terragrunt.hcl
@@ -21,6 +21,8 @@ inputs = {
     "profile-command-server",
     # ── Shared tooling ───────────────────────────────────────────────────────
     "migrator",
+    # Kafka topic provisioning from the event-topology registry (PreSync Job).
+    "topic-provisioner",
     # BuildKit registry cache sink for the CI image builds (tag = BIN name).
     "buildcache",
     # ── Existing fleet (servers) ─────────────────────────────────────────────


### PR DESCRIPTION
One-liner follow-up to #551: the binary was added to the CI matrix + overlays but not to the authoritative ECR registry list, so the currently-queued fleet-images runs will fail its push and skip the pin job. Applied to the live global unit immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB