### PR TITLE
fix(ci): push sha-pin commits over the deploy key — develop ruleset rejects the bot token

### DIFF
--- a/.github/workflows/fleet-images-deploy.yml
+++ b/.github/workflows/fleet-images-deploy.yml
@@ -122,6 +122,12 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
+          # Push over SSH with the repo deploy key: develop's ruleset requires
+          # PRs but grants DeployKey bypass, so this job (and only a holder of
+          # this key) may land the sha-pin commit directly. The default
+          # GITHUB_TOKEN push is rejected by the ruleset — GitHub can't grant
+          # the Actions app a ruleset bypass on user-owned repos.
+          ssh-key: ${{ secrets.FLEET_PIN_DEPLOY_KEY }}
 
       - name: Pin fleet images to the built commit SHA
         env:


### PR DESCRIPTION
The pin job has **never** landed a pin — every run's direct push to develop was rejected by the branch ruleset (\"changes must be made through a pull request\"), which is why the staging overlay still floats on `:staging` despite the pinning design.

Settings changes already applied (user-approved, develop-scoped):
- New ruleset **\"Standard Development Policy — develop (CI pin bypass)\"**: same rules as before + `DeployKey` bypass. The original ruleset is narrowed to `main` (unchanged posture there: PR-only, admin bypass).
- One write **deploy key** (`fleet-images pin job`) — the repo's only deploy key — with its private half in the `FLEET_PIN_DEPLOY_KEY` Actions secret.

This PR is the workflow half: checkout with `ssh-key:` so the pin push rides SSH under that key. (GitHub can't grant the Actions app itself a ruleset bypass on user-owned repos — org-only feature — hence the deploy-key route.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB