### PR TITLE
fix(platform): order topic-provisioner by sync-wave — PreSync deadlocked on fresh clusters

### DIFF
--- a/k8s/overlays/prod/external-secrets.yaml
+++ b/k8s/overlays/prod/external-secrets.yaml
@@ -8,13 +8,19 @@
 # cross-namespace serviceAccountRef ("namespace should be empty or match the
 # SecretStore's namespace"). A ClusterSecretStore is cluster-scoped and may
 # reference the operator's SA in external-secrets (the canonical IRSA pattern).
-# No sync-wave: ESO re-reconciles ExternalSecrets once the store exists, so gating
-# the fleet on the store (a prior sync-wave: -1) was unnecessary AND deployed 0
-# pods whenever the store failed to apply.
+# Sync-wave -3: the topic-provisioner Job (wave -1) hard-depends on the
+# backend-creds Secret (wave -2), which needs this store. A prior attempt left
+# these unwaved ("ESO re-reconciles once the store exists") — true for the fleet
+# pods, but the provisioner Job made the dependency hard and the first bring-up
+# deadlocked with the Job as a PreSync hook. The trade-off stands: if the store
+# fails to apply, the sync stalls before the fleet — which is now correct,
+# because the fleet can't publish without the topics the Job creates.
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: aws-secrets-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
 spec:
   provider:
     aws:
@@ -30,6 +36,10 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: backend-creds
+  annotations:
+    # Wave -2: materialized before the topic-provisioner Job (wave -1) starts —
+    # ArgoCD waits on this resource's Ready health before advancing the wave.
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/k8s/overlays/prod/topic-provisioner-job.yaml
+++ b/k8s/overlays/prod/topic-provisioner-job.yaml
@@ -6,11 +6,17 @@
 # Job producers fail UNKNOWN_TOPIC_OR_PART and consumers idle forever — nothing
 # else in the platform creates topics.
 #
-# ArgoCD PreSync hook: runs on every sync, so a topic added to the registry is
-# created by the same sync that rolls the code consuming it. Idempotent —
-# TOPIC_ALREADY_EXISTS is success. BeforeHookCreation replaces the (immutable)
-# finished Job on the next sync. If the Job fails, the sync fails: the fleet is
-# not rolled onto a broker missing its topics.
+# Ordered by SYNC-WAVE, deliberately NOT a PreSync hook: on a fresh cluster the
+# Job needs the ESO-synced backend-creds Secret, but a PreSync hook runs before
+# the sync that applies the ClusterSecretStore/ExternalSecret — a deadlock that
+# broke the first staging bring-up. Waves keep everything in one sync:
+#   -3 ClusterSecretStore → -2 backend-creds ExternalSecret → -1 this Job →
+#    0 the fleet. Replace=true re-applies the (immutable) finished Job on every
+# sync, so a topic added to the registry is created by the same sync that rolls
+# the code consuming it. Idempotent — TOPIC_ALREADY_EXISTS is success. If the
+# Job fails, the sync stops: the fleet is not rolled onto a broker missing its
+# topics. (If ESO is slow, the pod waits in CreateContainerConfigError and the
+# kubelet retries until the Secret lands — activeDeadlineSeconds bounds it.)
 #
 # TOPIC_REPLICATION_FACTOR is required by the binary (no default on purpose) and
 # MUST track the env's broker count / MSK default.replication.factor — prod
@@ -23,8 +29,8 @@ metadata:
   labels:
     app: topic-provisioner
   annotations:
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true,Force=true
 spec:
   backoffLimit: 6
   activeDeadlineSeconds: 600

--- a/k8s/overlays/staging/external-secrets.yaml
+++ b/k8s/overlays/staging/external-secrets.yaml
@@ -8,13 +8,19 @@
 # cross-namespace serviceAccountRef ("namespace should be empty or match the
 # SecretStore's namespace"). A ClusterSecretStore is cluster-scoped and may
 # reference the operator's SA in external-secrets (the canonical IRSA pattern).
-# No sync-wave: ESO re-reconciles ExternalSecrets once the store exists, so gating
-# the fleet on the store (a prior sync-wave: -1) was unnecessary AND deployed 0
-# pods whenever the store failed to apply.
+# Sync-wave -3: the topic-provisioner Job (wave -1) hard-depends on the
+# backend-creds Secret (wave -2), which needs this store. A prior attempt left
+# these unwaved ("ESO re-reconciles once the store exists") — true for the fleet
+# pods, but the provisioner Job made the dependency hard and the first bring-up
+# deadlocked with the Job as a PreSync hook. The trade-off stands: if the store
+# fails to apply, the sync stalls before the fleet — which is now correct,
+# because the fleet can't publish without the topics the Job creates.
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: aws-secrets-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
 spec:
   provider:
     aws:
@@ -30,6 +36,10 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: backend-creds
+  annotations:
+    # Wave -2: materialized before the topic-provisioner Job (wave -1) starts —
+    # ArgoCD waits on this resource's Ready health before advancing the wave.
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/k8s/overlays/staging/topic-provisioner-job.yaml
+++ b/k8s/overlays/staging/topic-provisioner-job.yaml
@@ -6,11 +6,17 @@
 # Job producers fail UNKNOWN_TOPIC_OR_PART and consumers idle forever — nothing
 # else in the platform creates topics.
 #
-# ArgoCD PreSync hook: runs on every sync, so a topic added to the registry is
-# created by the same sync that rolls the code consuming it. Idempotent —
-# TOPIC_ALREADY_EXISTS is success. BeforeHookCreation replaces the (immutable)
-# finished Job on the next sync. If the Job fails, the sync fails: the fleet is
-# not rolled onto a broker missing its topics.
+# Ordered by SYNC-WAVE, deliberately NOT a PreSync hook: on a fresh cluster the
+# Job needs the ESO-synced backend-creds Secret, but a PreSync hook runs before
+# the sync that applies the ClusterSecretStore/ExternalSecret — a deadlock that
+# broke the first staging bring-up. Waves keep everything in one sync:
+#   -3 ClusterSecretStore → -2 backend-creds ExternalSecret → -1 this Job →
+#    0 the fleet. Replace=true re-applies the (immutable) finished Job on every
+# sync, so a topic added to the registry is created by the same sync that rolls
+# the code consuming it. Idempotent — TOPIC_ALREADY_EXISTS is success. If the
+# Job fails, the sync stops: the fleet is not rolled onto a broker missing its
+# topics. (If ESO is slow, the pod waits in CreateContainerConfigError and the
+# kubelet retries until the Secret lands — activeDeadlineSeconds bounds it.)
 #
 # TOPIC_REPLICATION_FACTOR is required by the binary (no default on purpose) and
 # MUST track the env's broker count / MSK default.replication.factor — staging
@@ -23,8 +29,8 @@ metadata:
   labels:
     app: topic-provisioner
   annotations:
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true,Force=true
 spec:
   backoffLimit: 6
   activeDeadlineSeconds: 600


### PR DESCRIPTION
Live bring-up finding: PreSync hook Job needs backend-creds, which only exists after the main sync applies the ESO resources → deadlock on any fresh cluster. Re-ordered as waves within one sync (store -3 → creds -2 → Job -1 → fleet 0), Job re-applied via Replace=true. Same fail-closed semantics. Mirrored to prod overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB