### PR TITLE
fix(platform): build librdkafka with vendored OpenSSL — SASL_SSL was impossible fleet-wide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3494,6 +3503,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4450,6 +4460,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,13 @@ sqlx = { version = "0.8.6", features = [
     "ipnetwork",
 ] }
 fred = { version = "10.1.0", features = ["serde-json", "dynamic-pool"] }
-rdkafka = "0.38.0"
+# ssl-vendored: statically link a vendored OpenSSL into librdkafka. Without it
+# librdkafka is built WITHOUT SSL and rejects security.protocol=SASL_SSL at
+# client-config time ("OpenSSL not available at build time") — every managed-MSK
+# env (SASL/SCRAM over TLS) needs this; first hit live by the topic-provisioner
+# on the staging bring-up. SCRAM-SHA-512 is implemented inside librdkafka and
+# needs only OpenSSL (no libsasl2/gssapi).
+rdkafka = { version = "0.38.0", features = ["ssl-vendored"] }
 dashmap = "7.0.0-rc2"
 elasticsearch = "9.1.0-alpha.1"
 scylla = "1.4.1"


### PR DESCRIPTION
Third live bring-up finding: no rdkafka TLS features → librdkafka built without SSL → every fleet binary rejects SASL_SSL at config time. The provisioner was just first to touch real MSK. `ssl-vendored` statically links OpenSSL (SCRAM needs nothing else); verified locally that SASL_SSL config now passes and the client proceeds to broker I/O. CI will rebuild the cook layer (cold) and re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB