### PR TITLE
fix(platform): point vendored OpenSSL at the runtime CA bundle; longer admin timeout

### DIFF
--- a/crates/apps/topic-provisioner/src/main.rs
+++ b/crates/apps/topic-provisioner/src/main.rs
@@ -40,6 +40,12 @@ async fn main() -> Result<()> {
         Ok(v) => v.parse().context("TOPIC_PARTITIONS must be an integer")?,
         Err(_) => 12,
     };
+    // Creating the full registry (53 topics × partitions × RF) on small managed
+    // brokers takes real time; 30s timed out live on 2× kafka.t3.small.
+    let admin_timeout: u64 = match std::env::var("TOPIC_ADMIN_TIMEOUT_SECS") {
+        Ok(v) => v.parse().context("TOPIC_ADMIN_TIMEOUT_SECS must be an integer")?,
+        Err(_) => 180,
+    };
 
     let names = topic_names();
     println!(
@@ -60,7 +66,7 @@ async fn main() -> Result<()> {
     let results = admin
         .create_topics(
             new_topics.iter(),
-            &AdminOptions::new().operation_timeout(Some(Duration::from_secs(30))),
+            &AdminOptions::new().operation_timeout(Some(Duration::from_secs(admin_timeout))),
         )
         .await
         .context("create_topics admin call")?;

--- a/crates/platform/transport/src/kafka/config/client.rs
+++ b/crates/platform/transport/src/kafka/config/client.rs
@@ -21,7 +21,25 @@ pub struct KafkaClientConfig {
     /// Log-level forwarded to rdkafka's internal debug logger.
     /// Useful values: `"all"`, `"consumer"`, `"producer"`, `"topic"`.
     pub rdkafka_debug: Option<String>,
+
+    /// CA bundle path for TLS broker connections (`ssl.ca.location`).
+    ///
+    /// REQUIRED KNOWLEDGE for this workspace: librdkafka links a VENDORED,
+    /// statically-built OpenSSL (`rdkafka/ssl-vendored`), which has no baked-in
+    /// system CA path — without an explicit location every TLS handshake fails
+    /// certificate verification and surfaces only as a generic timeout (found
+    /// live on the staging bring-up: create_topics OperationTimedOut while a
+    /// dynamically-linked kcat from the same pod network succeeded). Defaults
+    /// to the Debian bundle the runtime image installs
+    /// (`/etc/ssl/certs/ca-certificates.crt`); override with
+    /// `KAFKA_SSL_CA_LOCATION` (e.g. macOS local dev against a cloud broker).
+    /// Only applied when `security_protocol` uses SSL.
+    pub ssl_ca_location: Option<String>,
 }
+
+/// Debian/Ubuntu CA bundle path — what `deploy/Dockerfile`'s runtime stage
+/// provides via `ca-certificates`.
+const DEFAULT_SSL_CA_LOCATION: &str = "/etc/ssl/certs/ca-certificates.crt";
 
 impl Default for KafkaClientConfig {
     fn default() -> Self {
@@ -32,6 +50,7 @@ impl Default for KafkaClientConfig {
             sasl_username: None,
             sasl_password: None,
             rdkafka_debug: None,
+            ssl_ca_location: None,
         }
     }
 }
@@ -56,6 +75,7 @@ impl KafkaClientConfig {
             sasl_username: std::env::var("KAFKA_SASL_USERNAME").ok(),
             sasl_password: std::env::var("KAFKA_SASL_PASSWORD").ok(),
             rdkafka_debug: std::env::var("KAFKA_DEBUG").ok(),
+            ssl_ca_location: std::env::var("KAFKA_SSL_CA_LOCATION").ok(),
         }
     }
 
@@ -80,6 +100,15 @@ impl KafkaClientConfig {
         }
         if let Some(d) = &self.rdkafka_debug {
             cfg.set("debug", d);
+        }
+
+        // Vendored OpenSSL has no system CA path — point it at the runtime
+        // image's bundle whenever the connection uses TLS (see field docs).
+        if self.security_protocol.to_ascii_uppercase().contains("SSL") {
+            cfg.set(
+                "ssl.ca.location",
+                self.ssl_ca_location.as_deref().unwrap_or(DEFAULT_SSL_CA_LOCATION),
+            );
         }
 
         cfg


### PR DESCRIPTION
Bring-up finding #4: `ssl-vendored` OpenSSL has no default CA store → TLS to MSK fails cert verification silently → generic OperationTimedOut (kcat with the same creds/network works, isolating CA loading). transport now sets `ssl.ca.location` (default: the runtime image's Debian bundle, env-overridable via `KAFKA_SSL_CA_LOCATION`) whenever the protocol uses SSL — fleet-wide. Provisioner admin timeout now 180s default (`TOPIC_ADMIN_TIMEOUT_SECS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB