### PR TITLE
fix(platform): PKCS#8 auth signing key + [cache] section for profile

### DIFF
--- a/infrastructure/modules/app-secrets/main.tf
+++ b/infrastructure/modules/app-secrets/main.tf
@@ -215,7 +215,11 @@ resource "aws_secretsmanager_secret" "auth_secrets" {
 resource "aws_secretsmanager_secret_version" "auth_secrets" {
   secret_id = aws_secretsmanager_secret.auth_secrets.id
   secret_string = jsonencode({
-    signing_private_pem    = tls_private_key.auth_signing.private_key_pem
+    # PKCS#8, not the default SEC1 ("EC PRIVATE KEY") PEM: auth's jsonwebtoken/
+    # ring EC path only accepts PKCS#8 — with SEC1 the key never loads and the
+    # service fail-closes with "no signing key is currently available" (found
+    # live on the staging bring-up).
+    signing_private_pem    = tls_private_key.auth_signing.private_key_pem_pkcs8
     signing_public_pem     = tls_private_key.auth_signing.public_key_pem
     keycloak_client_secret = random_password.keycloak_client_secret.result
   })

--- a/k8s/overlays/dev/infrastructure.toml
+++ b/k8s/overlays/dev/infrastructure.toml
@@ -25,6 +25,20 @@ rps   = 1000
 burst = 200
 scope = "per_method"
 
+# ── Cache profiles (consumed by profile's read-through caches) ────────────────
+[cache]
+default_profile = "standard"
+
+[cache.profiles.standard]
+ttl_secs = 300
+
+[cache.profiles.handles]
+ttl_secs = 600
+
+[cache.bindings]
+"profile-view" = "standard"
+"handle-lookup" = "handles"
+
 [telemetry]
 log_filter = "info"
 sampling   = { kind = "trace_id_ratio", ratio = 0.1 }

--- a/k8s/overlays/prod/infrastructure.toml
+++ b/k8s/overlays/prod/infrastructure.toml
@@ -25,6 +25,20 @@ rps   = 1000
 burst = 200
 scope = "per_method"
 
+# ── Cache profiles (consumed by profile's read-through caches) ────────────────
+[cache]
+default_profile = "standard"
+
+[cache.profiles.standard]
+ttl_secs = 300
+
+[cache.profiles.handles]
+ttl_secs = 600
+
+[cache.bindings]
+"profile-view" = "standard"
+"handle-lookup" = "handles"
+
 [telemetry]
 log_filter = "info"
 sampling   = { kind = "trace_id_ratio", ratio = 0.1 }

--- a/k8s/overlays/staging/infrastructure.toml
+++ b/k8s/overlays/staging/infrastructure.toml
@@ -25,6 +25,20 @@ rps   = 1000
 burst = 200
 scope = "per_method"
 
+# ── Cache profiles (consumed by profile's read-through caches) ────────────────
+[cache]
+default_profile = "standard"
+
+[cache.profiles.standard]
+ttl_secs = 300
+
+[cache.profiles.handles]
+ttl_secs = 600
+
+[cache.bindings]
+"profile-view" = "standard"
+"handle-lookup" = "handles"
+
 [telemetry]
 log_filter = "info"
 sampling   = { kind = "trace_id_ratio", ratio = 0.1 }


### PR DESCRIPTION
Bring-up findings #7+#8, both config-only. **auth:** Terraform seeded SEC1 EC PEM; jsonwebtoken/ring needs PKCS#8 → key never loaded, fail-closed boot. Now `private_key_pem_pkcs8`. **profile:** no overlay carried the required `[cache]` section — added to staging/prod/dev with the shape profile's IT harness pins. Rollout = terragrunt apply app-secrets + ES refresh + ConfigMap sync; no image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB