### PR TITLE
fix(gitops): ignore ESO-defaulted remoteRef fields — apps could never reach Synced

### DIFF
--- a/infrastructure/argocd/apps/deployments/prod/fleet.yaml
+++ b/infrastructure/argocd/apps/deployments/prod/fleet.yaml
@@ -23,6 +23,17 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: default
+  # ESO's admission webhook defaults remoteRef fields (conversionStrategy /
+  # decodingStrategy / metadataPolicy) on every ExternalSecret; without ignoring
+  # them the live objects diff against Git forever, the app can never reach
+  # Synced, and selfHeal loops — found live on the staging bring-up.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
   syncPolicy:
     automated:
       prune: true
@@ -33,6 +44,7 @@ spec:
       # CRDs come from the operator appsets, which sync independently — tolerate
       # them arriving after this app's first attempt (same rationale as staging).
       - SkipDryRunOnMissingResource=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 10
       backoff:

--- a/infrastructure/argocd/apps/deployments/staging/fleet.yaml
+++ b/infrastructure/argocd/apps/deployments/staging/fleet.yaml
@@ -33,6 +33,17 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: default
+  # ESO's admission webhook defaults remoteRef fields (conversionStrategy /
+  # decodingStrategy / metadataPolicy) on every ExternalSecret; without ignoring
+  # them the live objects diff against Git forever, the app can never reach
+  # Synced, and selfHeal loops — found live on the staging bring-up.
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
   syncPolicy:
     automated:
       prune: true
@@ -46,6 +57,7 @@ spec:
       # bring-up this app can sync before KEDA/CNPG/ESO CRDs exist — skip the
       # dry-run for missing kinds and retry instead of hard-failing.
       - SkipDryRunOnMissingResource=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 10
       backoff:


### PR DESCRIPTION
Bring-up finding #9: ESO admission defaults create a perpetual ExternalSecret diff → the fleet app can never reach Synced and selfHeal loops. Standard remedy: `ignoreDifferences` + `RespectIgnoreDifferences=true` on both env fleet Applications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB