### PR TITLE
fix(platform): allow the CNPG operator through the default-deny to instance pods

### DIFF
--- a/k8s/overlays/prod/networkpolicies.yaml
+++ b/k8s/overlays/prod/networkpolicies.yaml
@@ -198,3 +198,25 @@ spec:
               app: realtime-gateway
       ports:
         - { protocol: TCP, port: 50060 }
+---
+# The CNPG operator (ns cnpg-system) must reach every instance pod's status/
+# management API (:8000) — status extraction, ScheduledBackup orchestration and
+# failover all ride it. Cross-namespace, so the default-deny above blocks it
+# (found live: every cluster stuck on "Instance Status Extraction Error").
+# Instance pods carry the cnpg.io/cluster label.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator-to-instances
+spec:
+  podSelector:
+    matchExpressions:
+      - { key: cnpg.io/cluster, operator: Exists }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - { protocol: TCP, port: 8000 }

--- a/k8s/overlays/staging/networkpolicies.yaml
+++ b/k8s/overlays/staging/networkpolicies.yaml
@@ -198,3 +198,25 @@ spec:
               app: realtime-gateway
       ports:
         - { protocol: TCP, port: 50060 }
+---
+# The CNPG operator (ns cnpg-system) must reach every instance pod's status/
+# management API (:8000) — status extraction, ScheduledBackup orchestration and
+# failover all ride it. Cross-namespace, so the default-deny above blocks it
+# (found live: every cluster stuck on "Instance Status Extraction Error").
+# Instance pods carry the cnpg.io/cluster label.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator-to-instances
+spec:
+  podSelector:
+    matchExpressions:
+      - { key: cnpg.io/cluster, operator: Exists }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - { protocol: TCP, port: 8000 }


### PR DESCRIPTION
Bring-up finding #11: default-deny blocked cnpg-system → instance pods :8000 (status extraction, ScheduledBackup, failover). Scoped allow added, mirrored to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB