### PR TITLE
feat(observability): OTel collector — close the fleet's telemetry black hole

### DIFF
--- a/infrastructure/argocd/apps/infrastructure/observability/otel-collector/Chart.lock
+++ b/infrastructure/argocd/apps/infrastructure/observability/otel-collector/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.162.0
+digest: sha256:13c7cd5dc1c3df3e4ca4d7dd96cb4936b80ddf61f35024399bb57f4efa98d003
+generated: "2026-07-04T00:30:22.513019+02:00"

--- a/infrastructure/argocd/apps/infrastructure/observability/otel-collector/Chart.yaml
+++ b/infrastructure/argocd/apps/infrastructure/observability/otel-collector/Chart.yaml
@@ -1,0 +1,14 @@
+# Wrapper around the upstream OpenTelemetry Collector chart.
+#
+# This is the sink every fleet binary already points at: telemetry's OTLP
+# exporter reads OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability
+# .svc.cluster.local:4317 in every env file. Until this app existed the fleet's
+# traces/metrics went to a nonexistent Service — the "observability black hole"
+# from the infra review.
+apiVersion: v2
+name: otel-collector-wrapper
+version: 1.0.0
+dependencies:
+  - name: opentelemetry-collector
+    version: "0.162.0"
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/infrastructure/argocd/apps/infrastructure/observability/otel-collector/values.yaml
+++ b/infrastructure/argocd/apps/infrastructure/observability/otel-collector/values.yaml
@@ -1,0 +1,70 @@
+# infrastructure/argocd/apps/infrastructure/observability/otel-collector/values.yaml
+opentelemetry-collector:
+  # MUST stay `otel-collector`: every fleet env file exports OTLP to
+  # otel-collector.observability.svc.cluster.local:4317 — the Service name is
+  # the contract.
+  fullnameOverride: otel-collector
+
+  mode: deployment
+  replicaCount: 2
+
+  image:
+    repository: otel/opentelemetry-collector-contrib
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  # OTLP in → Prometheus out (metrics) / debug out (traces, logs).
+  # Metrics are exposed on :8889 and scraped by the kube-prometheus-stack
+  # Prometheus via the ServiceMonitor below. Traces have no backend yet —
+  # the debug exporter keeps them observable in collector logs at `basic`
+  # verbosity until Tempo/Jaeger lands (tracked follow-up).
+  config:
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+      debug: {}
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          exporters: [prometheus]
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          exporters: [debug]
+
+  # Only the OTLP ingest ports and the Prometheus-exporter port; the chart's
+  # jaeger/zipkin defaults are dead weight here.
+  ports:
+    jaeger-compact:
+      enabled: false
+    jaeger-thrift:
+      enabled: false
+    jaeger-grpc:
+      enabled: false
+    zipkin:
+      enabled: false
+    prom-exporter:
+      enabled: true
+      containerPort: 8889
+      servicePort: 8889
+      protocol: TCP
+
+  serviceMonitor:
+    enabled: true
+    # kube-prometheus-stack only selects ServiceMonitors carrying its release
+    # label (the monitoring app's Helm release name).
+    extraLabels:
+      release: monitoring
+    metricsEndpoints:
+      # Collector self-telemetry.
+      - port: metrics
+      # The fleet's metrics, re-exposed by the prometheus exporter.
+      - port: prom-exporter

--- a/infrastructure/argocd/bootstrap/prod/root-infra-observability.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-observability.yaml
@@ -24,6 +24,15 @@ spec:
                 - name: monitoring
                   folder: infrastructure/argocd/apps/infrastructure/observability/monitoring
                   valuesKey: "kube-prometheus-stack"
+                  destNamespace: monitoring
+                # OTLP sink the whole fleet exports to (otel-collector.observability
+                # .svc:4317) — metrics re-exposed to Prometheus, traces to debug
+                # until a traces backend lands.
+                - name: otel-collector
+                  folder: infrastructure/argocd/apps/infrastructure/observability/otel-collector
+                  valuesKey: "opentelemetry-collector"
+                  # MUST be `observability`: the fleet's OTLP endpoint DNS contract.
+                  destNamespace: observability
           - git:
               repoURL: https://github.com/arnaudmaillet/core-platform
               revision: main
@@ -51,7 +60,7 @@ spec:
           ref: values
       destination:
         server: https://kubernetes.default.svc
-        namespace: monitoring
+        namespace: '{{.destNamespace}}'
       syncPolicy:
         automated: 
           prune: true

--- a/infrastructure/argocd/bootstrap/staging/root-infra-observability.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-observability.yaml
@@ -24,6 +24,15 @@ spec:
                 - name: monitoring
                   folder: infrastructure/argocd/apps/infrastructure/observability/monitoring
                   valuesKey: "kube-prometheus-stack"
+                  destNamespace: monitoring
+                # OTLP sink the whole fleet exports to (otel-collector.observability
+                # .svc:4317) — metrics re-exposed to Prometheus, traces to debug
+                # until a traces backend lands.
+                - name: otel-collector
+                  folder: infrastructure/argocd/apps/infrastructure/observability/otel-collector
+                  valuesKey: "opentelemetry-collector"
+                  # MUST be `observability`: the fleet's OTLP endpoint DNS contract.
+                  destNamespace: observability
           - git:
               repoURL: https://github.com/arnaudmaillet/core-platform
               revision: develop
@@ -51,7 +60,7 @@ spec:
           ref: values
       destination:
         server: https://kubernetes.default.svc
-        namespace: monitoring
+        namespace: '{{.destNamespace}}'
       syncPolicy:
         automated: 
           prune: true


### PR DESCRIPTION
The fleet has always exported OTLP to `otel-collector.observability.svc:4317` — nothing served it (infra-review finding). Wrapper app around upstream chart 0.162.0: OTLP → Prometheus exporter → scraped by the existing kube-prometheus-stack (ServiceMonitor, `release: monitoring`); traces → debug exporter until Tempo (follow-up). Observability appset destination namespace is now per-element. Rendered + ServiceMonitor verified via helm template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB