### PR TITLE
fix(platform): allow the k6-operator through the default-deny to runner pods

### DIFF
--- a/k8s/overlays/staging/networkpolicies.yaml
+++ b/k8s/overlays/staging/networkpolicies.yaml
@@ -256,3 +256,25 @@ spec:
         - { protocol: TCP, port: 50052 }
         - { protocol: TCP, port: 50061 }
         - { protocol: TCP, port: 50060 }
+---
+# The k6-operator (ns k6-operator-system) drives its runner pods over their
+# REST API (:6565) — readiness check, start, teardown. Cross-namespace, so the
+# default-deny blocks it and a TestRun hangs at stage=created with paused
+# runners (same class as the CNPG operator rule above; found live launching
+# the first soak).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-k6-operator-to-runners
+spec:
+  podSelector:
+    matchLabels:
+      app: k6-loadtest
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: k6-operator-system
+      ports:
+        - { protocol: TCP, port: 6565 }


### PR DESCRIPTION
Finding #13: default-deny blocked k6-operator-system → runner :6565; TestRuns hang at stage=created. Scoped allow, staging-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB