### PR TITLE
fix(loadtest): key the k6 NetworkPolicies on the operator-stamped labels

### DIFF
--- a/k8s/overlays/staging/networkpolicies.yaml
+++ b/k8s/overlays/staging/networkpolicies.yaml
@@ -222,11 +222,11 @@ spec:
         - { protocol: TCP, port: 8000 }
 ---
 # Load-test ingress (STAGING ONLY — deliberately not mirrored to prod): k6
-# runner pods (app=k6-loadtest, spawned by the k6-operator TestRun) may call
+# runner pods (app=k6/runner=true, stamped by the k6-operator) may call
 # the tightened mesh callees on their gRPC ports. Without this, a soak can
 # only exercise the same-namespace-open services and never drives the post →
-# timeline/search/realtime fan-out. The label is the gate: nothing else
-# carries app=k6-loadtest.
+# timeline/search/realtime fan-out. The operator stamps app=k6/runner=true on
+# every runner pod (custom `app` labels are overridden) — that pair is the gate.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -248,7 +248,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app: k6-loadtest
+              app: k6
+              runner: "true"
       ports:
         - { protocol: TCP, port: 50059 }
         - { protocol: TCP, port: 50053 }
@@ -267,9 +268,13 @@ kind: NetworkPolicy
 metadata:
   name: allow-k6-operator-to-runners
 spec:
+  # The operator stamps its own labels on runner pods (app=k6, runner=true) —
+  # custom runner labels for `app` are overridden, found live: the first soak
+  # stayed paused because this policy keyed on a label the pods never carried.
   podSelector:
     matchLabels:
-      app: k6-loadtest
+      app: k6
+      runner: "true"
   policyTypes: [Ingress]
   ingress:
     - from:

--- a/tools/k6/soak.js
+++ b/tools/k6/soak.js
@@ -11,7 +11,7 @@
 // and the gRPC connection-recycling behavior under sustained load.
 //
 // NETWORK: post/profile/etc. are tightened mesh callees — the runner pods must
-// carry the `app: k6-loadtest` label (see testrun-soak.yaml) to pass the
+// carry the operator-stamped app=k6/runner=true labels to pass the
 // staging `allow-loadtest-to-mesh` NetworkPolicy.
 //
 // IDs are UUIDv7 (the fleet's id convention) generated inline — the script is

--- a/tools/k6/testrun-soak.yaml
+++ b/tools/k6/testrun-soak.yaml
@@ -11,9 +11,10 @@
 #   kubectl delete testrun fleet-soak -n default
 #   kubectl delete configmap k6-fleet-soak -n default
 #
-# The runner label app=k6-loadtest is the gate through the staging
-# `allow-loadtest-to-mesh` NetworkPolicy (post/profile/... are tightened mesh
-# callees). ~13 min total: 2m ramp → 10m soak at 10 VUs/runner → 1m down.
+# Runner pods are admitted through the staging `allow-loadtest-to-mesh` /
+# `allow-k6-operator-to-runners` NetworkPolicies by the labels the OPERATOR
+# stamps (app=k6, runner=true) — custom `app` labels are overridden, so don't
+# bother setting one. ~13 min: 2m ramp → 10m soak at 10 VUs/runner → 1m down.
 apiVersion: k6.io/v1alpha1
 kind: TestRun
 metadata:
@@ -26,9 +27,6 @@ spec:
       name: k6-fleet-soak
       file: soak.js
   runner:
-    metadata:
-      labels:
-        app: k6-loadtest
     resources:
       requests:
         cpu: 250m


### PR DESCRIPTION
The operator overrides custom runner `app` labels (pods carry app=k6, runner=true) — both soak netpols matched nothing. Corrected selectors; manifest cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB