### PR TITLE
fix(platform): 3 Scylla members in staging — RF3 keyspaces made every write fail

### DIFF
--- a/infrastructure/live/staging/env.hcl
+++ b/infrastructure/live/staging/env.hcl
@@ -28,10 +28,15 @@ locals {
     }
     database = {
       instance_types = ["t3.large"]
-      min_size       = 2
-      max_size       = 5
-      desired_size   = 2
-      labels         = { intent = "database" }
+      # 3 nodes: one per Scylla member — the fleet's keyspaces are created at
+      # NetworkTopologyStrategy RF 3 (per-service migrations) and every write
+      # is LOCAL_QUORUM, so fewer than 2 live members fails ALL writes (found
+      # live: the first soak's 6,850 CreatePost calls all failed on a 1-node
+      # Scylla). CNPG's 12 instances also breathe easier across 3 nodes.
+      min_size     = 3
+      max_size     = 5
+      desired_size = 3
+      labels       = { intent = "database" }
       taints = [{
         key    = "dedicated"
         value  = "database"

--- a/k8s/base/infra/scylla-cluster/scylla-cluster.yaml
+++ b/k8s/base/infra/scylla-cluster/scylla-cluster.yaml
@@ -30,9 +30,11 @@ spec:
     name: datacenter1
     racks:
       - name: rack1
-        # Single-node for disposable staging: avoids needing 3 dedicated DB nodes
-        # for anti-affinity, and is sufficient to validate the fleet. (Prod: 3.)
-        members: 1
+        # 3 members, NOT 1: the per-service migrations create every keyspace at
+        # NetworkTopologyStrategy RF 3 and the services write LOCAL_QUORUM —
+        # a single member fails every fleet write (soak finding #15). Three
+        # members also make staging exercise the real quorum paths.
+        members: 3
         # Pin to the database node tier and tolerate its taint, so Scylla lands on
         # the dedicated DB nodes instead of general/spot capacity.
         placement:


### PR DESCRIPTION
Soak finding #15: keyspaces are baked at NetworkTopologyStrategy RF3, writes are LOCAL_QUORUM, staging Scylla had 1 member → 100% write failure (6,850/6,850 CreatePost rejected at ~2.4ms). Staging goes to 3 members + a third t3.large DB node. Requires `terragrunt apply` on the staging eks unit (node group), done immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB