### PR TITLE
fix(resilience): honor Tower's clone-in-call readiness contract (Buffer panic)

### DIFF
--- a/crates/foundation/resilience/Cargo.toml
+++ b/crates/foundation/resilience/Cargo.toml
@@ -25,3 +25,7 @@ serde = ["dep:serde"]
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 serde_json = { workspace = true }
+# buffer: regression tests drive the middleware over a Buffer-backed inner —
+# the readiness contract violation these layers once had only manifests there
+# (tonic's Channel is Buffer-backed; see the clone-in-call comments).
+tower = { workspace = true, features = ["buffer", "util"] }

--- a/crates/foundation/resilience/src/circuit_breaker/service.rs
+++ b/crates/foundation/resilience/src/circuit_breaker/service.rs
@@ -50,7 +50,14 @@ where
 
     fn call(&mut self, req: Req) -> Self::Future {
         let sm = Arc::clone(&self.state_machine);
-        let mut svc = self.inner.clone();
+        // Tower's clone-in-call rule: readiness belongs to the INSTANCE the
+        // caller just polled. Take that instance and leave the fresh clone
+        // behind for the next poll_ready — calling a fresh clone of a
+        // Buffer-backed service (tonic's Channel) panics with "`send_item`
+        // called without first calling `poll_reserve`" (found live: 100% of
+        // timeline→social-graph calls died under the first staging soak).
+        let clone = self.inner.clone();
+        let mut svc = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
             // 1. Gate the request on the current circuit state.
@@ -132,5 +139,28 @@ mod tests {
         // Now Open: the request is rejected without touching the inner service.
         let rejected = svc.ready().await.unwrap().call(()).await.unwrap_err();
         assert!(matches!(rejected, ResilienceError::CircuitOpen));
+    }
+
+    /// Regression (staging soak finding #16): a Buffer-backed inner (tonic's
+    /// Channel is one) panics "`send_item` called without first calling
+    /// `poll_reserve`" if `call` runs on a fresh clone instead of the polled
+    /// instance. Drives the breaker over a real `tower::buffer::Buffer` and
+    /// makes many sequential calls; the clone-in-call fix keeps it from
+    /// panicking.
+    #[tokio::test]
+    async fn survives_buffer_backed_inner_across_many_calls() {
+        use tower::buffer::Buffer;
+
+        let inner = service_fn(|_: ()| async { Ok::<_, &str>("ok") });
+        let buffered = Buffer::new(inner, 8);
+        let mut svc = CircuitBreakerService::new(
+            buffered,
+            machine(CircuitBreakerConfig::default()),
+        );
+
+        for _ in 0..25 {
+            let out = svc.ready().await.unwrap().call(()).await.unwrap();
+            assert_eq!(out, "ok");
+        }
     }
 }

--- a/crates/foundation/resilience/src/retry/service.rs
+++ b/crates/foundation/resilience/src/retry/service.rs
@@ -4,16 +4,18 @@ use std::{
     task::{Context, Poll},
 };
 
-use tower::Service;
+use tower::{Service, ServiceExt};
 
 use super::{backoff::strategy::BackoffStrategy, config::RetryConfig, policy::RetryPolicy};
 use crate::error::ResilienceError;
 
 /// Tower [`Service`] that retries the inner service on transient failures.
 ///
-/// The inner service is cloned once per `call` invocation — callers must ensure
-/// `S: Clone`. This follows the standard tower pattern for services that are
-/// cheap to clone (e.g. `Arc`-backed clients).
+/// The inner service is taken via the clone-in-call pattern (`mem::replace`
+/// with a fresh clone), and every attempt re-drives `ready()` on that same
+/// instance before calling — readiness belongs to the instance the caller
+/// polled, and a Buffer-backed inner (tonic's `Channel`) panics when `call`ed
+/// on a clone whose slot was never reserved.
 pub struct RetryService<S, P, B> {
     inner: S,
     config: RetryConfig<B>,
@@ -43,7 +45,11 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let svc = self.inner.clone();
+        // Clone-in-call rule (same fix as the circuit breaker): take the
+        // instance whose readiness the caller just polled; leave the fresh
+        // clone behind for the next poll_ready.
+        let clone = self.inner.clone();
+        let mut svc = std::mem::replace(&mut self.inner, clone);
         let config = self.config.clone();
         let policy = self.policy.clone();
 
@@ -55,22 +61,36 @@ where
                 // Resolve each attempt fully to either a return or a backoff `delay`, so the
                 // (non-`Send`) response/error never crosses the `sleep` await below — keeping
                 // the boxed future `Send` without an `S::Response: Send` / `S::Error: Send` bound.
-                let delay = match svc.clone().call(req.clone()).await {
-                    Ok(response) => return Ok(response),
-                    Err(e) => {
-                        let retryable = attempt <= config.max_attempts
-                            && policy.should_retry(&e, attempt);
-
-                        if !retryable {
-                            // Budget exhausted, or the policy declined to retry.
-                            return if attempt > config.max_attempts {
-                                Err(ResilienceError::MaxRetriesExhausted(config.max_attempts))
-                            } else {
-                                Err(ResilienceError::Inner(e))
-                            };
+                // Each attempt re-drives readiness on the SAME instance before calling
+                // (idempotent when the slot is already held); a readiness error is an
+                // attempt failure like any other. The `map(|_| ())` drops the `&mut S`
+                // borrow immediately so nothing borrowed crosses the await points.
+                let delay = {
+                    let attempt_result = 'attempt: {
+                        if let Err(e) = svc.ready().await.map(|_| ()) {
+                            break 'attempt Err(e);
                         }
+                        svc.call(req.clone()).await
+                    };
+                    // The inner block scopes `attempt_result` so the non-`Send`
+                    // response/error provably drops before the sleep below.
+                    match attempt_result {
+                        Ok(response) => return Ok(response),
+                        Err(e) => {
+                            let retryable = attempt <= config.max_attempts
+                                && policy.should_retry(&e, attempt);
 
-                        config.backoff.next_delay(attempt)
+                            if !retryable {
+                                // Budget exhausted, or the policy declined to retry.
+                                return if attempt > config.max_attempts {
+                                    Err(ResilienceError::MaxRetriesExhausted(config.max_attempts))
+                                } else {
+                                    Err(ResilienceError::Inner(e))
+                                };
+                            }
+
+                            config.backoff.next_delay(attempt)
+                        }
                     }
                 };
 
@@ -150,5 +170,32 @@ mod tests {
         let err = svc.ready().await.unwrap().call(()).await.unwrap_err();
         assert!(matches!(err, ResilienceError::Inner("fatal")));
         assert_eq!(calls.load(Ordering::SeqCst), 1, "no retries for a non-retryable error");
+    }
+
+    /// Regression (staging soak finding #16): same Buffer-backed-inner panic as
+    /// the circuit breaker. The retry loop re-drives `ready()` on the taken
+    /// instance each attempt; this must not panic and must still retry.
+    #[tokio::test]
+    async fn survives_buffer_backed_inner() {
+        use tower::buffer::Buffer;
+
+        let calls = Arc::new(AtomicU32::new(0));
+        let counter = Arc::clone(&calls);
+        let inner = service_fn(move |_: ()| {
+            let counter = Arc::clone(&counter);
+            async move {
+                if counter.fetch_add(1, Ordering::SeqCst) < 2 {
+                    Err("transient")
+                } else {
+                    Ok::<_, &str>("ok")
+                }
+            }
+        });
+        let buffered = Buffer::new(inner, 8);
+        let mut svc = RetryService::new(buffered, fast_config(5), AlwaysRetryPolicy);
+
+        let out = svc.ready().await.unwrap().call(()).await.unwrap();
+        assert_eq!(out, "ok");
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "2 transient failures then success");
     }
 }


### PR DESCRIPTION
**Soak finding #16 — the highest-impact bug of the whole bring-up.** The first real inter-service load (timeline→social-graph on the feed cold-rebuild path) panicked the worker 100% of the time: `send_item called without first calling poll_reserve`. The circuit-breaker and retry `Service::call` delegated `poll_ready` to `self.inner` but then invoked a fresh `self.inner.clone()` — whose tower Buffer slot was never reserved. Since tonic's `Channel` is Buffer-backed, **every resilient client in the mesh was one load spike from this panic**; only the soak's read-path traffic exposed it.

Fix: clone-in-call (`mem::replace` + run on the polled instance) in both layers; retry re-drives `ready()` per attempt. Two new regression tests drive each layer over a real `tower::buffer::Buffer` and panic without the fix. Full workspace builds; resilience clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB