### PR TITLE
fix(social-graph): bind CQL LIMIT as i32 — i64 cast broke every paged list

### DIFF
--- a/crates/services/social-graph/src/infrastructure/persistence/scylla_social_graph_repository.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/scylla_social_graph_repository.rs
@@ -356,7 +356,10 @@ impl SocialGraphRepository for ScyllaSocialGraphRepository {
         limit:       i32,
         page_token:  Option<&str>,
     ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError> {
-        let limit = limit.clamp(1, 100) as i64;
+        // LIMIT binds as CQL `int` (32-bit); the old `as i64` cast made Scylla
+        // reject every query (SerializationError i64 vs Native(Int)) — the
+        // timeline feed cold-rebuild failed 100% under the staging soak.
+        let limit = limit.clamp(1, 100);
         let token = decode_follow_token(page_token)?;
 
         let rows: Vec<FollowRow> = if let Some(ref tok) = token {
@@ -407,7 +410,10 @@ impl SocialGraphRepository for ScyllaSocialGraphRepository {
         limit:       i32,
         page_token:  Option<&str>,
     ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError> {
-        let limit = limit.clamp(1, 100) as i64;
+        // LIMIT binds as CQL `int` (32-bit); the old `as i64` cast made Scylla
+        // reject every query (SerializationError i64 vs Native(Int)) — the
+        // timeline feed cold-rebuild failed 100% under the staging soak.
+        let limit = limit.clamp(1, 100);
         let token = decode_follow_token(page_token)?;
 
         let rows: Vec<FollowRow> = if let Some(ref tok) = token {
@@ -458,7 +464,10 @@ impl SocialGraphRepository for ScyllaSocialGraphRepository {
         limit:      i32,
         page_token: Option<&str>,
     ) -> Result<(Vec<BlockEdge>, Option<String>), SocialGraphError> {
-        let limit = limit.clamp(1, 100) as i64;
+        // LIMIT binds as CQL `int` (32-bit); the old `as i64` cast made Scylla
+        // reject every query (SerializationError i64 vs Native(Int)) — the
+        // timeline feed cold-rebuild failed 100% under the staging soak.
+        let limit = limit.clamp(1, 100);
 
         let token: Option<BlockPageToken> = page_token
             .map(|t| {
@@ -554,7 +563,7 @@ fn decode_follow_token(
 
 fn build_follow_page(
     rows:  Vec<FollowRow>,
-    limit: i64,
+    limit: i32,
 ) -> Result<(Vec<FollowEdge>, Option<String>), SocialGraphError> {
     let total = rows.len();
     let mut edges = Vec::with_capacity(total);


### PR DESCRIPTION
Soak finding #17 (revealed once #16 stopped the panic): timeline's feed rebuild → social-graph `list_following`, which cast the clamped limit to i64 before `LIMIT ?`. Scylla's LIMIT is a 32-bit int → 100% type-check failure. limit is clamped 1..100, so i32 is lossless; cast dropped at 3 sites + helper. Existing IT covers it but is Docker-gated — the soak was the first real-Scylla run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB