### PR TITLE
fix(social-graph): FollowRow position-only deserialization (skip_name_checks)

### DIFF
--- a/crates/services/social-graph/src/infrastructure/persistence/model/follow_row.rs
+++ b/crates/services/social-graph/src/infrastructure/persistence/model/follow_row.rs
@@ -5,11 +5,14 @@ use uuid::Uuid;
 /// Positional deserialization target for rows from the `followers` and `following` tables.
 ///
 /// SELECT must always emit `(profile_id_column, followed_at)` in this order.
-/// `enforce_order` matches fields by position rather than by column name, so the
+/// `enforce_order` + `skip_name_checks` matches fields by POSITION only, so the
 /// same struct serves both tables regardless of whether the first column is named
-/// `follower_id` or `followee_id`.
+/// `follower_id` or `followee_id`. Without `skip_name_checks`, `enforce_order`
+/// still verifies names and rejects both queries (`profile_id` != the CQL column
+/// name) — the timeline feed rebuild failed 100% on this until the staging soak
+/// exposed it.
 #[derive(DeserializeRow)]
-#[scylla(flavor = "enforce_order")]
+#[scylla(flavor = "enforce_order", skip_name_checks)]
 pub struct FollowRow {
     pub profile_id:  Uuid,
     pub followed_at: CqlTimestamp,


### PR DESCRIPTION
Soak finding #18 (revealed once #17 let the query run): `FollowRow` deserializes from two tables with differently-named first columns (follower_id / followee_id) into `profile_id`. `flavor="enforce_order"` still name-checks, so every row failed. Added `skip_name_checks` — position-only, exactly the struct's documented intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB