### PR TITLE
fix(infra): teardown robustness — global spot SLR + Karpenter instance reaper

### DIFF
--- a/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
+++ b/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
@@ -88,4 +88,27 @@ echo "Draining Karpenter nodes (EC2)..."
 kubectl delete nodeclaims --all --timeout=300s || true
 kubectl delete nodes -l karpenter.sh/nodepool --timeout=180s || true
 
+# 5b. Fallback: force-terminate any Karpenter instance the graceful drain left
+#     behind. The kubectl delete above times out when many nodes exist (e.g. a
+#     load-test scale-up) or Karpenter is already partway gone; the orphaned
+#     instances then hold ENIs in the EKS node security group and hang
+#     `aws_security_group.node` destroy for 10min+ (seen live 2026-07-04, 18
+#     nodes). Karpenter tags every instance `karpenter.sh/managed-by=<cluster>`
+#     (cluster-scoped + Karpenter-specific), so terminating by that tag can't
+#     touch another cluster's nodes and guarantees no leak regardless of the
+#     drain outcome above.
+echo "Force-terminating any leftover Karpenter instances..."
+LEFTOVER="$(aws ec2 describe-instances --region "${AWS_REGION}" \
+  --filters "Name=tag:karpenter.sh/managed-by,Values=${CLUSTER_NAME}" \
+            "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || true)"
+if [ -n "${LEFTOVER}" ]; then
+  echo "  terminating: ${LEFTOVER}"
+  # shellcheck disable=SC2086
+  aws ec2 terminate-instances --region "${AWS_REGION}" --instance-ids ${LEFTOVER} >/dev/null 2>&1 || true
+  aws ec2 wait instance-terminated --region "${AWS_REGION}" --instance-ids ${LEFTOVER} 2>/dev/null || true
+else
+  echo "  none left."
+fi
+
 echo "--- Cleanup finished, proceeding to Terraform Destroy ---"

--- a/infrastructure/live/global/security/ec2-spot-slr/terragrunt.hcl
+++ b/infrastructure/live/global/security/ec2-spot-slr/terragrunt.hcl
@@ -1,0 +1,18 @@
+# infrastructure/live/global/security/ec2-spot-slr/terragrunt.hcl
+#
+# Ensures the account-global EC2 Spot service-linked role exists. Applied ONCE
+# for the account (global tree), independent of any env's lifecycle — so an env
+# teardown never deletes it and never breaks Karpenter spot in the other envs.
+# Formerly created per-env inside modules/security/irsa-roles (removed there).
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../../modules/security/account-slr"
+}
+
+inputs = {
+  aws_region = "us-east-1"
+}

--- a/infrastructure/modules/security/account-slr/main.tf
+++ b/infrastructure/modules/security/account-slr/main.tf
@@ -1,0 +1,30 @@
+# infrastructure/modules/security/account-slr/main.tf
+#
+# Account-global AWS service-linked roles that must exist ONCE per account and
+# must OUTLIVE any single environment's teardown. Managed in the global tree,
+# never per-env: a per-env `aws_iam_service_linked_role` gets DELETED on that
+# env's destroy, which (a) fails with "unexpected state" while spot capacity is
+# still draining and (b) would break Karpenter spot in every OTHER env that
+# shares the account (seen live 2026-07-04, staging teardown).
+#
+# Idempotent + destroy-safe by construction: `terraform_data` + local-exec runs
+# `create-service-linked-role`, tolerating "already exists" (the role may have
+# been created by an earlier env, a prior run, or auto-created by AWS on first
+# spot launch). There is no destroy provisioner, so `terraform destroy` here is
+# a no-op on the real role — exactly the intent for an account-global primitive.
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+# EC2 Spot SLR — required for Karpenter (and any service) to request Spot.
+resource "terraform_data" "ec2_spot_slr" {
+  provisioner "local-exec" {
+    command = <<-SH
+      aws iam create-service-linked-role --aws-service-name spot.amazonaws.com \
+        --region ${var.aws_region} 2>/dev/null \
+        || echo "AWSServiceRoleForEC2Spot already exists (account-global); continuing."
+    SH
+  }
+}

--- a/infrastructure/modules/security/account-slr/outputs.tf
+++ b/infrastructure/modules/security/account-slr/outputs.tf
@@ -1,0 +1,5 @@
+# infrastructure/modules/security/account-slr/outputs.tf
+output "ensured" {
+  description = "Marker that the account-global SLRs have been reconciled."
+  value       = terraform_data.ec2_spot_slr.id
+}

--- a/infrastructure/modules/security/irsa-roles/main.tf
+++ b/infrastructure/modules/security/irsa-roles/main.tf
@@ -205,16 +205,20 @@ module "k6_irsa_role" {
 
 
 
-# --- 7. AWS SERVICE-LINKED ROLE FOR SPOT ---
-# Ce rôle est obligatoire pour que Karpenter (ou tout service EC2) 
-# puisse demander des instances Spot sur ce compte AWS.
-resource "aws_iam_service_linked_role" "spot" {
-  aws_service_name = "spot.amazonaws.com"
-
-  # On ajoute un cycle de vie pour éviter les erreurs si le rôle existe déjà 
-  # sur le compte AWS (car ce rôle est global au compte).
+# --- 7. AWS SERVICE-LINKED ROLE FOR SPOT (moved to the global tree) ---
+# The EC2 Spot SLR is account-global and must OUTLIVE any single env's teardown.
+# Managing it here (per-env) meant `terragrunt destroy` tried to DELETE it —
+# which fails "unexpected state" while spot drains AND would break Karpenter spot
+# in every other env sharing the account (seen live 2026-07-04). It now lives in
+# live/global/security/ec2-spot-slr (created once, destroy-safe).
+#
+# `removed { destroy = false }` migrates any env whose state still holds the old
+# resource: Terraform forgets it WITHOUT deleting the real account-global role.
+# (No live env holds it as of the move, so this is belt-and-suspenders.)
+removed {
+  from = aws_iam_service_linked_role.spot
   lifecycle {
-    ignore_changes = all
+    destroy = false
   }
 }
 # --- 7. EXTERNAL SECRETS OPERATOR (staging/prod only) ---


### PR DESCRIPTION
Two teardown bugs hit live on the 2026-07-04 staging destroy, both needing manual recovery.

**A — account-global spot SLR managed per-env.** `irsa-roles` tried to *delete* the shared `AWSServiceRoleForEC2Spot` on destroy → "unexpected state" failure that early-exited eks/vpc/data units, and deleting it would break Karpenter spot in every other env on the account. Moved to a new global unit (`live/global/security/ec2-spot-slr`, idempotent + destroy-safe); per-env resource replaced with `removed { destroy = false }`.

**B — Karpenter drain timeout leaked instances.** `kubectl delete nodeclaims` timed out on 18 load-test-scaled nodes; the orphans held node-SG ENIs and hung `aws_security_group.node` for 10min+. Added an EC2-API fallback in the cleanup hook that terminates instances tagged `karpenter.sh/managed-by=<cluster>` and waits.

Validated: global unit `plan` = 1 to add; irsa-roles module `validate` clean with the removed block; script `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB