### PR TITLE
feat(infra): scaffold prod bring-up prerequisites

### DIFF
--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,87 @@
+# .github/workflows/prod-promote.yml
+#
+# Promotes the STAGING-verified immutable image pins into the PROD overlay.
+#
+# Why this exists: the fleet-images workflow pins k8s/overlays/staging to the
+# built :<git-sha> tags after CI passes; the prod overlay (k8s/overlays/prod)
+# ships :prod PLACEHOLDER tags. Prod ArgoCD tracks `main`, and "merging
+# develop → main is the prod deploy" — but that would deploy placeholders.
+# This job copies each staging image's current sha tag onto the same image in
+# the prod overlay, ON DEVELOP, so the standard develop→main promotion PR
+# carries the exact images staging has been running (and soak-verified).
+#
+# Deliberately MANUAL (workflow_dispatch): a prod release is an intentional act.
+# It writes to develop via FLEET_PIN_DEPLOY_KEY (the same deploy key the staging
+# pin job uses — develop's ruleset grants it a bypass), so NO change to main's
+# protection is needed. After it runs, open/refresh the develop→main PR to ship.
+name: Promote staging image pins to prod overlay
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "promote" to confirm copying staging pins into the prod overlay.'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: Copy staging sha pins → prod overlay (develop)
+    if: ${{ github.event.inputs.confirm == 'promote' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          # Same deploy key + rationale as the staging pin job: develop's ruleset
+          # is PR-only for the bot token but grants this DeployKey a bypass.
+          ssh-key: ${{ secrets.FLEET_PIN_DEPLOY_KEY }}
+
+      - name: Copy each staging image's tag onto the prod overlay
+        run: |
+          set -euo pipefail
+          STAGING=k8s/overlays/staging/kustomization.yaml
+          PROD=k8s/overlays/prod/kustomization.yaml
+
+          # Every image the prod overlay declares. For each, read the tag the
+          # staging overlay currently pins and write it onto the prod entry.
+          # A staging image with a still-floating :staging tag is refused —
+          # prod must only ever receive immutable sha pins.
+          mapfile -t NAMES < <(yq '.images[].name' "$PROD")
+          changed=0
+          for name in "${NAMES[@]}"; do
+            tag="$(NAME="$name" yq '.images[] | select(.name == strenv(NAME)) | .newTag' "$STAGING")"
+            if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+              echo "::warning::$name has no staging entry — skipping (prod keeps its current tag)."
+              continue
+            fi
+            if [ "$tag" = "staging" ] || [ "$tag" = "prod" ]; then
+              echo "::error::$name is on a floating tag ':$tag' in staging — refusing to promote a non-immutable tag."
+              exit 1
+            fi
+            NAME="$name" TAG="$tag" yq -i \
+              '(.images[] | select(.name == strenv(NAME)).newTag) = strenv(TAG)' "$PROD"
+            echo "  $name -> $tag"
+            changed=1
+          done
+          echo "CHANGED=$changed" >> "$GITHUB_ENV"
+
+      - name: Commit the prod pins to develop
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- k8s/overlays/prod/kustomization.yaml; then
+            echo "Prod overlay already matches staging pins; nothing to promote."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add k8s/overlays/prod/kustomization.yaml
+          git commit -m "chore(deploy): promote staging-verified image pins to prod overlay [skip ci]"
+          git pull --rebase origin develop
+          git push origin develop
+          echo "::notice::Prod overlay pinned. Open/refresh the develop→main PR to deploy to prod."

--- a/infrastructure/live/prod/env.hcl
+++ b/infrastructure/live/prod/env.hcl
@@ -32,6 +32,15 @@ locals {
   vpc_cidr           = "10.10.0.0/16"
   single_nat_gateway = false
 
+  # --- Admin / CI ingress allow-list ---
+  # ⚠ REQUIRED BEFORE FIRST APPLY. Locks the public EKS API endpoint (eks unit)
+  # and — once wired — the ArgoCD/Grafana admin ALBs to these ranges. The
+  # "REPLACE.ME/32" sentinel is an invalid CIDR that makes `terragrunt apply`
+  # fail loudly rather than silently opening the API to 0.0.0.0/0 (fail-closed).
+  # Replace with your admin egress + the CI runner egress, e.g.:
+  #   admin_cidrs = ["203.0.113.4/32", "198.51.100.0/24"]
+  admin_cidrs = ["REPLACE.ME/32"]
+
   # --- EKS managed node groups (consumed by modules/eks) ---
   # Graviton for price/perf (ami_type selects the ARM AL2023 AMI — required, the
   # module default is x86); min 3 so losing an AZ leaves quorum for system

--- a/infrastructure/live/prod/us-east-1/eks/terragrunt.hcl
+++ b/infrastructure/live/prod/us-east-1/eks/terragrunt.hcl
@@ -24,9 +24,11 @@ inputs = {
   vpc_cidr           = dependency.vpc.outputs.vpc_cidr_block
   node_groups        = local.env_vars.locals.node_groups
 
-  # ⚠ REQUIRED BEFORE FIRST APPLY: prod must never expose the API to 0.0.0.0/0
-  # (the module default). Set the admin/CI ranges:
-  # endpoint_public_access_cidrs = ["<admin-cidr>", "<ci-cidr>"]
+  # Locks the public EKS API to the admin/CI ranges in env.hcl. This is NOT the
+  # module default (0.0.0.0/0) — prod must never expose the API to the world.
+  # env.hcl ships a REPLACE.ME placeholder that fails the apply on purpose until
+  # you set real CIDRs (fail-closed beats fail-open for prod).
+  endpoint_public_access_cidrs = local.env_vars.locals.admin_cidrs
 
   project_name = "core-platform"
   env          = local.env_vars.locals.env


### PR DESCRIPTION
The three documented prod prereqs from `live/prod/env.hcl`:

1. **State bucket** — created out-of-band (a backend bucket can't manage itself): `core-platform-terraform-state-prod`, versioned + AES256 + public-access-blocked + tagged. Already done on the account.
2. **EKS endpoint CIDR lockdown** — prod eks unit sets `endpoint_public_access_cidrs = local.admin_cidrs` (not the module's 0.0.0.0/0). `env.hcl` ships a `REPLACE.ME/32` sentinel that fails apply loudly until you set real ranges — fail-closed.
3. **Prod image-promote workflow** — copies staging's verified `:<sha>` pins onto the prod overlay on develop (via the existing deploy key, no main-protection change), refusing floating tags; the develop→main PR then ships real soak-verified images. 22/22 image parity verified.

**Needs you before first apply:** replace `admin_cidrs` in `live/prod/env.hcl`. Then `run --all apply` → merge develop→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB