### PR TITLE
feat(security): lock admin ALBs (ArgoCD + Grafana) to admin/CI CIDRs

### DIFF
--- a/infrastructure/argocd/apps/infrastructure/observability/monitoring/templates/grafana-ingress.yaml
+++ b/infrastructure/argocd/apps/infrastructure/observability/monitoring/templates/grafana-ingress.yaml
@@ -11,6 +11,11 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.certificateArn | quote }}
+    {{- if .Values.inboundCidrs }}
+    # Restrict this internet-facing admin ALB to the env's admin/CI ranges
+    # (Terraform-written adminCidrs). Empty (staging default) = open.
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.inboundCidrs | quote }}
+    {{- end }}
     external-dns.alpha.kubernetes.io/hostname: "grafana.core-platform.click"
 spec:
   ingressClassName: alb

--- a/infrastructure/argocd/apps/infrastructure/security/admin-access/templates/argocd-ingress.yaml
+++ b/infrastructure/argocd/apps/infrastructure/security/admin-access/templates/argocd-ingress.yaml
@@ -12,6 +12,12 @@ metadata:
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.certificateArn | quote }}
     alb.ingress.kubernetes.io/backend-protocol: HTTP
+    {{- if .Values.inboundCidrs }}
+    # Restrict this internet-facing admin ALB to the env's admin/CI ranges
+    # (Terraform-written global param adminCidrs → .Values.inboundCidrs). Empty
+    # (e.g. staging until it sets admin_cidrs) omits the annotation = open.
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.inboundCidrs | quote }}
+    {{- end }}
     external-dns.alpha.kubernetes.io/hostname: "argocd.core-platform.click"
 spec:
   ingressClassName: alb

--- a/infrastructure/argocd/bootstrap/prod/root-infra-observability.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-observability.yaml
@@ -55,6 +55,10 @@ spec:
             parameters:
               - name: "certificateArn"
                 value: "{{ .global.certificateArn }}"
+              # Admin/CI CIDR allow-list for the internet-facing Grafana ALB
+              # (empty → open; harmless no-op param for otel-collector).
+              - name: "inboundCidrs"
+                value: "{{ .global.adminCidrs }}"
         - repoURL: https://github.com/arnaudmaillet/core-platform
           targetRevision: main
           ref: values

--- a/infrastructure/argocd/bootstrap/prod/root-infra-security.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-security.yaml
@@ -86,6 +86,10 @@ spec:
               # {{ if eq .name "admin-access" }}
               - name: "certificateArn"
                 value: "{{ .global.certificateArn }}"
+              # Admin/CI CIDR allow-list for the internet-facing ArgoCD ALB
+              # (empty on envs that haven't set admin_cidrs → ALB stays open).
+              - name: "inboundCidrs"
+                value: "{{ .global.adminCidrs }}"
               # {{ end }}
         - repoURL: https://github.com/arnaudmaillet/core-platform
           targetRevision: main

--- a/infrastructure/argocd/bootstrap/staging/root-infra-observability.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-observability.yaml
@@ -55,6 +55,10 @@ spec:
             parameters:
               - name: "certificateArn"
                 value: "{{ .global.certificateArn }}"
+              # Admin/CI CIDR allow-list for the internet-facing Grafana ALB
+              # (empty → open; harmless no-op param for otel-collector).
+              - name: "inboundCidrs"
+                value: "{{ .global.adminCidrs }}"
         - repoURL: https://github.com/arnaudmaillet/core-platform
           targetRevision: develop
           ref: values

--- a/infrastructure/argocd/bootstrap/staging/root-infra-security.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-security.yaml
@@ -86,6 +86,10 @@ spec:
               # {{ if eq .name "admin-access" }}
               - name: "certificateArn"
                 value: "{{ .global.certificateArn }}"
+              # Admin/CI CIDR allow-list for the internet-facing ArgoCD ALB
+              # (empty on envs that haven't set admin_cidrs → ALB stays open).
+              - name: "inboundCidrs"
+                value: "{{ .global.adminCidrs }}"
               # {{ end }}
         - repoURL: https://github.com/arnaudmaillet/core-platform
           targetRevision: develop

--- a/infrastructure/live/prod/us-east-1/kubernetes/argocd/terragrunt.hcl
+++ b/infrastructure/live/prod/us-east-1/kubernetes/argocd/terragrunt.hcl
@@ -13,6 +13,7 @@ include "root" {
 locals {
   region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
   aws_region  = local.region_vars.locals.aws_region
+  env_vars    = read_terragrunt_config(find_in_parent_folders("env.hcl"))
 }
 
 dependency "vpc" {
@@ -101,6 +102,9 @@ inputs = {
 
   # --- Security & Certificates ---
   ssl_certificate_arn = dependency.acm_cert.outputs.certificate_arn
+  # Locks the internet-facing ArgoCD + Grafana admin ALBs to the admin/CI ranges
+  # (same REPLACE.ME sentinel as the EKS endpoint — fill before first apply).
+  admin_cidrs = local.env_vars.locals.admin_cidrs
 
   # --- CMP envsubst values (data-store endpoints for the workload overlay) ---
   msk_bootstrap_brokers = dependency.msk.outputs.bootstrap_brokers_sasl_scram

--- a/infrastructure/modules/kubernetes/argocd/addons/main.tf
+++ b/infrastructure/modules/kubernetes/argocd/addons/main.tf
@@ -5,7 +5,7 @@ resource "aws_eks_addon" "this" {
 
   cluster_name                = var.cluster_name
   addon_name                  = each.key
-  addon_version               = lookup(each.value, "addon_version", null) 
+  addon_version               = lookup(each.value, "addon_version", null)
   service_account_role_arn    = each.value.service_account_role_arn
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"

--- a/infrastructure/modules/kubernetes/argocd/bootstrap/main.tf
+++ b/infrastructure/modules/kubernetes/argocd/bootstrap/main.tf
@@ -86,14 +86,18 @@ resource "github_repository_file" "argocd_params" {
 
   content = jsonencode({
     global = {
-      region              = var.region
-      env                 = var.env
-      repository_url      = var.repository_url
-      target_revision     = var.target_revision
-      clusterName         = var.cluster_name
-      clusterEndpoint     = var.cluster_endpoint
-      vpcId               = var.vpc_id
-      certificateArn      = var.ssl_certificate_arn
+      region          = var.region
+      env             = var.env
+      repository_url  = var.repository_url
+      target_revision = var.target_revision
+      clusterName     = var.cluster_name
+      clusterEndpoint = var.cluster_endpoint
+      vpcId           = var.vpc_id
+      certificateArn  = var.ssl_certificate_arn
+      # ALB inbound-cidrs allow-list for the admin planes (ArgoCD/Grafana),
+      # comma-joined for the annotation. Empty string when admin_cidrs is unset
+      # (staging today) → the ingress templates omit the annotation (ALB open).
+      adminCidrs          = join(",", var.admin_cidrs)
       certManagerRoleArn  = var.addons_iam_roles["cert_manager"]
       karpenterRoleArn    = var.addons_iam_roles["karpenter"]
       lbControllerRoleArn = var.addons_iam_roles["lb_controller"]

--- a/infrastructure/modules/kubernetes/argocd/bootstrap/variables.tf
+++ b/infrastructure/modules/kubernetes/argocd/bootstrap/variables.tf
@@ -8,6 +8,11 @@ variable "vpc_id" { type = string }
 variable "cluster_name" { type = string }
 variable "cluster_endpoint" { type = string }
 variable "ssl_certificate_arn" { type = string }
+variable "admin_cidrs" {
+  type        = list(string)
+  description = "Admin/CI CIDRs allowed to reach the internet-facing ArgoCD/Grafana ALBs. Empty = no inbound-cidrs annotation (ALB open) — set per-env (prod: required)."
+  default     = []
+}
 variable "addons_iam_roles" { type = map(string) }
 
 # --- CMP envsubst values (runtime data-store endpoints) ----------------------

--- a/infrastructure/modules/kubernetes/argocd/main.tf
+++ b/infrastructure/modules/kubernetes/argocd/main.tf
@@ -26,6 +26,7 @@ module "bootstrap" {
   cluster_endpoint    = var.cluster_endpoint
   vpc_id              = var.vpc_id
   ssl_certificate_arn = var.ssl_certificate_arn
+  admin_cidrs         = var.admin_cidrs
   addons_iam_roles    = var.addons_iam_roles
   bootstrap_path      = var.bootstrap_path
   global_params_file  = var.global_params_file

--- a/infrastructure/modules/kubernetes/argocd/server/variables.tf
+++ b/infrastructure/modules/kubernetes/argocd/server/variables.tf
@@ -1,6 +1,6 @@
 # infrastructure/modules/kubernetes/argocd/server/variables.tf
 
-variable "cluster_name"           { type = string }
-variable "cluster_endpoint"       { type = string }
+variable "cluster_name" { type = string }
+variable "cluster_endpoint" { type = string }
 variable "cluster_ca_certificate" { type = string }
-variable "argocd_version"         { type = string }
+variable "argocd_version" { type = string }

--- a/infrastructure/modules/kubernetes/argocd/variables.tf
+++ b/infrastructure/modules/kubernetes/argocd/variables.tf
@@ -14,6 +14,11 @@ variable "cluster_ca_certificate" { type = string }
 variable "vpc_id" { type = string }
 variable "addons_iam_roles" { type = map(string) }
 variable "ssl_certificate_arn" { type = string }
+variable "admin_cidrs" {
+  type        = list(string)
+  description = "Admin/CI CIDRs for the ArgoCD/Grafana ALB inbound-cidrs lockdown. Empty = ALB open (staging default); prod passes live/prod/env.hcl admin_cidrs."
+  default     = []
+}
 variable "addons" { type = any }
 variable "tags" { type = map(string) }
 


### PR DESCRIPTION
Closes the "admin planes open" P1 for prod. Both internet-facing admin ALBs now gate on the same `admin_cidrs` as the EKS endpoint.

**Flow** (mirrors `certificateArn`): `env.hcl admin_cidrs` → prod argocd unit → server/bootstrap modules → `global-params-prod.json adminCidrs` (comma-joined) → security + observability appsets inject `inboundCidrs` → ingress templates render `alb.ingress.kubernetes.io/inbound-cidrs` **only when non-empty**.

**Staging unchanged**: `admin_cidrs` defaults `[]` → annotation omitted → ALB stays open until staging opts in. **Prod fail-closed**: the `REPLACE.ME` sentinel now blocks the EKS API *and* both ALBs until you set real ranges.

Verified via `helm template` (renders when set, omits when empty, both ingresses); terraform fmt + all 4 appset YAMLs + prod hcl clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB