### PR TITLE
fix(platform): soak-calibrated resource requests for the legacy-10 servers

### DIFF
--- a/k8s/base/services/account/server/deployment.yaml
+++ b/k8s/base/services/account/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "100m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/chat/server/deployment.yaml
+++ b/k8s/base/services/chat/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "100m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/comment/server/deployment.yaml
+++ b/k8s/base/services/comment/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "150m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/engagement/server/deployment.yaml
+++ b/k8s/base/services/engagement/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "150m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/geo-discovery/server/deployment.yaml
+++ b/k8s/base/services/geo-discovery/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "100m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/notification/server/deployment.yaml
+++ b/k8s/base/services/notification/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "150m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/post/server/deployment.yaml
+++ b/k8s/base/services/post/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "150m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/profile/server/deployment.yaml
+++ b/k8s/base/services/profile/server/deployment.yaml
@@ -78,9 +78,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "100m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/social-graph/server/deployment.yaml
+++ b/k8s/base/services/social-graph/server/deployment.yaml
@@ -80,9 +80,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "150m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:

--- a/k8s/base/services/timeline/server/deployment.yaml
+++ b/k8s/base/services/timeline/server/deployment.yaml
@@ -82,9 +82,12 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
+            # Soak-calibrated (2026-07-04): sized from observed throughput +
+            # stability (p95 34ms I/O-bound, 0 OOM/restart at 2 replicas), NOT
+            # measured utilization. Refine with `kubectl top` on next bring-up.
             requests:
-              cpu: "50m"
-              memory: "128Mi"
+              cpu: "150m"
+              memory: "256Mi"
             # No CPU limit: CFS throttling breaks tokio tail latency under
             # spikes; memory stays the hard cap.
             limits:


### PR DESCRIPTION
Closes the last open item from the infra review — the arbitrary `50m/128Mi` placeholders on the 10 core servers.

**Honest scope:** calibrated from the soak's *observed throughput + stability*, NOT measured per-pod utilization (`kubectl top`/Prometheus weren't captured before teardown). Clearly commented as such; refine on next bring-up.

**Memory → 256Mi (uniform):** Rust/tonic + Scylla/Redis driver pools sit above 128Mi; 128Mi vs the 512Mi limit was too wide an OOM-eviction gap (review finding 1d). Footprint is rate-insensitive, so uniform.

**CPU tiered by soak load** (request = scheduling honesty, not a cap; 50m over-packed nodes):
- **150m** — post/comment/engagement/timeline/social-graph (journey-loaded 15-30 RPS, p95 34ms, no pressure) + notification (fan-out consumer)
- **100m** — account/profile/chat/geo-discovery (~0 direct journey load)

CPU limits stay off; memory limit stays 512Mi. All three overlays render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvD5itGZn95hxzZcSz3UB