### PR TITLE
fix(infra): prod bring-up — set admin CIDRs + pin fleet workloads to amd64

### DIFF
--- a/infrastructure/live/prod/env.hcl
+++ b/infrastructure/live/prod/env.hcl
@@ -33,13 +33,16 @@ locals {
   single_nat_gateway = false
 
   # --- Admin / CI ingress allow-list ---
-  # ⚠ REQUIRED BEFORE FIRST APPLY. Locks the public EKS API endpoint (eks unit)
-  # and — once wired — the ArgoCD/Grafana admin ALBs to these ranges. The
-  # "REPLACE.ME/32" sentinel is an invalid CIDR that makes `terragrunt apply`
-  # fail loudly rather than silently opening the API to 0.0.0.0/0 (fail-closed).
-  # Replace with your admin egress + the CI runner egress, e.g.:
-  #   admin_cidrs = ["203.0.113.4/32", "198.51.100.0/24"]
-  admin_cidrs = ["REPLACE.ME/32"]
+  # Locks the public EKS API endpoint (eks unit) and the ArgoCD/Grafana admin
+  # ALBs to these ranges. Currently the admin workstation's egress IP
+  # (2026-07-04). CI runner egress is deliberately NOT listed: the GitHub
+  # workflows only push to git (fleet pin, prod-promote) and never touch the
+  # EKS API or admin ALBs; Terraform applies run from the workstation. Add a
+  # CIDR here if either of those facts changes, and update this entry when the
+  # workstation IP rotates (a wrong value locks kubectl/ArgoCD out, not
+  # Terraform — the AWS API is unaffected, so it is always recoverable by
+  # editing this list and re-applying the eks unit).
+  admin_cidrs = ["86.208.218.34/32"]
 
   # --- EKS managed node groups (consumed by modules/eks) ---
   # Graviton for price/perf (ami_type selects the ARM AL2023 AMI — required, the

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -182,6 +182,15 @@ images:
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
     newTag: prod
 patches:
+  # amd64 pin on every fleet workload: images are amd64-only but the prod system
+  # MNG is Graviton and untainted (see patch-arch-amd64.yaml). Remove with the
+  # multi-arch follow-up.
+  - path: patch-arch-amd64.yaml
+    target:
+      kind: Deployment
+  - path: patch-arch-amd64-job.yaml
+    target:
+      kind: Job
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml
     target:

--- a/k8s/overlays/prod/patch-arch-amd64-job.yaml
+++ b/k8s/overlays/prod/patch-arch-amd64-job.yaml
@@ -1,0 +1,14 @@
+# k8s/overlays/prod/patch-arch-amd64-job.yaml
+#
+# Same amd64 pin as patch-arch-amd64.yaml, for Jobs — the topic-provisioner
+# PreSync hook runs a fleet image too, and if it lands on a Graviton system
+# node the provision fails and the whole fleet sync fails with it.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ignored-by-target-selector
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64

--- a/k8s/overlays/prod/patch-arch-amd64.yaml
+++ b/k8s/overlays/prod/patch-arch-amd64.yaml
@@ -1,0 +1,23 @@
+# k8s/overlays/prod/patch-arch-amd64.yaml
+#
+# Pin every fleet Deployment to amd64 nodes. The fleet CI builds amd64-only
+# images (x86 runners, no --platform), and unlike staging (t3.* x86 MNGs) the
+# prod system managed node group is Graviton and UNTAINTED — without this pin
+# the scheduler can place a fleet pod there and it ImagePullBackOffs ("no match
+# for platform in manifest"), the same failure mode that broke the first staging
+# bring-up via the Karpenter system pool.
+#
+# Strategic merge (not JSON6902 like patch-securitycontext.yaml) on purpose:
+# nodeSelector maps MERGE, so the TIER-0 karpenter.sh/capacity-type=on-demand
+# selector survives. Covers the migrator init containers via the pod spec.
+# Remove once fleet-images-deploy.yml publishes multi-arch manifests (the same
+# gate as re-allowing arm64 in the Karpenter nodepools).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ignored-by-target-selector
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64


### PR DESCRIPTION
Closes the two config blockers from the 2026-07-04 production-readiness audit (fix 0 of the prod bring-up sequence). After this merges, the remaining deploy steps are: run `prod-promote`, merge develop→main, `terragrunt run --all apply` from `live/prod/us-east-1`.

## 1. `admin_cidrs` — REPLACE.ME sentinel filled

`infrastructure/live/prod/env.hcl` now carries `["86.208.218.34/32"]` — **the admin workstation's current egress IP (please double-check it's yours and not a VPN exit)**. It feeds both existing consumers:

- `eks` unit → `endpoint_public_access_cidrs` (public API endpoint)
- `kubernetes/argocd` unit → ArgoCD/Grafana ALB `inbound-cidrs` (#575)

CI runner egress is deliberately **not** listed: the fleet-pin and prod-promote workflows only push to git over SSH and never touch the EKS API or admin ALBs; Terraform applies run from the workstation. A wrong/rotated IP locks out kubectl/ArgoCD but never Terraform (AWS API unaffected), so it's always recoverable by editing the list and re-applying the eks unit.

## 2. amd64 pin on prod fleet workloads — Graviton scheduling trap

Fleet images are amd64-only (x86 runners, no `--platform`). Staging never exposed this on managed nodes because its MNGs are `t3.*` x86 — but the **prod system MNG is Graviton (`AL2023_ARM_64_STANDARD`) and untainted**, so any fleet pod without a nodeSelector (TIER-1 + legacy-10, plus the topic-provisioner PreSync Job) could schedule onto it and ImagePullBackOff with "no match for platform in manifest" — the exact failure that broke the first staging bring-up via the Karpenter system pool (since pinned amd64 in `karpenter-config`).

Fix: two **strategic-merge** patches in `k8s/overlays/prod` (not JSON6902 like `patch-securitycontext.yaml` — SMP merges the `nodeSelector` map, so the TIER-0 `karpenter.sh/capacity-type: on-demand` selector survives instead of being clobbered):

- `patch-arch-amd64.yaml` → all fleet Deployments (covers migrator init containers via the pod spec)
- `patch-arch-amd64-job.yaml` → the topic-provisioner Job (if it lands on ARM, provisioning fails and the whole fleet sync fails with it)

Kept Graviton for the system/database MNGs on purpose (system addons, CNPG, Scylla are multi-arch upstream images). Both patches are removed by the multi-arch follow-up, the same gate as re-allowing arm64 Karpenter pools.

## Verification

- `kubectl kustomize k8s/overlays/prod`: renders clean, **21/21 workloads pinned** (20 Deployments + 1 Job), auth retains `capacity-type: on-demand` alongside the arch key
- `kubectl kustomize k8s/overlays/staging`: **byte-identical** to before this change
- No docs with `.fr.md` mirrors touched — i18n gate unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ