### PR TITLE
release: drop k6-operator from prod operators

### DIFF
--- a/infrastructure/argocd/bootstrap/prod/root-infra-operators.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-operators.yaml
@@ -1,7 +1,13 @@
 # infrastructure/argocd/bootstrap/prod/root-infra-operators.yaml
 #
-# Prod operators — same set as staging (cnpg, k6, scylla-operator, scylla-manager,
-# external-secrets, keda), each in its own namespace. The ESO ServiceAccount
+# Prod operators — staging's set MINUS k6-operator (cnpg, scylla-operator,
+# scylla-manager, external-secrets, keda), each in its own namespace. k6 is
+# load-test tooling: prod deliberately ships no k6 NetworkPolicies (the k6 pods
+# couldn't reach the mesh anyway), and the operator was dead weight that also
+# CrashLooped on the first bring-up — the grafana manager image is amd64-only
+# and landed on a Graviton MNG node ("exec format error"; Helm catalog apps are
+# not covered by the fleet overlay's amd64 pin). Load tests run against staging.
+# The ESO ServiceAccount
 # receives its IRSA role-arn injected from global-params-prod
 # (externalSecretsRoleArn), the same pattern the platform
 # appset uses for lb-controller/karpenter. KEDA owns the keda.sh CRDs the
@@ -32,9 +38,6 @@ spec:
                 - name: cnpg-operator
                   folder: infrastructure/argocd/apps/infrastructure/operators/cnpg-operator
                   destNamespace: cnpg-system
-                - name: k6-operator
-                  folder: infrastructure/argocd/apps/infrastructure/operators/k6-operator
-                  destNamespace: k6-operator-system
                 - name: scylla-operator
                   folder: infrastructure/argocd/apps/infrastructure/operators/scylla-operator
                   destNamespace: scylla-operator


### PR DESCRIPTION
Release merge carrying #580: removes k6-operator from the prod operators appset (amd64-only manager image CrashLooping on Graviton; prod has no k6 NetworkPolicies — load tests run against staging). Prod ArgoCD tracks main; on sync the root-operators appset drops the k6-operator Application (resources orphaned by preserveResourcesOnDeletion, cleaned up manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ