### PR TITLE
release: scylla ignoreDifferences fix

### DIFF
--- a/infrastructure/argocd/apps/deployments/prod/scylla-cluster.yaml
+++ b/infrastructure/argocd/apps/deployments/prod/scylla-cluster.yaml
@@ -20,6 +20,31 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: scylla
+  # The scylla-operator's defaulting webhook fills unset CR fields on admission
+  # (image repositories, repair/backup tuning, per-rack agentResources); without
+  # ignoring them the live object diffs against Git forever and the app can never
+  # reach Synced — same class as the ESO remoteRef defaults on the fleet app.
+  # Snapshot of the defaulted paths observed live on the prod bring-up (2026-07-04).
+  ignoreDifferences:
+    - group: scylla.scylladb.com
+      kind: ScyllaCluster
+      jqPathExpressions:
+        - .spec.repository
+        - .spec.agentRepository
+        - .spec.backups[].numRetries
+        - .spec.repairs[].numRetries
+        - .spec.repairs[].intensity
+        - .spec.repairs[].parallel
+        - .spec.repairs[].smallTableThreshold
+        - .spec.datacenter.racks[].agentResources
+    # ESO's admission webhook defaults remoteRef fields on the co-located
+    # scylla-agent-config ExternalSecret (same fix as the fleet app).
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
   syncPolicy:
     automated:
       prune: true
@@ -30,6 +55,7 @@ spec:
       # The ScyllaCluster CRD comes from the scylla-operator app, which syncs
       # independently — tolerate it arriving after this app's first attempt.
       - SkipDryRunOnMissingResource=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 10
       backoff:

--- a/infrastructure/argocd/apps/deployments/staging/scylla-cluster.yaml
+++ b/infrastructure/argocd/apps/deployments/staging/scylla-cluster.yaml
@@ -25,6 +25,31 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: scylla
+  # The scylla-operator's defaulting webhook fills unset CR fields on admission
+  # (image repositories, repair/backup tuning, per-rack agentResources); without
+  # ignoring them the live object diffs against Git forever and the app can never
+  # reach Synced — same class as the ESO remoteRef defaults on the fleet app.
+  # Snapshot of the defaulted paths observed live on the prod bring-up (2026-07-04).
+  ignoreDifferences:
+    - group: scylla.scylladb.com
+      kind: ScyllaCluster
+      jqPathExpressions:
+        - .spec.repository
+        - .spec.agentRepository
+        - .spec.backups[].numRetries
+        - .spec.repairs[].numRetries
+        - .spec.repairs[].intensity
+        - .spec.repairs[].parallel
+        - .spec.repairs[].smallTableThreshold
+        - .spec.datacenter.racks[].agentResources
+    # ESO's admission webhook defaults remoteRef fields on the co-located
+    # scylla-agent-config ExternalSecret (same fix as the fleet app).
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
   syncPolicy:
     automated:
       prune: true
@@ -36,6 +61,7 @@ spec:
       # independently (appset sync-waves don't order across Applications) —
       # tolerate the CRD arriving after this app's first sync attempt.
       - SkipDryRunOnMissingResource=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 10
       backoff:

--- a/infrastructure/argocd/bootstrap/prod/root-infra-operators.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-operators.yaml
@@ -83,6 +83,22 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: '{{.destNamespace}}'
+      # scylla-manager's chart ships a ScyllaCluster CR whose unset fields the
+      # scylla-operator defaulting webhook fills on admission — perpetual
+      # OutOfSync otherwise. Matches only ScyllaCluster resources, so this is
+      # inert for every other operator app this template generates.
+      ignoreDifferences:
+        - group: scylla.scylladb.com
+          kind: ScyllaCluster
+          jqPathExpressions:
+            - .spec.repository
+            - .spec.agentRepository
+            - .spec.backups[].numRetries
+            - .spec.repairs[].numRetries
+            - .spec.repairs[].intensity
+            - .spec.repairs[].parallel
+            - .spec.repairs[].smallTableThreshold
+            - .spec.datacenter.racks[].agentResources
       syncPolicy:
         automated:
           prune: true
@@ -90,3 +106,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/infrastructure/argocd/bootstrap/staging/root-infra-operators.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-operators.yaml
@@ -80,6 +80,22 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: '{{.destNamespace}}'
+      # scylla-manager's chart ships a ScyllaCluster CR whose unset fields the
+      # scylla-operator defaulting webhook fills on admission — perpetual
+      # OutOfSync otherwise. Matches only ScyllaCluster resources, so this is
+      # inert for every other operator app this template generates.
+      ignoreDifferences:
+        - group: scylla.scylladb.com
+          kind: ScyllaCluster
+          jqPathExpressions:
+            - .spec.repository
+            - .spec.agentRepository
+            - .spec.backups[].numRetries
+            - .spec.repairs[].numRetries
+            - .spec.repairs[].intensity
+            - .spec.repairs[].parallel
+            - .spec.repairs[].smallTableThreshold
+            - .spec.datacenter.racks[].agentResources
       syncPolicy:
         automated:
           prune: true
@@ -87,3 +103,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true


### PR DESCRIPTION
Release merge carrying #582: ignoreDifferences + RespectIgnoreDifferences for scylla-operator webhook defaults, so prod-scylla-cluster and scylla-manager reach Synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ