### PR TITLE
fix(infra): teardown robustness round 2 — destroy mocks + Karpenter reaper tag filter

### DIFF
--- a/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
+++ b/infrastructure/assets/teardown/k8s-graceful-cleanup.sh
@@ -93,13 +93,18 @@ kubectl delete nodes -l karpenter.sh/nodepool --timeout=180s || true
 #     load-test scale-up) or Karpenter is already partway gone; the orphaned
 #     instances then hold ENIs in the EKS node security group and hang
 #     `aws_security_group.node` destroy for 10min+ (seen live 2026-07-04, 18
-#     nodes). Karpenter tags every instance `karpenter.sh/managed-by=<cluster>`
-#     (cluster-scoped + Karpenter-specific), so terminating by that tag can't
-#     touch another cluster's nodes and guarantees no leak regardless of the
-#     drain outcome above.
+#     nodes). Karpenter (v1) tags every instance `karpenter.sh/nodepool` plus
+#     `kubernetes.io/cluster/<cluster>=owned` — NOT `karpenter.sh/managed-by`,
+#     which this filter originally used and which matches nothing: on the
+#     2026-07-04 staging teardown 8 system-pool instances sailed past it and
+#     wedged the node SG + subnets. Filtering nodepool-tag-present AND
+#     cluster-owned is Karpenter-specific and cluster-scoped, so it can't touch
+#     another cluster's nodes (MNG nodes carry the cluster tag but never the
+#     nodepool tag).
 echo "Force-terminating any leftover Karpenter instances..."
 LEFTOVER="$(aws ec2 describe-instances --region "${AWS_REGION}" \
-  --filters "Name=tag:karpenter.sh/managed-by,Values=${CLUSTER_NAME}" \
+  --filters "Name=tag-key,Values=karpenter.sh/nodepool" \
+            "Name=tag:kubernetes.io/cluster/${CLUSTER_NAME},Values=owned" \
             "Name=instance-state-name,Values=pending,running,stopping,stopped" \
   --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null || true)"
 if [ -n "${LEFTOVER}" ]; then

--- a/infrastructure/live/prod/us-east-1/eks/terragrunt.hcl
+++ b/infrastructure/live/prod/us-east-1/eks/terragrunt.hcl
@@ -11,6 +11,15 @@ terraform {
 
 dependency "vpc" {
   config_path = "../networking/vpc"
+
+  # Destroy-only mocks — same rationale as irsa-roles' eks dependency: a partial
+  # teardown can leave the vpc unit without outputs, bricking this unit's destroy.
+  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs = {
+    vpc_id                 = "vpc-00000000000000000"
+    private_app_subnet_ids = ["subnet-00000000000000000"]
+    vpc_cidr_block         = "10.0.0.0/16"
+  }
 }
 
 locals {

--- a/infrastructure/live/prod/us-east-1/security/irsa-roles/terragrunt.hcl
+++ b/infrastructure/live/prod/us-east-1/security/irsa-roles/terragrunt.hcl
@@ -7,31 +7,43 @@ include "root" {
 
 dependency "eks" {
   config_path = "../../eks"
+
+  # Destroy-only mocks: after a partial teardown the eks unit's outputs are gone
+  # from state and this unit's destroy dies at HCL evaluation ("no variable named
+  # dependency") — seen live on the 2026-07-04 staging teardown. Inputs are not
+  # consulted when destroying from state, so mocks are safe here.
+  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs = {
+    cluster_name       = "mock-cluster"
+    oidc_provider_arn  = "arn:aws:iam::000000000000:oidc-provider/mock"
+    oidc_provider_url  = "oidc.eks.us-east-1.amazonaws.com/id/MOCK"
+    node_iam_role_arns = ["arn:aws:iam::000000000000:role/mock"]
+  }
 }
 
 # App IRSA scopes its policies to the exact Block 3 data-store ARNs.
 dependency "audit_kms" {
   config_path                             = "../../data/audit-kms"
   mock_outputs                            = { key_arn = "arn:aws:kms:us-east-1:000000000000:key/mock" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 dependency "audit_worm" {
   config_path                             = "../../data/audit-worm"
   mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-audit-worm" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 dependency "media_bucket" {
   config_path                             = "../../data/media-bucket"
   mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-media" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 dependency "cnpg_backups" {
   config_path                             = "../../data/cnpg-backups"
   mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-cnpg-backups" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 terraform {

--- a/infrastructure/live/staging/us-east-1/eks/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/eks/terragrunt.hcl
@@ -11,6 +11,15 @@ terraform {
 
 dependency "vpc" {
   config_path = "../networking/vpc"
+
+  # Destroy-only mocks — same rationale as irsa-roles' eks dependency: a partial
+  # teardown can leave the vpc unit without outputs, bricking this unit's destroy.
+  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs = {
+    vpc_id                 = "vpc-00000000000000000"
+    private_app_subnet_ids = ["subnet-00000000000000000"]
+    vpc_cidr_block         = "10.0.0.0/16"
+  }
 }
 
 locals {

--- a/infrastructure/live/staging/us-east-1/security/irsa-roles/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/security/irsa-roles/terragrunt.hcl
@@ -9,31 +9,43 @@ include "root" {
 
 dependency "eks" {
   config_path = "../../eks"
+
+  # Destroy-only mocks: after a partial teardown the eks unit's outputs are gone
+  # from state and this unit's destroy dies at HCL evaluation ("no variable named
+  # dependency") — seen live on the 2026-07-04 staging teardown. Inputs are not
+  # consulted when destroying from state, so mocks are safe here.
+  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs = {
+    cluster_name       = "mock-cluster"
+    oidc_provider_arn  = "arn:aws:iam::000000000000:oidc-provider/mock"
+    oidc_provider_url  = "oidc.eks.us-east-1.amazonaws.com/id/MOCK"
+    node_iam_role_arns = ["arn:aws:iam::000000000000:role/mock"]
+  }
 }
 
 # App IRSA scopes its policies to the exact Block 3 data-store ARNs.
 dependency "audit_kms" {
   config_path                             = "../../data/audit-kms"
   mock_outputs                            = { key_arn = "arn:aws:kms:us-east-1:000000000000:key/mock" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 dependency "audit_worm" {
   config_path                             = "../../data/audit-worm"
   mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-audit-worm" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 dependency "media_bucket" {
   config_path                             = "../../data/media-bucket"
   mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-media" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 dependency "cnpg_backups" {
   config_path                             = "../../data/cnpg-backups"
   mock_outputs                            = { bucket_arn = "arn:aws:s3:::mock-cnpg-backups" }
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "destroy"]
 }
 
 terraform {


### PR DESCRIPTION
Both found (and both fixes verified) live on today's staging rebuild→soak→teardown cycle:

1. **Destroy-scoped `mock_outputs`** on `irsa-roles→eks` and `eks→vpc` (staging + prod), plus `"destroy"` added to the allowed-commands of irsa-roles' existing data-unit mocks. A partial teardown that wipes a dependency's outputs previously bricked every dependent unit's destroy at HCL evaluation.

2. **Karpenter reaper tag filter**: `karpenter.sh/managed-by` is not a tag Karpenter v1 applies — the #573 reaper matched nothing, and 8 system-pool instances survived to wedge the node SG and subnets. Now filters `tag-key=karpenter.sh/nodepool` AND `kubernetes.io/cluster/<cluster>=owned`.

Verified: with these edits the remaining staging units destroyed cleanly (14/14 total, zero residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ