### PR TITLE
ci: add unnecessary_sort_by to the clippy ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,4 @@ jobs:
           -A clippy::too_many_arguments
           -A clippy::type_complexity
           -A clippy::unnecessary_map_or
+          -A clippy::unnecessary_sort_by


### PR DESCRIPTION
First live ci.yml run: **test job passed** (6.5 min); clippy failed on one lint kind my local (older) stable doesn't flag: `clippy::unnecessary_sort_by`. Adds it to the documented ratchet allow-list. Consider a `rust-toolchain.toml` pin later to stop stable-version drift from flapping the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ