### PR TITLE
chore: pin the Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci.yml'
+      - 'rust-toolchain.toml'
   push:
     branches: [develop]
     paths:
@@ -30,6 +31,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci.yml'
+      - 'rust-toolchain.toml'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -38,7 +38,11 @@
 #     -t <ecr>/core-platform-$BIN:$TAG --push .
 
 # ── Chef base ─────────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS chef
+# Minor pinned in lockstep with rust-toolchain.toml (see its bump procedure) —
+# the floating `rust:1` tag is the same drift class that flapped the CI clippy
+# gate on launch day. NB: the toolchain file also reaches this stage via the
+# image's rustup, so a mismatched tag would trigger a redundant download.
+FROM rust:1.96-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+# Single source of truth for the workspace toolchain. Why pinned: CI's floating
+# `stable` flapped the clippy gate the day it launched (1.96 flags lints 1.91
+# doesn't — unnecessary_sort_by, found within hours of adding the gate). The
+# rustup shim honors this file everywhere it exists: dev machines, CI (the
+# dtolnay/rust-toolchain@stable install is overridden at cargo-invocation time),
+# and the deploy/Dockerfile builder (whose base tag is aligned manually — keep
+# `rust:<minor>-bookworm` in lockstep when bumping this).
+#
+# Bumping: update channel here + the Dockerfile FROM tag in ONE PR; the CI run
+# on that PR revalidates test + clippy -D warnings under the new lint set.
+[toolchain]
+channel    = "1.96.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Closes the toolchain-drift follow-up from the CI gate launch: `rust-toolchain.toml` pinning `1.96.0` (+clippy/rustfmt components) and the Dockerfile builder tag `rust:1-bookworm` → `rust:1.96-bookworm`, documented to bump in lockstep.

1.96.0 = the version the whole tree was validated against today (test green, bare `-D warnings` clippy green). This PR's CI run is the proof under the pinned toolchain; the fleet-images build on merge proves the Dockerfile side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ