### PR TITLE
feat(account,auth): mint audit:* permissions into edge tokens via account RBAC

### DIFF
--- a/crates/contracts/proto/account/v1/messages.proto
+++ b/crates/contracts/proto/account/v1/messages.proto
@@ -27,6 +27,10 @@ message AccountView {
     int64                           version              = 12;
     google.protobuf.Timestamp       created_at           = 13;
     google.protobuf.Timestamp       updated_at           = 14;
+    // Effective fine-grained grants (role expansion ∪ permission_overrides),
+    // e.g. audit:read — minted verbatim into edge tokens by auth. Additive:
+    // absent on old servers, in which case callers fall back to roles only.
+    repeated string                 permissions          = 15;
 }
 
 // GDPR compliance record — returned only to authorised compliance officers.

--- a/crates/services/account/src/application/query/get_account_by_id.rs
+++ b/crates/services/account/src/application/query/get_account_by_id.rs
@@ -28,6 +28,9 @@ pub struct AccountView {
     pub kyc_status: String,
     pub roles: Vec<String>,
     pub permission_overrides: Vec<String>,
+    /// Effective fine-grained grants (role expansion ∪ overrides) — what auth
+    /// mints into edge tokens alongside the role names.
+    pub permissions: Vec<String>,
     pub country_of_residence: Option<String>,
     pub last_login_at: Option<DateTime<Utc>>,
     pub is_locked: bool,
@@ -53,6 +56,7 @@ impl From<&Account> for AccountView {
             phone_verified: a.phone_verified(),
             kyc_status: a.kyc_status().to_string(),
             roles: a.roles().iter().map(|r| r.to_string()).collect(),
+            permissions: a.effective_permissions(),
             permission_overrides: a
                 .permission_overrides()
                 .iter()

--- a/crates/services/account/src/domain/aggregate/account.rs
+++ b/crates/services/account/src/domain/aggregate/account.rs
@@ -680,6 +680,22 @@ impl Account {
 
     pub fn permission_overrides(&self) -> &[String] { &self.permission_overrides }
 
+    /// The effective fine-grained permission set: the union of every assigned
+    /// role's grants and the per-account `permission_overrides`, deduplicated
+    /// and sorted (deterministic output — these are minted into edge tokens by
+    /// `auth` and compared in tests/audit trails).
+    pub fn effective_permissions(&self) -> Vec<String> {
+        let mut permissions: Vec<String> = self
+            .roles
+            .iter()
+            .flat_map(|role| role.granted_permissions().iter().map(|p| (*p).to_owned()))
+            .chain(self.permission_overrides.iter().cloned())
+            .collect();
+        permissions.sort_unstable();
+        permissions.dedup();
+        permissions
+    }
+
     pub fn created_by(&self) -> Option<AccountId> { self.created_by }
 
     pub fn created_at(&self) -> DateTime<Utc> { self.created_at }
@@ -717,5 +733,103 @@ impl Account {
         let now = Utc::now();
         self.touch(now);
         now
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admin_account_with_overrides(overrides: Vec<String>) -> Account {
+        Account::reconstitute(
+            AccountId::new(),
+            IdentityId::new("idp|test-subject").expect("identity id"),
+            AccountStatus::Active,
+            None,
+            None,
+            EmailAddress::new("ops@example.com").expect("email"),
+            true,
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            0,
+            None,
+            None,
+            MfaState::default(),
+            KycStatus::NotStarted,
+            None,
+            None,
+            None,
+            None,
+            GdprRecord::default(),
+            vec![AccountRole::Admin, AccountRole::SuperAdmin],
+            overrides,
+            1,
+            Utc::now(),
+            Utc::now(),
+            None,
+        )
+    }
+
+    /// Union semantics: overlapping role grants (Admin ⊂ SuperAdmin) collapse,
+    /// overrides join the set, duplicates against role grants disappear, and
+    /// the result is sorted — the exact string set auth mints into the token.
+    #[test]
+    fn effective_permissions_union_roles_and_overrides_deduped_sorted() {
+        let account = admin_account_with_overrides(vec![
+            "audit:read".to_owned(),      // duplicate of a role grant
+            "compliance:hold".to_owned(), // pure override
+        ]);
+
+        assert_eq!(
+            account.effective_permissions(),
+            vec![
+                "audit:export".to_owned(),
+                "audit:read".to_owned(),
+                "audit:record".to_owned(),
+                "audit:verify".to_owned(),
+                "compliance:hold".to_owned(),
+            ]
+        );
+    }
+
+    /// A plain user's token must carry no fine-grained grants at all.
+    #[test]
+    fn baseline_account_has_no_effective_permissions() {
+        let account = Account::reconstitute(
+            AccountId::new(),
+            IdentityId::new("idp|plain-user").expect("identity id"),
+            AccountStatus::Active,
+            None,
+            None,
+            EmailAddress::new("user@example.com").expect("email"),
+            true,
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            0,
+            None,
+            None,
+            MfaState::default(),
+            KycStatus::NotStarted,
+            None,
+            None,
+            None,
+            None,
+            GdprRecord::default(),
+            vec![AccountRole::User],
+            Vec::new(),
+            1,
+            Utc::now(),
+            Utc::now(),
+            None,
+        );
+        assert!(account.effective_permissions().is_empty());
     }
 }

--- a/crates/services/account/src/domain/value_object/account_role.rs
+++ b/crates/services/account/src/domain/value_object/account_role.rs
@@ -39,6 +39,34 @@ impl AccountRole {
         }
     }
 
+    /// Fine-grained permission grants this role carries into the edge token.
+    ///
+    /// `account` is authoritative for RBAC: `auth` re-reads these on every
+    /// login/refresh and mints them verbatim (opaque strings by contract —
+    /// see `auth-context::Permission`). Today the only fine-grained consumers
+    /// are the audit ledger's read-side gates (`audit-service
+    /// infrastructure/grpc/access.rs`), which fail closed on absence:
+    ///
+    /// * `audit:read`   — query ledger records (need-to-know read)
+    /// * `audit:verify` — integrity verification (chain reports, no payloads)
+    /// * `audit:export` — evidence-bundle egress (stricter than read)
+    /// * `audit:record` — the synchronous break-glass record lane
+    ///
+    /// Admin gets read+verify (operate and prove the ledger, no bulk egress);
+    /// SuperAdmin adds export and the break-glass lane. Per-account exceptions
+    /// (e.g. a compliance officer needing export without SuperAdmin) belong in
+    /// `permission_overrides` on the aggregate, not here.
+    pub fn granted_permissions(&self) -> &'static [&'static str] {
+        match self {
+            Self::User             => &[],
+            Self::ContentModerator => &[],
+            Self::SupportAgent     => &[],
+            Self::FinanceOperator  => &[],
+            Self::Admin            => &["audit:read", "audit:verify"],
+            Self::SuperAdmin       => &["audit:read", "audit:verify", "audit:export", "audit:record"],
+        }
+    }
+
     /// Numeric privilege level for ordering and audit comparisons.
     ///
     /// Higher values indicate broader access. Roles at the same level have
@@ -82,5 +110,34 @@ impl TryFrom<String> for AccountRole {
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::try_from(s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The audit gate contract (audit access.rs `perm` module) — baseline roles
+    /// carry no audit grants; Admin can operate/prove the ledger but not bulk-
+    /// export; only SuperAdmin holds the egress + break-glass grants.
+    #[test]
+    fn audit_grants_follow_privilege_boundaries() {
+        for role in [
+            AccountRole::User,
+            AccountRole::ContentModerator,
+            AccountRole::SupportAgent,
+            AccountRole::FinanceOperator,
+        ] {
+            assert!(role.granted_permissions().is_empty(), "{role} must grant nothing");
+        }
+
+        let admin = AccountRole::Admin.granted_permissions();
+        assert!(admin.contains(&"audit:read") && admin.contains(&"audit:verify"));
+        assert!(!admin.contains(&"audit:export") && !admin.contains(&"audit:record"));
+
+        let sa = AccountRole::SuperAdmin.granted_permissions();
+        for p in ["audit:read", "audit:verify", "audit:export", "audit:record"] {
+            assert!(sa.contains(&p), "SuperAdmin must grant {p}");
+        }
     }
 }

--- a/crates/services/account/src/infrastructure/grpc/handler/account_service_handler.rs
+++ b/crates/services/account/src/infrastructure/grpc/handler/account_service_handler.rs
@@ -460,6 +460,7 @@ fn account_view_to_proto(v: AccountView) -> proto::AccountView {
         kyc_status: kyc_status_str_to_i32(&v.kyc_status),
         country_of_residence: v.country_of_residence.unwrap_or_default(),
         roles: v.roles,
+        permissions: v.permissions,
         version: v.version,
         created_at: Some(dt_to_ts(v.created_at)),
         updated_at: Some(dt_to_ts(v.updated_at)),

--- a/crates/services/auth/src/infrastructure/directory/grpc_account_directory.rs
+++ b/crates/services/auth/src/infrastructure/directory/grpc_account_directory.rs
@@ -70,7 +70,15 @@ impl AccountDirectory for GrpcAccountDirectory {
             AccountStatus::Active => AccountActivation::Active,
             other => AccountActivation::Inactive { reason: status_name(other) },
         };
-        let permissions = view.roles.into_iter().map(Permission::new).collect();
+        // Union of coarse role names (pre-existing behaviour — downstream gates
+        // may match on them) and account's effective fine-grained grants (the
+        // `permissions` field, e.g. `audit:read`; empty from servers predating
+        // it, which degrades to exactly the old roles-only token).
+        let mut grants = view.roles;
+        grants.extend(view.permissions);
+        grants.sort_unstable();
+        grants.dedup();
+        let permissions = grants.into_iter().map(Permission::new).collect();
 
         Ok(AccountSnapshot { activation, permissions })
     }


### PR DESCRIPTION
Unlocks the audit ledger's read surface: the #546 CallerGate requires `audit:*` permissions that nothing minted — deny-all for every human caller. The fix follows the existing ownership contract: **account is authoritative for RBAC**, auth re-reads and mints on every login/refresh.

## Grant matrix

| Role | audit:read | audit:verify | audit:export | audit:record |
|---|---|---|---|---|
| User / ContentModerator / SupportAgent / FinanceOperator | — | — | — | — |
| Admin | ✅ | ✅ | — | — |
| SuperAdmin | ✅ | ✅ | ✅ | ✅ (break-glass) |

Per-account exceptions (compliance officer needing export without SuperAdmin) use the aggregate's existing `permission_overrides` — that's what it's for.

## Mechanics

- `AccountRole::granted_permissions()` + `Account::effective_permissions()` (roles ∪ overrides, deduped, sorted — deterministic token content)
- `AccountView.permissions = 15` (additive proto field; buf breaking validates)
- auth's directory adapter mints **union of role names + fine-grained grants** — an account server predating the field degrades to exactly today's roles-only token; nothing that matches on role names breaks

## Verification

- New tests: grant-boundary matrix, union/dedup/sort with an override duplicating a role grant, baseline-mints-nothing
- `cargo test`: account + auth green (80 existing auth tests untouched)
- `clippy -D warnings` clean on both crates; `buf lint` clean; the PR's buf-breaking + CI runs are the gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ