### PR TITLE
release: audit:* permissions via account RBAC (+ toolchain pin, clippy-clean)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,4 @@ jobs:
           -A clippy::too_many_arguments
           -A clippy::type_complexity
           -A clippy::unnecessary_map_or
+          -A clippy::unnecessary_sort_by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,26 +67,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      # -D warnings with a RATCHET: the -A list below is exactly the lint kinds
-      # firing on the tree today (~35 mild style hits, audited 2026-07-05) so the
-      # gate lands green while every OTHER clippy lint becomes a hard error from
-      # day one. Shrink this list as cleanup lands; never grow it.
+      # Bare -D warnings: the tree was clippy-cleaned 2026-07-05 (53 sites —
+      # auto-fixes, real refactors, and documented targeted #[allow]s for the
+      # structural lints). Keep it clean; add targeted allows in code, not here.
       - name: cargo clippy --workspace --all-targets
-        run: >
-          cargo clippy --workspace --all-targets -- -D warnings
-          -A clippy::clone_on_copy
-          -A clippy::cloned_ref_to_slice_refs
-          -A clippy::collapsible_if
-          -A clippy::field_reassign_with_default
-          -A clippy::items_after_test_module
-          -A clippy::let_underscore_future
-          -A clippy::manual_async_fn
-          -A clippy::manual_clamp
-          -A clippy::manual_is_multiple_of
-          -A clippy::manual_range_contains
-          -A clippy::module_inception
-          -A clippy::new_without_default
-          -A clippy::too_many_arguments
-          -A clippy::type_complexity
-          -A clippy::unnecessary_map_or
-          -A clippy::unnecessary_sort_by
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci.yml'
+      - 'rust-toolchain.toml'
   push:
     branches: [develop]
     paths:
@@ -30,6 +31,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci.yml'
+      - 'rust-toolchain.toml'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/crates/apps/migrator/src/main.rs
+++ b/crates/apps/migrator/src/main.rs
@@ -306,6 +306,19 @@ fn split_statements(content: &str) -> Vec<String> {
     statements
 }
 
+/// Whether a Scylla error is a benign "this DDL target already exists" — used to
+/// keep non-`IF NOT EXISTS` statements (notably `ALTER TABLE ... ADD`) idempotent
+/// on a fresh cluster.
+fn is_already_exists(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("already exists") || m.contains("conflicts with an existing column")
+}
+
+/// First non-empty line of a statement, for error context.
+fn first_line(stmt: &str) -> &str {
+    stmt.lines().map(str::trim).find(|l| !l.is_empty()).unwrap_or(stmt)
+}
+
 #[cfg(test)]
 mod tests {
     use super::split_statements;
@@ -327,17 +340,4 @@ mod tests {
         assert_eq!(stmts.len(), 1);
         assert!(stmts[0].starts_with("CREATE KEYSPACE ks"));
     }
-}
-
-/// Whether a Scylla error is a benign "this DDL target already exists" — used to
-/// keep non-`IF NOT EXISTS` statements (notably `ALTER TABLE ... ADD`) idempotent
-/// on a fresh cluster.
-fn is_already_exists(msg: &str) -> bool {
-    let m = msg.to_ascii_lowercase();
-    m.contains("already exists") || m.contains("conflicts with an existing column")
-}
-
-/// First non-empty line of a statement, for error context.
-fn first_line(stmt: &str) -> &str {
-    stmt.lines().map(str::trim).find(|l| !l.is_empty()).unwrap_or(stmt)
 }

--- a/crates/contracts/proto/account/v1/messages.proto
+++ b/crates/contracts/proto/account/v1/messages.proto
@@ -27,6 +27,10 @@ message AccountView {
     int64                           version              = 12;
     google.protobuf.Timestamp       created_at           = 13;
     google.protobuf.Timestamp       updated_at           = 14;
+    // Effective fine-grained grants (role expansion ∪ permission_overrides),
+    // e.g. audit:read — minted verbatim into edge tokens by auth. Additive:
+    // absent on old servers, in which case callers fall back to roles only.
+    repeated string                 permissions          = 15;
 }
 
 // GDPR compliance record — returned only to authorised compliance officers.

--- a/crates/foundation/infra-config/src/telemetry.rs
+++ b/crates/foundation/infra-config/src/telemetry.rs
@@ -50,13 +50,12 @@ impl TelemetrySection {
     /// validated here without a tracing dependency; it is checked at apply time
     /// by the sink (a bad directive is rejected, leaving the previous filter).
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if let Some(TelemetrySamplingSpec::TraceIdRatio { ratio }) = &self.sampling {
-            if !(0.0..=1.0).contains(ratio) {
+        if let Some(TelemetrySamplingSpec::TraceIdRatio { ratio }) = &self.sampling
+            && !(0.0..=1.0).contains(ratio) {
                 return Err(ConfigError::validation(format!(
                     "[telemetry] sampling ratio {ratio} must be in [0.0, 1.0]"
                 )));
             }
-        }
         Ok(())
     }
 }

--- a/crates/platform/auth-context/src/extractor/oidc.rs
+++ b/crates/platform/auth-context/src/extractor/oidc.rs
@@ -184,13 +184,12 @@ impl ClaimsExtractor<OidcClaims> for OidcClaimsExtractor {
                 }
 
                 RoleSource::RealmAccessRoles => {
-                    if let Some(ref realm) = raw.realm_access {
-                        if let Some(ref roles) = realm.roles {
+                    if let Some(ref realm) = raw.realm_access
+                        && let Some(ref roles) = realm.roles {
                             for role in roles {
                                 push(role);
                             }
                         }
-                    }
                 }
 
                 RoleSource::PermissionsClaim => {
@@ -210,13 +209,12 @@ impl ClaimsExtractor<OidcClaims> for OidcClaimsExtractor {
                 }
 
                 RoleSource::Custom(key) => {
-                    if let Some(val) = raw.extra.get(key) {
-                        if let Some(arr) = val.as_array() {
+                    if let Some(val) = raw.extra.get(key)
+                        && let Some(arr) = val.as_array() {
                             for item in arr.iter().filter_map(|v| v.as_str()) {
                                 push(item);
                             }
                         }
-                    }
                 }
             }
         }

--- a/crates/platform/auth-context/src/principal/mod.rs
+++ b/crates/platform/auth-context/src/principal/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)] // file-per-concept layout: dir + core file share the name
 pub mod principal;
 
 pub use principal::{CurrentPrincipal, Permission, PrincipalId};

--- a/crates/platform/cqrs/src/command/mod.rs
+++ b/crates/platform/cqrs/src/command/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bus;
+#[allow(clippy::module_inception)] // file-per-concept layout: dir + core file share the name
 pub(crate) mod command;
 pub(crate) mod handler;
 pub(crate) mod registry;

--- a/crates/platform/cqrs/src/envelope/mod.rs
+++ b/crates/platform/cqrs/src/envelope/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)] // file-per-concept layout: dir + core file share the name
 pub(crate) mod envelope;
 
 pub use envelope::*;

--- a/crates/platform/cqrs/src/query/mod.rs
+++ b/crates/platform/cqrs/src/query/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bus;
 pub(crate) mod handler;
+#[allow(clippy::module_inception)] // file-per-concept layout: dir + core file share the name
 pub(crate) mod query;
 pub(crate) mod registry;
 

--- a/crates/platform/telemetry/src/control.rs
+++ b/crates/platform/telemetry/src/control.rs
@@ -20,16 +20,18 @@ pub struct TelemetryControl {
     inner: Arc<ControlInner>,
 }
 
+/// Reloads the global `EnvFilter` from a directive string. Boxed so the
+/// subscriber type parameter of the underlying reload handle stays erased.
+pub(crate) type SetFilterFn = Box<dyn Fn(&str) -> Result<(), TelemetryError> + Send + Sync>;
+
 struct ControlInner {
-    /// Reloads the global `EnvFilter` from a directive string. Boxed so the
-    /// subscriber type parameter of the underlying reload handle stays erased.
-    set_filter: Box<dyn Fn(&str) -> Result<(), TelemetryError> + Send + Sync>,
+    set_filter: SetFilterFn,
     sampler: DynamicSampler,
 }
 
 impl TelemetryControl {
     pub(crate) fn new(
-        set_filter: Box<dyn Fn(&str) -> Result<(), TelemetryError> + Send + Sync>,
+        set_filter: SetFilterFn,
         sampler: DynamicSampler,
     ) -> Self {
         Self { inner: Arc::new(ControlInner { set_filter, sampler }) }

--- a/crates/platform/telemetry/src/metrics/layer.rs
+++ b/crates/platform/telemetry/src/metrics/layer.rs
@@ -26,11 +26,10 @@ impl MetricsPipeline {
     }
 
     pub(crate) fn shutdown(&self) {
-        if let Some(provider) = &self.meter_provider {
-            if let Err(e) = provider.shutdown() {
+        if let Some(provider) = &self.meter_provider
+            && let Err(e) = provider.shutdown() {
                 eprintln!("[telemetry] meter provider shutdown error: {e}");
             }
-        }
     }
 }
 

--- a/crates/platform/telemetry/src/trace/layer.rs
+++ b/crates/platform/telemetry/src/trace/layer.rs
@@ -28,11 +28,15 @@ use crate::error::TelemetryError;
 ///           └─ Resource { service.name, service.version }
 ///           └─ DynamicSampler  → swappable { AlwaysOn | AlwaysOff | ParentBased(ratio) }
 /// ```
+/// Everything a subscriber needs from the trace plane: the erased layer, the
+/// provider (kept for shutdown flush), and the sampler control handle.
+pub type BuiltTraceLayer<S> = (Box<dyn Layer<S> + Send + Sync>, TracerProvider, DynamicSampler);
+
 pub fn build_trace_layer<S>(
     config: &TraceConfig,
     service_name: &str,
     service_version: &str,
-) -> Result<(Box<dyn Layer<S> + Send + Sync>, TracerProvider, DynamicSampler), TelemetryError>
+) -> Result<BuiltTraceLayer<S>, TelemetryError>
 where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span> + Send + Sync,
 {

--- a/crates/platform/validation/src/middleware/layer.rs
+++ b/crates/platform/validation/src/middleware/layer.rs
@@ -62,6 +62,10 @@ pub struct ValidationCommandBus<S> {
 }
 
 impl<S: CommandBus> CommandBus for ValidationCommandBus<S> {
+    // Explicit RPIT (not `async fn`) on purpose: it keeps the `+ Send` bound
+    // visible at the impl and matches the trait's declared signature — the
+    // crate-wide no-async_trait idiom.
+    #[allow(clippy::manual_async_fn)]
     fn dispatch<C: Command>(
         &self,
         envelope: Envelope<C>,

--- a/crates/services/account/src/application/command/create_account.rs
+++ b/crates/services/account/src/application/command/create_account.rs
@@ -49,25 +49,23 @@ impl Validate for CreateAccountCommand {
             violations.push(FieldViolation::new("email", "VAL-2003", "email format is invalid"));
         }
 
-        if let Some(phone) = &self.phone {
-            if !phone.starts_with('+') || phone.len() < 7 {
+        if let Some(phone) = &self.phone
+            && (!phone.starts_with('+') || phone.len() < 7) {
                 violations.push(FieldViolation::new(
                     "phone",
                     "VAL-2004",
                     "phone must be in E.164 format (e.g. +12025551234)",
                 ));
             }
-        }
 
-        if let Some(country) = &self.country_of_residence {
-            if country.len() != 2 || !country.chars().all(|c| c.is_ascii_alphabetic()) {
+        if let Some(country) = &self.country_of_residence
+            && (country.len() != 2 || !country.chars().all(|c| c.is_ascii_alphabetic())) {
                 violations.push(FieldViolation::new(
                     "country_of_residence",
                     "VAL-2005",
                     "country_of_residence must be an ISO 3166-1 alpha-2 code",
                 ));
             }
-        }
 
         if violations.is_empty() { Ok(()) } else { Err(violations) }
     }

--- a/crates/services/account/src/application/query/get_account_by_id.rs
+++ b/crates/services/account/src/application/query/get_account_by_id.rs
@@ -28,6 +28,9 @@ pub struct AccountView {
     pub kyc_status: String,
     pub roles: Vec<String>,
     pub permission_overrides: Vec<String>,
+    /// Effective fine-grained grants (role expansion ∪ overrides) — what auth
+    /// mints into edge tokens alongside the role names.
+    pub permissions: Vec<String>,
     pub country_of_residence: Option<String>,
     pub last_login_at: Option<DateTime<Utc>>,
     pub is_locked: bool,
@@ -53,6 +56,7 @@ impl From<&Account> for AccountView {
             phone_verified: a.phone_verified(),
             kyc_status: a.kyc_status().to_string(),
             roles: a.roles().iter().map(|r| r.to_string()).collect(),
+            permissions: a.effective_permissions(),
             permission_overrides: a
                 .permission_overrides()
                 .iter()

--- a/crates/services/account/src/application/query/get_account_status.rs
+++ b/crates/services/account/src/application/query/get_account_status.rs
@@ -55,7 +55,7 @@ impl QueryHandler<GetAccountStatusQuery> for GetAccountStatusHandler {
 
         Ok(AccountStatusView {
             account_id: id_str.clone(),
-            status: account.status().clone(),
+            status: account.status(),
             suspension_reason: account.suspension_reason().map(str::to_owned),
             is_locked: account.is_locked(),
         })

--- a/crates/services/account/src/application/query/list_accounts_by_status.rs
+++ b/crates/services/account/src/application/query/list_accounts_by_status.rs
@@ -46,7 +46,7 @@ impl QueryHandler<ListAccountsByStatusQuery> for ListAccountsByStatusHandler {
         let status = AccountStatus::try_from(cmd.status.as_str())
             .map_err(|_| AccountError::InvalidAccountStatus(cmd.status.clone()))?;
 
-        let limit = cmd.limit.max(1).min(1000);
+        let limit = cmd.limit.clamp(1, 1000);
         let offset = cmd.offset.max(0);
 
         let (accounts, total) = tokio::try_join!(

--- a/crates/services/account/src/domain/aggregate/account.rs
+++ b/crates/services/account/src/domain/aggregate/account.rs
@@ -651,7 +651,7 @@ impl Account {
     pub fn locked_until(&self) -> Option<DateTime<Utc>> { self.locked_until }
 
     pub fn is_locked(&self) -> bool {
-        self.locked_until.map_or(false, |until| until > Utc::now())
+        self.locked_until.is_some_and(|until| until > Utc::now())
     }
 
     pub fn last_login_at(&self) -> Option<DateTime<Utc>> { self.last_login_at }

--- a/crates/services/account/src/domain/aggregate/account.rs
+++ b/crates/services/account/src/domain/aggregate/account.rs
@@ -680,6 +680,22 @@ impl Account {
 
     pub fn permission_overrides(&self) -> &[String] { &self.permission_overrides }
 
+    /// The effective fine-grained permission set: the union of every assigned
+    /// role's grants and the per-account `permission_overrides`, deduplicated
+    /// and sorted (deterministic output — these are minted into edge tokens by
+    /// `auth` and compared in tests/audit trails).
+    pub fn effective_permissions(&self) -> Vec<String> {
+        let mut permissions: Vec<String> = self
+            .roles
+            .iter()
+            .flat_map(|role| role.granted_permissions().iter().map(|p| (*p).to_owned()))
+            .chain(self.permission_overrides.iter().cloned())
+            .collect();
+        permissions.sort_unstable();
+        permissions.dedup();
+        permissions
+    }
+
     pub fn created_by(&self) -> Option<AccountId> { self.created_by }
 
     pub fn created_at(&self) -> DateTime<Utc> { self.created_at }
@@ -717,5 +733,103 @@ impl Account {
         let now = Utc::now();
         self.touch(now);
         now
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admin_account_with_overrides(overrides: Vec<String>) -> Account {
+        Account::reconstitute(
+            AccountId::new(),
+            IdentityId::new("idp|test-subject").expect("identity id"),
+            AccountStatus::Active,
+            None,
+            None,
+            EmailAddress::new("ops@example.com").expect("email"),
+            true,
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            0,
+            None,
+            None,
+            MfaState::default(),
+            KycStatus::NotStarted,
+            None,
+            None,
+            None,
+            None,
+            GdprRecord::default(),
+            vec![AccountRole::Admin, AccountRole::SuperAdmin],
+            overrides,
+            1,
+            Utc::now(),
+            Utc::now(),
+            None,
+        )
+    }
+
+    /// Union semantics: overlapping role grants (Admin ⊂ SuperAdmin) collapse,
+    /// overrides join the set, duplicates against role grants disappear, and
+    /// the result is sorted — the exact string set auth mints into the token.
+    #[test]
+    fn effective_permissions_union_roles_and_overrides_deduped_sorted() {
+        let account = admin_account_with_overrides(vec![
+            "audit:read".to_owned(),      // duplicate of a role grant
+            "compliance:hold".to_owned(), // pure override
+        ]);
+
+        assert_eq!(
+            account.effective_permissions(),
+            vec![
+                "audit:export".to_owned(),
+                "audit:read".to_owned(),
+                "audit:record".to_owned(),
+                "audit:verify".to_owned(),
+                "compliance:hold".to_owned(),
+            ]
+        );
+    }
+
+    /// A plain user's token must carry no fine-grained grants at all.
+    #[test]
+    fn baseline_account_has_no_effective_permissions() {
+        let account = Account::reconstitute(
+            AccountId::new(),
+            IdentityId::new("idp|plain-user").expect("identity id"),
+            AccountStatus::Active,
+            None,
+            None,
+            EmailAddress::new("user@example.com").expect("email"),
+            true,
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            0,
+            None,
+            None,
+            MfaState::default(),
+            KycStatus::NotStarted,
+            None,
+            None,
+            None,
+            None,
+            GdprRecord::default(),
+            vec![AccountRole::User],
+            Vec::new(),
+            1,
+            Utc::now(),
+            Utc::now(),
+            None,
+        );
+        assert!(account.effective_permissions().is_empty());
     }
 }

--- a/crates/services/account/src/domain/value_object/account_role.rs
+++ b/crates/services/account/src/domain/value_object/account_role.rs
@@ -39,6 +39,34 @@ impl AccountRole {
         }
     }
 
+    /// Fine-grained permission grants this role carries into the edge token.
+    ///
+    /// `account` is authoritative for RBAC: `auth` re-reads these on every
+    /// login/refresh and mints them verbatim (opaque strings by contract —
+    /// see `auth-context::Permission`). Today the only fine-grained consumers
+    /// are the audit ledger's read-side gates (`audit-service
+    /// infrastructure/grpc/access.rs`), which fail closed on absence:
+    ///
+    /// * `audit:read`   — query ledger records (need-to-know read)
+    /// * `audit:verify` — integrity verification (chain reports, no payloads)
+    /// * `audit:export` — evidence-bundle egress (stricter than read)
+    /// * `audit:record` — the synchronous break-glass record lane
+    ///
+    /// Admin gets read+verify (operate and prove the ledger, no bulk egress);
+    /// SuperAdmin adds export and the break-glass lane. Per-account exceptions
+    /// (e.g. a compliance officer needing export without SuperAdmin) belong in
+    /// `permission_overrides` on the aggregate, not here.
+    pub fn granted_permissions(&self) -> &'static [&'static str] {
+        match self {
+            Self::User             => &[],
+            Self::ContentModerator => &[],
+            Self::SupportAgent     => &[],
+            Self::FinanceOperator  => &[],
+            Self::Admin            => &["audit:read", "audit:verify"],
+            Self::SuperAdmin       => &["audit:read", "audit:verify", "audit:export", "audit:record"],
+        }
+    }
+
     /// Numeric privilege level for ordering and audit comparisons.
     ///
     /// Higher values indicate broader access. Roles at the same level have
@@ -82,5 +110,34 @@ impl TryFrom<String> for AccountRole {
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::try_from(s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The audit gate contract (audit access.rs `perm` module) — baseline roles
+    /// carry no audit grants; Admin can operate/prove the ledger but not bulk-
+    /// export; only SuperAdmin holds the egress + break-glass grants.
+    #[test]
+    fn audit_grants_follow_privilege_boundaries() {
+        for role in [
+            AccountRole::User,
+            AccountRole::ContentModerator,
+            AccountRole::SupportAgent,
+            AccountRole::FinanceOperator,
+        ] {
+            assert!(role.granted_permissions().is_empty(), "{role} must grant nothing");
+        }
+
+        let admin = AccountRole::Admin.granted_permissions();
+        assert!(admin.contains(&"audit:read") && admin.contains(&"audit:verify"));
+        assert!(!admin.contains(&"audit:export") && !admin.contains(&"audit:record"));
+
+        let sa = AccountRole::SuperAdmin.granted_permissions();
+        for p in ["audit:read", "audit:verify", "audit:export", "audit:record"] {
+            assert!(sa.contains(&p), "SuperAdmin must grant {p}");
+        }
     }
 }

--- a/crates/services/account/src/domain/value_object/phone_number.rs
+++ b/crates/services/account/src/domain/value_object/phone_number.rs
@@ -34,7 +34,7 @@ impl PhoneNumber {
         }
 
         let len = s.len();
-        if len < Self::MIN_LEN || len > Self::MAX_LEN {
+        if !(Self::MIN_LEN..=Self::MAX_LEN).contains(&len) {
             return Err(AccountError::InvalidPhone(format!(
                 "phone number length must be between {} and {} characters (got {})",
                 Self::MIN_LEN,

--- a/crates/services/account/src/infrastructure/grpc/handler/account_service_handler.rs
+++ b/crates/services/account/src/infrastructure/grpc/handler/account_service_handler.rs
@@ -423,7 +423,7 @@ where
             .ok_or_else(|| Status::invalid_argument("invalid status value"))?;
         let query = ListAccountsByStatusQuery {
             status: status.to_owned(),
-            limit: req.limit.max(1).min(1000) as i64,
+            limit: req.limit.clamp(1, 1000) as i64,
             offset: req.offset.max(0) as i64,
         };
         let view: AccountListView = self

--- a/crates/services/account/src/infrastructure/grpc/handler/account_service_handler.rs
+++ b/crates/services/account/src/infrastructure/grpc/handler/account_service_handler.rs
@@ -460,6 +460,7 @@ fn account_view_to_proto(v: AccountView) -> proto::AccountView {
         kyc_status: kyc_status_str_to_i32(&v.kyc_status),
         country_of_residence: v.country_of_residence.unwrap_or_default(),
         roles: v.roles,
+        permissions: v.permissions,
         version: v.version,
         created_at: Some(dt_to_ts(v.created_at)),
         updated_at: Some(dt_to_ts(v.updated_at)),

--- a/crates/services/auth/src/application/command/refresh.rs
+++ b/crates/services/auth/src/application/command/refresh.rs
@@ -152,8 +152,8 @@ impl RefreshHandler {
     ) -> Result<(), AuthError> {
         self.cache.bump_generation(&account_id).await?;
         self.refresh_tokens.revoke_all_for_session(&session_id).await?;
-        if let Some(mut session) = self.sessions.find_by_id(&session_id).await? {
-            if session.status() == SessionStatus::Active {
+        if let Some(mut session) = self.sessions.find_by_id(&session_id).await?
+            && session.status() == SessionStatus::Active {
                 session.revoke(now, RevocationReason::RefreshReuse, correlation_id)?;
                 self.sessions.save(&session).await?;
                 self.cache.blacklist_session(&session_id, self.policy.access_ttl).await?;
@@ -161,7 +161,6 @@ impl RefreshHandler {
                     self.publisher.publish(event).await?;
                 }
             }
-        }
         Ok(())
     }
 }

--- a/crates/services/auth/src/application/fakes.rs
+++ b/crates/services/auth/src/application/fakes.rs
@@ -68,6 +68,12 @@ pub struct StubAccountDirectory {
     snapshots: Mutex<HashMap<AccountId, AccountSnapshot>>,
 }
 
+impl Default for StubAccountDirectory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StubAccountDirectory {
     pub fn new() -> Self {
         Self { subjects: Mutex::new(HashMap::new()), snapshots: Mutex::new(HashMap::new()) }
@@ -119,6 +125,12 @@ pub struct InMemorySubjectLinkRepository {
     links: Mutex<HashMap<IdpSubject, SubjectLink>>,
 }
 
+impl Default for InMemorySubjectLinkRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InMemorySubjectLinkRepository {
     pub fn new() -> Self {
         Self { links: Mutex::new(HashMap::new()) }
@@ -154,6 +166,12 @@ impl SubjectLinkRepository for InMemorySubjectLinkRepository {
 
 pub struct InMemorySessionRepository {
     sessions: Mutex<HashMap<SessionId, Session>>,
+}
+
+impl Default for InMemorySessionRepository {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl InMemorySessionRepository {
@@ -200,6 +218,12 @@ pub struct InMemoryRefreshTokenRepository {
     tokens: Mutex<HashMap<RefreshTokenHash, RefreshToken>>,
 }
 
+impl Default for InMemoryRefreshTokenRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InMemoryRefreshTokenRepository {
     pub fn new() -> Self {
         Self { tokens: Mutex::new(HashMap::new()) }
@@ -232,6 +256,12 @@ impl RefreshTokenRepository for InMemoryRefreshTokenRepository {
 pub struct InMemorySessionCache {
     generations: Mutex<HashMap<AccountId, Generation>>,
     blacklist: Mutex<HashSet<SessionId>>,
+}
+
+impl Default for InMemorySessionCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl InMemorySessionCache {
@@ -271,6 +301,12 @@ impl SessionCache for InMemorySessionCache {
 
 pub struct StubTokenMinter {
     issued: Mutex<HashMap<String, AccessTokenClaims>>,
+}
+
+impl Default for StubTokenMinter {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl StubTokenMinter {
@@ -314,6 +350,12 @@ pub struct RecordingEventPublisher {
     events: Mutex<Vec<DomainEvent>>,
 }
 
+impl Default for RecordingEventPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RecordingEventPublisher {
     pub fn new() -> Self {
         Self { events: Mutex::new(Vec::new()) }
@@ -351,6 +393,12 @@ pub struct Fixture {
     pub minter: Arc<StubTokenMinter>,
     pub publisher: Arc<RecordingEventPublisher>,
     pub policy: SessionPolicy,
+}
+
+impl Default for Fixture {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Fixture {

--- a/crates/services/auth/src/infrastructure/directory/grpc_account_directory.rs
+++ b/crates/services/auth/src/infrastructure/directory/grpc_account_directory.rs
@@ -70,7 +70,15 @@ impl AccountDirectory for GrpcAccountDirectory {
             AccountStatus::Active => AccountActivation::Active,
             other => AccountActivation::Inactive { reason: status_name(other) },
         };
-        let permissions = view.roles.into_iter().map(Permission::new).collect();
+        // Union of coarse role names (pre-existing behaviour — downstream gates
+        // may match on them) and account's effective fine-grained grants (the
+        // `permissions` field, e.g. `audit:read`; empty from servers predating
+        // it, which degrades to exactly the old roles-only token).
+        let mut grants = view.roles;
+        grants.extend(view.permissions);
+        grants.sort_unstable();
+        grants.dedup();
+        let permissions = grants.into_iter().map(Permission::new).collect();
 
         Ok(AccountSnapshot { activation, permissions })
     }

--- a/crates/services/auth/src/infrastructure/token/es256_token_minter.rs
+++ b/crates/services/auth/src/infrastructure/token/es256_token_minter.rs
@@ -99,8 +99,8 @@ impl Es256TokenMinter {
         }
 
         let mut validation = Validation::new(Algorithm::ES256);
-        validation.set_issuer(&[active.issuer.clone()]);
-        validation.set_audience(&[active.audience.clone()]);
+        validation.set_issuer(std::slice::from_ref(&active.issuer));
+        validation.set_audience(std::slice::from_ref(&active.audience));
         validation.set_required_spec_claims(&["exp", "iss", "aud", "sub"]);
 
         let mut header = Header::new(Algorithm::ES256);

--- a/crates/services/counter/src/application/fakes.rs
+++ b/crates/services/counter/src/application/fakes.rs
@@ -182,7 +182,7 @@ impl CounterStore for InMemoryHotStore {
             .get(metric.as_str())
             .map(|b| b.values().cloned().collect())
             .unwrap_or_default();
-        ranked.sort_by(|a, b| b.1.cmp(&a.1));
+        ranked.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         Ok(ranked
             .into_iter()
             .take(limit)

--- a/crates/services/geo-discovery/src/application/command/index_post.rs
+++ b/crates/services/geo-discovery/src/application/command/index_post.rs
@@ -140,11 +140,10 @@ where
         }
 
         // ── 4. Redis card cache (Focus path — conditional on score threshold) ──
-        if score.exceeds_threshold(self.card_cache_threshold) {
-            if let Err(e) = self.card_store.set(&card, ttl).await {
+        if score.exceeds_threshold(self.card_cache_threshold)
+            && let Err(e) = self.card_store.set(&card, ttl).await {
                 tracing::warn!(post_id = %post_id, error = %e, "card cache write failed — ScyllaDB is durable");
             }
-        }
 
         tracing::debug!(
             post_id  = %post_id,

--- a/crates/services/geo-discovery/src/domain/value_object/geo_coordinate.rs
+++ b/crates/services/geo-discovery/src/domain/value_object/geo_coordinate.rs
@@ -14,8 +14,8 @@ pub struct GeoCoordinate {
 
 impl GeoCoordinate {
     pub fn new(lat: f64, lng: f64) -> Result<Self, GeoDiscoveryError> {
-        if !lat.is_finite() || lat < -90.0 || lat > 90.0
-            || !lng.is_finite() || lng < -180.0 || lng > 180.0
+        if !lat.is_finite() || !(-90.0..=90.0).contains(&lat)
+            || !lng.is_finite() || !(-180.0..=180.0).contains(&lng)
         {
             return Err(GeoDiscoveryError::InvalidCoordinate { lat, lng });
         }

--- a/crates/services/geo-discovery/src/domain/value_object/retention_ttl.rs
+++ b/crates/services/geo-discovery/src/domain/value_object/retention_ttl.rs
@@ -20,7 +20,7 @@ impl RetentionTtl {
     }
 
     pub fn from_secs(secs: u64) -> Self {
-        let clamped = secs.min(Self::MAX_SECS).max(1);
+        let clamped = secs.clamp(1, Self::MAX_SECS);
         Self(Duration::from_secs(clamped))
     }
 

--- a/crates/services/notification/src/domain/aggregate/notification.rs
+++ b/crates/services/notification/src/domain/aggregate/notification.rs
@@ -56,6 +56,7 @@ impl Notification {
 
     /// Reconstitutes a collapsed notification produced by the CollapseFlushWorker.
     /// `sender_profile_id` is the most-recent sender in the window.
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn create_collapsed(
         id:                NotificationId,
         target_profile_id: ProfileId,
@@ -82,6 +83,7 @@ impl Notification {
     }
 
     /// Reconstitutes an aggregate from a ScyllaDB row (for query projections).
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn reconstitute(
         id:                NotificationId,
         target_profile_id: ProfileId,

--- a/crates/services/notification/src/domain/value_object/notification_id.rs
+++ b/crates/services/notification/src/domain/value_object/notification_id.rs
@@ -12,6 +12,12 @@ pub struct NotificationId(Uuid);
 /// notification and break idempotency across a deployment boundary.
 const NOTIFICATION_NAMESPACE: Uuid = Uuid::from_u128(0x9d2f7e54_4b1c_4f6a_9c3d_2a7b8e0f1c63);
 
+impl Default for NotificationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NotificationId {
     pub fn new() -> Self {
         Self(Uuid::now_v7())

--- a/crates/services/notification/src/infrastructure/worker/comment_worker.rs
+++ b/crates/services/notification/src/infrastructure/worker/comment_worker.rs
@@ -73,6 +73,7 @@ where
     U: UnreadCounter,
     S: StreamRegistry,
 {
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn new(
         kafka_config: KafkaClientConfig,
         redis:        RedisClient,

--- a/crates/services/notification/src/infrastructure/worker/mention_worker.rs
+++ b/crates/services/notification/src/infrastructure/worker/mention_worker.rs
@@ -82,6 +82,7 @@ where
     U: UnreadCounter,
     S: StreamRegistry,
 {
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn new(
         kafka_config: KafkaClientConfig,
         redis:        RedisClient,

--- a/crates/services/notification/src/infrastructure/worker/reaction_worker.rs
+++ b/crates/services/notification/src/infrastructure/worker/reaction_worker.rs
@@ -165,6 +165,7 @@ where
     U: UnreadCounter,
     S: StreamRegistry,
 {
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn new(
         kafka_config: KafkaClientConfig,
         redis:        RedisClient,

--- a/crates/services/post/src/domain/aggregate/post.rs
+++ b/crates/services/post/src/domain/aggregate/post.rs
@@ -30,6 +30,7 @@ pub struct Post {
 }
 
 impl Post {
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn create(
         id:          PostId,
         profile_id:  ProfileId,
@@ -64,6 +65,7 @@ impl Post {
         })
     }
 
+    #[allow(clippy::too_many_arguments)] // aggregate/worker constructor — same precedent as chat
     pub fn reconstitute(
         id:           PostId,
         profile_id:   ProfileId,
@@ -229,11 +231,10 @@ fn validate_attachments(kind: PostKind, attachments: &[MediaAttachment]) -> Resu
                     if a.thumbnail_url.is_none() {
                         return Err(PostError::MissingVideoThumbnail { index: i });
                     }
-                    if let Some(d) = a.duration_seconds {
-                        if d > MAX_CAROUSEL_VIDEO_SECS {
+                    if let Some(d) = a.duration_seconds
+                        && d > MAX_CAROUSEL_VIDEO_SECS {
                             return Err(PostError::CarouselVideoTooLong { index: i, duration: d });
                         }
-                    }
                 }
                 if a.width == 0 || a.height == 0 {
                     return Err(PostError::InvalidDimensions {

--- a/crates/services/profile/src/application/query/get_profile_by_handle.rs
+++ b/crates/services/profile/src/application/query/get_profile_by_handle.rs
@@ -33,11 +33,10 @@ impl QueryHandler<GetProfileByHandleQuery> for GetProfileByHandleHandler {
         let handle = Handle::new(&envelope.payload.handle)?;
 
         // Two-hop cache path: handle → profile_id → full view.
-        if let Some(profile_id) = self.cache.get_profile_id_by_handle(handle.as_str()).await? {
-            if let Some(view) = self.cache.get_by_id(&profile_id).await? {
+        if let Some(profile_id) = self.cache.get_profile_id_by_handle(handle.as_str()).await?
+            && let Some(view) = self.cache.get_by_id(&profile_id).await? {
                 return Ok(Some(view));
             }
-        }
 
         let profile = match self.repo.find_by_handle(&handle).await? {
             Some(p) => p,

--- a/crates/services/profile/src/infrastructure/grpc/handler/profile_service_handler.rs
+++ b/crates/services/profile/src/infrastructure/grpc/handler/profile_service_handler.rs
@@ -283,7 +283,7 @@ where
         request: Request<proto::ListProfilesByAccountRequest>,
     ) -> Result<Response<proto::ListProfilesByAccountResponse>, Status> {
         let req = request.into_inner();
-        let limit = req.limit.max(1).min(100) as u32;
+        let limit = req.limit.clamp(1, 100) as u32;
         let query = ListProfilesByAccountQuery {
             account_id:  req.account_id,
             limit,

--- a/crates/services/timeline/src/infrastructure/cache/redis_audio_feed_store.rs
+++ b/crates/services/timeline/src/infrastructure/cache/redis_audio_feed_store.rs
@@ -141,7 +141,7 @@ impl AudioFeedStore for RedisAudioFeedStore {
             .await
             .map_err(fred_err)?;
 
-        if raw.len() % 2 != 0 {
+        if !raw.len().is_multiple_of(2) {
             return Err(TimelineError::ScriptReturnInvalid {
                 context: "audio_range_desc interleaved parse",
             });

--- a/crates/services/timeline/src/infrastructure/cache/redis_feed_store.rs
+++ b/crates/services/timeline/src/infrastructure/cache/redis_feed_store.rs
@@ -244,7 +244,7 @@ return removed
 
 /// Parses interleaved [member, score, member, score, ...] Lua output.
 fn parse_interleaved(raw: Vec<String>) -> Result<Vec<FeedEntry>, TimelineError> {
-    if raw.len() % 2 != 0 {
+    if !raw.len().is_multiple_of(2) {
         return Err(TimelineError::ScriptReturnInvalid { context: "range_desc interleaved parse" });
     }
     raw.chunks_exact(2)

--- a/crates/services/timeline/src/infrastructure/cache/redis_vip_registry.rs
+++ b/crates/services/timeline/src/infrastructure/cache/redis_vip_registry.rs
@@ -140,7 +140,7 @@ return redis.call('ZREM', KEYS[1], ARGV[1])
             .await
             .map_err(fred_err)?;
 
-        if raw.len() % 2 != 0 {
+        if !raw.len().is_multiple_of(2) {
             return Err(TimelineError::ScriptReturnInvalid { context: "vip_range_desc interleaved parse" });
         }
 

--- a/crates/storage/redis/src/client/builder.rs
+++ b/crates/storage/redis/src/client/builder.rs
@@ -97,7 +97,7 @@ impl RedisClientBuilder {
         // init() connects the client and waits until the initial connection is
         // established. The returned ConnectHandle drives the background I/O
         // loop; dropping it does NOT cancel the task.
-        let _ = client
+        let _connect_handle = client
             .init()
             .await
             .map_err(RedisStorageError::from)?;

--- a/crates/storage/redis/src/pool/builder.rs
+++ b/crates/storage/redis/src/pool/builder.rs
@@ -102,7 +102,7 @@ impl RedisPoolBuilder {
         // init() connects all pool members concurrently and waits until every
         // member has established its initial connection. Dropping the returned
         // ConnectHandle does NOT cancel the background I/O tasks.
-        let _ = pool
+        let _connect_handle = pool
             .init()
             .await
             .map_err(RedisStorageError::from)?;

--- a/crates/storage/redis/tests/error_mapping.rs
+++ b/crates/storage/redis/tests/error_mapping.rs
@@ -318,11 +318,13 @@ fn fred_not_found_converts_to_rds_4004() {
 async fn unreachable_host_produces_disconnected_or_timeout_error() {
     common::setup::init_tracing();
 
-    let mut config = RedisConfig::default();
-    config.hosts              = vec!["192.0.2.1:6379".into()]; // TEST-NET — never routable
-    config.connection_timeout = Duration::from_secs(2);
-    config.command_timeout    = Duration::from_millis(2_000);
-    config.fail_fast          = true;
+    let config = RedisConfig {
+        hosts:              vec!["192.0.2.1:6379".into()], // TEST-NET — never routable
+        connection_timeout: Duration::from_secs(2),
+        command_timeout:    Duration::from_millis(2_000),
+        fail_fast:          true,
+        ..RedisConfig::default()
+    };
 
     let result = RedisClientBuilder::new(config).build().await;
     assert!(result.is_err());

--- a/crates/storage/scylla/tests/error_mapping.rs
+++ b/crates/storage/scylla/tests/error_mapping.rs
@@ -264,9 +264,11 @@ async fn bad_contact_point_produces_bootstrap_error() {
     use scylla_storage::{ScyllaSessionBuilder, config::ScyllaConfig};
 
     common::init_tracing();
-    let mut config = ScyllaConfig::default();
-    config.contact_points = vec!["192.0.2.1:9042".into()]; // TEST-NET — never routable
-    config.connect_timeout = std::time::Duration::from_secs(2);
+    let config = ScyllaConfig {
+        contact_points:  vec!["192.0.2.1:9042".into()], // TEST-NET — never routable
+        connect_timeout: std::time::Duration::from_secs(2),
+        ..ScyllaConfig::default()
+    };
 
     let result = ScyllaSessionBuilder::new(config).build().await;
     assert!(result.is_err());

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -38,7 +38,11 @@
 #     -t <ecr>/core-platform-$BIN:$TAG --push .
 
 # ── Chef base ─────────────────────────────────────────────────────────────────
-FROM rust:1-bookworm AS chef
+# Minor pinned in lockstep with rust-toolchain.toml (see its bump procedure) —
+# the floating `rust:1` tag is the same drift class that flapped the CI clippy
+# gate on launch day. NB: the toolchain file also reaches this stage via the
+# image's rustup, so a mismatched tag would trigger a redundant download.
+FROM rust:1.96-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -104,71 +104,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: d66dffff3d9921428d26ed9904214f80ed8b3076
+    newTag: db973590261e1a5cdc479a76d6b219c28788588f
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+# Single source of truth for the workspace toolchain. Why pinned: CI's floating
+# `stable` flapped the clippy gate the day it launched (1.96 flags lints 1.91
+# doesn't — unnecessary_sort_by, found within hours of adding the gate). The
+# rustup shim honors this file everywhere it exists: dev machines, CI (the
+# dtolnay/rust-toolchain@stable install is overridden at cargo-invocation time),
+# and the deploy/Dockerfile builder (whose base tag is aligned manually — keep
+# `rust:<minor>-bookworm` in lockstep when bumping this).
+#
+# Bumping: update channel here + the Dockerfile FROM tag in ONE PR; the CI run
+# on that PR revalidates test + clippy -D warnings under the new lint set.
+[toolchain]
+channel    = "1.96.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Release merge carrying #591 (audit:* grants minted into edge tokens — Admin: read/verify, SuperAdmin: +export/record; unlocks the audit read surface), plus the develop-only items since the last release: #589 clippy-clean workspace, #590 Rust 1.96.0 pin.

Code changes reach prod via the next image promotion (prod-promote workflow), not this merge — this keeps main current so that promotion is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ