### PR TITLE
feat(infra): re-allow arm64 in the Karpenter nodepools

### DIFF
--- a/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/templates/nodepools.yaml
+++ b/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/templates/nodepools.yaml
@@ -13,16 +13,20 @@ spec:
         kind: EC2NodeClass
         name: default
       requirements:
-        # --- GESTION DE L'ARCHITECTURE ---
-        # amd64 EVERYWHERE for now: the fleet CI builds amd64-only images
-        # (x86 runners, no --platform), so an arm64 node ImagePullBackOffs any
-        # fleet pod scheduled onto it ("no match for platform in manifest" —
-        # exactly what broke the first staging bring-up: Karpenter picked
-        # cheaper Graviton for the system pool). Re-allow arm64 here ONLY
-        # after fleet-images-deploy.yml publishes multi-arch manifests.
+        # --- ARCHITECTURE ---
+        # Both arches allowed: fleet-images-deploy.yml publishes multi-arch
+        # manifests (amd64 + arm64, stitch job verifies both platforms per
+        # sha), so kubelet resolves the right image on Graviton — the
+        # ImagePullBackOff that broke the first staging bring-up (amd64-only
+        # images, arm64 system pool) can't recur for any sha built since.
+        # Karpenter picks the cheapest fitting instance, which on-demand/spot
+        # is usually Graviton. NB: the prod OVERLAY still pins fleet pods to
+        # amd64 (k8s/overlays/prod/patch-arch-amd64*.yaml) until the first
+        # multi-arch sha is promoted — those pins, not this file, are the
+        # rollout gate.
         - key: "kubernetes.io/arch"
           operator: In
-          values: ["amd64"]
+          values: ["amd64", "arm64"]
         
         - key: "karpenter.sh/capacity-type"
           operator: In


### PR DESCRIPTION
Companion to #593: with verified multi-arch manifests, the amd64-only Karpenter guard is obsolete — pools may provision Graviton wherever it's cheapest.

Safe ordering, by construction:
- **prod**: fleet pods carry amd64 nodeSelector pins (overlay patches from #578) until the first multi-arch sha is promoted — Karpenter honors the pod selector and keeps provisioning x86 for them regardless of this change
- **staging**: torn down; its next rebuild uses post-#593 multi-arch pins and becomes the live arm64 validation

Merge after #593's first fleet build is verified multi-arch in ECR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ