### PR TITLE
feat(infra): VPC CNI prefix delegation — decouple max-pods from instance size

### DIFF
--- a/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/templates/nodeclass.yaml
+++ b/infrastructure/argocd/apps/infrastructure/platform/karpenter-config/templates/nodeclass.yaml
@@ -19,6 +19,13 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         karpenter.sh/discovery: "{{ .Values.global.clusterName }}"
+  # Karpenter does NOT infer pod capacity from the CNI's prefix-delegation
+  # setting — without an explicit override it applies the per-ENI-IP formula
+  # and small instances stay pod-starved. 110 is the upstream kubelet default
+  # ceiling and is safely below prefix-delegation capacity for every size the
+  # pools allow.
+  kubelet:
+    maxPods: 110
   tags:
     Intent: apps
     ManagedBy: Karpenter

--- a/infrastructure/live/staging/env.hcl
+++ b/infrastructure/live/staging/env.hcl
@@ -20,8 +20,10 @@ locals {
       # on platform pods alone — on the 2026-07-04 rebuild both system nodes hit
       # the cap and the node-exporter DaemonSet pods were unschedulable ("Too many
       # pods") until pods were manually evicted. t3.large lifts the cap to 35.
-      # Deeper fix (tracked): VPC CNI prefix delegation decouples max-pods from
-      # instance size entirely.
+      # Prefix delegation is now enabled cluster-wide (modules/eks vpc-cni
+      # addon, before_compute) so max-pods no longer binds at 17 even on
+      # mediums; t3.large is kept anyway — the saturation was also a CPU/mem
+      # headroom signal, not just a pod-slot one.
       instance_types = ["t3.large"]
       min_size       = 2
       max_size       = 3

--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -28,8 +28,26 @@ module "eks" {
   # default-deny ingress does not break liveness/readiness probes.
   cluster_addons = {
     vpc-cni = {
+      # before_compute: the addon (and its config below) must exist BEFORE the
+      # managed node groups are created — EKS computes each nodegroup's
+      # max-pods at launch-template creation time, and only accounts for
+      # prefix delegation if it is already enabled. Without this, fresh
+      # nodegroups get the per-ENI-IP limit (t3.medium = 17), which saturated
+      # on platform pods alone during the 2026-07-04 staging rebuild and left
+      # node-exporter DaemonSet pods unschedulable.
+      before_compute = true
       configuration_values = jsonencode({
         enableNetworkPolicy = "true"
+        env = {
+          # /28 prefixes per ENI slot instead of individual secondary IPs —
+          # decouples max-pods from instance size. Existing nodes keep their
+          # boot-time max-pods until recycled; only NEW launch templates and
+          # Karpenter nodes (kubelet.maxPods in the nodeclass) benefit.
+          ENABLE_PREFIX_DELEGATION = "true"
+          # Keep one whole warm prefix (16 IPs) per node — the recommended
+          # default; raising it trades subnet IPs for faster pod-start bursts.
+          WARM_PREFIX_TARGET = "1"
+        }
       })
     }
   }


### PR DESCRIPTION
The durable fix for the system-MNG pod-saturation finding from the staging rebuild cycle:

- **vpc-cni addon**: `ENABLE_PREFIX_DELEGATION=true`, `WARM_PREFIX_TARGET=1`, and `before_compute = true` — the ordering matters: EKS bakes max-pods into the nodegroup launch template at creation and only accounts for prefix delegation if it's already enabled
- **Karpenter EC2NodeClass**: explicit `kubelet.maxPods: 110` — Karpenter applies the per-ENI-IP formula regardless of CNI settings, so without this, small instances stay pod-starved even with delegation on
- staging keeps t3.large (the saturation doubled as a headroom signal)

Rollout characteristics: on live prod (when applied + released) the addon update rolls `aws-node` with no workload disruption; existing nodes keep their boot-time max-pods until recycled; new Karpenter nodes benefit immediately. Staging's next rebuild validates the full path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ