### PR TITLE
fix(infra): trust the restore-drill SA on the CNPG backup role

### DIFF
--- a/infrastructure/live/prod/us-east-1/security/irsa-roles/terragrunt.hcl
+++ b/infrastructure/live/prod/us-east-1/security/irsa-roles/terragrunt.hcl
@@ -81,6 +81,11 @@ inputs = {
     "default:prod-moderation-postgres",
     "default:prod-auth-postgres",
     "default:prod-media-postgres",
+    # Restore-drill scratch cluster (docs/runbooks): CNPG names the SA after the
+    # cluster, and the trust list is exact-match — without this entry a recovery
+    # bootstrap can't read the backup bucket (barman exit 4, found live on the
+    # first prod drill 2026-07-05). Read path only in practice; same policy.
+    "default:prod-restore-drill-account",
   ]
 
   tags = {

--- a/infrastructure/live/staging/us-east-1/security/irsa-roles/terragrunt.hcl
+++ b/infrastructure/live/staging/us-east-1/security/irsa-roles/terragrunt.hcl
@@ -83,6 +83,11 @@ inputs = {
     "default:staging-moderation-postgres",
     "default:staging-auth-postgres",
     "default:staging-media-postgres",
+    # Restore-drill scratch cluster (docs/runbooks): CNPG names the SA after the
+    # cluster, and the trust list is exact-match — without this entry a recovery
+    # bootstrap can't read the backup bucket (barman exit 4, found live on the
+    # first prod drill 2026-07-05). Read path only in practice; same policy.
+    "default:staging-restore-drill-account",
   ]
 
   tags = {


### PR DESCRIPTION
Found live by the first prod restore drill: CNPG recovery scratch clusters can't assume the backup role — the IRSA trust is an exact-match list of the six cluster SAs, and CNPG fixes the SA name to the cluster name. Adds `default:<env>-restore-drill-account` to both envs so drills are repeatable. Requires a terraform apply of the irsa-roles unit to take effect (prod apply as part of completing the in-flight drill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ