### PR TITLE
fix(gitops): ESO ignoreDifferences on the platform appset (keycloak-secrets drift)

### DIFF
--- a/infrastructure/argocd/bootstrap/prod/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-platform.yaml
@@ -91,6 +91,17 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: "{{.destNamespace}}"
+      # ESO's admission webhook defaults remoteRef fields on ExternalSecrets
+      # (keycloak-secrets) — without ignoring them the app diffs against Git
+      # forever (fleet finding #9 class). Matches only ExternalSecret kinds;
+      # inert for every other platform app.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - .spec.data[].remoteRef.conversionStrategy
+            - .spec.data[].remoteRef.decodingStrategy
+            - .spec.data[].remoteRef.metadataPolicy
       syncPolicy:
         automated:
           prune: true
@@ -98,3 +109,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
@@ -91,6 +91,17 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: "{{.destNamespace}}"
+      # ESO's admission webhook defaults remoteRef fields on ExternalSecrets
+      # (keycloak-secrets) — without ignoring them the app diffs against Git
+      # forever (fleet finding #9 class). Matches only ExternalSecret kinds;
+      # inert for every other platform app.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - .spec.data[].remoteRef.conversionStrategy
+            - .spec.data[].remoteRef.decodingStrategy
+            - .spec.data[].remoteRef.metadataPolicy
       syncPolicy:
         automated:
           prune: true
@@ -98,3 +109,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true


### PR DESCRIPTION
Fleet finding-#9 class on the new keycloak app's ExternalSecret, observed live on prod right after bring-up. Same jqPathExpressions fix as the fleet and operators appsets; rides the pins release to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ