### PR TITLE
release: Keycloak activation — JWKS-capable fleet images + platform-appset ESO fix

### DIFF
--- a/infrastructure/argocd/bootstrap/prod/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/prod/root-infra-platform.yaml
@@ -91,6 +91,17 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: "{{.destNamespace}}"
+      # ESO's admission webhook defaults remoteRef fields on ExternalSecrets
+      # (keycloak-secrets) — without ignoring them the app diffs against Git
+      # forever (fleet finding #9 class). Matches only ExternalSecret kinds;
+      # inert for every other platform app.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - .spec.data[].remoteRef.conversionStrategy
+            - .spec.data[].remoteRef.decodingStrategy
+            - .spec.data[].remoteRef.metadataPolicy
       syncPolicy:
         automated:
           prune: true
@@ -98,3 +109,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
+++ b/infrastructure/argocd/bootstrap/staging/root-infra-platform.yaml
@@ -91,6 +91,17 @@ spec:
       destination:
         server: https://kubernetes.default.svc
         namespace: "{{.destNamespace}}"
+      # ESO's admission webhook defaults remoteRef fields on ExternalSecrets
+      # (keycloak-secrets) — without ignoring them the app diffs against Git
+      # forever (fleet finding #9 class). Matches only ExternalSecret kinds;
+      # inert for every other platform app.
+      ignoreDifferences:
+        - group: external-secrets.io
+          kind: ExternalSecret
+          jqPathExpressions:
+            - .spec.data[].remoteRef.conversionStrategy
+            - .spec.data[].remoteRef.decodingStrategy
+            - .spec.data[].remoteRef.metadataPolicy
       syncPolicy:
         automated:
           prune: true
@@ -98,3 +109,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -116,71 +116,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -104,71 +104,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: fad599f6ba785af526cd2c961eb51273ed6b55d7
+    newTag: ebeaef503387c9bb183456d9afff588927379619
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml


### PR DESCRIPTION
Final leg of the Keycloak activation: the promoted `ebeaef50` pins (fleet built from the #599 tree — auth serves /.well-known/jwks.json on :8081) and #601 (platform-appset ESO ignoreDifferences → keycloak app reaches Synced). Merging rolls the prod fleet; realtime/audit verifier gates flip from deny-all once auth serves keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ