### PR TITLE
fix(account): failed_login_attempts SMALLINT → INTEGER — every full-row read failed

### DIFF
--- a/crates/services/account/migrations/0002_failed_login_attempts_int4.sql
+++ b/crates/services/account/migrations/0002_failed_login_attempts_int4.sql
@@ -1,0 +1,11 @@
+-- failed_login_attempts was SMALLINT while every Rust layer (domain aggregate,
+-- persistence row, proto mapping) uses i32: sqlx's strict decode rejects
+-- INT2→i32, so EVERY full-row read (GetAccountById / GetAccountByIdentityId —
+-- and therefore auth's directory lookup, i.e. login) failed with "mismatched
+-- types" the moment a row existed. Writes worked (parameter coercion), which
+-- is why creation succeeded and the bug only surfaced on the first live read
+-- (found by the prod Keycloak E2E login drill, 2026-07-05; the feature-gated
+-- integration-account suite exercises this read and passes with this
+-- migration — but it never runs in CI, which is the real gap and the tracked
+-- follow-up).
+ALTER TABLE accounts ALTER COLUMN failed_login_attempts TYPE INTEGER;


### PR DESCRIPTION
Found live by the Keycloak E2E login drill on prod: `GetAccountByIdentityId` (and thus `auth.Login`'s directory lookup) dies with `mismatched types; Rust i32 (INT4) is not compatible with SQL INT2` — the schema's one `SMALLINT` column vs `i32` everywhere in Rust. Writes coerce, reads strict-decode, so accounts could be created but never read back.

Fix: migration `0002` alters the column to `INTEGER` (the migrator initContainer applies it idempotently on rollout). Validated with the live `integration-account` suite against a real Postgres — green.

The meta-finding: this suite would catch the class, but it's feature-gated and never runs in CI. Tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ