### PR TITLE
release: account read-path fix (migration 0002) — login unblocked

### DIFF
--- a/crates/services/account/migrations/0002_failed_login_attempts_int4.sql
+++ b/crates/services/account/migrations/0002_failed_login_attempts_int4.sql
@@ -1,0 +1,11 @@
+-- failed_login_attempts was SMALLINT while every Rust layer (domain aggregate,
+-- persistence row, proto mapping) uses i32: sqlx's strict decode rejects
+-- INT2→i32, so EVERY full-row read (GetAccountById / GetAccountByIdentityId —
+-- and therefore auth's directory lookup, i.e. login) failed with "mismatched
+-- types" the moment a row existed. Writes worked (parameter coercion), which
+-- is why creation succeeded and the bug only surfaced on the first live read
+-- (found by the prod Keycloak E2E login drill, 2026-07-05; the feature-gated
+-- integration-account suite exercises this read and passes with this
+-- migration — but it never runs in CI, which is the real gap and the tracked
+-- follow-up).
+ALTER TABLE accounts ALTER COLUMN failed_login_attempts TYPE INTEGER;

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -116,71 +116,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -104,71 +104,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: ebeaef503387c9bb183456d9afff588927379619
+    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml


### PR DESCRIPTION
Carries #603 (failed_login_attempts SMALLINT→INTEGER; every full-row account read — and therefore login — failed on strict decode) with the fleet promoted to f5b765e1. The migrator applies 0002 on rollout; the prod Keycloak E2E login drill resumes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ