### PR TITLE
fix(account): optimistic CAS bound the post-mutation version — every mutation aborted

### DIFF
--- a/crates/services/account/src/infrastructure/persistence/pg_account_repository.rs
+++ b/crates/services/account/src/infrastructure/persistence/pg_account_repository.rs
@@ -188,7 +188,14 @@ impl AccountRepository for PgAccountRepository {
                 .await
         } else {
             // Existing aggregate — UPDATE with optimistic CAS on version.
-            let expected_version = account.version();
+            // `version()` was ALREADY incremented by the aggregate's `touch()`
+            // (every mutation bumps it in memory), so the row still holds the
+            // pre-mutation value: CAS on version() - 1 — the same convention as
+            // auth's session/refresh repos and profile's LWT. Binding version()
+            // itself made EVERY mutation on EVERY account abort with
+            // ConcurrentModification (found by the prod Keycloak E2E drill:
+            // VerifyEmail could never activate an account).
+            let expected_version = account.version() - 1;
 
             self.tx_manager
                 .run_on_shard(&id, |tx| {

--- a/crates/services/account/tests/account_it/harness/mod.rs
+++ b/crates/services/account/tests/account_it/harness/mod.rs
@@ -20,7 +20,7 @@ use postgres_storage::config::StatementLogLevel;
 use postgres_storage::{PgPoolBuilder, PostgresConfig};
 
 use account::app::App;
-use account::application::command::CreateAccountCommand;
+use account::application::command::{CreateAccountCommand, RecordLoginCommand, VerifyEmailCommand};
 use account::application::query::{AccountView, GetAccountByIdentityIdQuery};
 
 pub use test_support::await_until;
@@ -69,6 +69,29 @@ impl TestHarness {
         dispatch_create(Arc::clone(&self.command_bus), identity_id.to_owned(), email.to_owned())
             .await
             .expect("create_account");
+    }
+
+    /// Dispatches VerifyEmail — the canonical first MUTATION of an account's
+    /// life (PendingVerification → Active). Exists because the optimistic-CAS
+    /// regression made every mutation abort while create+read stayed green.
+    pub async fn verify_email(&self, account_id: &str) -> Result<(), CqrsError> {
+        self.command_bus
+            .dispatch(Envelope::new(
+                Uuid::now_v7(),
+                VerifyEmailCommand { account_id: account_id.to_owned() },
+            ))
+            .await
+    }
+
+    /// Dispatches RecordLogin — a second, distinct mutation to prove the CAS
+    /// survives reload cycles (not just the first bump).
+    pub async fn record_login(&self, account_id: &str) -> Result<(), CqrsError> {
+        self.command_bus
+            .dispatch(Envelope::new(
+                Uuid::now_v7(),
+                RecordLoginCommand { account_id: account_id.to_owned() },
+            ))
+            .await
     }
 
     /// Resolves an account by its IdP identity id (`Err` when absent).

--- a/crates/services/account/tests/account_it/scenarios/mod.rs
+++ b/crates/services/account/tests/account_it/scenarios/mod.rs
@@ -3,3 +3,4 @@
 
 mod persistence_roundtrip;
 mod uniqueness_race;
+mod mutation_roundtrip;

--- a/crates/services/account/tests/account_it/scenarios/mutation_roundtrip.rs
+++ b/crates/services/account/tests/account_it/scenarios/mutation_roundtrip.rs
@@ -1,0 +1,33 @@
+//! Regression: the optimistic-CAS write path. The repository binds the
+//! aggregate's PRE-mutation version (`version() - 1` — `touch()` already
+//! bumped it in memory); binding `version()` made every mutation on every
+//! account abort with ConcurrentModification while create+read stayed green —
+//! found live by the prod Keycloak E2E login drill (VerifyEmail could never
+//! activate an account, so no login could ever succeed).
+
+use crate::account_it::harness::{self, TestHarness, DEADLINE};
+
+#[tokio::test]
+async fn mutations_survive_the_optimistic_cas_across_reload_cycles() {
+    let h = TestHarness::start().await;
+    let identity = harness::random_identity();
+    let email = harness::random_email();
+    h.create(&identity, &email).await;
+
+    let identity_q = identity.clone();
+    harness::await_until("account readable", DEADLINE, || {
+        let h = &h;
+        let identity_q = identity_q.clone();
+        async move { h.get_by_identity(&identity_q).await.is_ok() }
+    })
+    .await;
+    let view = h.get_by_identity(&identity).await.expect("account exists");
+
+    // First mutation of the account's life: PendingVerification -> Active.
+    h.verify_email(&view.id).await.expect("verify_email must not abort on CAS");
+    let view = h.get_by_identity(&identity).await.expect("account exists");
+    assert_eq!(view.status, "active", "verify_email must activate the account");
+
+    // Second, distinct mutation after a reload cycle: the CAS must keep holding.
+    h.record_login(&view.id).await.expect("record_login must not abort on CAS");
+}


### PR DESCRIPTION
Second live find from the Keycloak E2E drill: `touch()` pre-increments the aggregate version, the repo CAS'd on the incremented value → `UPDATE ... WHERE version = <n+1>` against a row holding `n` → **every mutation on every account aborted** with ConcurrentModification. Create/read fine; activation (and thus login) structurally impossible.

One-line fix to the convention auth + profile already follow (`version() - 1`), plus a `mutation_roundtrip` integration scenario and harness helpers — suite green against real Postgres.

Same meta-cause as #603: the only suite that exercises this path is feature-gated out of CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ