### PR TITLE
release: account CAS fix — mutations (and login) unblocked

### DIFF
--- a/crates/services/account/src/infrastructure/persistence/pg_account_repository.rs
+++ b/crates/services/account/src/infrastructure/persistence/pg_account_repository.rs
@@ -188,7 +188,14 @@ impl AccountRepository for PgAccountRepository {
                 .await
         } else {
             // Existing aggregate — UPDATE with optimistic CAS on version.
-            let expected_version = account.version();
+            // `version()` was ALREADY incremented by the aggregate's `touch()`
+            // (every mutation bumps it in memory), so the row still holds the
+            // pre-mutation value: CAS on version() - 1 — the same convention as
+            // auth's session/refresh repos and profile's LWT. Binding version()
+            // itself made EVERY mutation on EVERY account abort with
+            // ConcurrentModification (found by the prod Keycloak E2E drill:
+            // VerifyEmail could never activate an account).
+            let expected_version = account.version() - 1;
 
             self.tx_manager
                 .run_on_shard(&id, |tx| {

--- a/crates/services/account/tests/account_it/harness/mod.rs
+++ b/crates/services/account/tests/account_it/harness/mod.rs
@@ -20,7 +20,7 @@ use postgres_storage::config::StatementLogLevel;
 use postgres_storage::{PgPoolBuilder, PostgresConfig};
 
 use account::app::App;
-use account::application::command::CreateAccountCommand;
+use account::application::command::{CreateAccountCommand, RecordLoginCommand, VerifyEmailCommand};
 use account::application::query::{AccountView, GetAccountByIdentityIdQuery};
 
 pub use test_support::await_until;
@@ -69,6 +69,29 @@ impl TestHarness {
         dispatch_create(Arc::clone(&self.command_bus), identity_id.to_owned(), email.to_owned())
             .await
             .expect("create_account");
+    }
+
+    /// Dispatches VerifyEmail — the canonical first MUTATION of an account's
+    /// life (PendingVerification → Active). Exists because the optimistic-CAS
+    /// regression made every mutation abort while create+read stayed green.
+    pub async fn verify_email(&self, account_id: &str) -> Result<(), CqrsError> {
+        self.command_bus
+            .dispatch(Envelope::new(
+                Uuid::now_v7(),
+                VerifyEmailCommand { account_id: account_id.to_owned() },
+            ))
+            .await
+    }
+
+    /// Dispatches RecordLogin — a second, distinct mutation to prove the CAS
+    /// survives reload cycles (not just the first bump).
+    pub async fn record_login(&self, account_id: &str) -> Result<(), CqrsError> {
+        self.command_bus
+            .dispatch(Envelope::new(
+                Uuid::now_v7(),
+                RecordLoginCommand { account_id: account_id.to_owned() },
+            ))
+            .await
     }
 
     /// Resolves an account by its IdP identity id (`Err` when absent).

--- a/crates/services/account/tests/account_it/scenarios/mod.rs
+++ b/crates/services/account/tests/account_it/scenarios/mod.rs
@@ -3,3 +3,4 @@
 
 mod persistence_roundtrip;
 mod uniqueness_race;
+mod mutation_roundtrip;

--- a/crates/services/account/tests/account_it/scenarios/mutation_roundtrip.rs
+++ b/crates/services/account/tests/account_it/scenarios/mutation_roundtrip.rs
@@ -1,0 +1,33 @@
+//! Regression: the optimistic-CAS write path. The repository binds the
+//! aggregate's PRE-mutation version (`version() - 1` — `touch()` already
+//! bumped it in memory); binding `version()` made every mutation on every
+//! account abort with ConcurrentModification while create+read stayed green —
+//! found live by the prod Keycloak E2E login drill (VerifyEmail could never
+//! activate an account, so no login could ever succeed).
+
+use crate::account_it::harness::{self, TestHarness, DEADLINE};
+
+#[tokio::test]
+async fn mutations_survive_the_optimistic_cas_across_reload_cycles() {
+    let h = TestHarness::start().await;
+    let identity = harness::random_identity();
+    let email = harness::random_email();
+    h.create(&identity, &email).await;
+
+    let identity_q = identity.clone();
+    harness::await_until("account readable", DEADLINE, || {
+        let h = &h;
+        let identity_q = identity_q.clone();
+        async move { h.get_by_identity(&identity_q).await.is_ok() }
+    })
+    .await;
+    let view = h.get_by_identity(&identity).await.expect("account exists");
+
+    // First mutation of the account's life: PendingVerification -> Active.
+    h.verify_email(&view.id).await.expect("verify_email must not abort on CAS");
+    let view = h.get_by_identity(&identity).await.expect("account exists");
+    assert_eq!(view.status, "active", "verify_email must activate the account");
+
+    // Second, distinct mutation after a reload cycle: the CAS must keep holding.
+    h.record_login(&view.id).await.expect("record_login must not abort on CAS");
+}

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -116,71 +116,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -104,71 +104,71 @@ configMapGenerator:
 images:
   - name: core-platform-chat-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-chat-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-social-graph-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-social-graph-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-profile-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-profile-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-geo-discovery-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-geo-discovery-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-notification-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-notification-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-post-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-post-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-comment-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-comment-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-engagement-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-engagement-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-account-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-account-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-timeline-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-timeline-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-migrator
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-migrator
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-topic-provisioner
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-topic-provisioner
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   # ── New fleet (one image per binary) ─────────────────────────────────────────
   - name: core-platform-counter-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-counter-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-counter-worker
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-audit-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-audit-worker
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-audit-worker
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-auth-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-auth-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-media-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-media-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-moderation-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-moderation-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-search-server
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-search-server
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-realtime-gateway
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-gateway
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
   - name: core-platform-realtime-dispatcher
     newName: 724772065879.dkr.ecr.us-east-1.amazonaws.com/core-platform-realtime-dispatcher
-    newTag: f5b765e1450b8de177061e9f6e6e490a092476ac
+    newTag: 7b75e32a12932ca080e216966f5d11ad927d413e
 patches:
   # Baseline pod-security hardening (non-root, seccomp, drop caps) on every Deployment.
   - path: patch-securitycontext.yaml


### PR DESCRIPTION
Carries the optimistic-CAS fix (every account mutation aborted; VerifyEmail/login structurally impossible) with the fleet promoted to 7b75e32a. E2E drill resumes after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ