### PR TITLE
fix(auth): missing Kafka env — Login hung publishing to the localhost default

### DIFF
--- a/k8s/overlays/prod/auth.env
+++ b/k8s/overlays/prod/auth.env
@@ -31,3 +31,11 @@ AUTH_KEYCLOAK_SCOPE=openid
 # ── Observability ─────────────────────────────────────────────────────────────
 RUST_LOG=info
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317
+
+# ── Kafka (managed MSK, SASL/SCRAM over TLS; creds via backend-creds) ─────────
+# Auth PRODUCES session/login events; without these the client fell back to its
+# localhost:9092 default and Login RPCs hung on the first publish (found by the
+# prod E2E drill — boot health never touches Kafka, so the pod looked Ready).
+KAFKA_BROKERS=${MSK_BOOTSTRAP_BROKERS_SASL_SCRAM}
+KAFKA_SECURITY_PROTOCOL=SASL_SSL
+KAFKA_SASL_MECHANISM=SCRAM-SHA-512

--- a/k8s/overlays/staging/auth.env
+++ b/k8s/overlays/staging/auth.env
@@ -31,3 +31,11 @@ AUTH_KEYCLOAK_SCOPE=openid
 # ── Observability ─────────────────────────────────────────────────────────────
 RUST_LOG=info
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317
+
+# ── Kafka (managed MSK, SASL/SCRAM over TLS; creds via backend-creds) ─────────
+# Auth PRODUCES session/login events; without these the client fell back to its
+# localhost:9092 default and Login RPCs hung on the first publish (found by the
+# prod E2E drill — boot health never touches Kafka, so the pod looked Ready).
+KAFKA_BROKERS=${MSK_BOOTSTRAP_BROKERS_SASL_SCRAM}
+KAFKA_SECURITY_PROTOCOL=SASL_SSL
+KAFKA_SASL_MECHANISM=SCRAM-SHA-512


### PR DESCRIPTION
Third live find of the E2E drill, one layer deeper than the CAS fix: auth.env never had the MSK block, the producer defaulted to localhost:9092, and Login blocked on its first event publish. Boot health never touches Kafka so the pod always looked Ready. Config-only (overlay), both envs; auth pods roll on the ConfigMap hash change. Design follow-up tracked: TIER-0 login shouldn't hard-couple to broker availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ