### PR TITLE
release: auth Kafka env fix

### DIFF
--- a/k8s/overlays/prod/auth.env
+++ b/k8s/overlays/prod/auth.env
@@ -31,3 +31,11 @@ AUTH_KEYCLOAK_SCOPE=openid
 # ── Observability ─────────────────────────────────────────────────────────────
 RUST_LOG=info
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317
+
+# ── Kafka (managed MSK, SASL/SCRAM over TLS; creds via backend-creds) ─────────
+# Auth PRODUCES session/login events; without these the client fell back to its
+# localhost:9092 default and Login RPCs hung on the first publish (found by the
+# prod E2E drill — boot health never touches Kafka, so the pod looked Ready).
+KAFKA_BROKERS=${MSK_BOOTSTRAP_BROKERS_SASL_SCRAM}
+KAFKA_SECURITY_PROTOCOL=SASL_SSL
+KAFKA_SASL_MECHANISM=SCRAM-SHA-512

--- a/k8s/overlays/staging/auth.env
+++ b/k8s/overlays/staging/auth.env
@@ -31,3 +31,11 @@ AUTH_KEYCLOAK_SCOPE=openid
 # ── Observability ─────────────────────────────────────────────────────────────
 RUST_LOG=info
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc.cluster.local:4317
+
+# ── Kafka (managed MSK, SASL/SCRAM over TLS; creds via backend-creds) ─────────
+# Auth PRODUCES session/login events; without these the client fell back to its
+# localhost:9092 default and Login RPCs hung on the first publish (found by the
+# prod E2E drill — boot health never touches Kafka, so the pod looked Ready).
+KAFKA_BROKERS=${MSK_BOOTSTRAP_BROKERS_SASL_SCRAM}
+KAFKA_SECURITY_PROTOCOL=SASL_SSL
+KAFKA_SASL_MECHANISM=SCRAM-SHA-512


### PR DESCRIPTION
Carries #607 (auth.env MSK block — Login no longer hangs on the localhost default). Overlay-only; auth rolls on ConfigMap hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYY5JC8dBqJvnJDNSE3pbZ